### PR TITLE
feat: add default date in frontmatter for older versions of terraform-plugin-sdk

### DIFF
--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/best-practices/depending-on-providers.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/best-practices/depending-on-providers.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Depending on Providers
 description: How to safely depend on providers and understand their interfaces.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T14:21:02-06:00
-last_modified: 2025-03-06T14:21:02-06:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T14:21:02-06:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -5,8 +5,8 @@ description: |-
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T14:21:02-06:00
-last_modified: 2025-03-06T14:21:02-06:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Patterns that ensure a consistent user experience, including naming,
   deprecation, beta features, testing, and versioning.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T14:21:02-06:00
-last_modified: 2025-03-06T14:21:02-06:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/best-practices/naming.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/best-practices/naming.mdx
@@ -4,8 +4,8 @@ description: |-
   Our recommendations for naming resources, data sources, and attributes in
   providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T14:21:02-06:00
-last_modified: 2025-03-06T14:21:02-06:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/best-practices/other-languages.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/best-practices/other-languages.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Non-Go Providers
 description: Information about writing providers in programming languages other than Go.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T14:21:02-06:00
-last_modified: 2025-03-06T14:21:02-06:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/best-practices/sensitive-state.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/best-practices/sensitive-state.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Sensitive State Best Practices
 description: Recommendations for handling sensitive information in state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T14:21:02-06:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/best-practices/testing.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/best-practices/testing.mdx
@@ -4,8 +4,8 @@ description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T14:21:02-06:00
-last_modified: 2025-03-06T14:21:02-06:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/best-practices/versioning.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/best-practices/versioning.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Versioning Best Practices
 description: Recommendations for version numbering and documentation.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T14:21:02-06:00
-last_modified: 2025-03-06T14:21:02-06:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T14:21:02-06:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -4,8 +4,8 @@ description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T14:21:02-06:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -2,8 +2,8 @@
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T14:21:02-06:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -2,8 +2,8 @@
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T14:21:02-06:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/index.mdx
@@ -2,8 +2,8 @@
 page_title: 'Home - Plugin Development: SDKv2'
 description: Learn about version 2 of the Terraform Plugin SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T14:21:02-06:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T14:21:02-06:00
-last_modified: 2025-03-06T14:21:02-06:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/resources/import.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Import
 description: Implementing resource import support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T14:21:02-06:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T14:21:02-06:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T14:21:02-06:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - State Migration
 description: Migrating state values within resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T14:21:02-06:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T14:21:02-06:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -4,8 +4,8 @@ description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T14:21:02-06:00
-last_modified: 2025-03-06T14:21:02-06:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T14:21:02-06:00
-last_modified: 2025-03-06T14:21:02-06:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -5,8 +5,8 @@ description: |-
   defines what kind of values users can provide in their configuration for an
   element.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T14:21:02-06:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T14:21:02-06:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -4,8 +4,8 @@ description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T14:21:02-06:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -4,8 +4,8 @@ description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T14:21:02-06:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -4,8 +4,8 @@ description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T14:21:02-06:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/testing/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T14:21:02-06:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T14:21:02-06:00
-last_modified: 2025-03-06T14:21:02-06:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T14:21:02-06:00
-last_modified: 2025-03-06T14:21:02-06:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.15.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -4,8 +4,8 @@ description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T14:21:02-06:00
-last_modified: 2025-03-06T14:21:02-06:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/best-practices/depending-on-providers.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/best-practices/depending-on-providers.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Depending on Providers
 description: How to safely depend on providers and understand their interfaces.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -5,8 +5,8 @@ description: |-
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Patterns that ensure a consistent user experience, including naming,
   deprecation, beta features, testing, and versioning.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/best-practices/naming.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/best-practices/naming.mdx
@@ -4,8 +4,8 @@ description: |-
   Our recommendations for naming resources, data sources, and attributes in
   providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/best-practices/other-languages.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/best-practices/other-languages.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Non-Go Providers
 description: Information about writing providers in programming languages other than Go.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/best-practices/sensitive-state.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/best-practices/sensitive-state.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Sensitive State Best Practices
 description: Recommendations for handling sensitive information in state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/best-practices/testing.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/best-practices/testing.mdx
@@ -4,8 +4,8 @@ description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/best-practices/versioning.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/best-practices/versioning.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Versioning Best Practices
 description: Recommendations for version numbering and documentation.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -4,8 +4,8 @@ description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -2,8 +2,8 @@
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -2,8 +2,8 @@
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/index.mdx
@@ -2,8 +2,8 @@
 page_title: 'Home - Plugin Development: SDKv2'
 description: Learn about version 2 of the Terraform Plugin SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/resources/import.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Import
 description: Implementing resource import support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - State Migration
 description: Migrating state values within resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -4,8 +4,8 @@ description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -5,8 +5,8 @@ description: |-
   defines what kind of values users can provide in their configuration for an
   element.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -4,8 +4,8 @@ description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -4,8 +4,8 @@ description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -4,8 +4,8 @@ description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/testing/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.16.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -4,8 +4,8 @@ description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/best-practices/depending-on-providers.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/best-practices/depending-on-providers.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Depending on Providers
 description: How to safely depend on providers and understand their interfaces.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -5,8 +5,8 @@ description: |-
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Patterns that ensure a consistent user experience, including naming,
   deprecation, beta features, testing, and versioning.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/best-practices/naming.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/best-practices/naming.mdx
@@ -4,8 +4,8 @@ description: |-
   Our recommendations for naming resources, data sources, and attributes in
   providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/best-practices/other-languages.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/best-practices/other-languages.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Non-Go Providers
 description: Information about writing providers in programming languages other than Go.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/best-practices/sensitive-state.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/best-practices/sensitive-state.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Sensitive State Best Practices
 description: Recommendations for handling sensitive information in state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/best-practices/testing.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/best-practices/testing.mdx
@@ -4,8 +4,8 @@ description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/best-practices/versioning.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/best-practices/versioning.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Versioning Best Practices
 description: Recommendations for version numbering and documentation.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -4,8 +4,8 @@ description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -2,8 +2,8 @@
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -2,8 +2,8 @@
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/index.mdx
@@ -2,8 +2,8 @@
 page_title: 'Home - Plugin Development: SDKv2'
 description: Learn about version 2 of the Terraform Plugin SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/resources/import.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Import
 description: Implementing resource import support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - State Migration
 description: Migrating state values within resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -4,8 +4,8 @@ description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -5,8 +5,8 @@ description: |-
   defines what kind of values users can provide in their configuration for an
   element.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -4,8 +4,8 @@ description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -4,8 +4,8 @@ description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -4,8 +4,8 @@ description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/testing/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.17.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -4,8 +4,8 @@ description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/best-practices/depending-on-providers.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/best-practices/depending-on-providers.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Depending on Providers
 description: How to safely depend on providers and understand their interfaces.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -5,8 +5,8 @@ description: |-
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Patterns that ensure a consistent user experience, including naming,
   deprecation, beta features, testing, and versioning.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/best-practices/naming.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/best-practices/naming.mdx
@@ -4,8 +4,8 @@ description: |-
   Our recommendations for naming resources, data sources, and attributes in
   providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/best-practices/other-languages.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/best-practices/other-languages.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Non-Go Providers
 description: Information about writing providers in programming languages other than Go.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/best-practices/sensitive-state.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/best-practices/sensitive-state.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Sensitive State Best Practices
 description: Recommendations for handling sensitive information in state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/best-practices/testing.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/best-practices/testing.mdx
@@ -4,8 +4,8 @@ description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/best-practices/versioning.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/best-practices/versioning.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Versioning Best Practices
 description: Recommendations for version numbering and documentation.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -4,8 +4,8 @@ description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -2,8 +2,8 @@
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -2,8 +2,8 @@
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/index.mdx
@@ -2,8 +2,8 @@
 page_title: 'Home - Plugin Development: SDKv2'
 description: Learn about version 2 of the Terraform Plugin SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/resources/import.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Import
 description: Implementing resource import support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - State Migration
 description: Migrating state values within resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -4,8 +4,8 @@ description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -5,8 +5,8 @@ description: |-
   defines what kind of values users can provide in their configuration for an
   element.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -4,8 +4,8 @@ description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -4,8 +4,8 @@ description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -4,8 +4,8 @@ description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/testing/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.18.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -4,8 +4,8 @@ description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/best-practices/depending-on-providers.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/best-practices/depending-on-providers.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Depending on Providers
 description: How to safely depend on providers and understand their interfaces.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -5,8 +5,8 @@ description: |-
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Patterns that ensure a consistent user experience, including naming,
   deprecation, beta features, testing, and versioning.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/best-practices/naming.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/best-practices/naming.mdx
@@ -4,8 +4,8 @@ description: |-
   Our recommendations for naming resources, data sources, and attributes in
   providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/best-practices/other-languages.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/best-practices/other-languages.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Non-Go Providers
 description: Information about writing providers in programming languages other than Go.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/best-practices/sensitive-state.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/best-practices/sensitive-state.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Sensitive State Best Practices
 description: Recommendations for handling sensitive information in state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/best-practices/testing.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/best-practices/testing.mdx
@@ -4,8 +4,8 @@ description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/best-practices/versioning.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/best-practices/versioning.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Versioning Best Practices
 description: Recommendations for version numbering and documentation.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -4,8 +4,8 @@ description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -2,8 +2,8 @@
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -2,8 +2,8 @@
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/index.mdx
@@ -2,8 +2,8 @@
 page_title: 'Home - Plugin Development: SDKv2'
 description: Learn about version 2 of the Terraform Plugin SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/resources/import.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Import
 description: Implementing resource import support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - State Migration
 description: Migrating state values within resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -4,8 +4,8 @@ description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -5,8 +5,8 @@ description: |-
   defines what kind of values users can provide in their configuration for an
   element.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -4,8 +4,8 @@ description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -4,8 +4,8 @@ description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -4,8 +4,8 @@ description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/testing/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.19.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -4,8 +4,8 @@ description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/best-practices/depending-on-providers.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/best-practices/depending-on-providers.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Depending on Providers
 description: How to safely depend on providers and understand their interfaces.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -5,8 +5,8 @@ description: |-
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Patterns that ensure a consistent user experience, including naming,
   deprecation, beta features, testing, and versioning.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/best-practices/naming.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/best-practices/naming.mdx
@@ -4,8 +4,8 @@ description: |-
   Our recommendations for naming resources, data sources, and attributes in
   providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/best-practices/other-languages.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/best-practices/other-languages.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Non-Go Providers
 description: Information about writing providers in programming languages other than Go.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/best-practices/sensitive-state.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/best-practices/sensitive-state.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Sensitive State Best Practices
 description: Recommendations for handling sensitive information in state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/best-practices/testing.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/best-practices/testing.mdx
@@ -4,8 +4,8 @@ description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/best-practices/versioning.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/best-practices/versioning.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Versioning Best Practices
 description: Recommendations for version numbering and documentation.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -4,8 +4,8 @@ description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -2,8 +2,8 @@
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -2,8 +2,8 @@
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/index.mdx
@@ -2,8 +2,8 @@
 page_title: 'Home - Plugin Development: SDKv2'
 description: Learn about version 2 of the Terraform Plugin SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/logging/http-transport.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/logging/http-transport.mdx
@@ -3,8 +3,8 @@ page_title: Plugin Development - Logging HTTP Transport
 description: |-
   SDKv2 provides a helper to send all the HTTP transactions to structured logging.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/logging/index.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/logging/index.mdx
@@ -3,8 +3,8 @@ page_title: Plugin Development - Logging
 description: |-
   High-quality logs are important when debugging your provider. Learn to set-up logging and write meaningful logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/resources/import.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Import
 description: Implementing resource import support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - State Migration
 description: Migrating state values within resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -4,8 +4,8 @@ description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -5,8 +5,8 @@ description: |-
   defines what kind of values users can provide in their configuration for an
   element.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -4,8 +4,8 @@ description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -4,8 +4,8 @@ description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -4,8 +4,8 @@ description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/testing/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.20.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -4,8 +4,8 @@ description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/best-practices/depending-on-providers.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/best-practices/depending-on-providers.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Depending on Providers
 description: How to safely depend on providers and understand their interfaces.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -5,8 +5,8 @@ description: |-
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Patterns that ensure a consistent user experience, including naming,
   deprecation, beta features, testing, and versioning.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/best-practices/naming.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/best-practices/naming.mdx
@@ -4,8 +4,8 @@ description: |-
   Our recommendations for naming resources, data sources, and attributes in
   providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/best-practices/other-languages.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/best-practices/other-languages.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Non-Go Providers
 description: Information about writing providers in programming languages other than Go.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/best-practices/sensitive-state.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/best-practices/sensitive-state.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Sensitive State Best Practices
 description: Recommendations for handling sensitive information in state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/best-practices/testing.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/best-practices/testing.mdx
@@ -4,8 +4,8 @@ description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/best-practices/versioning.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/best-practices/versioning.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Versioning Best Practices
 description: Recommendations for version numbering and documentation.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -4,8 +4,8 @@ description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -2,8 +2,8 @@
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -2,8 +2,8 @@
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/index.mdx
@@ -2,8 +2,8 @@
 page_title: 'Home - Plugin Development: SDKv2'
 description: Learn about version 2 of the Terraform Plugin SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/logging/http-transport.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/logging/http-transport.mdx
@@ -3,8 +3,8 @@ page_title: Plugin Development - Logging HTTP Transport
 description: |-
   SDKv2 provides a helper to send all the HTTP transactions to structured logging.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/logging/index.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/logging/index.mdx
@@ -3,8 +3,8 @@ page_title: Plugin Development - Logging
 description: |-
   High-quality logs are important when debugging your provider. Learn to set-up logging and write meaningful logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/resources/import.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Import
 description: Implementing resource import support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - State Migration
 description: Migrating state values within resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -4,8 +4,8 @@ description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -5,8 +5,8 @@ description: |-
   defines what kind of values users can provide in their configuration for an
   element.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -4,8 +4,8 @@ description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -4,8 +4,8 @@ description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -4,8 +4,8 @@ description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/testing/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.21.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -4,8 +4,8 @@ description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/best-practices/depending-on-providers.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/best-practices/depending-on-providers.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Depending on Providers
 description: How to safely depend on providers and understand their interfaces.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -5,8 +5,8 @@ description: |-
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Patterns that ensure a consistent user experience, including naming,
   deprecation, beta features, testing, and versioning.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/best-practices/naming.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/best-practices/naming.mdx
@@ -4,8 +4,8 @@ description: |-
   Our recommendations for naming resources, data sources, and attributes in
   providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/best-practices/other-languages.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/best-practices/other-languages.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Non-Go Providers
 description: Information about writing providers in programming languages other than Go.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/best-practices/sensitive-state.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/best-practices/sensitive-state.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Sensitive State Best Practices
 description: Recommendations for handling sensitive information in state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/best-practices/testing.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/best-practices/testing.mdx
@@ -4,8 +4,8 @@ description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/best-practices/versioning.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/best-practices/versioning.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Versioning Best Practices
 description: Recommendations for version numbering and documentation.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -4,8 +4,8 @@ description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -2,8 +2,8 @@
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -2,8 +2,8 @@
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/index.mdx
@@ -2,8 +2,8 @@
 page_title: 'Home - Plugin Development: SDKv2'
 description: Learn about version 2 of the Terraform Plugin SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/logging/http-transport.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/logging/http-transport.mdx
@@ -3,8 +3,8 @@ page_title: Plugin Development - Logging HTTP Transport
 description: |-
   SDKv2 provides a helper to send all the HTTP transactions to structured logging.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/logging/index.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/logging/index.mdx
@@ -3,8 +3,8 @@ page_title: Plugin Development - Logging
 description: |-
   High-quality logs are important when debugging your provider. Learn to set-up logging and write meaningful logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/resources/import.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Import
 description: Implementing resource import support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - State Migration
 description: Migrating state values within resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -4,8 +4,8 @@ description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -5,8 +5,8 @@ description: |-
   defines what kind of values users can provide in their configuration for an
   element.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -4,8 +4,8 @@ description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -4,8 +4,8 @@ description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -4,8 +4,8 @@ description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/testing/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.22.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -4,8 +4,8 @@ description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/best-practices/depending-on-providers.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/best-practices/depending-on-providers.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Depending on Providers
 description: How to safely depend on providers and understand their interfaces.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -5,8 +5,8 @@ description: |-
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Patterns that ensure a consistent user experience, including naming,
   deprecation, beta features, testing, and versioning.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/best-practices/naming.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/best-practices/naming.mdx
@@ -4,8 +4,8 @@ description: |-
   Our recommendations for naming resources, data sources, and attributes in
   providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/best-practices/other-languages.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/best-practices/other-languages.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Non-Go Providers
 description: Information about writing providers in programming languages other than Go.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/best-practices/sensitive-state.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/best-practices/sensitive-state.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Sensitive State Best Practices
 description: Recommendations for handling sensitive information in state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/best-practices/testing.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/best-practices/testing.mdx
@@ -4,8 +4,8 @@ description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/best-practices/versioning.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/best-practices/versioning.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Versioning Best Practices
 description: Recommendations for version numbering and documentation.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -4,8 +4,8 @@ description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -2,8 +2,8 @@
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -2,8 +2,8 @@
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/index.mdx
@@ -2,8 +2,8 @@
 page_title: 'Home - Plugin Development: SDKv2'
 description: Learn about version 2 of the Terraform Plugin SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/logging/http-transport.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/logging/http-transport.mdx
@@ -3,8 +3,8 @@ page_title: Plugin Development - Logging HTTP Transport
 description: |-
   SDKv2 provides a helper to send all the HTTP transactions to structured logging.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/logging/index.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/logging/index.mdx
@@ -3,8 +3,8 @@ page_title: Plugin Development - Logging
 description: |-
   High-quality logs are important when debugging your provider. Learn to set-up logging and write meaningful logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/resources/import.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Import
 description: Implementing resource import support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - State Migration
 description: Migrating state values within resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -4,8 +4,8 @@ description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -5,8 +5,8 @@ description: |-
   defines what kind of values users can provide in their configuration for an
   element.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -4,8 +4,8 @@ description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -4,8 +4,8 @@ description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -4,8 +4,8 @@ description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/testing/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.23.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -4,8 +4,8 @@ description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/best-practices/depending-on-providers.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/best-practices/depending-on-providers.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Depending on Providers
 description: How to safely depend on providers and understand their interfaces.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -5,8 +5,8 @@ description: |-
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Patterns that ensure a consistent user experience, including naming,
   deprecation, beta features, testing, and versioning.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/best-practices/naming.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/best-practices/naming.mdx
@@ -4,8 +4,8 @@ description: |-
   Our recommendations for naming resources, data sources, and attributes in
   providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/best-practices/other-languages.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/best-practices/other-languages.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Non-Go Providers
 description: Information about writing providers in programming languages other than Go.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/best-practices/sensitive-state.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/best-practices/sensitive-state.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Sensitive State Best Practices
 description: Recommendations for handling sensitive information in state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/best-practices/testing.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/best-practices/testing.mdx
@@ -4,8 +4,8 @@ description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/best-practices/versioning.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/best-practices/versioning.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Versioning Best Practices
 description: Recommendations for version numbering and documentation.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -4,8 +4,8 @@ description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -2,8 +2,8 @@
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -2,8 +2,8 @@
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/index.mdx
@@ -2,8 +2,8 @@
 page_title: 'Home - Plugin Development: SDKv2'
 description: Maintain plugins built on the legacy SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/logging/http-transport.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/logging/http-transport.mdx
@@ -3,8 +3,8 @@ page_title: Plugin Development - Logging HTTP Transport
 description: |-
   SDKv2 provides a helper to send all the HTTP transactions to structured logging.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/logging/index.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/logging/index.mdx
@@ -3,8 +3,8 @@ page_title: Plugin Development - Logging
 description: |-
   High-quality logs are important when debugging your provider. Learn to set-up logging and write meaningful logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/resources/import.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Import
 description: Implementing resource import support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - State Migration
 description: Migrating state values within resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -4,8 +4,8 @@ description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -5,8 +5,8 @@ description: |-
   defines what kind of values users can provide in their configuration for an
   element.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -4,8 +4,8 @@ description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -4,8 +4,8 @@ description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -4,8 +4,8 @@ description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/testing/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.24.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -4,8 +4,8 @@ description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/best-practices/depending-on-providers.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/best-practices/depending-on-providers.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Depending on Providers
 description: How to safely depend on providers and understand their interfaces.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -5,8 +5,8 @@ description: |-
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Patterns that ensure a consistent user experience, including naming,
   deprecation, beta features, testing, and versioning.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/best-practices/naming.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/best-practices/naming.mdx
@@ -4,8 +4,8 @@ description: |-
   Our recommendations for naming resources, data sources, and attributes in
   providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/best-practices/other-languages.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/best-practices/other-languages.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Non-Go Providers
 description: Information about writing providers in programming languages other than Go.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/best-practices/sensitive-state.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/best-practices/sensitive-state.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Sensitive State Best Practices
 description: Recommendations for handling sensitive information in state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/best-practices/testing.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/best-practices/testing.mdx
@@ -4,8 +4,8 @@ description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/best-practices/versioning.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/best-practices/versioning.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Versioning Best Practices
 description: Recommendations for version numbering and documentation.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -4,8 +4,8 @@ description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -2,8 +2,8 @@
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -2,8 +2,8 @@
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/index.mdx
@@ -2,8 +2,8 @@
 page_title: 'Home - Plugin Development: SDKv2'
 description: Maintain plugins built on the legacy SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/logging/http-transport.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/logging/http-transport.mdx
@@ -3,8 +3,8 @@ page_title: Plugin Development - Logging HTTP Transport
 description: |-
   SDKv2 provides a helper to send all the HTTP transactions to structured logging.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/logging/index.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/logging/index.mdx
@@ -3,8 +3,8 @@ page_title: Plugin Development - Logging
 description: |-
   High-quality logs are important when debugging your provider. Learn to set-up logging and write meaningful logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/resources/import.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Import
 description: Implementing resource import support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - State Migration
 description: Migrating state values within resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -4,8 +4,8 @@ description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -5,8 +5,8 @@ description: |-
   defines what kind of values users can provide in their configuration for an
   element.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -4,8 +4,8 @@ description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -4,8 +4,8 @@ description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -4,8 +4,8 @@ description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/testing/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.25.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -4,8 +4,8 @@ description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - SDKv2 Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -5,8 +5,8 @@ description: |-
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -3,8 +3,8 @@ page_title: Plugin Development - SDKv2 Best Practices
 description: >-
   Patterns that ensure a consistent user experience, including deprecation, beta features, and detecting drift.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -4,8 +4,8 @@ description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -2,8 +2,8 @@
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -2,8 +2,8 @@
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/index.mdx
@@ -2,8 +2,8 @@
 page_title: 'Home - Plugin Development: SDKv2'
 description: Maintain plugins built on the legacy SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/logging/http-transport.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/logging/http-transport.mdx
@@ -3,8 +3,8 @@ page_title: Plugin Development - Logging HTTP Transport
 description: |-
   SDKv2 provides a helper to send all the HTTP transactions to structured logging.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/logging/index.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/logging/index.mdx
@@ -3,8 +3,8 @@ page_title: Plugin Development - Logging
 description: |-
   High-quality logs are important when debugging your provider. Learn to set-up logging and write meaningful logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/resources/import.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Import
 description: Implementing resource import support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - State Migration
 description: Migrating state values within resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -4,8 +4,8 @@ description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -5,8 +5,8 @@ description: |-
   defines what kind of values users can provide in their configuration for an
   element.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -4,8 +4,8 @@ description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -4,8 +4,8 @@ description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -4,8 +4,8 @@ description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/testing/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.26.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -4,8 +4,8 @@ description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - SDKv2 Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -5,8 +5,8 @@ description: |-
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -3,8 +3,8 @@ page_title: Plugin Development - SDKv2 Best Practices
 description: >-
   Patterns that ensure a consistent user experience, including deprecation, beta features, and detecting drift.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -4,8 +4,8 @@ description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -2,8 +2,8 @@
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -2,8 +2,8 @@
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/index.mdx
@@ -2,8 +2,8 @@
 page_title: 'Home - Plugin Development: SDKv2'
 description: Maintain plugins built on the legacy SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/logging/http-transport.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/logging/http-transport.mdx
@@ -3,8 +3,8 @@ page_title: Plugin Development - Logging HTTP Transport
 description: |-
   SDKv2 provides a helper to send all the HTTP transactions to structured logging.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/logging/index.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/logging/index.mdx
@@ -3,8 +3,8 @@ page_title: Plugin Development - Logging
 description: |-
   High-quality logs are important when debugging your provider. Learn to set-up logging and write meaningful logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/resources/import.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Import
 description: Implementing resource import support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - State Migration
 description: Migrating state values within resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -4,8 +4,8 @@ description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -5,8 +5,8 @@ description: |-
   defines what kind of values users can provide in their configuration for an
   element.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -4,8 +4,8 @@ description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -4,8 +4,8 @@ description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -4,8 +4,8 @@ description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/testing/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.27.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -4,8 +4,8 @@ description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - SDKv2 Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -5,8 +5,8 @@ description: |-
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -3,8 +3,8 @@ page_title: Plugin Development - SDKv2 Best Practices
 description: >-
   Patterns that ensure a consistent user experience, including deprecation, beta features, and detecting drift.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -4,8 +4,8 @@ description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -2,8 +2,8 @@
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -2,8 +2,8 @@
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/index.mdx
@@ -2,8 +2,8 @@
 page_title: 'Home - Plugin Development: SDKv2'
 description: Maintain plugins built on the legacy SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/logging/http-transport.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/logging/http-transport.mdx
@@ -3,8 +3,8 @@ page_title: Plugin Development - Logging HTTP Transport
 description: |-
   SDKv2 provides a helper to send all the HTTP transactions to structured logging.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/logging/index.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/logging/index.mdx
@@ -3,8 +3,8 @@ page_title: Plugin Development - Logging
 description: |-
   High-quality logs are important when debugging your provider. Learn to set-up logging and write meaningful logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Data Consistency Errors
 description: Fixing data consistency errors caused by this SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/resources/import.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Import
 description: Implementing resource import support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - State Migration
 description: Migrating state values within resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -4,8 +4,8 @@ description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -5,8 +5,8 @@ description: |-
   defines what kind of values users can provide in their configuration for an
   element.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -4,8 +4,8 @@ description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -4,8 +4,8 @@ description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -4,8 +4,8 @@ description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/testing/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.28.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -4,8 +4,8 @@ description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - SDKv2 Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -5,8 +5,8 @@ description: |-
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -3,8 +3,8 @@ page_title: Plugin Development - SDKv2 Best Practices
 description: >-
   Patterns that ensure a consistent user experience, including deprecation, beta features, and detecting drift.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -4,8 +4,8 @@ description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -2,8 +2,8 @@
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -2,8 +2,8 @@
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/index.mdx
@@ -2,8 +2,8 @@
 page_title: 'Home - Plugin Development: SDKv2'
 description: Maintain plugins built on the legacy SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/logging/http-transport.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/logging/http-transport.mdx
@@ -3,8 +3,8 @@ page_title: Plugin Development - Logging HTTP Transport
 description: |-
   SDKv2 provides a helper to send all the HTTP transactions to structured logging.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/logging/index.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/logging/index.mdx
@@ -3,8 +3,8 @@ page_title: Plugin Development - Logging
 description: |-
   High-quality logs are important when debugging your provider. Learn to set-up logging and write meaningful logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Data Consistency Errors
 description: Fixing data consistency errors caused by this SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/resources/import.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Import
 description: Implementing resource import support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - State Migration
 description: Migrating state values within resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -4,8 +4,8 @@ description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -5,8 +5,8 @@ description: |-
   defines what kind of values users can provide in their configuration for an
   element.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -4,8 +4,8 @@ description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -4,8 +4,8 @@ description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -4,8 +4,8 @@ description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/testing/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -4,8 +4,8 @@ description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - SDKv2 Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -5,8 +5,8 @@ description: |-
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -3,8 +3,8 @@ page_title: Plugin Development - SDKv2 Best Practices
 description: >-
   Patterns that ensure a consistent user experience, including deprecation, beta features, and detecting drift.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -4,8 +4,8 @@ description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -2,8 +2,8 @@
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -2,8 +2,8 @@
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/index.mdx
@@ -2,8 +2,8 @@
 page_title: 'Home - Plugin Development: SDKv2'
 description: Maintain plugins built on the legacy SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/logging/http-transport.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/logging/http-transport.mdx
@@ -3,8 +3,8 @@ page_title: Plugin Development - Logging HTTP Transport
 description: |-
   SDKv2 provides a helper to send all the HTTP transactions to structured logging.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/logging/index.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/logging/index.mdx
@@ -3,8 +3,8 @@ page_title: Plugin Development - Logging
 description: |-
   High-quality logs are important when debugging your provider. Learn to set-up logging and write meaningful logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Data Consistency Errors
 description: Fixing data consistency errors caused by this SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/resources/import.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Import
 description: Implementing resource import support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - State Migration
 description: Migrating state values within resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -4,8 +4,8 @@ description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -5,8 +5,8 @@ description: |-
   defines what kind of values users can provide in their configuration for an
   element.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -4,8 +4,8 @@ description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -4,8 +4,8 @@ description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -4,8 +4,8 @@ description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/testing/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -4,8 +4,8 @@ description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - SDKv2 Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -5,8 +5,8 @@ description: |-
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -3,8 +3,8 @@ page_title: Plugin Development - SDKv2 Best Practices
 description: >-
   Patterns that ensure a consistent user experience, including deprecation, beta features, and detecting drift.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -4,8 +4,8 @@ description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -2,8 +2,8 @@
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -2,8 +2,8 @@
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/index.mdx
@@ -2,8 +2,8 @@
 page_title: 'Home - Plugin Development: SDKv2'
 description: Maintain plugins built on the legacy SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/logging/http-transport.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/logging/http-transport.mdx
@@ -3,8 +3,8 @@ page_title: Plugin Development - Logging HTTP Transport
 description: |-
   SDKv2 provides a helper to send all the HTTP transactions to structured logging.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/logging/index.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/logging/index.mdx
@@ -3,8 +3,8 @@ page_title: Plugin Development - Logging
 description: |-
   High-quality logs are important when debugging your provider. Learn to set-up logging and write meaningful logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Data Consistency Errors
 description: Fixing data consistency errors caused by this SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/resources/import.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Import
 description: Implementing resource import support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - State Migration
 description: Migrating state values within resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -4,8 +4,8 @@ description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -5,8 +5,8 @@ description: |-
   defines what kind of values users can provide in their configuration for an
   element.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -4,8 +4,8 @@ description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -4,8 +4,8 @@ description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -4,8 +4,8 @@ description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/testing/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -4,8 +4,8 @@ description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - SDKv2 Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -5,8 +5,8 @@ description: |-
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -3,8 +3,8 @@ page_title: Plugin Development - SDKv2 Best Practices
 description: >-
   Patterns that ensure a consistent user experience, including deprecation, beta features, and detecting drift.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -4,8 +4,8 @@ description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -2,8 +2,8 @@
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -2,8 +2,8 @@
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/index.mdx
@@ -2,8 +2,8 @@
 page_title: 'Home - Plugin Development: SDKv2'
 description: Maintain plugins built on the legacy SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/logging/http-transport.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/logging/http-transport.mdx
@@ -3,8 +3,8 @@ page_title: Plugin Development - Logging HTTP Transport
 description: |-
   SDKv2 provides a helper to send all the HTTP transactions to structured logging.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/logging/index.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/logging/index.mdx
@@ -3,8 +3,8 @@ page_title: Plugin Development - Logging
 description: |-
   High-quality logs are important when debugging your provider. Learn to set-up logging and write meaningful logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Data Consistency Errors
 description: Fixing data consistency errors caused by this SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/resources/import.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Import
 description: Implementing resource import support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - State Migration
 description: Migrating state values within resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -4,8 +4,8 @@ description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -5,8 +5,8 @@ description: |-
   defines what kind of values users can provide in their configuration for an
   element.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -4,8 +4,8 @@ description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -4,8 +4,8 @@ description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -4,8 +4,8 @@ description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/testing/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -4,8 +4,8 @@ description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - SDKv2 Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -5,8 +5,8 @@ description: |-
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -3,8 +3,8 @@ page_title: Plugin Development - SDKv2 Best Practices
 description: >-
   Patterns that ensure a consistent user experience, including deprecation, beta features, and detecting drift.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -4,8 +4,8 @@ description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -2,8 +2,8 @@
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -2,8 +2,8 @@
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/index.mdx
@@ -2,8 +2,8 @@
 page_title: 'Home - Plugin Development: SDKv2'
 description: Maintain plugins built on the legacy SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/logging/http-transport.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/logging/http-transport.mdx
@@ -3,8 +3,8 @@ page_title: Plugin Development - Logging HTTP Transport
 description: |-
   SDKv2 provides a helper to send all the HTTP transactions to structured logging.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/logging/index.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/logging/index.mdx
@@ -3,8 +3,8 @@ page_title: Plugin Development - Logging
 description: |-
   High-quality logs are important when debugging your provider. Learn to set-up logging and write meaningful logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Data Consistency Errors
 description: Fixing data consistency errors caused by this SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/resources/import.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Import
 description: Implementing resource import support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - State Migration
 description: Migrating state values within resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -4,8 +4,8 @@ description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -5,8 +5,8 @@ description: |-
   defines what kind of values users can provide in their configuration for an
   element.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -4,8 +4,8 @@ description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -4,8 +4,8 @@ description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -4,8 +4,8 @@ description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/testing/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -4,8 +4,8 @@ description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - SDKv2 Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -5,8 +5,8 @@ description: |-
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -3,8 +3,8 @@ page_title: Plugin Development - SDKv2 Best Practices
 description: >-
   Patterns that ensure a consistent user experience, including deprecation, beta features, and detecting drift.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -4,8 +4,8 @@ description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -2,8 +2,8 @@
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -2,8 +2,8 @@
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/index.mdx
@@ -2,8 +2,8 @@
 page_title: 'Home - Plugin Development: SDKv2'
 description: Maintain plugins built on the legacy SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/logging/http-transport.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/logging/http-transport.mdx
@@ -3,8 +3,8 @@ page_title: Plugin Development - Logging HTTP Transport
 description: |-
   SDKv2 provides a helper to send all the HTTP transactions to structured logging.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/logging/index.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/logging/index.mdx
@@ -3,8 +3,8 @@ page_title: Plugin Development - Logging
 description: |-
   High-quality logs are important when debugging your provider. Learn to set-up logging and write meaningful logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Data Consistency Errors
 description: Fixing data consistency errors caused by this SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/resources/import.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Import
 description: Implementing resource import support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - State Migration
 description: Migrating state values within resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -4,8 +4,8 @@ description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -5,8 +5,8 @@ description: |-
   defines what kind of values users can provide in their configuration for an
   element.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -4,8 +4,8 @@ description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -4,8 +4,8 @@ description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -4,8 +4,8 @@ description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/testing/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -4,8 +4,8 @@ description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/best-practices/deprecations.mdx
@@ -2,8 +2,8 @@
 page_title: 'Plugin Development - SDKv2 Deprecations, Removals, and Renames Best Practices'
 description: 'Recommendations for deprecations, removals, and renames.'
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/best-practices/detecting-drift.mdx
@@ -5,8 +5,8 @@ description: |-
   to ensure that Terraform detects drift so that users will know when their
   infrastructure has changed.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/best-practices/index.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/best-practices/index.mdx
@@ -3,8 +3,8 @@ page_title: Plugin Development - SDKv2 Best Practices
 description: >-
   Patterns that ensure a consistent user experience, including deprecation, beta features, and detecting drift.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/debugging.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/debugging.mdx
@@ -2,8 +2,8 @@
 page_title: Plugin Development - Debugging SDKv2 Providers
 description: How to implement debugger support in SDKv2 Terraform providers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/guides/terraform-0.12-compatibility.mdx
@@ -4,8 +4,8 @@ description: |-
   Compatibility with Terraform 0.12 requires some changes to existing provider
   codebases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/guides/v1-upgrade-guide.mdx
@@ -2,8 +2,8 @@
 page_title: Terraform Plugin SDK
 description: Official standalone SDK for Terraform plugin development
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/guides/v2-upgrade-guide.mdx
@@ -2,8 +2,8 @@
 page_title: Terraform Plugin SDK v2 Upgrade Guide
 description: Upgrade guide for version 2 of the Terraform Plugin SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/index.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/index.mdx
@@ -2,8 +2,8 @@
 page_title: 'Home - Plugin Development: SDKv2'
 description: Maintain plugins built on the legacy SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/logging/http-transport.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/logging/http-transport.mdx
@@ -3,8 +3,8 @@ page_title: Plugin Development - Logging HTTP Transport
 description: |-
   SDKv2 provides a helper to send all the HTTP transactions to structured logging.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/logging/index.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/logging/index.mdx
@@ -3,8 +3,8 @@ page_title: Plugin Development - Logging
 description: |-
   High-quality logs are important when debugging your provider. Learn to set-up logging and write meaningful logs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/resources/customizing-differences.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Customizing Differences
 description: Difference customization within Resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Data Consistency Errors
 description: Fixing data consistency errors caused by this SDK.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/resources/import.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/resources/import.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Import
 description: Implementing resource import support.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/resources/index.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/resources/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Resources are a key component to provider development. Learn to use advanced
   resource APIs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/resources/retries-and-customizable-timeouts.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - Retries and Customizable Timeouts
 description: Helpers for handling retries within Resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/resources/state-migration.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/resources/state-migration.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - State Migration
 description: Migrating state values within resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/schemas/index.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/schemas/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Schemas define plugin attributes and behaviors. Learn how to create schemas
   in SDKv2.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/schemas/schema-behaviors.mdx
@@ -4,8 +4,8 @@ description: |-
   Schemas define plugin attributes and behaviors. Learn about the fields that
   you can use to define element behaviors in SDKv2.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/schemas/schema-methods.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/schemas/schema-types.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/schemas/schema-types.mdx
@@ -5,8 +5,8 @@ description: |-
   defines what kind of values users can provide in their configuration for an
   element.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/testing/acceptance-tests/sweepers.mdx
@@ -4,8 +4,8 @@ description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/testing/acceptance-tests/testcase.mdx
@@ -4,8 +4,8 @@ description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/testing/acceptance-tests/teststep.mdx
@@ -4,8 +4,8 @@ description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/testing/index.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/testing/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/testing/testing-api.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/testing/testing-api.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/testing/testing-patterns.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/testing/unit-testing.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/testing/unit-testing.mdx
@@ -4,8 +4,8 @@ description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-11-19T09:33:54-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 


### PR DESCRIPTION
### Description

This PR adds a default date for the metadata for older versions of the terraform-plugin-sdk documentation. This change should not affect the developer site as it is a change to the frontmatter. This change will help to keep our sitemap more accurate for SEO and LLMs. The date frontmatter was generated using the add-date-metadata.mjs script. To keep this information up to date, there will be a github action to handle all updates to date metadata: https://github.com/hashicorp/web-unified-docs/pull/1715. Older docs versions have been updated with default dates for the versions specified in [this spreadsheet](https://docs.google.com/spreadsheets/d/16FpDhKA4ZBOVtxHWw2ebMjS56mdSask1FBCVecn9QnQ/edit?gid=0#gid=0)

### Testing

Check that terraform-plugin-sdk docs look normal in the preview: https://unified-docs-frontend-preview-rlty0q3b0-hashicorp.vercel.app/terraform/plugin/sdkv2