### PR TITLE
feat: add default date in frontmatter for older versions of terraform-plugin-testing

### DIFF
--- a/content/terraform-plugin-testing/v1.0.x/docs/plugin/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-testing/v1.0.x/docs/plugin/testing/acceptance-tests/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.0.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-testing/v1.0.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
@@ -4,8 +4,8 @@ description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.0.x/docs/plugin/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-testing/v1.0.x/docs/plugin/testing/acceptance-tests/testcase.mdx
@@ -4,8 +4,8 @@ description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.0.x/docs/plugin/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-testing/v1.0.x/docs/plugin/testing/acceptance-tests/teststep.mdx
@@ -4,8 +4,8 @@ description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.0.x/docs/plugin/testing/index.mdx
+++ b/content/terraform-plugin-testing/v1.0.x/docs/plugin/testing/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.0.x/docs/plugin/testing/testing-api.mdx
+++ b/content/terraform-plugin-testing/v1.0.x/docs/plugin/testing/testing-api.mdx
@@ -4,8 +4,8 @@ description: |-
   Plugin Development is a section for content dedicated to developing Plugins
   to extend Terraform's core offering.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.0.x/docs/plugin/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-testing/v1.0.x/docs/plugin/testing/testing-patterns.mdx
@@ -4,8 +4,8 @@ description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.0.x/docs/plugin/testing/unit-testing.mdx
+++ b/content/terraform-plugin-testing/v1.0.x/docs/plugin/testing/unit-testing.mdx
@@ -4,8 +4,8 @@ description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.1.x/docs/plugin/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-testing/v1.1.x/docs/plugin/testing/acceptance-tests/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.1.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-testing/v1.1.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
@@ -4,8 +4,8 @@ description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.1.x/docs/plugin/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-testing/v1.1.x/docs/plugin/testing/acceptance-tests/testcase.mdx
@@ -4,8 +4,8 @@ description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.1.x/docs/plugin/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-testing/v1.1.x/docs/plugin/testing/acceptance-tests/teststep.mdx
@@ -4,8 +4,8 @@ description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.1.x/docs/plugin/testing/index.mdx
+++ b/content/terraform-plugin-testing/v1.1.x/docs/plugin/testing/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-14T15:35:42-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.1.x/docs/plugin/testing/migrating.mdx
+++ b/content/terraform-plugin-testing/v1.1.x/docs/plugin/testing/migrating.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development: Migrating testing from SDKv2 to the testing mod
 description: >-
   Migrate your provider's acceptance testing dependencies from SDKv2 to the testing module.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.1.x/docs/plugin/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-testing/v1.1.x/docs/plugin/testing/testing-patterns.mdx
@@ -4,8 +4,8 @@ description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.1.x/docs/plugin/testing/unit-testing.mdx
+++ b/content/terraform-plugin-testing/v1.1.x/docs/plugin/testing/unit-testing.mdx
@@ -4,8 +4,8 @@ description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/configuration.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/configuration.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Configuration specifies the configuration to be used during an acceptance test at the TestStep level. Terraform variables define the values to be used
   in conjunction with Terraform configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/bool.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Bool Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/custom.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Custom Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/float32.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/float32.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Float32 Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/float64.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Float64 Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/index.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/index.mdx
@@ -4,8 +4,8 @@ description: >-
     How to use known values in the testing module.
     Known values define an expected type, and value for a resource attribute, or output value in a Terraform plan or state for use in Plan Checks or State Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/int32.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/int32.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Int32 Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/int64.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Int64 Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/list.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     List Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/map.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Map Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/not-null.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/not-null.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     NotNull Value Checks for use with Plan Checks or State Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/null.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/null.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Null Value Checks for use with Plan Checks or State Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/number.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Number Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/object.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Object Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/set.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Set Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/string.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     String Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/tuple.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/known-value-checks/tuple.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Tuple Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/plan-checks/custom.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/plan-checks/custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. Custom Plan Checks can be implemented.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/plan-checks/index.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/plan-checks/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Plan Checks for common use-cases, and custom Plan Checks can also be implemented.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/plan-checks/output.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/plan-checks/output.mdx
@@ -4,8 +4,8 @@ description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Output Value Plan Checks for common use-cases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/plan-checks/resource.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/plan-checks/resource.mdx
@@ -4,8 +4,8 @@ description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Managed Resource and Data Source Plan Checks for common use-cases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/state-checks/custom.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/state-checks/custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: State Checks'
 description: >-
   State Checks are test assertions that can inspect state during a TestStep. Custom State Checks can be implemented.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/state-checks/index.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/state-checks/index.mdx
@@ -4,8 +4,8 @@ description: >-
   State Checks are test assertions that can inspect state during a TestStep. The testing module
   provides built-in State Checks for common use-cases, and custom State Checks can also be implemented.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/state-checks/output.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/state-checks/output.mdx
@@ -4,8 +4,8 @@ description: >-
   State Checks are test assertions that can inspect state during a TestStep. The testing module
   provides built-in Output Value State Checks for common use-cases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/state-checks/resource.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/state-checks/resource.mdx
@@ -4,8 +4,8 @@ description: >-
   State Checks are test assertions that can inspect state during a TestStep. The testing module
   provides built-in Managed Resource and Data Source State Checks for common use-cases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
@@ -4,8 +4,8 @@ description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/testcase.mdx
@@ -4,8 +4,8 @@ description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/teststep.mdx
@@ -4,8 +4,8 @@ description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/tfjson-paths.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/tfjson-paths.mdx
@@ -4,8 +4,8 @@ description: >-
     How to implement attribute paths in the testing module.
     Attribute paths represent the location of an attribute within Terraform JSON data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/tfversion-checks.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/tfversion-checks.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Version Checks are generic checks defined at the TestCase level that check logic against the Terraform CLI version. The testing module
   provides built-in Version Checks for common use-cases, but custom Version Checks can also be implemented.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/value-comparers/index.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/acceptance-tests/value-comparers/index.mdx
@@ -4,8 +4,8 @@ description: >-
     How to use value comparers in the testing module.
     Value comparers define a comparison for a resource attribute, or output value for use in State Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/index.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/migrating.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/migrating.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development: Migrating testing from SDKv2 to the testing mod
 description: >-
   Migrate your provider's acceptance testing dependencies from SDKv2 to the testing module.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/testing-patterns.mdx
@@ -4,8 +4,8 @@ description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/unit-testing.mdx
+++ b/content/terraform-plugin-testing/v1.10.x/docs/plugin/testing/unit-testing.mdx
@@ -4,8 +4,8 @@ description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/configuration.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/configuration.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Configuration specifies the configuration to be used during an acceptance test at the TestStep level. Terraform variables define the values to be used
   in conjunction with Terraform configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/ephemeral-resources.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/ephemeral-resources.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Ephemeral Resources'
 description: >-
     Guidance on how to test ephemeral resources and data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/bool.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Bool Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/custom.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Custom Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/float32.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/float32.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Float32 Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/float64.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Float64 Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/index.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/index.mdx
@@ -4,8 +4,8 @@ description: >-
     How to use known values in the testing module.
     Known values define an expected type, and value for a resource attribute, or output value in a Terraform plan or state for use in Plan Checks or State Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/int32.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/int32.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Int32 Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/int64.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Int64 Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/list.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     List Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/map.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Map Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/not-null.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/not-null.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     NotNull Value Checks for use with Plan Checks or State Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/null.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/null.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Null Value Checks for use with Plan Checks or State Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/number.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Number Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/object.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Object Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/set.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Set Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/string.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     String Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/tuple.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/known-value-checks/tuple.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Tuple Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/plan-checks/custom.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/plan-checks/custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. Custom Plan Checks can be implemented.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/plan-checks/index.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/plan-checks/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Plan Checks for common use-cases, and custom Plan Checks can also be implemented.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/plan-checks/output.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/plan-checks/output.mdx
@@ -4,8 +4,8 @@ description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Output Value Plan Checks for common use-cases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/plan-checks/resource.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/plan-checks/resource.mdx
@@ -4,8 +4,8 @@ description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Managed Resource and Data Source Plan Checks for common use-cases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/state-checks/custom.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/state-checks/custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: State Checks'
 description: >-
   State Checks are test assertions that can inspect state during a TestStep. Custom State Checks can be implemented.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/state-checks/index.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/state-checks/index.mdx
@@ -4,8 +4,8 @@ description: >-
   State Checks are test assertions that can inspect state during a TestStep. The testing module
   provides built-in State Checks for common use-cases, and custom State Checks can also be implemented.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/state-checks/output.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/state-checks/output.mdx
@@ -4,8 +4,8 @@ description: >-
   State Checks are test assertions that can inspect state during a TestStep. The testing module
   provides built-in Output Value State Checks for common use-cases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/state-checks/resource.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/state-checks/resource.mdx
@@ -4,8 +4,8 @@ description: >-
   State Checks are test assertions that can inspect state during a TestStep. The testing module
   provides built-in Managed Resource and Data Source State Checks for common use-cases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
@@ -4,8 +4,8 @@ description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/testcase.mdx
@@ -4,8 +4,8 @@ description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/teststep.mdx
@@ -4,8 +4,8 @@ description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/tfjson-paths.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/tfjson-paths.mdx
@@ -4,8 +4,8 @@ description: >-
     How to implement attribute paths in the testing module.
     Attribute paths represent the location of an attribute within Terraform JSON data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/tfversion-checks.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/tfversion-checks.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Version Checks are generic checks defined at the TestCase level that check logic against the Terraform CLI version. The testing module
   provides built-in Version Checks for common use-cases, but custom Version Checks can also be implemented.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/value-comparers/index.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/acceptance-tests/value-comparers/index.mdx
@@ -4,8 +4,8 @@ description: >-
     How to use value comparers in the testing module.
     Value comparers define a comparison for a resource attribute, or output value for use in State Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/index.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/migrating.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/migrating.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development: Migrating testing from SDKv2 to the testing mod
 description: >-
   Migrate your provider's acceptance testing dependencies from SDKv2 to the testing module.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/testing-patterns.mdx
@@ -4,8 +4,8 @@ description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/unit-testing.mdx
+++ b/content/terraform-plugin-testing/v1.11.x/docs/plugin/testing/unit-testing.mdx
@@ -4,8 +4,8 @@ description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.2.x/docs/plugin/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-testing/v1.2.x/docs/plugin/testing/acceptance-tests/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.2.x/docs/plugin/testing/acceptance-tests/plan-checks.mdx
+++ b/content/terraform-plugin-testing/v1.2.x/docs/plugin/testing/acceptance-tests/plan-checks.mdx
@@ -4,8 +4,8 @@ description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Plan Checks for common use-cases, but custom Plan Checks can also be implemented.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.2.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-testing/v1.2.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
@@ -4,8 +4,8 @@ description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.2.x/docs/plugin/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-testing/v1.2.x/docs/plugin/testing/acceptance-tests/testcase.mdx
@@ -4,8 +4,8 @@ description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.2.x/docs/plugin/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-testing/v1.2.x/docs/plugin/testing/acceptance-tests/teststep.mdx
@@ -4,8 +4,8 @@ description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.2.x/docs/plugin/testing/index.mdx
+++ b/content/terraform-plugin-testing/v1.2.x/docs/plugin/testing/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.2.x/docs/plugin/testing/migrating.mdx
+++ b/content/terraform-plugin-testing/v1.2.x/docs/plugin/testing/migrating.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development: Migrating testing from SDKv2 to the testing mod
 description: >-
   Migrate your provider's acceptance testing dependencies from SDKv2 to the testing module.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.2.x/docs/plugin/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-testing/v1.2.x/docs/plugin/testing/testing-patterns.mdx
@@ -4,8 +4,8 @@ description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.2.x/docs/plugin/testing/unit-testing.mdx
+++ b/content/terraform-plugin-testing/v1.2.x/docs/plugin/testing/unit-testing.mdx
@@ -4,8 +4,8 @@ description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.3.x/docs/plugin/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-testing/v1.3.x/docs/plugin/testing/acceptance-tests/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.3.x/docs/plugin/testing/acceptance-tests/plan-checks.mdx
+++ b/content/terraform-plugin-testing/v1.3.x/docs/plugin/testing/acceptance-tests/plan-checks.mdx
@@ -4,8 +4,8 @@ description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Plan Checks for common use-cases, but custom Plan Checks can also be implemented.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.3.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-testing/v1.3.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
@@ -4,8 +4,8 @@ description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.3.x/docs/plugin/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-testing/v1.3.x/docs/plugin/testing/acceptance-tests/testcase.mdx
@@ -4,8 +4,8 @@ description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.3.x/docs/plugin/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-testing/v1.3.x/docs/plugin/testing/acceptance-tests/teststep.mdx
@@ -4,8 +4,8 @@ description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.3.x/docs/plugin/testing/acceptance-tests/tfversion-checks.mdx
+++ b/content/terraform-plugin-testing/v1.3.x/docs/plugin/testing/acceptance-tests/tfversion-checks.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Version Checks are generic checks defined at the TestCase level that check logic against the Terraform CLI version. The testing module
   provides built-in Version Checks for common use-cases, but custom Version Checks can also be implemented.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.3.x/docs/plugin/testing/index.mdx
+++ b/content/terraform-plugin-testing/v1.3.x/docs/plugin/testing/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.3.x/docs/plugin/testing/migrating.mdx
+++ b/content/terraform-plugin-testing/v1.3.x/docs/plugin/testing/migrating.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development: Migrating testing from SDKv2 to the testing mod
 description: >-
   Migrate your provider's acceptance testing dependencies from SDKv2 to the testing module.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.3.x/docs/plugin/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-testing/v1.3.x/docs/plugin/testing/testing-patterns.mdx
@@ -4,8 +4,8 @@ description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.3.x/docs/plugin/testing/unit-testing.mdx
+++ b/content/terraform-plugin-testing/v1.3.x/docs/plugin/testing/unit-testing.mdx
@@ -4,8 +4,8 @@ description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.4.x/docs/plugin/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-testing/v1.4.x/docs/plugin/testing/acceptance-tests/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.4.x/docs/plugin/testing/acceptance-tests/plan-checks.mdx
+++ b/content/terraform-plugin-testing/v1.4.x/docs/plugin/testing/acceptance-tests/plan-checks.mdx
@@ -4,8 +4,8 @@ description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Plan Checks for common use-cases, but custom Plan Checks can also be implemented.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.4.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-testing/v1.4.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
@@ -4,8 +4,8 @@ description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.4.x/docs/plugin/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-testing/v1.4.x/docs/plugin/testing/acceptance-tests/testcase.mdx
@@ -4,8 +4,8 @@ description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.4.x/docs/plugin/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-testing/v1.4.x/docs/plugin/testing/acceptance-tests/teststep.mdx
@@ -4,8 +4,8 @@ description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.4.x/docs/plugin/testing/acceptance-tests/tfjson-paths.mdx
+++ b/content/terraform-plugin-testing/v1.4.x/docs/plugin/testing/acceptance-tests/tfjson-paths.mdx
@@ -4,8 +4,8 @@ description: >-
     How to implement attribute paths in the testing module.
     Attribute paths represent the location of an attribute within Terraform JSON data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.4.x/docs/plugin/testing/acceptance-tests/tfversion-checks.mdx
+++ b/content/terraform-plugin-testing/v1.4.x/docs/plugin/testing/acceptance-tests/tfversion-checks.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Version Checks are generic checks defined at the TestCase level that check logic against the Terraform CLI version. The testing module
   provides built-in Version Checks for common use-cases, but custom Version Checks can also be implemented.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.4.x/docs/plugin/testing/index.mdx
+++ b/content/terraform-plugin-testing/v1.4.x/docs/plugin/testing/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.4.x/docs/plugin/testing/migrating.mdx
+++ b/content/terraform-plugin-testing/v1.4.x/docs/plugin/testing/migrating.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development: Migrating testing from SDKv2 to the testing mod
 description: >-
   Migrate your provider's acceptance testing dependencies from SDKv2 to the testing module.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.4.x/docs/plugin/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-testing/v1.4.x/docs/plugin/testing/testing-patterns.mdx
@@ -4,8 +4,8 @@ description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.4.x/docs/plugin/testing/unit-testing.mdx
+++ b/content/terraform-plugin-testing/v1.4.x/docs/plugin/testing/unit-testing.mdx
@@ -4,8 +4,8 @@ description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/acceptance-tests/configuration.mdx
+++ b/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/acceptance-tests/configuration.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Configuration specifies the configuration to be used during an acceptance test at the TestStep level. Terraform variables define the values to be used
   in conjunction with Terraform configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/acceptance-tests/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/acceptance-tests/plan-checks.mdx
+++ b/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/acceptance-tests/plan-checks.mdx
@@ -4,8 +4,8 @@ description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Plan Checks for common use-cases, but custom Plan Checks can also be implemented.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
@@ -4,8 +4,8 @@ description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/acceptance-tests/testcase.mdx
@@ -4,8 +4,8 @@ description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/acceptance-tests/teststep.mdx
@@ -4,8 +4,8 @@ description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/acceptance-tests/tfjson-paths.mdx
+++ b/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/acceptance-tests/tfjson-paths.mdx
@@ -4,8 +4,8 @@ description: >-
     How to implement attribute paths in the testing module.
     Attribute paths represent the location of an attribute within Terraform JSON data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/acceptance-tests/tfversion-checks.mdx
+++ b/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/acceptance-tests/tfversion-checks.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Version Checks are generic checks defined at the TestCase level that check logic against the Terraform CLI version. The testing module
   provides built-in Version Checks for common use-cases, but custom Version Checks can also be implemented.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/index.mdx
+++ b/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/migrating.mdx
+++ b/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/migrating.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development: Migrating testing from SDKv2 to the testing mod
 description: >-
   Migrate your provider's acceptance testing dependencies from SDKv2 to the testing module.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/testing-patterns.mdx
@@ -4,8 +4,8 @@ description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/unit-testing.mdx
+++ b/content/terraform-plugin-testing/v1.5.x/docs/plugin/testing/unit-testing.mdx
@@ -4,8 +4,8 @@ description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/acceptance-tests/configuration.mdx
+++ b/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/acceptance-tests/configuration.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Configuration specifies the configuration to be used during an acceptance test at the TestStep level. Terraform variables define the values to be used
   in conjunction with Terraform configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/acceptance-tests/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/acceptance-tests/plan-checks/custom.mdx
+++ b/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/acceptance-tests/plan-checks/custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. Custom Plan Checks can be implemented.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/acceptance-tests/plan-checks/index.mdx
+++ b/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/acceptance-tests/plan-checks/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Plan Checks for common use-cases, and custom Plan Checks can also be implemented.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/acceptance-tests/plan-checks/output.mdx
+++ b/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/acceptance-tests/plan-checks/output.mdx
@@ -4,8 +4,8 @@ description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Output Value Plan Checks for common use-cases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/acceptance-tests/plan-checks/resource.mdx
+++ b/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/acceptance-tests/plan-checks/resource.mdx
@@ -4,8 +4,8 @@ description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Managed Resource and Data Source Plan Checks for common use-cases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
@@ -4,8 +4,8 @@ description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/acceptance-tests/testcase.mdx
@@ -4,8 +4,8 @@ description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/acceptance-tests/teststep.mdx
@@ -4,8 +4,8 @@ description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/acceptance-tests/tfjson-paths.mdx
+++ b/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/acceptance-tests/tfjson-paths.mdx
@@ -4,8 +4,8 @@ description: >-
     How to implement attribute paths in the testing module.
     Attribute paths represent the location of an attribute within Terraform JSON data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/acceptance-tests/tfversion-checks.mdx
+++ b/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/acceptance-tests/tfversion-checks.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Version Checks are generic checks defined at the TestCase level that check logic against the Terraform CLI version. The testing module
   provides built-in Version Checks for common use-cases, but custom Version Checks can also be implemented.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/index.mdx
+++ b/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/migrating.mdx
+++ b/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/migrating.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development: Migrating testing from SDKv2 to the testing mod
 description: >-
   Migrate your provider's acceptance testing dependencies from SDKv2 to the testing module.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/testing-patterns.mdx
@@ -4,8 +4,8 @@ description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/unit-testing.mdx
+++ b/content/terraform-plugin-testing/v1.6.x/docs/plugin/testing/unit-testing.mdx
@@ -4,8 +4,8 @@ description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/configuration.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/configuration.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Configuration specifies the configuration to be used during an acceptance test at the TestStep level. Terraform variables define the values to be used
   in conjunction with Terraform configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/bool.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Bool Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/custom.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Custom Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/float64.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Float64 Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/index.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/index.mdx
@@ -4,8 +4,8 @@ description: >-
     How to use known values in the testing module.
     Known values define an expected type, and value for a resource attribute, or output value in a Terraform plan for use in Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/int64.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Int64 Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/list.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     List Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/map.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Map Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/not-null.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/not-null.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     NotNull Value Checks for use with Plan Checks or State Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/null.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/null.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Null Value Checks for use with Plan Checks or State Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/number.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Number Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/object.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Object Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/set.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Set Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/string.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/known-value-checks/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     String Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/plan-checks/custom.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/plan-checks/custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. Custom Plan Checks can be implemented.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/plan-checks/index.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/plan-checks/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Plan Checks for common use-cases, and custom Plan Checks can also be implemented.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/plan-checks/output.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/plan-checks/output.mdx
@@ -4,8 +4,8 @@ description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Output Value Plan Checks for common use-cases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/plan-checks/resource.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/plan-checks/resource.mdx
@@ -4,8 +4,8 @@ description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Managed Resource and Data Source Plan Checks for common use-cases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/state-checks/custom.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/state-checks/custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: State Checks'
 description: >-
   State Checks are test assertions that can inspect state during a TestStep. Custom State Checks can be implemented.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/state-checks/index.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/state-checks/index.mdx
@@ -4,8 +4,8 @@ description: >-
   State Checks are test assertions that can inspect state during a TestStep. The testing module
   provides built-in State Checks for common use-cases, and custom State Checks can also be implemented.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/state-checks/output.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/state-checks/output.mdx
@@ -4,8 +4,8 @@ description: >-
   State Checks are test assertions that can inspect state during a TestStep. The testing module
   provides built-in Output Value State Checks for common use-cases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/state-checks/resource.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/state-checks/resource.mdx
@@ -4,8 +4,8 @@ description: >-
   State Checks are test assertions that can inspect state during a TestStep. The testing module
   provides built-in Managed Resource and Data Source State Checks for common use-cases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
@@ -4,8 +4,8 @@ description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/testcase.mdx
@@ -4,8 +4,8 @@ description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/teststep.mdx
@@ -4,8 +4,8 @@ description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/tfjson-paths.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/tfjson-paths.mdx
@@ -4,8 +4,8 @@ description: >-
     How to implement attribute paths in the testing module.
     Attribute paths represent the location of an attribute within Terraform JSON data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/tfversion-checks.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/acceptance-tests/tfversion-checks.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Version Checks are generic checks defined at the TestCase level that check logic against the Terraform CLI version. The testing module
   provides built-in Version Checks for common use-cases, but custom Version Checks can also be implemented.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/index.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/migrating.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/migrating.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development: Migrating testing from SDKv2 to the testing mod
 description: >-
   Migrate your provider's acceptance testing dependencies from SDKv2 to the testing module.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/testing-patterns.mdx
@@ -4,8 +4,8 @@ description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/unit-testing.mdx
+++ b/content/terraform-plugin-testing/v1.7.x/docs/plugin/testing/unit-testing.mdx
@@ -4,8 +4,8 @@ description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/configuration.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/configuration.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Configuration specifies the configuration to be used during an acceptance test at the TestStep level. Terraform variables define the values to be used
   in conjunction with Terraform configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/bool.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Bool Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/custom.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Custom Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/float64.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Float64 Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/index.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/index.mdx
@@ -4,8 +4,8 @@ description: >-
     How to use known values in the testing module.
     Known values define an expected type, and value for a resource attribute, or output value in a Terraform plan for use in Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/int64.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Int64 Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/list.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     List Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/map.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Map Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/not-null.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/not-null.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     NotNull Value Checks for use with Plan Checks or State Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/null.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/null.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Null Value Checks for use with Plan Checks or State Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/number.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Number Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/object.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Object Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/set.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Set Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/string.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     String Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/tuple.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/known-value-checks/tuple.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Tuple Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/plan-checks/custom.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/plan-checks/custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. Custom Plan Checks can be implemented.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/plan-checks/index.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/plan-checks/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Plan Checks for common use-cases, and custom Plan Checks can also be implemented.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/plan-checks/output.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/plan-checks/output.mdx
@@ -4,8 +4,8 @@ description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Output Value Plan Checks for common use-cases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/plan-checks/resource.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/plan-checks/resource.mdx
@@ -4,8 +4,8 @@ description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Managed Resource and Data Source Plan Checks for common use-cases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/state-checks/custom.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/state-checks/custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: State Checks'
 description: >-
   State Checks are test assertions that can inspect state during a TestStep. Custom State Checks can be implemented.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/state-checks/index.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/state-checks/index.mdx
@@ -4,8 +4,8 @@ description: >-
   State Checks are test assertions that can inspect state during a TestStep. The testing module
   provides built-in State Checks for common use-cases, and custom State Checks can also be implemented.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/state-checks/output.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/state-checks/output.mdx
@@ -4,8 +4,8 @@ description: >-
   State Checks are test assertions that can inspect state during a TestStep. The testing module
   provides built-in Output Value State Checks for common use-cases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/state-checks/resource.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/state-checks/resource.mdx
@@ -4,8 +4,8 @@ description: >-
   State Checks are test assertions that can inspect state during a TestStep. The testing module
   provides built-in Managed Resource and Data Source State Checks for common use-cases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
@@ -4,8 +4,8 @@ description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/testcase.mdx
@@ -4,8 +4,8 @@ description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/teststep.mdx
@@ -4,8 +4,8 @@ description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/tfjson-paths.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/tfjson-paths.mdx
@@ -4,8 +4,8 @@ description: >-
     How to implement attribute paths in the testing module.
     Attribute paths represent the location of an attribute within Terraform JSON data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/tfversion-checks.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/acceptance-tests/tfversion-checks.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Version Checks are generic checks defined at the TestCase level that check logic against the Terraform CLI version. The testing module
   provides built-in Version Checks for common use-cases, but custom Version Checks can also be implemented.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/index.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/migrating.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/migrating.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development: Migrating testing from SDKv2 to the testing mod
 description: >-
   Migrate your provider's acceptance testing dependencies from SDKv2 to the testing module.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/testing-patterns.mdx
@@ -4,8 +4,8 @@ description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/unit-testing.mdx
+++ b/content/terraform-plugin-testing/v1.8.x/docs/plugin/testing/unit-testing.mdx
@@ -4,8 +4,8 @@ description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/configuration.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/configuration.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Configuration specifies the configuration to be used during an acceptance test at the TestStep level. Terraform variables define the values to be used
   in conjunction with Terraform configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/index.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Terraform includes a framework for constructing acceptance tests that
   imitate applying one or more configuration files.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/bool.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/bool.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Bool Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/custom.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Custom Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/float32.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/float32.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Float32 Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/float64.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/float64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Float64 Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/index.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/index.mdx
@@ -4,8 +4,8 @@ description: >-
     How to use known values in the testing module.
     Known values define an expected type, and value for a resource attribute, or output value in a Terraform plan for use in Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/int32.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/int32.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Int32 Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/int64.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/int64.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Int64 Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/list.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/list.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     List Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/map.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/map.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Map Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/not-null.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/not-null.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     NotNull Value Checks for use with Plan Checks or State Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/null.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/null.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Null Value Checks for use with Plan Checks or State Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/number.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/number.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Number Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/object.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/object.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Object Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/set.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/set.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Set Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/string.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/string.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     String Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/tuple.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/known-value-checks/tuple.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Known Values'
 description: >-
     Tuple Value Checks for use with Plan Checks.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/plan-checks/custom.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/plan-checks/custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: Plan Checks'
 description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. Custom Plan Checks can be implemented.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/plan-checks/index.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/plan-checks/index.mdx
@@ -4,8 +4,8 @@ description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Plan Checks for common use-cases, and custom Plan Checks can also be implemented.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/plan-checks/output.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/plan-checks/output.mdx
@@ -4,8 +4,8 @@ description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Output Value Plan Checks for common use-cases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/plan-checks/resource.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/plan-checks/resource.mdx
@@ -4,8 +4,8 @@ description: >-
   Plan Checks are test assertions that can inspect a plan at different phases in a TestStep. The testing module
   provides built-in Managed Resource and Data Source Plan Checks for common use-cases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/state-checks/custom.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/state-checks/custom.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development - Acceptance Testing: State Checks'
 description: >-
   State Checks are test assertions that can inspect state during a TestStep. Custom State Checks can be implemented.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/state-checks/index.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/state-checks/index.mdx
@@ -4,8 +4,8 @@ description: >-
   State Checks are test assertions that can inspect state during a TestStep. The testing module
   provides built-in State Checks for common use-cases, and custom State Checks can also be implemented.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/state-checks/output.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/state-checks/output.mdx
@@ -4,8 +4,8 @@ description: >-
   State Checks are test assertions that can inspect state during a TestStep. The testing module
   provides built-in Output Value State Checks for common use-cases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/state-checks/resource.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/state-checks/resource.mdx
@@ -4,8 +4,8 @@ description: >-
   State Checks are test assertions that can inspect state during a TestStep. The testing module
   provides built-in Managed Resource and Data Source State Checks for common use-cases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/sweepers.mdx
@@ -4,8 +4,8 @@ description: >-
   Acceptance tests provision and verify real infrastructure with Terraform's
   testing framework. Sweepers clean up leftover infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/testcase.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/testcase.mdx
@@ -4,8 +4,8 @@ description: |-
   Acceptance tests are expressed in terms of Test Cases. Each Test Case
   creates a set of resources then verifies the new infrastructure.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/teststep.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/teststep.mdx
@@ -4,8 +4,8 @@ description: |-
   TestSteps represent the application of an actual Terraform configuration
   file to a given state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/tfjson-paths.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/tfjson-paths.mdx
@@ -4,8 +4,8 @@ description: >-
     How to implement attribute paths in the testing module.
     Attribute paths represent the location of an attribute within Terraform JSON data.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/tfversion-checks.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/acceptance-tests/tfversion-checks.mdx
@@ -4,8 +4,8 @@ description: >-
   Terraform Version Checks are generic checks defined at the TestCase level that check logic against the Terraform CLI version. The testing module
   provides built-in Version Checks for common use-cases, but custom Version Checks can also be implemented.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/index.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/index.mdx
@@ -4,8 +4,8 @@ description: |-
   Learn how to write successful acceptance and unit tests for Terraform
   plugins.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/migrating.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/migrating.mdx
@@ -3,8 +3,8 @@ page_title: 'Plugin Development: Migrating testing from SDKv2 to the testing mod
 description: >-
   Migrate your provider's acceptance testing dependencies from SDKv2 to the testing module.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/testing-patterns.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/testing-patterns.mdx
@@ -4,8 +4,8 @@ description: |-
   Testing Patterns covers essential acceptance test patterns to implement for
   Terraform resources.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/unit-testing.mdx
+++ b/content/terraform-plugin-testing/v1.9.x/docs/plugin/testing/unit-testing.mdx
@@ -4,8 +4,8 @@ description: |-
   Unit tests are commonly used for testing helper methods that expand or
   flatten API responses into data structures that Terraform stores as state.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-03-06T10:49:53-05:00
-last_modified: 2025-03-06T10:49:53-05:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 


### PR DESCRIPTION
### Description

This PR adds a default date for the metadata for older versions of the terraform-plugin-testing documentation. This change should not affect the developer site as it is a change to the frontmatter. This change will help to keep our sitemap more accurate for SEO and LLMs. The date frontmatter was generated using the add-date-metadata.mjs script. To keep this information up to date, there will be a github action to handle all updates to date metadata: https://github.com/hashicorp/web-unified-docs/pull/1715. Older docs versions have been updated with default dates for the versions specified in [this spreadsheet](https://docs.google.com/spreadsheets/d/16FpDhKA4ZBOVtxHWw2ebMjS56mdSask1FBCVecn9QnQ/edit?gid=0#gid=0)

### Testing

Check that terraform-plugin-testing docs look normal in the preview: https://unified-docs-frontend-preview-b14sw9az4-hashicorp.vercel.app/terraform/plugin/testing