### PR TITLE
feat: update date metadata for terraform-enterprise v1.2.x

### DIFF
--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/_template.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/_template.mdx
@@ -4,6 +4,10 @@ description: >-
   Use the Terraform Enterprise API's `/endpoint-name` to {A meaningful
   description of this endpoint}. Aim for 130-160 characters total.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 Follow this template to format each API method. There are usually multiple sections like this on a given API endpoint page.

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/account.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/account.mdx
@@ -5,6 +5,10 @@ description: >-
   user. Learn how to read and update your account's details and change your
   password.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/admin/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/admin/index.mdx
@@ -2,6 +2,10 @@
 page_title: /admin API reference for Terraform Enterprise
 description: >-
   Use the `/admin` set of endpoints to configure and support your Terraform Enterprise installation. Learn about operations available in the HTTP API.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise Admin API Documentation

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/admin/initial-admin-user.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/admin/initial-admin-user.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: /initial-admin-user/ API reference for Terraform Enterprise
 description: Learn how to call the initial-admin-user API endpoint to create the initial admin user.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # `initial-admin-user` API endpoint

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/admin/module-sharing.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/admin/module-sharing.mdx
@@ -2,6 +2,10 @@
 page_title: /module-consumers API reference for Terraform Enterprise
 description: >-
   Use the `/module-consumers` endpoint to manage sharing permissions for modules in your registry. Learn how to update an organization's module consumers using the API.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/admin/opa-versions.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/admin/opa-versions.mdx
@@ -2,6 +2,10 @@
 page_title: /admin/opa-versions API reference for Terraform Enterprise
 description: >-
   Use the `/admin/opa-versions` endpoint to manage available Open Policy Agent (OPA) versions. Learn how to list, show, create, update, and delete OPA versions using the HTTP API.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/admin/organizations.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/admin/organizations.mdx
@@ -2,6 +2,10 @@
 page_title: /admin/organizations API reference for Terraform Enterprise
 description: >-
   Use the `/admin/organizations` endpoint to manage organizations. Learn how to list, show, update, and delete organizations, list module and provider consumers, and update module consumers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/admin/registry-sharing.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/admin/registry-sharing.mdx
@@ -2,6 +2,10 @@
 page_title: /registry-partnerships API reference for Terraform Enterprise
 description: >-
   Use the `/registry-partnerships` endpoint to configure registry sharing. Learn how to update which organizations can use modules and providers from your private registry using the HTTP API.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/admin/runs.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/admin/runs.mdx
@@ -2,6 +2,10 @@
 page_title: /admin/runs API reference for Terraform Enterprise
 description: >-
   Use the `/admin/runs` endpoint to interact with Terraform runs. Learn how to list runs and cancel runs using the HTTP API.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/admin/sentinel-versions.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/admin/sentinel-versions.mdx
@@ -2,6 +2,10 @@
 page_title: /admin/sentinel-versions API reference for Terraform Enterprise
 description: >-
   Use the `/admin/sentinel-versions` endpoint to manage available Sentinel versions. Learn how to list, show, create, update, and delete Sentinel versions using the HTTP API.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/admin/settings.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/admin/settings.mdx
@@ -2,6 +2,10 @@
 page_title: /admin/general-settings API reference for Terraform Enterprise
 description: >-
   Use the `/admin/general-settings` set of endpoints to configure Terraform Enterprise. Learn how to list and update general, customization, cost estimation, SAML, SMTP, and Twilio settings using the HTTP API.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/admin/terraform-versions.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/admin/terraform-versions.mdx
@@ -2,6 +2,10 @@
 page_title: /admin/terraform-versions API reference for Terraform Enterprise
 description: >-
   Use the `/admin/terraform-versions` endpoint to manage available Terraform versions. Learn how to list, show, create, update, and delete Terraform versions using the HTTP API.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/admin/users.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/admin/users.mdx
@@ -2,6 +2,10 @@
 page_title: /admin/users API reference for Terraform Enterprise
 description: >-
   Use the `/admin/users` endpoint to manage users. Learn how to list, delete, suspend, re-activate, and impersonate users, grant and revoke administrative privileges, and disable 2FA.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/admin/workspaces.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/admin/workspaces.mdx
@@ -2,6 +2,10 @@
 page_title: /admin/workspaces API reference for Terraform Enterprise
 description: >-
   Use the `/admin/workspaces` endpoint to manage workspaces. Learn how to list, show, and destroy workspaces using the HTTP API.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/agent-tokens.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/agent-tokens.mdx
@@ -4,6 +4,10 @@ description: >-
   Use the Terraform Enterprise API's `/authentication-tokens` endpoint to manage
   agent tokens. Learn how to read, create, and destroy agent tokens.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/agents.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/agents.mdx
@@ -5,6 +5,10 @@ description: >-
   agents. Use the `/agent-pools` endpoint to read, create, update, and delete
   agent pools.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/applies.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/applies.mdx
@@ -4,6 +4,10 @@ description: >-
   Use the Terraform Enterprise API's `/applies` endpoint to read the results of
   a Terraform apply and to recover any failed state uploads after applying.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/assessment-results.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/assessment-results.mdx
@@ -5,6 +5,10 @@ description: >-
   health assessment's results, including details on continuous validation and
   drift detection.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/change-requests.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/change-requests.mdx
@@ -4,6 +4,10 @@ description: >-
   Use the `/change_requests` endpoint to view and archive change requests on
   given workspace.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/changelog.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/changelog.mdx
@@ -5,6 +5,10 @@ description: >-
   Use this log of Terraform Enterprise API changes to track new features and
   evolving functionality over time.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 # API Changelog

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/comments.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/comments.mdx
@@ -4,6 +4,10 @@ description: >-
   Use the Terraform Enterprise API's `/comments` endpoint to create and read
   comments on Terraform runs.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/configuration-versions.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/configuration-versions.mdx
@@ -4,6 +4,10 @@ description: >-
   Use the Terraform Enterprise API's `/configuration-versions` endpoint to list,
   show, and create a configuration version and its files within a workspace.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/cost-estimates.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/cost-estimates.mdx
@@ -4,6 +4,10 @@ description: >-
   Use the Terraform Enterprise API's `/cost-estimates` endpoint to read a cost
   estimate using its ID.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/data-retention-policies.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/data-retention-policies.mdx
@@ -2,6 +2,10 @@
 page_title: /data-retention-policy API endpoint reference
 description: >-
   Use the `/data-retention-policy` endpoint to configure data storage policy. Learn how to call the data retention policy endpoint to delete data after a specific number of days.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/diagnostics.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/diagnostics.mdx
@@ -2,6 +2,10 @@
 page_title: Diagnostics API reference for Terraform Enterprise
 description: >-
   Use the Diagnostics API endpoint to perform comprehensive health diagnostics of all Terraform Enterprise subsystems.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-03T16:18:24-05:00
+last_modified: 2026-02-05T15:57:12-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Diagnostics API reference

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/explorer.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/explorer.mdx
@@ -5,6 +5,10 @@ description: >-
   save, and sort data about resources, modules, and providers across your
   workspaces and projects.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-06T08:59:42-08:00
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/github-app-installations.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/github-app-installations.mdx
@@ -5,6 +5,10 @@ description: >-
   view details about where you have installed the Terraform Enterprise GitHub
   App.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/index.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn about API authentication, response codes, versioning, formatting, rate
   limiting, and clients.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-06T08:59:42-08:00
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/no-code-provisioning.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/no-code-provisioning.mdx
@@ -5,6 +5,10 @@ description: >-
   and configure no-code modules. You can also use this endpoint to deploy and
   upgrade no-code workspaces.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/nodes.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/nodes.mdx
@@ -2,6 +2,10 @@
 page_title: Nodes API reference for Terraform Enterprise
 description: >-
   Use the Nodes endpoint to retrieve a list of all node IDs in your Terraform Enterprise installation.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # `/nodes` endpoint reference

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/notification-configurations.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/notification-configurations.mdx
@@ -5,6 +5,10 @@ description: >-
   read, create, update, verify, and delete workspace configurations and create
   team configurations.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/oauth-clients.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/oauth-clients.mdx
@@ -5,6 +5,10 @@ description: >-
   connections between VCS providers and organizations and projects. Learn how to
   read, create, update, and destroy clients.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/oauth-tokens.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/oauth-tokens.mdx
@@ -5,6 +5,10 @@ description: >-
   OAuth tokens that connect workspaces to VCS providers. Learn how to read,
   update, and destroy tokens.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/organization-memberships.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/organization-memberships.mdx
@@ -5,6 +5,10 @@ description: >-
   manage membership in an organization. Invite, list, and remove members from
   organizations.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/organization-tags.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/organization-tags.mdx
@@ -4,6 +4,10 @@ description: >-
   Use the Terraform Enterprise API's organization `/tags` endpoint to assign,
   list, and delete tags for an organization.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/organization-tokens.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/organization-tokens.mdx
@@ -4,6 +4,10 @@ description: >-
   Use the Terraform Enterprise API's `/organizations/authentication-token`
   endpoint to generate and delete organization-level API tokens.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/organizations.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/organizations.mdx
@@ -5,6 +5,10 @@ description: >-
   update, and destroy organizations, and read their entitlement sets, module
   producers, and data retention policies.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-05T15:09:47-08:00
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/ping.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/ping.mdx
@@ -2,6 +2,10 @@
 page_title: System Ping API reference for Terraform Enterprise
 description: >-
   Use the Ping endpoint to check the health of the System API of your Terraform Enterprise system.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # `/ping` endpoint reference

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/plan-exports.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/plan-exports.mdx
@@ -4,6 +4,10 @@ description: >-
   Use the `/plan-exports` endpoint to manage plan exports for a Terraform run.
   Create and show plan exports, or download and delete exported plan data.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Plan exports API reference

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/plans.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/plans.mdx
@@ -4,6 +4,10 @@ description: >-
   Use the Terraform Enterprise API's `/plans` endpoint to read a Terraform run
   plan or generate JSON-formatted execution plans.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/policies.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/policies.mdx
@@ -4,6 +4,10 @@ description: >-
   Use the Terraform Enterprise API's `/policies` endpoint to list, show, create,
   upload, update, and delete Sentinel and OPA policies.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/policy-checks.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/policy-checks.mdx
@@ -4,6 +4,10 @@ description: >-
   Use the Terraform Enterprise API's `/policy-checks` endpoint to manage and
   override the Sentinel policy checks that HCP Terraform performs during a run.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/policy-evaluations.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/policy-evaluations.mdx
@@ -5,6 +5,10 @@ description: >-
   policy outcomes and evaluations from Sentinel and OPA policies that HCP
   Terraform performs during a Terraform run.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/policy-set-params.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/policy-set-params.mdx
@@ -5,6 +5,10 @@ description: >-
   key/value pairs that Sentinel uses for policy checks. Read, create, update,
   and delete parameters.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/policy-sets.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/policy-sets.mdx
@@ -5,6 +5,10 @@ description: >-
   delete, update and version Sentinel and OPA policy sets. Also, attach,
   exclude, and detach policy sets to workspaces and projects.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/private-registry/gpg-keys.mdx
@@ -5,6 +5,10 @@ description: >-
   update, and delete the GPG keys that HCP Terraform uses to sign private
   providers.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/private-registry/manage-module-versions.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/private-registry/manage-module-versions.mdx
@@ -4,6 +4,10 @@ description: >-
   Use these module management endpoints to deprecate, revoke, and revert the
   status of module versions you published to an organization's private registry.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/private-registry/modules.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/private-registry/modules.mdx
@@ -5,6 +5,10 @@ description: >-
   publish, update, delete, and add versions to modules in your organization's
   private registry.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/private-registry/provider-versions-platforms.mdx
@@ -5,6 +5,10 @@ description: >-
   create, and delete private providers versions and platforms in your private
   registry.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/private-registry/providers.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/private-registry/providers.mdx
@@ -4,6 +4,10 @@ description: >-
   Use the Terraform Enterprise API's organization `/registry-providers` endpoint
   to list, create, get, and delete providers in your private registry.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/private-registry/test-configuration.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/private-registry/test-configuration.mdx
@@ -4,6 +4,10 @@ description: >-
   Use the test configuration API to manage OIDC dynamic credentials for module
   testing.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:55:25Z
+last_modified: 2026-02-05T15:09:47-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Test configuration API

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/private-registry/tests.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/private-registry/tests.mdx
@@ -4,6 +4,10 @@ description: >-
   Use the Terraform Enterprise API's `/tests` endpoint to list, get, create, and
   cancel Terraform test runs.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/project-team-access.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/project-team-access.mdx
@@ -4,6 +4,10 @@ description: >-
   Use the Terraform Enterprise API's `/team-projects` endpoint to read, add,
   update, and remove team access from a project.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/projects.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/projects.mdx
@@ -4,6 +4,10 @@ description: >-
   Use the Terraform Enterprise API's `/projects` endpoint to list, show, create,
   update, and delete an organization's projects.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/queries/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/queries/index.mdx
@@ -4,6 +4,10 @@ description: >-
   Call the Terraform Enterprise API's `/queries` endpoint to create and manage
   query runs.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:55:25Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/readiness.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/readiness.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Readiness endpoint
 description: Learn how to use the readiness endpoint to check if Terraform Enterprise is ready to accept requests.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-04T17:44:36-05:00
+last_modified: 2026-02-10T13:34:28-05:00
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/reserved-tag-keys.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/reserved-tag-keys.mdx
@@ -4,6 +4,10 @@ description: >-
   Use the `/reserved-tag-keys` API endpoints to reserve tag keys that have
   special meaning for your organization. 
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/run-tasks/run-task-stages-and-results.mdx
@@ -4,6 +4,10 @@ description: >-
   Use the Terraform Enterprise API's `/task-stages` endpoint to read run tasks
   and their results, and override run task stages.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/run-tasks/run-tasks-integration.mdx
@@ -4,6 +4,10 @@ description: >-
   Use Terraform Enterprise API's run task integration API to trigger run tasks
   at specific run phases and learn how to read run task responses.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/run-tasks/run-tasks.mdx
@@ -5,6 +5,10 @@ description: >-
   delete run tasks, and read, update, delete and associate run tasks to
   workspaces.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/run-triggers.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/run-triggers.mdx
@@ -4,6 +4,10 @@ description: >-
   Use the Terraform Enterprise API's `/run-triggers` endpoint to read, create,
   and delete run triggers.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/run.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/run.mdx
@@ -5,6 +5,10 @@ description: >-
   apply, discard, execute, and cancel Terraform runs. You can also list a
   workspace's or organization's runs.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/ssh-keys.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/ssh-keys.mdx
@@ -4,6 +4,10 @@ description: >-
   Use the Terraform Enterprise API's `/ssh-keys` endpoint to read, get, create,
   update, and delete an organization's SSH keys.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/stability-policy.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/stability-policy.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how HashiCorp plans for stability, backward compatibility, and
   deprecation for the Terraform Enterprise APIs.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # API stability policy

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/state-version-outputs.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/state-version-outputs.mdx
@@ -5,6 +5,10 @@ description: >-
   the outputs from a specified Terraform state version or a workspace's current
   outputs.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/state-versions.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/state-versions.mdx
@@ -5,6 +5,10 @@ description: >-
   upload, fetch, rollback, delete, and mark state versions for garbage
   collection.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-05T15:09:47-08:00
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/support-bundle.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/support-bundle.mdx
@@ -2,6 +2,10 @@
 page_title: Support Bundle API reference for Terraform Enterprise
 description: >-
   Use the Support Bundle API endpoint to generate, list, download and delete support bundles in Terraform Enterprise (TFE).
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Support bundle requests API reference

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/team-access.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/team-access.mdx
@@ -5,6 +5,10 @@ description: >-
   access to a workspace. Read, add, update, and remove a team's access to
   workspaces.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/team-members.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/team-members.mdx
@@ -4,6 +4,10 @@ description: >-
   Use the Terraform Enterprise API's `/relationships` endpoints to add and
   remove users from teams using an account or organization membership ID.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/team-tokens.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/team-tokens.mdx
@@ -4,6 +4,10 @@ description: >-
   Use the Terraform Enterprise API's `/teams/:team_id/authentication-tokens`
   endpoint to generate, delete, and list a team's API tokens.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/teams.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/teams.mdx
@@ -4,6 +4,10 @@ description: >-
   Use the Terraform Enterprise API's `/teams` endpoint to read, create, update,
   and delete teams.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/usage-bundle.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/usage-bundle.mdx
@@ -2,6 +2,10 @@
 page_title: System Usage/Bundle API reference for Terraform Enterprise
 description: >-
   Use the Usage/Bundle endpoint to download a usage bundle.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # `/usage/bundle` endpoint reference

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/user-tokens.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/user-tokens.mdx
@@ -4,6 +4,10 @@ description: >-
   Use the Terraform Enterprise API's `/users/authentication-tokens` endpoint to
   read, create, and destroy user-specific API tokens.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/users.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/users.mdx
@@ -2,6 +2,10 @@
 page_title: /users API reference for Terraform Enterprise
 description: Use the Terraform Enterprise API's `/users` endpoint to read a user's details.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/variable-sets.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/variable-sets.mdx
@@ -5,6 +5,10 @@ description: >-
   update, and delete variable sets, and apply or remove variable sets from
   workspaces and projects.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/variables.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/variables.mdx
@@ -5,6 +5,10 @@ description: >-
   organization-level variables. Learn how to read, create, update, and delete
   variables using the API.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/vcs-events.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/vcs-events.mdx
@@ -4,6 +4,10 @@ description: >-
   Use the Terraform Enterprise API's `/vcs-events` endpoint to list VCS-related
   events within your organization.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # VCS events API reference

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/workspace-resources.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/workspace-resources.mdx
@@ -4,6 +4,10 @@ description: >-
   Use the Terraform Enterprise API's `/workspaces/resources` endpoint to list
   all of a workspace's resources.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/workspace-variables.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/workspace-variables.mdx
@@ -5,6 +5,10 @@ description: >-
   manage workspace-specific variables. Read, create, update, and delete
   workspace variables.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/workspaces.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/workspaces.mdx
@@ -5,6 +5,10 @@ description: >-
   update, lock, unlock, and delete workspaces and manage SSH keys, tags, and
   remote state consumers.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/application-administration/admin-access.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/application-administration/admin-access.mdx
@@ -2,6 +2,10 @@
 page_title: Access Terraform Enterprise administration settings
 description: >-
   The admin interface provides access to general settings, system-wide integration settings, and accounts and resources. Learn how to access the administration settings.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Access Administration Settings

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/application-administration/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/application-administration/agents-on-tfe.mdx
@@ -2,6 +2,10 @@
 page_title: HCP Terraform agents for Terraform Enterprise
 description: HCP Terraform agents let Terraform manage isolated, private, or on-premises
   infrastructure. Learn about HCP Terraform agent behavior for Terraform Enterprise.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # HCP Terraform agents for Terraform Enterprise

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/application-administration/customization.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/application-administration/customization.mdx
@@ -2,6 +2,10 @@
 page_title: Customize the UI
 description: >-
   Use customization settings to modify the Terraform Enterprise user interface. Learn how to change UI text, customize support email addresses, and provide instructions in the UI.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Customize the UI

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/application-administration/general.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/application-administration/general.mdx
@@ -2,6 +2,10 @@
 page_title: Configure general Terraform Enterprise settings
 description: >-
   Use general settings to control global behavior. Learn how to enable 2FA, limit organization creation, set timeouts, connect agents, and control remote state sharing and speculative plans.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Configure General Settings

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/application-administration/github-app-integration.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/application-administration/github-app-integration.mdx
@@ -2,6 +2,10 @@
 page_title: Integrate with a GitHub App
 description: >-
   Learn how to integrate Terraform Enterprise with a GitHub App to let organizations access GitHub repositories.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Integrate with a GitHub App

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/application-administration/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/application-administration/index.mdx
@@ -2,6 +2,10 @@
 page_title: Terraform Enterprise application administration
 description: >-
   Use application administration settings to customize your Terraform Enterprise instance. 
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Application administration overview

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/application-administration/integration.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/application-administration/integration.mdx
@@ -2,6 +2,10 @@
 page_title: Integrate with external services 
 description: >-
     Integrate with external services to send communications and authenticate users. Learn how to configure cost estimation, and SAML, SMTP, and Twilio integrations.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-04T15:01:51-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Integrate with External Services 

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/application-administration/opa-tool-versions.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/application-administration/opa-tool-versions.mdx
@@ -2,6 +2,10 @@
 page_title: Add an Open Policy Agent (OPA) tool version
 description: >-
     Learn how to add and manage Open Policy Agent (OPA) versions in the UI.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Manage Open Policy Agent tool versions

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/application-administration/registry-sharing.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/application-administration/registry-sharing.mdx
@@ -2,6 +2,10 @@
 page_title: Share modules and providers from a private registry
 description: >-
   Use registry sharing to share modules and providers with other organizations in the same Terraform Enterprise instance. Learn how to manage shared registries, stop sharing, and edit registry sharing settings in the UI.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Share Modules and Providers from a Private Registry

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/application-administration/resources.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/application-administration/resources.mdx
@@ -2,6 +2,10 @@
 page_title: Manage Terraform Enterprise accounts and resources
 description: >-
   Learn how Terraform Enterprise administrators can manage resources, users, organizations, workspaces, runs, and Terraform versions.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Manage Accounts and Resources

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/application-administration/sentinel-tool-versions.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/application-administration/sentinel-tool-versions.mdx
@@ -2,6 +2,10 @@
 page_title: Manage Sentinel tool versions in Terraform Enterprise
 description: >-
     Learn how to add and manage Sentinel versions in the Terraform Enterprise user interface.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Manage Sentinel tool versions

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/cost-estimation/aws.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/cost-estimation/aws.mdx
@@ -2,6 +2,10 @@
 page_title: AWS resources included in cost estimation in Terraform Enterprise
 description: Learn which AWS resources Terraform Enterprise includes in cost estimation.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # AWS resources included in cost estimation

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/cost-estimation/azure.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/cost-estimation/azure.mdx
@@ -2,6 +2,10 @@
 page_title: Azure resources included in cost estimation in Terraform Enterprise
 description: Learn which Azure resources Terraform Enterprise includes in cost estimation.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Azure resources included in cost estimation

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/cost-estimation/gcp.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/cost-estimation/gcp.mdx
@@ -2,6 +2,10 @@
 page_title: GCP resources included in cost estimation in Terraform Enterprise
 description: Learn which GCP resources Terraform Enterprise includes in cost estimation.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # GCP resources included in cost estimation

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/cost-estimation/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/cost-estimation/index.mdx
@@ -5,6 +5,10 @@ description: >-
   your Terraform configuration. Use cost estimation to get hourly and monthly
   cost estimates for each resource.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Cost estimation overview

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/configuration/admin-console.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/configuration/admin-console.mdx
@@ -2,6 +2,10 @@
 page_title: Configure Admin Console
 description: >-
   Configure and manage your Terraform Enterprise installation using the admin console web interface.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Configure admin console

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/configuration/enable-explorer.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/configuration/enable-explorer.mdx
@@ -2,6 +2,10 @@
 page_title: Enable Explorer for Terraform Enterprise
 description: >-
   Learn about the configuration options for deploying Explorer on Terraform Enterprise.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-04T14:30:26-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Enable Explorer on Terraform Enterprise 

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/configuration/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/configuration/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Create deployment configuration overview
 description: Learn about the deployment configuration file for your runtime environment 
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Create deployment configuration overview

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/configuration/license.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/configuration/license.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Configure a Terraform Enterprise license
 description: You must configure a license to deploy Terraform Enterprise to a supported runtime environment. Learn how to acquire and configure a Terraform Enterprise license.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Configure a license

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/configuration/network.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/configuration/network.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Configure network access for Terraform Enterprise installation
 description: Linux instances running Terraform Enterprise require network access to send and receive traffic. Learn how to configure network access.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Configure network access

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/configuration/storage/configure-mode.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/configuration/storage/configure-mode.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Configure operational mode for Terraform Enterprise deployments
 description: Terraform Enterprise's operational mode determines data storage, which affects resilience and scalability. Learn how to configure the operational mode for your deployment. 
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Configure the operational mode

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/configuration/storage/connect-database/aurora.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/configuration/storage/connect-database/aurora.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Connect to a PostgreSQL cluster deployed to Aurora
 description: Learn how to connect Terraform Enterprise to a highly-available PostgreSQL database cluster deployed to AWS Aurora.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Connect to a PostgreSQL cluster deployed to Aurora

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/configuration/storage/connect-database/failover-resilience.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/configuration/storage/connect-database/failover-resilience.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Measure failover resilience
 description: Learn how to measure database failover resilience for Terraform Enteprise deployments connect to an HA PostgreSQL cluster.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Measure failover resilience

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/configuration/storage/connect-database/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/configuration/storage/connect-database/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Database connection overview
 description: Terraform Enterprise uses an external PostgreSQL database to store stateful application data in external or active-active mode. Learn about connecting external PostgreSQL databases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Database connection overview

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/configuration/storage/connect-database/patroni.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/configuration/storage/connect-database/patroni.mdx
@@ -1,6 +1,10 @@
 ---
 page_title:  Connect to a PostgreSQL cluster deployed to Patroni
 description: Learn how to connect Terraform Enterprise to a PostgresSQL cluster deployed to Patroni in high availability mode so that you can enable HA failover workflows.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Connect to a PostgreSQL cluster deployed to Patroni

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/configuration/storage/connect-database/postgres-cluster.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/configuration/storage/connect-database/postgres-cluster.mdx
@@ -4,6 +4,10 @@ description:
   Learn how to configure Terraform Enterprise to connect to an external
   PostgreSQL database cluster so that your Terraform Enterprise instances can store
   stateful application data in a highly-available database.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Connect to a PostgreSQL cluster

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/configuration/storage/connect-database/postgres.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/configuration/storage/connect-database/postgres.mdx
@@ -4,6 +4,10 @@ description:
   Learn how to configure Terraform Enterprise to connect to an external
   PostgreSQL database so that your Terraform Enterprise instances can store
   stateful application data.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Connect to an external PostgreSQL database

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/configuration/storage/connect-object.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/configuration/storage/connect-object.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Configure data object storage
 description: Learn how to configure the Terraform Enterprise connection to an S3-compatible data storage service.  
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Configure data object storage

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/configuration/storage/connect-redis.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/configuration/storage/connect-redis.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Configure Redis data store connection
 description: Learn how to configure the connection to an externally-managed Redis data store when operating Terraform Enterprise in `active-active` mode.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Configure Redis data store connection

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/configuration/storage/connect-vault.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/configuration/storage/connect-vault.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Connect to an external Vault server
 description: Using an external Vault server can help satisfy data encryption and auditing compliance requirements. Learn how to connect external Vault servers. 
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Connect to an external Vault server

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/configuration/storage/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/configuration/storage/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Data storage settings overview
 description: Learn about Terraform Enterprise data storage and management configurations, including operational modes, PostgreSQL database connection settings, Redis connection settings, and external Vault server settings
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Data storage settings overview

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/custom-image.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/custom-image.mdx
@@ -2,6 +2,10 @@
 page_title: Build and deploy a custom worker image
 description: >-
   Terraform Enterprise requires a custom worker image to add custom tools and logic to the run enviornment. Learn how to build and run a custom worker image.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Build and deploy a custom worker image

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/docker/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/docker/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Deploy Terraform Enterprise to Docker overview
 description: Learn how to deploy Terraform Enterprise to Docker using Docker Compose.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Deploy Terraform Enterprise to Docker

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/docker/scale.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/docker/scale.mdx
@@ -2,6 +2,10 @@
 page_title: Scale Terraform Enterprise instances hosted on Docker
 description: >-
   Learn how to migrate Terraform Enterprise instances hosted on Docker to `active-active` mode so that you can scale your deployment.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Scale Terraform Enterprise instances hosted on Docker

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Enterprise deployment overview
 description: Terraform Enterprise offers flexible deployment options for container runtime environments and data management modes. Learn about the deployment process.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise deployment overview

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/initial-admin-user.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/initial-admin-user.mdx
@@ -2,6 +2,10 @@
 page_title: Create the initial admin user for Terraform Enterprise
 description: >-
   You must create an admin user to manage Terraform Enterprise and run workloads. Learn how to create the initial admin user in Terraform Enterprise.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Create initial Terraform Enterprise admin user

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/kubernetes/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/kubernetes/index.mdx
@@ -2,6 +2,10 @@
 page_title: Deploy Terraform Enterprise to Kubernetes
 description: >-
   Learn how to deploy Terraform Enterprise to Kubernetes-orchestrated containers using Helm.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Deploy Terraform Enterprise to Kubernetes

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/kubernetes/scale/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/kubernetes/scale/index.mdx
@@ -2,6 +2,10 @@
 page_title: Scale Terraform Enterprise instances on Kubernetes
 description: >-
   Learn how to increase the number of replica instances of your Terraform Enterprise deployment on Kubernetes to scale up Terraform activities.   
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Scale Terraform Enterprise instances on Kubernetes

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/kubernetes/scale/replicas.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/kubernetes/scale/replicas.mdx
@@ -2,6 +2,10 @@
 page_title: Increase number of replica instances
 description: >-
   Learn how to increase the number of replica instances of your Terraform Enterprise deployment on Kubernetes.   
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Increase number of replica instances

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/kubernetes/scale/run-capacity.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/kubernetes/scale/run-capacity.mdx
@@ -2,6 +2,10 @@
 page_title: Increase Terraform Enterprise run capacity on Kubernetes
 description: >-
   Learn how to increase the run capacity when operating Terraform Enterprise on Kubernetes.   
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Increase Terraform Enterprise run capacity

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/manage/access-admin-console.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/manage/access-admin-console.mdx
@@ -2,6 +2,10 @@
 page_title: Access the admin console
 description: >-
   Learn how to authenticate and access the admin console web interface for Terraform Enterprise.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Access the admin console

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/manage/access-cli.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/manage/access-cli.mdx
@@ -2,6 +2,10 @@
 page_title: Access the Terraform Enterprise CLI
 description: >-
   The Terraform Enterprise CLI lets you reconfigure Terraform Enterprise, stop the application safely, and produce support bundles. Learn how to access the CLI.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Access the Terraform Enterprise CLI

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/manage/backup-restore.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/manage/backup-restore.mdx
@@ -2,6 +2,10 @@
 page_title: Back up and restore Terraform Enterprise
 description: >-
   Use Terraform Enterprise's back up and restore APIs for disaster recovery.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Back up and restore Terraform Enterprise

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/manage/failover.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/manage/failover.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: PostgreSQL database failover 
 description: Learn how implementing automatic failover for your Terraform Enterprise database and a high-availability (HA) PostgreSQL database cluster improves resilience and reduces data loss in the event of a failure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # PostgreSQL database failover

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/manage/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/manage/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Manage Terraform Enterprise deployment overview
 description: Learn about Terraform Enterprise deployment management procedures, including monitoring, backing up, and upgrading your Terraform Enterprise installation.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Manage Terraform Enterprise deployment overview

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/manage/license-report.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/manage/license-report.mdx
@@ -2,6 +2,10 @@
 page_title: Enable automated license utilization reports
 description: >-
   License utilization reports provide insights about consumption to help you manage your budget. Learn how to enable automated license utilization reports.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Enable automated license utilization reporting

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/manage/monitor/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/manage/monitor/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Monitor Terraform Enterprise deployments
 description: Learn how to enable logs and metrics to monitor your Terraform Enterprise installation's performance.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-05T08:17:12-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Monitor Terraform Enterprise

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/manage/monitor/logs.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/manage/monitor/logs.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Service and Audit Logs
 description: Learn about service and audit logging in Terraform Enterprise to monitor security events and system performance.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Logging

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/manage/monitor/metrics.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/manage/monitor/metrics.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Enable metrics collection
 description: Learn how to enable metrics collection so that you can monitor your Terraform Enterprise installation's performance.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Enable metrics collection

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/manage/product-report/automated.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/manage/product-report/automated.mdx
@@ -2,6 +2,10 @@
 page_title: Enable automated product usage reports
 description: >-
   Learn how to enable automated product usage reports.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Enable automated product usage reports

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/manage/product-report/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/manage/product-report/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Product usage report overview
 description: Terraform Enterprise product usage reports tell you how much more infrastructure you can deploy under your current contract and help your budget consumption.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Product usage report overview

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/manage/product-report/manual.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/manage/product-report/manual.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Manually generate a product usage report
 description: You can use the admin console or `tfectl` command to manually generate product usage reports when Terraform Enterprise is deployed to an air-gapped environment.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Manually generate product usage reports

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/manage/upgrade.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/manage/upgrade.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Upgrade Terraform Enterprise
 description: Learn how to upgrade Terraform Enterprise using Docker Compose and Helm to run new versions on Nomad, Kubernetes, OpenShift, Podman, or Docker.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Upgrade Terraform Enterprise

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/nomad.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/nomad.mdx
@@ -2,6 +2,10 @@
 page_title: Deploy Terraform Enterprise to HashiCorp Nomad
 description: >-
   Learn how to install Terraform Enterprise on Nomad.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Deploy Terraform Enterprise to HashiCorp Nomad

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/openshift.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/openshift.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Deploy Terraform Enterprise to OpenShift
 description: Learn how to deploy Terraform Enterprise to Red Hat OpenShift.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Deploy Terraform Enterprise to OpenShift

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/podman.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/podman.mdx
@@ -2,6 +2,10 @@
 page_title: Deploy Terraform Enterprise to Podman
 description: >-
   Learn how to deploy Terraform Enterprise using Podman.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Deploy Terraform Enterprise to Podman

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/prepare-host.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/prepare-host.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Prepare host environment
 description: This topic describes how to configure the host environment for running Terraform Enterprise.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Prepare the Terraform Enterprise host environment

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/reference/application-security.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/reference/application-security.mdx
@@ -2,6 +2,10 @@
 page_title: Terraform Enterprise security reference
 description: >-
   Learn about Terraform Enterprise application roles and security best practices.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise security reference

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/reference/cli.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/reference/cli.mdx
@@ -2,6 +2,10 @@
 page_title: Terraform Enterprise admin CLI reference
 description: >-
  Learn how to use `tfectl` subcommands to manage your Terraform Enterprise deployment. 
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-09T15:55:30-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise admin CLI reference

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/reference/configuration.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/reference/configuration.mdx
@@ -2,6 +2,10 @@
 page_title: Terraform Enterprise configuration reference
 description: >-
   Learn about the configuration options for deploying Terraform Enterprise.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-03T13:21:43-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise configuration reference

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/reference/data-security.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/reference/data-security.mdx
@@ -3,6 +3,10 @@ page_title: Terraform Enterprise data security reference
 description: >-
   Terraform Enterprise objects may contain sensitive data. Learn about storage
   and encryption methods Terraform Enterprise uses to protect sensitive data.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 @include "replicated-and-fdo/architecture/data-security-partial.mdx"

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/reference/license-data.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/reference/license-data.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: License report reference
 description: Learn about the license usage information HashiCorp collects in order to meter license consumption in your organization.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # License report reference

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/reference/metrics.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/reference/metrics.mdx
@@ -2,6 +2,10 @@
 page_title: Container metrics reference
 description: >-
   Learn about the metrics that are exposed by Terraform Enterprise.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Container metrics reference

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/reference/product-data.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/reference/product-data.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Enterprise usage data reference
 description: Learn about the product usage data Terraform Enterprise collects. 
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise usage data reference

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/reference/services.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/reference/services.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Terraform Enterprise services reference
 description: Reference information about the services included with Terraform Enterprise.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise services

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/reference/startup-checks.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/reference/startup-checks.mdx
@@ -3,6 +3,10 @@ page_title: Startup checks reference
 description: >-
   Terraform Enterprise startup checks validate the Terraform Enterprise
   configuration. Learn about the checks that run when you start Terraform Enterprise.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Startup checks reference

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated-migration.mdx
@@ -2,6 +2,10 @@
 page_title: Migrate from Replicated to another runtime
 description: >-
   Learn how to migrate your Terraform Enterprise installation from Replicated to another supported runtime environment.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Migrate from Replicated to another runtime

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/administration/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/administration/index.mdx
@@ -2,6 +2,10 @@
 page_title: Administration for Replicated deployments overview
 description: >-
   Learn about administrating Terraform Enterprise deployments on the legacy Replicated platform.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Administration for Replicated deployments overview

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/administration/infrastructure/admin-cli.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/administration/infrastructure/admin-cli.mdx
@@ -2,6 +2,10 @@
 page_title: Admin CLI Commands - Infrastructure Administration - Terraform Enterprise
 description: >-
   Use the admin CLI to configure Terraform Enterprise when in active/active mode. Learn how to change the configuration, stop the application safely, upgrade TFE, and patch Terraform Enterprise instances using the CLI.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise Admin CLI Commands

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/administration/infrastructure/automated-recovery.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/administration/infrastructure/automated-recovery.mdx
@@ -2,6 +2,10 @@
 page_title: Automated Recovery - Infrastructure Administration - Terraform Enterprise
 description: >-
   Use automated recovery to provice a short Mean-Time-To-Recovery (MTTR) in the event of an outage. Learn how to configure and restore snapshots.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise Automated Recovery

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/administration/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/administration/infrastructure/backup-restore.mdx
@@ -2,6 +2,10 @@
 page_title: Backups and Restores - Infrastructure Administration - Terraform Enterprise
 description: >-
   Use the `/_backup` endpoint to backup and restore all data stored in your installation. Learn how to create and restore backups using the HTTP API.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise Backups and Restores

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/administration/infrastructure/consolidated-services.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/administration/infrastructure/consolidated-services.mdx
@@ -2,6 +2,10 @@
 page_title: Consolidated Services - Infrastructure Administration - Terraform Enterprise
 description: >-
   Terraform Enterprise is adopting a simplified architecture where all server services are consolidated into a single container named `terraform-enterprise`.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise Consolidated Services Architecture

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/administration/infrastructure/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/administration/infrastructure/index.mdx
@@ -2,6 +2,10 @@
 page_title: Infrastructure administration overview 
 description: >-
     Learn about administrating Terraform Enterprise infrastructure deployed to the legacy Replicated platform.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Infrastructure administration overview for Replicated deployments

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/administration/infrastructure/mounted-to-external-migration.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/administration/infrastructure/mounted-to-external-migration.mdx
@@ -2,6 +2,10 @@
 page_title: Migrating from Mounted Disk Mode to External Services Mode - Infrastructure Administration - Terraform Enterprise
 description: >-
   Migrating from Mounted Disk Mode to External Services Mode
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Migrating from `disk` to `external` mode

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/administration/infrastructure/upgrades/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/administration/infrastructure/upgrades/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Upgrade Replicated deployment overview
 description: This overview describes how to upgrade Terraform Enterprise deployments, including air-gapped Terraform Enterprise deployments, that run on Replicated.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Upgrade Replicated deployment overview

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/administration/infrastructure/upgrades/prepare.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/administration/infrastructure/upgrades/prepare.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Prepare your Terraform Enterprise environment for a version upgrade
 description: This overview describes how to upgrade Terraform Enterprise deployments, including air-gapped Terraform Enterprise deployments, that run on Replicated.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Prepare your environment for a version upgrade

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/administration/infrastructure/upgrades/upgrade.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/administration/infrastructure/upgrades/upgrade.mdx
@@ -2,6 +2,10 @@
 page_title: Upgrades - Infrastructure Administration - Terraform Enterprise
 description: >-
   Learn how to upgrade Terraform Enterprise deployments, including air-gapped Terraform Enteprise deployments, that run on Replicated.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Upgrade Terraform Enterprise deployed to Replicated  

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/administration/infrastructure/worker-to-agent-migration.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/administration/infrastructure/worker-to-agent-migration.mdx
@@ -2,6 +2,10 @@
 page_title: >-
   Migrate from Alternative Worker Images to Custom Agents - v202302-1
 description: Learn how to migrate from using alternative worker images to custom agents. Available as of Terraform Enterprise v202302-1.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Migrate Alternative Worker Images to Agents: v202302-1

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/administration/license/automated-license-utilization-reporting.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/administration/license/automated-license-utilization-reporting.mdx
@@ -2,6 +2,10 @@
 page_title: Automated license utilization reporting
 description: >-
   Learn what data HashiCorp collects to meter Enterprise license utilization. Enable or disable reporting. Review sample payloads and logs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 @include "replicated-and-fdo/admin/license-utilization-intro.mdx"

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/administration/license/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/administration/license/index.mdx
@@ -3,6 +3,10 @@ page_title: Administration - Legacy Deployment - Terraform Enterprise
 description: >-
   Learn how to administer the Terraform Enterprise application itself, and the
   infrastructure that it runs on.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise Licenses

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/administration/license/update-tfe-license.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/administration/license/update-tfe-license.mdx
@@ -4,6 +4,10 @@ page_title: >-
   Enterprise
 description: >-
   Use the Replicated console to manage your Terraform Enterprise license. Learn how to find your license expiration date, update the license online or offline, and troubleshoot license issues.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Updating a Terraform Enterprise License

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/architecture/reference-architecture/aws.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/architecture/reference-architecture/aws.mdx
@@ -3,6 +3,10 @@ page_title: AWS Reference Architecture - Terraform Enterprise
 description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on AWS.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise AWS Reference Architecture

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/architecture/reference-architecture/azure.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/architecture/reference-architecture/azure.mdx
@@ -4,6 +4,10 @@ description: |-
   This document provides recommended practices and a reference
   architecture for HashiCorp Terraform Enterprise
   implementations on Azure.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise Azure Reference Architecture

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/architecture/reference-architecture/gcp.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/architecture/reference-architecture/gcp.mdx
@@ -3,6 +3,10 @@ page_title: GCP Reference Architecture - Terraform Enterprise
 description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on GCP.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise GCP Reference Architecture

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/architecture/reference-architecture/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/architecture/reference-architecture/index.mdx
@@ -3,6 +3,10 @@ page_title: Reference Architectures - Terraform Enterprise
 description: >-
   Links to Terraform Enterprise reference architectures for AWS, Azure, Google
   Cloud Platform, and VMware.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise Reference Architectures

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/architecture/reference-architecture/vmware.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/architecture/reference-architecture/vmware.mdx
@@ -3,6 +3,10 @@ page_title: VMware Reference Architecture - Terraform Enterprise
 description: |-
   This document provides recommended practices and a reference architecture for
   HashiCorp Terraform Enterprise implementations on VMware.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise VMware Reference Architecture

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/architecture/system-overview/capacity.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/architecture/system-overview/capacity.mdx
@@ -3,6 +3,10 @@ page_title: Capacity and Performance - System Overview - Terraform Enterprise
 description: >-
   Learn about maximum capacity and performance as well as how to adjust capacity
   and memory for your instance.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Capacity and Performance

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/architecture/system-overview/data-security.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/architecture/system-overview/data-security.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn which parts of the application contain sensitive data and what storage
   and encryption methods we use.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Data Security

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/architecture/system-overview/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/architecture/system-overview/index.mdx
@@ -2,6 +2,10 @@
 page_title: System Overview - Terraform Enterprise
 description: >-
   Learn about the architecture and operational characteristics of Terraform Enterprise.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # System Overview

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/architecture/system-overview/reliability-availability.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/architecture/system-overview/reliability-availability.mdx
@@ -3,6 +3,10 @@ page_title: Reliability and Availability - System Overview - Terraform Enterpris
 description: >-
   Learn about the components that determine reliability and how to recover from
   failures in each operation mode.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Reliability and Availability

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/architecture/system-overview/security-model.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/architecture/system-overview/security-model.mdx
@@ -3,6 +3,10 @@ page_title: Security Model- System Overview - Terraform Enterprise
 description: >-
   Learn the organizational roles required for security and our recommendations
   for securely operating Terraform Enterprise.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise Security Model

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/index.mdx
@@ -2,6 +2,10 @@
 page_title: Legacy Deployment Overview (Replicated) - Terraform Enterprise
 description: >-
   Learn about the history and context of the Terraform Enterprise Replicated deployment option.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise on Replicated

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/install/automated/active-active.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/install/automated/active-active.mdx
@@ -2,6 +2,10 @@
 page_title: Automated Installation - Active/Active - Terraform Enterprise
 description: >-
   Use active/active architecture to increase the reliability and performance of Terraform Enterprise. Learn how to prepare for an external Redis server, update configuration files, connect to external Redis, and then scale to two nodes.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise Active/Active

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/install/automated/automating-initial-user.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/install/automated/automating-initial-user.mdx
@@ -2,6 +2,10 @@
 page_title: Automating Initial User - Install and Config - Terraform Enterprise
 description: >-
   Use the `/admin/initial-admin-user` endpoint to create the initial admin user. Generate an initial admin creation token and then create the initial admin user with the HTTP API.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise - Automating Initial User Creation

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/install/automated/automating-the-installer.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/install/automated/automating-the-installer.mdx
@@ -2,6 +2,10 @@
 page_title: Automated Installation - Install and Config - Terraform Enterprise
 description: >-
   Do an automated installation of Terraform Enterprise. Learn about application and installer settings, and how to wait for Terraform Enterprise to become ready.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Automated Terraform Enterprise Installation

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/install/automated/encryption-password.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/install/automated/encryption-password.mdx
@@ -2,6 +2,10 @@
 page_title: Encryption Password - Install and Config - Terraform Enterprise
 description: >-
   The Terraform Enterprise encryption password protects the internally-managed Vault unseal key and root token. Learn how to specify and retrieve the encryption password.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise Encryption Password

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/install/interactive/config.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/install/interactive/config.mdx
@@ -2,6 +2,10 @@
 page_title: Configuration - Install and Config - Terraform Enterprise
 description: >-
   Use a web browser to configure Terraform Enterprise after installation. Learn how to create an administrator with the UI or HTTP API, and create your first organization.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise Configuration

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/install/interactive/installer.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/install/interactive/installer.mdx
@@ -2,6 +2,10 @@
 page_title: Interactive Installation - Install and Config - Terraform Enterprise
 description: >-
   Use the Terraform Enterprise installer on a customer-controlled machine. Learn about proxy usage, TLS configuration, using a custom container image, operational mode, installation, and configuration.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Interactive Terraform Enterprise Installation

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/install/operation-modes.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/install/operation-modes.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Operational Modes - Terraform Enterprise
 description: Learn about the different operational modes of Terraform Enterprise.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise Operational Modes

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/install/pre-install-checklist.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/install/pre-install-checklist.mdx
@@ -3,6 +3,10 @@ page_title: Pre-Install Checklist - Before Installing - Terraform Enterprise
 description: >-
   Make key architecture decisions and prepare infrastructure and data files for
   Terraform Enterprise.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise Pre-Install Checklist

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/install/uninstall.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/install/uninstall.mdx
@@ -3,6 +3,10 @@ page_title: Uninstall - Terraform Enterprise
 description: >-
   Learn to run a script that removes Terraform Enterprise and all of its
   services (excluding Docker) from a system.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Uninstall Terraform Enterprise

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/install/vault.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/install/vault.mdx
@@ -2,6 +2,10 @@
 page_title: External Vault - Terraform Enterprise
 description: >-
   Learn about the data storage requirements of using an external Vault server with Terraform Enterprise.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # External Vault Requirements for Terraform Enterprise

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/monitoring/logging.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/monitoring/logging.mdx
@@ -2,6 +2,10 @@
 page_title: Log Forwarding - Infrastructure Administration - Terraform Enterprise
 description: >-
   Use log forwarding to increase observability, meet retention requirements, and aid troubleshooting. Learn how to configure forwarding, and audit and rotate logs.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise Log Forwarding

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/monitoring/monitoring.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/monitoring/monitoring.mdx
@@ -2,6 +2,10 @@
 page_title: Monitoring - Infrastructure Administration - Terraform Enterprise
 description: >-
   Learn how to use health checks, metrics, and telemetry to monitor the health of your Terraform Enterprise instance.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Monitoring a Terraform Enterprise Instance

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/requirements/credentials.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/requirements/credentials.mdx
@@ -3,6 +3,10 @@ page_title: Credentials - Requirements - Terraform Enterprise
 description: >-
   You must obtain a license file from HashiCorp, a TLS certificate, and a
   private key.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Credentials

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/requirements/data-storage/minio-setup-guide.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/requirements/data-storage/minio-setup-guide.mdx
@@ -2,6 +2,10 @@
 page_title: Minio Setup Guide - Installation - Terraform Enterprise
 description: >-
   Learn how to set up Minio for external object storage for HashiCorp Terraform Enterprise.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 @include "replicated-and-fdo/requirements/minio-partial.mdx"

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/requirements/data-storage/operational-mode-requirements.mdx
@@ -2,6 +2,10 @@
 page_title: Operational Mode Requirements - Requirements - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for each Terraform Enterprise operational mode.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Operation Mode Data Storage Requirements

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/requirements/data-storage/postgres-requirements.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/requirements/data-storage/postgres-requirements.mdx
@@ -2,6 +2,10 @@
 page_title: PostgreSQL Requirements - Before Installing - Terraform Enterprise
 description: >-
   Learn about the data storage requirements for PostgreSQL when using the external services operational mode of Terraform Enterprise.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # PostgreSQL Requirements for Terraform Enterprise

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/requirements/docker_engine.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/requirements/docker_engine.mdx
@@ -3,6 +3,10 @@ page_title: Docker Engine - Legacy Deployment - Requirements - Terraform Enterpr
 description: >-
   Configure and verify a Docker engine for your Terraform Enterprise
   installation.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Docker Engine Requirements

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/requirements/hardware.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/requirements/hardware.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Hardware and Data Storage - Requirements - Terraform Enterprise
 description: Required disk space and memory for your Terraform Enterprise instance.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Hardware and Data Storage Requirements

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/requirements/network.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/requirements/network.mdx
@@ -3,6 +3,10 @@ page_title: Network Requirements - Before Installing - Terraform Enterprise
 description: >-
   The Linux instance that runs Terraform Enterprise must allow several kinds of
   incoming network access.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Network Requirements for Terraform Enterprise

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/requirements/os-specific/centos-requirements.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/requirements/os-specific/centos-requirements.mdx
@@ -2,6 +2,10 @@
 page_title: CentOS Linux Requirements - Installation - Terraform Enterprise
 description: >-
   Learn about the requirements for installing Terraform Enterprise on CentOS Linux.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # CentOS Requirements for Terraform Enterprise

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/requirements/os-specific/rhel-requirements.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/requirements/os-specific/rhel-requirements.mdx
@@ -2,6 +2,10 @@
 page_title: RHEL Requirements - Installation - Terraform Enterprise
 description: >-
   Learn about the requirements for installing Terraform Enterprise on RedHat Enterprise Linux.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # RHEL Requirements for Terraform Enterprise

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/requirements/os-specific/supported-os.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/requirements/os-specific/supported-os.mdx
@@ -3,6 +3,10 @@ page_title: Supported Operating Systems - Requirements - Terraform Enterprise
 description: >-
   Terraform Enterprise can run on Debian, Ubuntu, CentOS, and several types of
   Linux (RedHat, Amazon, and Oracle).
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Supported Operating Systems

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/troubleshoot/contact-support.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/troubleshoot/contact-support.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Get support for Terraform Enterprise
 description: Learn to how to get HashiCorp support for Terraform Enterprise.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Get support for Terraform Enterprise

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/troubleshoot/error-messages.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/troubleshoot/error-messages.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Troubleshooting common application errors
 description: Learn about the errors Terraform Enterprise may report if your deployment is misconfigured and how to resolve them.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Troubleshooting common application errors

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/troubleshoot/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/troubleshoot/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Troubleshooting Terraform Enterprise 
 description: Use Terraform Enterprise logs and error messages to troubleshoot and debug errors.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-03T16:18:24-05:00
+# END AUTO GENERATED METADATA
 ---
 
 # Troubleshooting overview

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/troubleshoot/perform-diagnostics.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/troubleshoot/perform-diagnostics.mdx
@@ -2,6 +2,10 @@
 page_title: Perform diagnostics on your Terraform Enterprise deployment
 description: >-
   Instructions for diagnosing problems with your Terraform Enterprise deployment.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-11T23:50:38+05:30
+# END AUTO GENERATED METADATA
 ---
 
 # Perform diagnostics on your Terraform Enterprise deployment

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/dynamic-provider-credentials/aws-configuration.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/dynamic-provider-credentials/aws-configuration.mdx
@@ -4,6 +4,10 @@ description: >-
   Use OpenID Connect to get short-term credentials for the AWS Terraform
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-05T15:09:47-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Use dynamic credentials with the AWS provider

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/dynamic-provider-credentials/azure-configuration.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/dynamic-provider-credentials/azure-configuration.mdx
@@ -4,6 +4,10 @@ description: >-
   Use OpenID Connect to get short-term credentials for the Azure Terraform
   providers in your Terraform Enterprise runs.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 # Use dynamic credentials with the Azure provider

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/dynamic-provider-credentials/gcp-configuration.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/dynamic-provider-credentials/gcp-configuration.mdx
@@ -4,6 +4,10 @@ description: >-
   Use OpenID Connect to get short-term credentials for the GCP Terraform
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Use dynamic credentials with the GCP provider

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/dynamic-provider-credentials/hcp-configuration.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/dynamic-provider-credentials/hcp-configuration.mdx
@@ -4,6 +4,10 @@ description: >-
   Use OpenID Connect to get short-term credentials for the HCP provider in your
   Terraform Enterprise runs.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Dynamic Credentials with the HCP Provider

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/dynamic-provider-credentials/hcp-vault-secrets-backed/aws-configuration.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/dynamic-provider-credentials/hcp-vault-secrets-backed/aws-configuration.mdx
@@ -6,6 +6,10 @@ description: >-
   Use OpenID Connect and HCP Vault Secrets to get short-term credentials for the
   AWS Terraform provider in your Terraform Enterprise runs.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # HCP Vault Secrets-Backed Dynamic Credentials with the AWS Provider

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/dynamic-provider-credentials/hcp-vault-secrets-backed/gcp-configuration.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/dynamic-provider-credentials/hcp-vault-secrets-backed/gcp-configuration.mdx
@@ -6,6 +6,10 @@ description: >-
   Use OpenID Connect and HCP Vault Secrets to get short-term credentials for the
   GCP Terraform provider in your Terraform Enterprise runs.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # HCP Vault Secrets-Backed Dynamic Credentials with the GCP Provider

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/dynamic-provider-credentials/hcp-vault-secrets-backed/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/dynamic-provider-credentials/hcp-vault-secrets-backed/index.mdx
@@ -6,6 +6,10 @@ description: >-
   Configure HCP Vault Secrets-backed dynamic credentials for supported
   providers.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # HCP Vault Secrets-Backed Dynamic Credentials

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/dynamic-provider-credentials/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/dynamic-provider-credentials/index.mdx
@@ -5,6 +5,10 @@ description: >-
   Enterprise runs. Learn how dynamic credentials for Vault, AWS, Azure,
   Kubernetes, and GCP can improve your security.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 # Dynamic provider credentials

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/dynamic-provider-credentials/kubernetes-configuration.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/dynamic-provider-credentials/kubernetes-configuration.mdx
@@ -6,6 +6,10 @@ description: >-
   Use OpenID Connect to get short-term credentials for the Kubernetes and Helm
   Terraform providers in your Terraform Enterprise runs.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-05T15:09:47-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Use dynamic credentials with the Kubernetes and Helm providers

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/dynamic-provider-credentials/manual-generation.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/dynamic-provider-credentials/manual-generation.mdx
@@ -5,6 +5,10 @@ description: >-
   safely authenticate with custom workflows and providers that do not natively
   support dynamic credentials.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Manually generate workload identity tokens

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/dynamic-provider-credentials/specifying-multiple-configurations.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/dynamic-provider-credentials/specifying-multiple-configurations.mdx
@@ -4,6 +4,10 @@ description: >-
   Specify multiple dynamic provider credential configurations for the same
   workspace to create aliases for different provider configurations.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Specify multiple dynamic credential configurations

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/dynamic-provider-credentials/vault-backed/aws-configuration.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/dynamic-provider-credentials/vault-backed/aws-configuration.mdx
@@ -6,6 +6,10 @@ description: >-
   Use OpenID Connect and Vault to get short-term credentials for the AWS
   Terraform provider in your Terraform Enterprise runs.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Use Vault-backed dynamic credentials with the AWS provider

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
@@ -6,6 +6,10 @@ description: >-
   Use OpenID Connect and Vault to get short-term credentials for the Azure
   Terraform provider in your Terraform Enterprise runs.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Use Vault-backed dynamic credentials with the Azure provider

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/dynamic-provider-credentials/vault-backed/gcp-configuration.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/dynamic-provider-credentials/vault-backed/gcp-configuration.mdx
@@ -6,6 +6,10 @@ description: >-
   Use OpenID Connect and Vault to get short-term credentials for the GCP
   Terraform provider in your Terraform Enterprise runs.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Use Vault-backed dynamic credentials with the GCP provider

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/dynamic-provider-credentials/vault-backed/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/dynamic-provider-credentials/vault-backed/index.mdx
@@ -5,6 +5,10 @@ description: >-
   credentials for Terraform Enterprise runs. Learn how Vault-backed dynamic
   credentials for AWS, Azure, and GCP can improve your security.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Use Vault-backed dynamic credentials

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/dynamic-provider-credentials/vault-configuration.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/dynamic-provider-credentials/vault-configuration.mdx
@@ -4,6 +4,10 @@ description: >-
   Use OpenID Connect to get short-term credentials for the Vault Terraform
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Use dynamic credentials with the Vault provider

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/dynamic-provider-credentials/workload-identity-tokens.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/dynamic-provider-credentials/workload-identity-tokens.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how workload identity uses OpenID Connect (OIDC) to allow Terraform
   plans and applies to safely authenticate to external systems.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 # Workload identity

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/index.mdx
@@ -3,6 +3,10 @@ page_title: Terraform Enterprise
 description: >-
   Terraform Enterprise is a self-hosted instance of HCP Terraform with
   features like audit logging and SAML single sign-on.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/aws-service-catalog/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/aws-service-catalog/index.mdx
@@ -4,6 +4,10 @@ description: >-
   Terraform Enterprise for AWS Service Catalog lets you provision infrastructure
   with HCP Terraform inside AWS Service Catalog.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 # HCP Terraform for AWS Service Catalog overview

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/index.mdx
@@ -4,6 +4,10 @@ description: >-
   Use Terraform Enterprise integrations to connect HCP Terraform with
   third-party platforms and systems.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 # Overview

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/kubernetes/annotations-and-labels.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/kubernetes/annotations-and-labels.mdx
@@ -4,6 +4,10 @@ description: >-
   Use annotations and labels with the Terraform Enterprise Operator for
   Kubernetes to manage Terraform runs.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 # HCP Terraform Operator for Kubernetes annotations and labels

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/kubernetes/api-reference.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/kubernetes/api-reference.mdx
@@ -4,6 +4,10 @@ description: >-
   Use the Terraform Enterprise Operator for Kubernetes API to manage HCP
   Terraform workspaces, modules, and agent pools.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 # HCP Terraform Operator for Kubernetes API reference

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/kubernetes/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/kubernetes/index.mdx
@@ -4,6 +4,10 @@ description: >-
   The Terraform Enterprise Operator for Kubernetes allows you to provision
   infrastructure directly from the Kubernetes control plane.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-05T15:09:47-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # HCP Terraform Operator for Kubernetes overview

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/kubernetes/metrics.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/kubernetes/metrics.mdx
@@ -4,6 +4,10 @@ description: >-
   Use Prometheus-compatible metrics to monitor and gain insights into the
   Terraform Enterprise Operator for Kubernetes.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:55:25Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 # HCP Terraform Operator for Kubernetes metrics

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/kubernetes/ops-v2-migration.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/kubernetes/ops-v2-migration.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how to upgrade the Terraform Kubernetes Operator from version 1 to
   version 2.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Migrate to HCP Terraform Operator for Kubernetes v2

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/kubernetes/setup.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/kubernetes/setup.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how to install and configure the Terraform Enterprise Operator for
   Kubernetes.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Set up the HCP Terraform Operator for Kubernetes

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/run-tasks/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/run-tasks/index.mdx
@@ -4,6 +4,10 @@ description: >-
   Use run tasks to execute tasks in external systems at specific points in the
   Terraform Enterprise run lifecycle.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Set up run task integrations

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/service-now/service-catalog-terraform/admin-guide.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/service-now/service-catalog-terraform/admin-guide.mdx
@@ -2,6 +2,10 @@
 page_title: Configure the ServiceNow Service Catalog integration
 description: Learn how to configure the ServiceNow Service Catalog integration workers.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Configure the ServiceNow Service Catalog integration

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/service-now/service-catalog-terraform/developer-reference.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/service-now/service-catalog-terraform/developer-reference.mdx
@@ -2,6 +2,10 @@
 page_title: ServiceNow Service Catalog integration developer reference
 description: Learn how developers can customize the ServiceNow Service Catalog integration.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform ServiceNow Service Catalog Integration Developer Reference

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/service-now/service-catalog-terraform/example-customizations.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/service-now/service-catalog-terraform/example-customizations.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn from example common customizations of the ServiceNow Service Catalog
   integration.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # ServiceNow Service Catalog integration example configurations

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/service-now/service-catalog-terraform/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/service-now/service-catalog-terraform/index.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how to set up the ServiceNow Service Catalog integration for Terraform
   Enterprise.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 # Set up ServiceNow Service Catalog integration for HCP Terraform

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/service-now/service-catalog-terraform/service-catalog-config.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/service-now/service-catalog-terraform/service-catalog-config.mdx
@@ -4,6 +4,10 @@ description: >-
   Create and manage service catalog items to allow end users to provision
   infrastructure using ServiceNow and Terraform Enterprise.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Create and manage ServiceNow Service Catalog items

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/service-now/service-catalog-terraform/troubleshoot.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/service-now/service-catalog-terraform/troubleshoot.mdx
@@ -4,6 +4,10 @@ page_title: >-
   Enterprise
 description: Troubleshooting tips for ServiceNow Service Catalog Integration.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Troubleshoot the ServiceNow Service Catalog integration

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/service-now/service-graph/customizations.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/service-now/service-graph/customizations.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how to edit ETL mappings in the ServiceNow Service Graph Connector for
   Terraform Enterprise integration.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Customize the ServiceNow Service Graph Connector for Terraform

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/service-now/service-graph/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/service-now/service-graph/index.mdx
@@ -4,6 +4,10 @@ description: >-
   Use the ServiceNow Service Graph Connector to enable users to import Terraform
   Enterprise-built infrastructure into ServiceNow CMDB.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # ServiceNow Service Graph Connector for Terraform overview

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/service-now/service-graph/resource-coverage/aws.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/service-now/service-graph/resource-coverage/aws.mdx
@@ -4,6 +4,10 @@ description: >-
   Use the ServiceNow Service Graph integration to import selected resources from
   AWS into ServiceNow CMDB.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # ServiceNow Service Graph Connector AWS resource coverage

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/service-now/service-graph/resource-coverage/azure.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/service-now/service-graph/resource-coverage/azure.mdx
@@ -4,6 +4,10 @@ description: >-
   Use the ServiceNow Service Graph integration to import selected resources from
   Microsoft Azure into ServiceNow CMDB.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # ServiceNow Service Graph Connector Microsoft Azure resource coverage

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/service-now/service-graph/resource-coverage/gcp.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/service-now/service-graph/resource-coverage/gcp.mdx
@@ -4,6 +4,10 @@ description: >-
   Use the ServiceNow Service Graph for Terraform Enterprise integration to
   import selected resources from Google Cloud into ServiceNow CMDB.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # ServiceNow Service Graph Connector Google Cloud resource coverage

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/service-now/service-graph/resource-coverage/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/service-now/service-graph/resource-coverage/index.mdx
@@ -6,6 +6,10 @@ description: >-
   The ServiceNow Service Graph for Terraform Enterprise integration imports
   selected resources from major cloud providers into ServiceNow CMDB.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # ServiceNow Service Graph Connector for Terraform resource coverage overview

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/service-now/service-graph/resource-coverage/vsphere.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/service-now/service-graph/resource-coverage/vsphere.mdx
@@ -4,6 +4,10 @@ description: >-
   Use the ServiceNow Service Graph integration to import selected resources from
   VMware vSphere into ServiceNow CMDB.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # ServiceNow Service Graph Connector VMware vSphere resource coverage

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/service-now/service-graph/service-graph-setup.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/integrations/service-now/service-graph/service-graph-setup.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how to set up the ServiceNow Service Graph Connector for Terraform
   Enterprise.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 # Set up the ServiceNow Service Graph Connector

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/migrate.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/migrate.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how to migrate existing Terraform state to Terraform Enterprise or
   Terraform Enterprise using the CLI, API, or tf-migrate.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 # Migrate Terraform state to HCP Terraform or Terraform Enterprise

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/no-code-provisioning/module-design.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/no-code-provisioning/module-design.mdx
@@ -4,6 +4,10 @@ description: >-
   No-code ready modules let users deploy a module's resources without writing
   configuration. Learn how to prepare modules for no-code provisioning.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Design no-code ready modules

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/no-code-provisioning/provisioning.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/no-code-provisioning/provisioning.mdx
@@ -5,6 +5,10 @@ description: >-
   configuration. Learn how to provision infrastructure from a no-code ready
   module.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Provision no-code infrastructure

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/policy-enforcement/define-policies/custom-sentinel.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/policy-enforcement/define-policies/custom-sentinel.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how to use the Sentinel policy language to create policies in Terraform
   Enterprise.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Define Sentinel policies in HCP Terraform

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/policy-enforcement/define-policies/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/policy-enforcement/define-policies/index.mdx
@@ -5,6 +5,10 @@ description: >-
   Learn how to define policies for governing how Terraform provisions
   infrastructure.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Define policies overview

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/policy-enforcement/define-policies/opa.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/policy-enforcement/define-policies/opa.mdx
@@ -4,6 +4,10 @@ description: >-
   Use the Rego policy language to define Open Policy Agent (OPA) policies for
   Terraform Enterprise.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Define Open Policy Agent policies for HCP Terraform

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/policy-enforcement/import-reference/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/policy-enforcement/import-reference/index.mdx
@@ -4,6 +4,10 @@ description: >-
   Use the Sentinel import function to configure policy behaviors in custom
   Sentinel policies.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # `import` function reference overview

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/policy-enforcement/import-reference/tfconfig-v2.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/policy-enforcement/import-reference/tfconfig-v2.mdx
@@ -4,6 +4,10 @@ description: >-
   Use the tfconfig/v2 import to give Sentinel access to a Terraform
   configuration.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 -> **Note:** This is documentation for the next version of the `tfconfig`

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/policy-enforcement/import-reference/tfconfig.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/policy-enforcement/import-reference/tfconfig.mdx
@@ -2,6 +2,10 @@
 page_title: tfconfig Sentinel import
 description: Use tfconfig import to give Sentinel access to a Terraform configuration.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # tfconfig Sentinel import

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/policy-enforcement/import-reference/tfplan-v2.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/policy-enforcement/import-reference/tfplan-v2.mdx
@@ -2,6 +2,10 @@
 page_title: tfplan/v2 Sentinel import
 description: Use tfplan/v2 import to give Sentinel access to a Terraform plan.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 -> **Note:** This is documentation for the next version of the `tfplan` Sentinel

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/policy-enforcement/import-reference/tfplan.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/policy-enforcement/import-reference/tfplan.mdx
@@ -2,6 +2,10 @@
 page_title: tfplan Sentinel import reference
 description: Use the tfplan import to give Sentinel access to a Terraform plan.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # tfplan Sentinel import reference

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/policy-enforcement/import-reference/tfrun.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/policy-enforcement/import-reference/tfrun.mdx
@@ -4,6 +4,10 @@ description: >-
   Use tfrun import to give Sentinel access to data associated with a Terraform
   run.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # tfrun Sentinel import reference

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/policy-enforcement/import-reference/tfstate-v2.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/policy-enforcement/import-reference/tfstate-v2.mdx
@@ -2,6 +2,10 @@
 page_title: tfstate/v2 Sentinel import
 description: Use tfstate/v2 import to give Sentinel access to Terraform state.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 -> **Note:** This is documentation for the next version of the `tfstate`

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/policy-enforcement/import-reference/tfstate.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/policy-enforcement/import-reference/tfstate.mdx
@@ -2,6 +2,10 @@
 page_title: tfstate Sentinel import
 description: Use the tfstate import to give Sentinel access to Terraform state.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfstate

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/policy-enforcement/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/policy-enforcement/index.mdx
@@ -5,6 +5,10 @@ description: >-
   validate Terraform plans. Learn how to use Sentinel and OPA to enforce
   policies.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # HCP Terraform policy enforcement overview

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/policy-enforcement/manage-policy-sets/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/policy-enforcement/manage-policy-sets/index.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how to create and manage policies and policy sets in Terraform
   Enterprise.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Manage policies and policy sets in HCP Terraform

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/policy-enforcement/manage-policy-sets/opa-vcs.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/policy-enforcement/manage-policy-sets/opa-vcs.mdx
@@ -2,6 +2,10 @@
 page_title: Configure an OPA policy set with a VCS repository
 description: Use a VCS repository to configure an OPA policy set in Terraform Enterprise.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Configure an OPA policy set with a VCS repository

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/policy-enforcement/manage-policy-sets/sentinel-vcs.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/policy-enforcement/manage-policy-sets/sentinel-vcs.mdx
@@ -4,6 +4,10 @@ description: >-
   Use a VCS repository to configure a Sentinel policy set in Terraform
   Enterprise.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Configure a Sentinel policy set with a VCS repository

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/policy-enforcement/prewritten-library.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/policy-enforcement/prewritten-library.mdx
@@ -5,6 +5,10 @@ description: >-
   that enforce CIS and other compliance standards. Learn about the available
   pre-written policies.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Pre-written policy library reference

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/policy-enforcement/prewritten-sentinel.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/policy-enforcement/prewritten-sentinel.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how to download and install pre-written Sentinel policies created and
   maintained by HashiCorp.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Run pre-written Sentinel policies

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/policy-enforcement/test-sentinel.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/policy-enforcement/test-sentinel.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how to generate mock Sentinel data to test your policies with Terraform
   Enterprise.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Generate mock Sentinel data with Terraform

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/policy-enforcement/view-results/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/policy-enforcement/view-results/index.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how to view and override policy enforcement results in Terraform
   Enterprise.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # View policy enforcement results

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/policy-enforcement/view-results/json.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/policy-enforcement/view-results/json.mdx
@@ -2,6 +2,10 @@
 page_title: View and filter Sentinel JSON data
 description: Learn how to view and filter Sentinel JSON data.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # View and filter Sentinel JSON data

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/projects/best-practices.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/projects/best-practices.mdx
@@ -4,6 +4,10 @@ description: >-
   Best practices to structure your configuration and Terraform Enterprise
   projects
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Project Best Practices

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/projects/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/projects/index.mdx
@@ -4,6 +4,10 @@ description: >-
   Use projects to organize and group workspaces and create ownership boundaries
   across your infrastructure.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 # Overview

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/projects/manage.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/projects/manage.mdx
@@ -4,6 +4,10 @@ description: |-
   Use projects to organize and group workspaces and create ownership boundaries
   across your infrastructure.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 # Manage projects

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/registry/add.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/registry/add.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how to add providers and modules from the public Terraform registry to
   your organization's private registry.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [vcs]: /terraform/enterprise/vcs

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/registry/airgapped-providers.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/registry/airgapped-providers.mdx
@@ -3,6 +3,10 @@ page_title: Publish a public provider to an airgapped private registry
 description: >-
   Private registries in airgapped environments cannot access public providers. Learn how to publish an official public provider to an
   airgapped private registry.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Publish Public Providers to an Airgapped Private Registry

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/registry/design.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/registry/design.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how to outline a configuration with private modules and define variables
   with the Terraform Enterprise configuration designer.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Use the configuration designer

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/registry/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/registry/index.mdx
@@ -4,6 +4,10 @@ description: >-
   The Terraform Enterprise private registry lets you share private modules and
   providers across your organization.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # HCP Terraform private registry overview

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/registry/manage-module-versions.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/registry/manage-module-versions.mdx
@@ -6,6 +6,10 @@ description: >-
   and revoking a module version signals you no longer maintain support for a
   module version and blocks new consumers.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Manage module versions

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/registry/publish-modules.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/registry/publish-modules.mdx
@@ -4,6 +4,10 @@ description: >-
   Use the Terraform Enterprise private registry to publish and share private
   modules across your organization.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 [vcs]: /terraform/enterprise/vcs

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/registry/publish-providers.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/registry/publish-providers.mdx
@@ -4,6 +4,10 @@ description: >-
   Use the Terraform Enterprise private registry to publish and share private
   providers across your organization.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 # Publish private providers to the HCP Terraform private registry

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/registry/test.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/registry/test.mdx
@@ -2,6 +2,10 @@
 page_title: Test private modules in the Terraform Enterprise private registry
 description: Use the Terraform Enterprise private registry to run module tests.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Test private modules in the HCP Terraform private registry

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/registry/test/dynamic-credentials/aws.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/registry/test/dynamic-credentials/aws.mdx
@@ -4,6 +4,10 @@ description: >-
   Configure AWS IAM to trust Terraform Enterprise's OIDC tokens for module test
   runs, eliminating the need for static AWS credentials.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:55:25Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 # Configure dynamic credentials for AWS in module testing

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/registry/test/dynamic-credentials/azure.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/registry/test/dynamic-credentials/azure.mdx
@@ -5,6 +5,10 @@ description: >-
   Enterprise's OIDC tokens for module test runs, eliminating the need for static
   Azure credentials.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:55:25Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 # Configure dynamic credentials for Azure in module testing

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/registry/test/dynamic-credentials/gcp.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/registry/test/dynamic-credentials/gcp.mdx
@@ -5,6 +5,10 @@ description: >-
   OIDC tokens for module test runs, eliminating the need for static GCP
   credentials.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:55:25Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 # Configure dynamic credentials for GCP in module testing

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/registry/test/dynamic-credentials/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/registry/test/dynamic-credentials/index.mdx
@@ -4,6 +4,10 @@ description: >-
   Use OpenID Connect to get short-term credentials for testing private registry
   modules in Terraform Enterprise without managing static credentials.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:55:25Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 # Use dynamic credentials with module testing

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/registry/test/dynamic-credentials/vault.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/registry/test/dynamic-credentials/vault.mdx
@@ -5,6 +5,10 @@ description: >-
   for module test runs, enabling dynamic secret generation without static
   credentials.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:55:25Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 # Configure dynamic credentials for Vault in module testing

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/registry/test/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/registry/test/index.mdx
@@ -2,6 +2,10 @@
 page_title: Test private modules in the Terraform Enterprise private registry
 description: Use the Terraform Enterprise private registry to run module tests.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:55:25Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 # Test private modules in the HCP Terraform private registry

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/registry/using.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/registry/using.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how to use artifacts from the Terraform Enterprise private registry in
   your Terraform configuration.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 # Use artifacts from the HCP Terraform private registry

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/1.0.x/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/1.0.x/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 1.0.x - Terraform Enterprise
 description: The 1.0.x Terraform Enterprise.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise 1.0.x

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/1.1.x/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/1.1.x/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 1.1.x - Terraform Enterprise
 description: The 1.1.x Terraform Enterprise.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise 1.1.x

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/1.2.x/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/1.2.x/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 1.2.x - Terraform Enterprise
 description: The 1.2.x Terraform Enterprise.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T14:40:57-08:00
+last_modified: 2026-02-11T23:49:07+05:30
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise 1.2.x

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2018/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2018/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 2018 Releases - Terraform Enterprise
 description: The 2018 Terraform Enterprise releases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise Releases - 2018

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2019/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2019/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 2019 Releases - Terraform Enterprise
 description: The 2019 Terraform Enterprise releases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise Releases - 2019

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2020/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2020/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 2020 Releases - Terraform Enterprise
 description: The 2020 Terraform Enterprise releases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise Releases - 2020

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2021/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2021/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 2021 Releases - Terraform Enterprise
 description: The 2021 Terraform Enterprise releases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise Releases - 2021

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2021/v202101-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2021/v202101-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202101-1 (504) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # TFE Release v202101-1 (504)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2021/v202102-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2021/v202102-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202102-1 (507) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # TFE Release v202102-1 (507)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2021/v202102-2.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2021/v202102-2.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202102-2 (509) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # TFE Release v202102-2 (509)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2021/v202103-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-1 (519) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # TFE Release v202103-1 (519 Required)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2021/v202103-2.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2021/v202103-2.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-2 (520) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # TFE Release v202103-2 (520)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2021/v202103-3.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2021/v202103-3.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202103-3 (523) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # TFE Release v202103-3 (523)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2021/v202104-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2021/v202104-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202104-1 (528) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # TFE Release v202104-1 (528)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2021/v202105-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2021/v202105-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202105-1 (534) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # TFE Release v202105-1 (534)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2021/v202106-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2021/v202106-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202106-1 (544) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # TFE Release v202106-1 (544)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2021/v202107-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2021/v202107-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202107-1 (550) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # TFE Release v202107-1 (550)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2021/v202108-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2021/v202108-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202108-1 (557) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # TFE Release v202108-1 (557)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2021/v202109-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2021/v202109-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202109-1 (565) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # TFE Release v202109-1 (565)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2021/v202109-2.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2021/v202109-2.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202109-2 (568) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # TFE Release v202109-2 (568)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2021/v202110-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2021/v202110-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202110-1 (576) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # TFE Release v202110-1 (576)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2021/v202111-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2021/v202111-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202111-1 (582) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # TFE Release v202111-1 (582)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2021/v202112-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2021/v202112-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202112-1 (588) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # TFE Release v202112-1 (588)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2021/v202112-2.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2021/v202112-2.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the known issues, bug fixes, deprecations, breaking changes, features and security fixes for the v202112-2 (590) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # TFE Release v202112-2 (590)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2022/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2022/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 2022 Releases - Terraform Enterprise
 description: The 2022 Terraform Enterprise releases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise Releases - 2022

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2022/v202201-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2022/v202201-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-1 (594) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202201-1 (594)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2022/v202201-2.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2022/v202201-2.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-2 (595) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202201-2 (595)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2022/v202202-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2022/v202202-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202202-1 (599) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202202-1 (599)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2022/v202203-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2022/v202203-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202203-1 (607) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202203-1 (607)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2022/v202204-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2022/v202204-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202201-1 (594) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202204-1 (609)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2022/v202204-2.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2022/v202204-2.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202204-2 (610) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202204-2 (610 Required)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2022/v202205-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2022/v202205-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202205-1 (619) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202205-1 (619)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2022/v202206-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2022/v202206-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202206-1 (636) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202206-1 (636)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2022/v202207-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2022/v202207-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202207-1 (641) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202207-1 (641)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2022/v202207-2.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2022/v202207-2.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202207-2 (642) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202207-2 (642 Required)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2022/v202208-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2022/v202208-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-1 (647) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202208-1  (647)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2022/v202208-2.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2022/v202208-2.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-2 (651) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202208-2 (651)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2022/v202208-3.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2022/v202208-3.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202208-3 (652) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202208-3 (652)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2022/v202209-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2022/v202209-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202209-1 (654) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202209-1 (654)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2022/v202209-2.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2022/v202209-2.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202209-2 (655) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202209-2 (655)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2022/v202210-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2022/v202210-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202210-1 (659) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202210-1 (659)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2022/v202211-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2022/v202211-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202211-1 (660) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202211-1 (660)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2022/v202212-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2022/v202212-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202212-1 (665) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202212-1 (665)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2022/v202212-2.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2022/v202212-2.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202212-2 (667) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202212-2 (667)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2023/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2023/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 2023 Releases - Terraform Enterprise
 description: The 2023 Terraform Enterprise releases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise Releases - 2023

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2023/v202301-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2023/v202301-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202301-1 (675) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202301-1 (675)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2023/v202301-2.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2023/v202301-2.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202301-2 (676) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202301-2 (676)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2023/v202302-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202302-1 (681) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202302-1 (681)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2023/v202303-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2023/v202303-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202303-1 (688) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202303-1 (688)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2023/v202304-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2023/v202304-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202304-1 (692) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202304-1 (692)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2023/v202305-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2023/v202305-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202305-1 (703) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202305-1 (703)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2023/v202305-2.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2023/v202305-2.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202305-2 (704) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202305-2 (706)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2023/v202306-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2023/v202306-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202306-1 (710) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202306-1 (713)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2023/v202307-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2023/v202307-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202307-1 (722) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202307-1 (722)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2023/v202308-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2023/v202308-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202308-1 (725) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202308-1 (725)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2023/v202309-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2023/v202309-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202309-1 (733) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202309-1 (733)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2023/v202310-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2023/v202310-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202310-1 (741) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202310-1 (741)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2023/v202311-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2023/v202311-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202311-1 (742) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202311-1 (742)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2023/v202312-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2023/v202312-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202312-1 (745) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202312-1 (745)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2024/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2024/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 2024 Releases - Terraform Enterprise
 description: The 2024 Terraform Enterprise releases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise Releases - 2024

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2024/v202401-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2024/v202401-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202401-1 (751) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202401-1 (751)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2024/v202401-2.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2024/v202401-2.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202401-2 (755) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202401-2 (757)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2024/v202402-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2024/v202402-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202402-1 (759) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202402-1 (759)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2024/v202402-2.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2024/v202402-2.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202402-2 (760) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202402-2 (760)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2024/v202404-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2024/v202404-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202404-1 (763) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202404-1 (763)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2024/v202404-2.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2024/v202404-2.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202404-2 (764) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202404-2 (764)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2024/v202405-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2024/v202405-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202405-1 (772) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202405-1 (772)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2024/v202406-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2024/v202406-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202406-1 (776) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202406-1 (776)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2024/v202407-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2024/v202407-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202407-1 (779) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202407-1 (779)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2024/v202408-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2024/v202408-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202408-1 (781) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202408-1 (781)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2024/v202409-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2024/v202409-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202409-1 (787) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202409-1 (787)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2024/v202409-2.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2024/v202409-2.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202409-2 (789) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202409-2 (789)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2024/v202409-3.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2024/v202409-3.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202409-3 (791) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202409-3 (791)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2024/v202410-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2024/v202410-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202410-1 (798) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202410-1 (798)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2024/v202411-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2024/v202411-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202411-1 (804) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202411-1 (804)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2024/v202411-2.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2024/v202411-2.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202411-2 (805) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202411-2 (805)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2025/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2025/index.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: 2025 Releases - Terraform Enterprise
 description: The 2025 Terraform Enterprise releases.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise Releases - 2025

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2025/v202501-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2025/v202501-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202501-1 (806) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202501-1 (806)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2025/v202502-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2025/v202502-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202502-1 (808) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202502-1 (808)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2025/v202502-2.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2025/v202502-2.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202502-2 (810) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202502-2 (810)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2025/v202503-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2025/v202503-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202503-1 (811) release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202503-1 (811)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2025/v202504-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2025/v202504-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202504-1 release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202504-1

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2025/v202505-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2025/v202505-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202505-1 release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202505-1

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2025/v202506-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2025/v202506-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202506-1 release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202506-1

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2025/v202507-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2025/v202507-1.mdx
@@ -2,6 +2,10 @@
 page_title: Releases - Terraform Enterprise
 description: >-
   Learn about the changes, known issues, deprecations, highlights, features, improvements, bug fixes, and security fixes for the v202507-1 release.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise v202507-1

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/index.mdx
@@ -3,6 +3,10 @@ page_title: Releases - Terraform Enterprise
 description: >-
   We ship a new Terraform Enterprise release each month. Find a list of recent
   releases and associated release notes.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-11T18:12:15+05:30
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform Enterprise Releases

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/run/api.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/run/api.mdx
@@ -4,6 +4,10 @@ description: >-
   Use Terraform Enterprise's API-driven run workflow to enable external tools to
   upload Terraform configurations and trigger new runs.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # The API-driven run workflow

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/run/cli.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/run/cli.mdx
@@ -4,6 +4,10 @@ description: >-
   Configure the Terraform CLI to trigger remote runs in Terraform Enterprise
   from your terminal. 
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [private]: /terraform/enterprise/registry

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/run/install-software.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/run/install-software.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how to install Terraform providers, cloud CLIs, or configuration
   management tools and software on Terraform Enterprise workers.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Install software in the run environment

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/run/manage.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/run/manage.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how to view and interact with runs in Terraform Enterprise, and how to
   unlock and lock workspaces to prevent new runs.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Manage and view runs

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/run/modes-and-options.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/run/modes-and-options.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn about the different run modes and options available in Terraform
   Enterprise to customize behavior during runs.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Run modes and options

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/run/remote-operations.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/run/remote-operations.mdx
@@ -4,6 +4,10 @@ description: >-
   Terraform Enterprise runs Terraform operations remotely through the UI, API,
   or CLI. Learn how HCP Terraform manages runs.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Remote operations

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/run/run-environment.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/run/run-environment.mdx
@@ -5,6 +5,10 @@ description: >-
   network access, concurrency for runs, state access authentication, and
   environment variables.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # HCP Terraform's run environment

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/run/states.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/run/states.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn the run stages of Terraform operations. Understanding run stages and
   their states can help you follow a run's progress.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Run states and stages

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/run/ui.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/run/ui.mdx
@@ -5,6 +5,10 @@ description: >-
   queue runs when merging new commits to the VCS repository branch associated
   with a workspace.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # UI and VCS-driven run workflow

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/saml/attributes.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/saml/attributes.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: SAML user attributes reference for Terraform Enterprise
 description: Terraform Enterprise updates an account with data from SAML user attributes when a new user logs in. Learn how SAML user attributes map to Terraform Enterprise user data.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # SAML User Attributes Reference

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/saml/configuration.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/saml/configuration.mdx
@@ -2,6 +2,10 @@
 page_title: Configure Terraform Enterprise as the SAML service provider
 description: >-
   Learn how to configure Terraform Enterprise as the service provider (SP) when integrating with a SAML identity provider for authentication and authorization. 
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Configure Terraform Enterprise as the SAML service provider

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/saml/idp-configuration/aad.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/saml/idp-configuration/aad.mdx
@@ -3,6 +3,10 @@ page_title: >-
   Configure Azure Active Directory as the identity provider Terraform Enterprise  
 description: >-
   Learn how to use Azure Active Directory as the identify provider for Terraform Enterprise when setting up single-sign on (SSO) over SAML.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Configure an Azure Active Directory Identity Provider

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/saml/idp-configuration/adfs.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/saml/idp-configuration/adfs.mdx
@@ -2,6 +2,10 @@
 page_title: Configure ADFS as the identify provider for Terraform Enterprise
 description: >-
   Learn how to use Active Directory Federated Services (ADFS) as the identify provider for Terraform Enterprise when setting up single-sign on (SSO) over SAML.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Configure an ADFS Identity Provider

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/saml/idp-configuration/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/saml/idp-configuration/index.mdx
@@ -2,6 +2,10 @@
 page_title: Sample authentication request and response for a SAML identity provider
 description: >-
   You can enable Terraform Enterprise to authenticate and authorize users over SAML single sign-on. Review a sample SAML request and response to validate your SSO.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Sample SAML Authentication Request and Response

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/saml/idp-configuration/okta.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/saml/idp-configuration/okta.mdx
@@ -2,6 +2,10 @@
 page_title: Configure Okta as the identity provider for Terraform Enterprise
 description: >-
   Learn how to use Okta as the identity provider for Terraform Enterprise when setting up single-sign on (SSO) over SAML.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Configure an Okta Identity Provider 

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/saml/idp-configuration/onelogin.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/saml/idp-configuration/onelogin.mdx
@@ -2,6 +2,10 @@
 page_title: Configure OneLogin as the identity provider for Terraform Enterprise
 description: >-
   Learn how to use OneLogin as the identity provider for Terraform Enterprise when setting up single-sign on (SSO) over SAML.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Configure a OneLogin Identity Provider

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/saml/login.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/saml/login.mdx
@@ -3,6 +3,10 @@ page_title: Log into Terraform Enterprise with SAML
 description: >-
   Log into Terraform Enterprise after configuring SAML. Learn how to visit the login page and how admins can change the user API
   token session timeout.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Log into Terraform Enterprise with SAML

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/saml/team-membership.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/saml/team-membership.mdx
@@ -1,6 +1,10 @@
 ---
 page_title: Enable the SAML identity provider to control team membership mapping
 description: You can enable the SAML IdP to control team membership mapping. Learn how to automatically add users to teams based on their SAML assertion.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Enable the SAML Identity Provider to Map Team Membership

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/saml/troubleshooting.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/saml/troubleshooting.mdx
@@ -2,6 +2,10 @@
 page_title: Troubleshoot SAML SSO integrations for Terraform Enterprise
 description: >-
   Terraform Enterprise includes debugging functionality to help you troubleshoot SAML SSO issues. Learn how SAML single sign-on troubleshooting tasks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Troubleshoot SAML SSO Integrations

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/users-teams-organizations/2fa.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/users-teams-organizations/2fa.mdx
@@ -2,6 +2,10 @@
 page_title: Configure two-factor authentication
 description: Use two-factor authentication to secure access to Terraform Enterprise.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 # Configure two-factor authentication

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/users-teams-organizations/api-tokens.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/users-teams-organizations/api-tokens.mdx
@@ -4,6 +4,10 @@ description: >-
   Use API tokens to authenticate with Terraform Enterprise and perform API
   operations.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # API Tokens

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/users-teams-organizations/organizations/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/users-teams-organizations/organizations/index.mdx
@@ -5,6 +5,10 @@ description: >-
   collaborate. Learn how to create and manage Terraform Enterprise
   organizations.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 [teams]: /terraform/enterprise/users-teams-organizations/teams

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/users-teams-organizations/organizations/manage-reserved-tags.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/users-teams-organizations/organizations/manage-reserved-tags.mdx
@@ -4,6 +4,10 @@ description: >-
   Reserved tag keys let you organize projects and workspaces and track
   consumption. Learn how to create and manage reserved tag keys.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Create and manage reserved tag keys

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/users-teams-organizations/organizations/vcs-speculative-plan-management.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/users-teams-organizations/organizations/vcs-speculative-plan-management.mdx
@@ -5,6 +5,10 @@ description: >-
   plan operations triggered by pull requests when new commits are pushed to the
   VCS.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Automatically cancel plan-only workspace runs

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/users-teams-organizations/organizations/vcs-status-checks.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/users-teams-organizations/organizations/vcs-status-checks.mdx
@@ -4,6 +4,10 @@ description: >-
   VCS status checks send notifications to your version control provider. Learn
   how to configure VCS status checks in Terraform Enterprise.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Configure VCS status checks

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/users-teams-organizations/permissions/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/users-teams-organizations/permissions/index.mdx
@@ -4,6 +4,10 @@ description: >-
   Use the Terraform Enterprise permission model to manage user access to
   organizations, projects, and workspaces.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Permissions overview

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/users-teams-organizations/permissions/organization.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/users-teams-organizations/permissions/organization.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn about the organization permissions that you can grant to let your users
   interact with your organization's resources and settings.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-05T15:09:47-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Organization permissions

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/users-teams-organizations/permissions/project.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/users-teams-organizations/permissions/project.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn about the project permissions that you can grant to let your users
   interact with your project's resources and settings.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 # Project permissions

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/users-teams-organizations/permissions/set-permissions.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/users-teams-organizations/permissions/set-permissions.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how to set permissions in Terraform Enterprise to grant permissions for
   users at the organization, project, and workspace levels.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Set permissions

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/users-teams-organizations/permissions/workspace.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/users-teams-organizations/permissions/workspace.mdx
@@ -4,6 +4,10 @@ description: >-
   Use the Terraform Enterprise permission model to manage user access to
   organizations, projects, and workspaces.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 # Workspace permissions

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/users-teams-organizations/teams/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/users-teams-organizations/teams/index.mdx
@@ -4,6 +4,10 @@ description: >-
   Teams are a group of users within an organization. Learn about managing teams,
   team membership, team permissions, and more.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 [organizations]: /terraform/enterprise/users-teams-organizations/organizations

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/users-teams-organizations/teams/manage.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/users-teams-organizations/teams/manage.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how to manage team creation, team deletion, team membership, and team
   access to workspaces, projects, and organizations.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 # Manage teams

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/users-teams-organizations/teams/notifications.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/users-teams-organizations/teams/notifications.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how to set up team notifications to notify team members on external
   systems whenever a particular action takes place.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 # Manage team notifications

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/users-teams-organizations/users.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/users-teams-organizations/users.mdx
@@ -2,6 +2,10 @@
 page_title: Create and manage users in Terraform Enterprise
 description: Learn how to create and manage users in Terraform Enterprise.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-05T15:09:47-08:00
+# END AUTO GENERATED METADATA
 ---
 
 [organizations]: /terraform/enterprise/users-teams-organizations/organizations

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/variables/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/variables/index.mdx
@@ -4,6 +4,10 @@ description: >-
   Variables let you customize runs in Terraform Enterprise. Learn how to use
   Terraform variables and environment variables.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Variables overview

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/variables/managing-variables.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/variables/managing-variables.mdx
@@ -4,6 +4,10 @@ description: >-
   Use workspace variables and variable sets to customize Terraform Enterprise
   runs.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Manage variables and variable sets

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/vcs/azure-devops-server.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/vcs/azure-devops-server.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how to use an on-premises installation of Azure DevOps Server with
   workspaces and private registry modules in Terraform Enterprise.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Set up the Azure DevOps Server VCS provider

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/vcs/azure-devops-services-pat.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/vcs/azure-devops-services-pat.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how to use Azure DevOps Services with workspaces and private registry
   modules in Terraform Enterprise using personal access tokens.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Set up the Azure DevOps Services VCS provider using personal access tokens

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/vcs/azure-devops-services.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/vcs/azure-devops-services.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how to use Azure DevOps Services with workspaces and private registry
   modules using OAuth.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Set up the Azure DevOps Services VCS provider using OAuth

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/vcs/bitbucket-cloud.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/vcs/bitbucket-cloud.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how to use Bitbucket Cloud with workspaces and private registry modules
   in Terraform Enterprise.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Set up the Bitbucket Cloud VCS provider

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/vcs/bitbucket-data-center.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/vcs/bitbucket-data-center.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how to use Bitbucket Data Center with workspaces and private registry
   modules in Terraform Enterprise.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Set up the Bitbucket Data Center VCS provider

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/vcs/github-enterprise.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/vcs/github-enterprise.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how to use an on-premise installation of GitHub Enterprise with
   workspaces and private registry modules in Terraform Enterprise.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Set up the GitHub Enterprise VCS provider

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/vcs/github.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/vcs/github.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how to use GitHub.com with workspaces and private registry modules in
   Terraform Enterprise with a per-organization OAuth connection.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Set up the GitHub.com OAuth VCS provider

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/vcs/gitlab-com.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/vcs/gitlab-com.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how to use GitLab.com repositories with workspaces and private registry
   modules.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Set up the GitLab.com VCS provider

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/vcs/gitlab-eece.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/vcs/gitlab-eece.mdx
@@ -5,6 +5,10 @@ description: >-
   GitLab Community Edition (CE) with workspaces and private registry module in
   Terraform Enterprise.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Set up the GitLab EE and CE VCS provider

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/vcs/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/vcs/index.mdx
@@ -5,6 +5,10 @@ description: >-
   your workflow. Learn how to automate Terraform runs when you commit changes to
   your code.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Connect to VCS Providers

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/vcs/troubleshooting.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/vcs/troubleshooting.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how to address common problems in VCS integrations for Terraform
   Enterprise.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Troubleshoot VCS providers

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/best-practices.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/best-practices.mdx
@@ -4,6 +4,10 @@ description: >-
   Best practices to structure your configuration and Terraform Enterprise
   workspaces
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Workspace Best Practices

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/browse.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/browse.mdx
@@ -5,6 +5,10 @@ description: >-
   to create different views of the resource data that the app manages so that
   you can track consumption across your organizations.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Browse workspaces

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/change-requests/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/change-requests/index.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how change requests can help you create a backlog of actionable todos
   directly on a workspace.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 # Change requests overview

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/change-requests/manage.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/change-requests/manage.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how to create, view, and archive change requests to manage a backlog of
   actionable todos on workspaces.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 # Manage change requests

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/configurations.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/configurations.mdx
@@ -4,6 +4,10 @@ description: >-
   Workspaces organize infrastructure and state. Learn how to provide
   configuration versions for a workspace and organize multiple environments.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Manage Terraform configurations

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/cost-estimation/aws.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/cost-estimation/aws.mdx
@@ -2,6 +2,10 @@
 page_title: AWS resources included in cost estimation in Terraform Enterprise
 description: Learn which AWS resources Terraform Enterprise includes in cost estimation.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # AWS resources included in cost estimation

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/cost-estimation/azure.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/cost-estimation/azure.mdx
@@ -2,6 +2,10 @@
 page_title: Azure resources included in cost estimation in Terraform Enterprise
 description: Learn which Azure resources Terraform Enterprise includes in cost estimation.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Azure resources included in cost estimation

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/cost-estimation/gcp.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/cost-estimation/gcp.mdx
@@ -2,6 +2,10 @@
 page_title: GCP resources included in cost estimation in Terraform Enterprise
 description: Learn which GCP resources Terraform Enterprise includes in cost estimation.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # GCP resources included in cost estimation

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/cost-estimation/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/cost-estimation/index.mdx
@@ -5,6 +5,10 @@ description: >-
   your Terraform configuration. Use cost estimation to get hourly and monthly
   cost estimates for each resource.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 # Cost estimation overview

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/create.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/create.mdx
@@ -4,6 +4,10 @@ description: >-
   Workspaces organize infrastructure and state into groups. Learn how to create
   and configure Terraform Enterprise workspaces through the UI.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Create workspaces

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/dynamic-provider-credentials/aws-configuration.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/dynamic-provider-credentials/aws-configuration.mdx
@@ -4,6 +4,10 @@ description: >-
   Use OpenID Connect to get short-term credentials for the AWS Terraform
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Use dynamic credentials with the AWS provider

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/dynamic-provider-credentials/azure-configuration.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/dynamic-provider-credentials/azure-configuration.mdx
@@ -4,6 +4,10 @@ description: >-
   Use OpenID Connect to get short-term credentials for the Azure Terraform
   providers in your Terraform Enterprise runs.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Use dynamic credentials with the Azure provider

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/dynamic-provider-credentials/gcp-configuration.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/dynamic-provider-credentials/gcp-configuration.mdx
@@ -4,6 +4,10 @@ description: >-
   Use OpenID Connect to get short-term credentials for the GCP Terraform
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Use dynamic credentials with the GCP provider

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/dynamic-provider-credentials/hcp-configuration.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/dynamic-provider-credentials/hcp-configuration.mdx
@@ -4,6 +4,10 @@ description: >-
   Use OpenID Connect to get short-term credentials for the HCP provider in your
   Terraform Enterprise runs.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Dynamic Credentials with the HCP Provider

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/dynamic-provider-credentials/hcp-vault-secrets-backed/aws-configuration.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/dynamic-provider-credentials/hcp-vault-secrets-backed/aws-configuration.mdx
@@ -6,6 +6,10 @@ description: >-
   Use OpenID Connect and HCP Vault Secrets to get short-term credentials for the
   AWS Terraform provider in your Terraform Enterprise runs.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # HCP Vault Secrets-Backed Dynamic Credentials with the AWS Provider

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/dynamic-provider-credentials/hcp-vault-secrets-backed/gcp-configuration.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/dynamic-provider-credentials/hcp-vault-secrets-backed/gcp-configuration.mdx
@@ -6,6 +6,10 @@ description: >-
   Use OpenID Connect and HCP Vault Secrets to get short-term credentials for the
   GCP Terraform provider in your Terraform Enterprise runs.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # HCP Vault Secrets-Backed Dynamic Credentials with the GCP Provider

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/dynamic-provider-credentials/hcp-vault-secrets-backed/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/dynamic-provider-credentials/hcp-vault-secrets-backed/index.mdx
@@ -6,6 +6,10 @@ description: >-
   Configure HCP Vault Secrets-backed dynamic credentials for supported
   providers.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # HCP Vault Secrets-Backed Dynamic Credentials

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/dynamic-provider-credentials/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/dynamic-provider-credentials/index.mdx
@@ -5,6 +5,10 @@ description: >-
   Enterprise runs. Learn how dynamic credentials for Vault, AWS, Azure,
   Kubernetes, and GCP can improve your security.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Dynamic provider credentials

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/dynamic-provider-credentials/kubernetes-configuration.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/dynamic-provider-credentials/kubernetes-configuration.mdx
@@ -6,6 +6,10 @@ description: >-
   Use OpenID Connect to get short-term credentials for the Kubernetes and Helm
   Terraform providers in your Terraform Enterprise runs.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Use dynamic credentials with the Kubernetes and Helm providers

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/dynamic-provider-credentials/manual-generation.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/dynamic-provider-credentials/manual-generation.mdx
@@ -5,6 +5,10 @@ description: >-
   safely authenticate with custom workflows and providers that do not natively
   support dynamic credentials.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Manually generate workload identity tokens

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/dynamic-provider-credentials/specifying-multiple-configurations.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/dynamic-provider-credentials/specifying-multiple-configurations.mdx
@@ -4,6 +4,10 @@ description: >-
   Specify multiple dynamic provider credential configurations for the same
   workspace to create aliases for different provider configurations.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Specify multiple dynamic credential configurations

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/aws-configuration.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/aws-configuration.mdx
@@ -6,6 +6,10 @@ description: >-
   Use OpenID Connect and Vault to get short-term credentials for the AWS
   Terraform provider in your Terraform Enterprise runs.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Use Vault-backed dynamic credentials with the AWS provider

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
@@ -6,6 +6,10 @@ description: >-
   Use OpenID Connect and Vault to get short-term credentials for the Azure
   Terraform provider in your Terraform Enterprise runs.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Use Vault-backed dynamic credentials with the Azure provider

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/gcp-configuration.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/gcp-configuration.mdx
@@ -6,6 +6,10 @@ description: >-
   Use OpenID Connect and Vault to get short-term credentials for the GCP
   Terraform provider in your Terraform Enterprise runs.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Use Vault-backed dynamic credentials with the GCP provider

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/dynamic-provider-credentials/vault-backed/index.mdx
@@ -5,6 +5,10 @@ description: >-
   credentials for Terraform Enterprise runs. Learn how Vault-backed dynamic
   credentials for AWS, Azure, and GCP can improve your security.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Use Vault-backed dynamic credentials

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/dynamic-provider-credentials/vault-configuration.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/dynamic-provider-credentials/vault-configuration.mdx
@@ -4,6 +4,10 @@ description: >-
   Use OpenID Connect to get short-term credentials for the Vault Terraform
   provider in your Terraform Enterprise runs.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Use dynamic credentials with the Vault provider

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/dynamic-provider-credentials/workload-identity-tokens.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/dynamic-provider-credentials/workload-identity-tokens.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how workload identity uses OpenID Connect (OIDC) to allow Terraform
   plans and applies to safely authenticate to external systems.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Workload identity

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/explorer.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/explorer.mdx
@@ -5,6 +5,10 @@ description: >-
   workspaces and projects in Terraform Enterprise with the explorer for
   workspace visibility.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-06T08:59:42-08:00
+# END AUTO GENERATED METADATA
 ---
 
 # Explorer for workspace visibility

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/health.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/health.mdx
@@ -5,6 +5,10 @@ description: >-
   whether their real infrastructure matches the requirements defined in your
   Terraform configuration.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Health

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/import.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/import.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how to use Terraform search to find unmanaged infrastructure and import
   it into your workspace in bulk.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:55:25Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 # Import existing resources to state

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/index.mdx
@@ -5,6 +5,10 @@ description: >-
   Enterprise. Learn what workspaces contain, how they perform Terraform runs,
   and how to create and organize them.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Workspaces

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/json-filtering.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/json-filtering.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how to filter and create custom datasets on pages that display JSON data
   in Terraform Enterprise.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # JSON data filtering

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/no-code-provisioning/module-design.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/no-code-provisioning/module-design.mdx
@@ -4,6 +4,10 @@ description: >-
   No-code ready modules let users deploy a module's resources without writing
   configuration. Learn how to prepare modules for no-code provisioning.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Design no-code ready modules

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/no-code-provisioning/provisioning.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/no-code-provisioning/provisioning.mdx
@@ -5,6 +5,10 @@ description: >-
   configuration. Learn how to provision infrastructure from a no-code ready
   module.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Provision no-code infrastructure

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/policy-enforcement/define-policies/custom-sentinel.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/policy-enforcement/define-policies/custom-sentinel.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how to use the Sentinel policy language to create policies in Terraform
   Enterprise.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Define Sentinel policies in HCP Terraform

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/policy-enforcement/define-policies/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/policy-enforcement/define-policies/index.mdx
@@ -5,6 +5,10 @@ description: >-
   Learn how to define policies for governing how Terraform provisions
   infrastructure.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Define policies overview

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/policy-enforcement/define-policies/opa.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/policy-enforcement/define-policies/opa.mdx
@@ -4,6 +4,10 @@ description: >-
   Use the Rego policy language to define Open Policy Agent (OPA) policies for
   Terraform Enterprise.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Define Open Policy Agent policies for HCP Terraform

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/policy-enforcement/import-reference/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/policy-enforcement/import-reference/index.mdx
@@ -4,6 +4,10 @@ description: >-
   Use the Sentinel import function to configure policy behaviors in custom
   Sentinel policies.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # `import` function reference overview

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/policy-enforcement/import-reference/tfconfig-v2.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/policy-enforcement/import-reference/tfconfig-v2.mdx
@@ -4,6 +4,10 @@ description: >-
   Use the tfconfig/v2 import to give Sentinel access to a Terraform
   configuration.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 -> **Note:** This is documentation for the next version of the `tfconfig`

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/policy-enforcement/import-reference/tfconfig.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/policy-enforcement/import-reference/tfconfig.mdx
@@ -2,6 +2,10 @@
 page_title: tfconfig Sentinel import
 description: Use tfconfig import to give Sentinel access to a Terraform configuration.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # tfconfig Sentinel import

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/policy-enforcement/import-reference/tfplan-v2.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/policy-enforcement/import-reference/tfplan-v2.mdx
@@ -2,6 +2,10 @@
 page_title: tfplan/v2 Sentinel import
 description: Use tfplan/v2 import to give Sentinel access to a Terraform plan.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 -> **Note:** This is documentation for the next version of the `tfplan` Sentinel

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/policy-enforcement/import-reference/tfplan.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/policy-enforcement/import-reference/tfplan.mdx
@@ -2,6 +2,10 @@
 page_title: tfplan Sentinel import reference
 description: Use the tfplan import to give Sentinel access to a Terraform plan.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # tfplan Sentinel import reference

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/policy-enforcement/import-reference/tfrun.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/policy-enforcement/import-reference/tfrun.mdx
@@ -4,6 +4,10 @@ description: >-
   Use tfrun import to give Sentinel access to data associated with a Terraform
   run.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # tfrun Sentinel import reference

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/policy-enforcement/import-reference/tfstate-v2.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/policy-enforcement/import-reference/tfstate-v2.mdx
@@ -2,6 +2,10 @@
 page_title: tfstate/v2 Sentinel import
 description: Use tfstate/v2 import to give Sentinel access to Terraform state.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 -> **Note:** This is documentation for the next version of the `tfstate`

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/policy-enforcement/import-reference/tfstate.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/policy-enforcement/import-reference/tfstate.mdx
@@ -2,6 +2,10 @@
 page_title: tfstate Sentinel import
 description: Use the tfstate import to give Sentinel access to Terraform state.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Import: tfstate

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/policy-enforcement/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/policy-enforcement/index.mdx
@@ -5,6 +5,10 @@ description: >-
   validate Terraform plans. Learn how to use Sentinel and OPA to enforce
   policies.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # HCP Terraform policy enforcement overview

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/policy-enforcement/manage-policy-sets/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/policy-enforcement/manage-policy-sets/index.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how to create and manage policies and policy sets in Terraform
   Enterprise.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 # Manage policies and policy sets in HCP Terraform

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/policy-enforcement/manage-policy-sets/opa-vcs.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/policy-enforcement/manage-policy-sets/opa-vcs.mdx
@@ -2,6 +2,10 @@
 page_title: Configure an OPA policy set with a VCS repository
 description: Use a VCS repository to configure an OPA policy set in Terraform Enterprise.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 # Configure an OPA policy set with a VCS repository

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/policy-enforcement/manage-policy-sets/sentinel-vcs.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/policy-enforcement/manage-policy-sets/sentinel-vcs.mdx
@@ -4,6 +4,10 @@ description: >-
   Use a VCS repository to configure a Sentinel policy set in Terraform
   Enterprise.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Configure a Sentinel policy set with a VCS repository

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/policy-enforcement/prewritten-library.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/policy-enforcement/prewritten-library.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn about HashiCorp's pre-written Sentinel policies for CIS, FSBP, PCI DSS,
   and NIST SP 800-53 Revision 5.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 # Pre-written policy library reference

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/policy-enforcement/prewritten-sentinel.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/policy-enforcement/prewritten-sentinel.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how to download and install pre-written Sentinel policies created and
   maintained by HashiCorp.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Run pre-written Sentinel policies

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/policy-enforcement/test-sentinel.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/policy-enforcement/test-sentinel.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how to generate mock Sentinel data to test your policies with Terraform
   Enterprise.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Generate mock Sentinel data with Terraform

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/policy-enforcement/view-results/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/policy-enforcement/view-results/index.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how to view and override policy enforcement results in Terraform
   Enterprise.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # View policy enforcement results

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/policy-enforcement/view-results/json.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/policy-enforcement/view-results/json.mdx
@@ -2,6 +2,10 @@
 page_title: View and filter Sentinel JSON data
 description: Learn how to view and filter Sentinel JSON data.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # View and filter Sentinel JSON data

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/run/api.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/run/api.mdx
@@ -4,6 +4,10 @@ description: >-
   Use Terraform Enterprise's API-driven run workflow to enable external tools to
   upload Terraform configurations and trigger new runs.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # The API-driven run workflow

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/run/cli.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/run/cli.mdx
@@ -4,6 +4,10 @@ description: >-
   Configure the Terraform CLI to trigger remote runs in Terraform Enterprise
   from your terminal.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [private]: /terraform/enterprise/registry

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/run/install-software.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/run/install-software.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how to install Terraform providers, cloud CLIs, or configuration
   management tools and software on Terraform Enterprise workers.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Install software in the run environment

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/run/manage.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/run/manage.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how to view and interact with runs in Terraform Enterprise, and how to
   unlock and lock workspaces to prevent new runs.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 # Manage and view runs

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/run/modes-and-options.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/run/modes-and-options.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn about the different run modes and options available in Terraform
   Enterprise to customize behavior during runs.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Run modes and options

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/run/remote-operations.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/run/remote-operations.mdx
@@ -4,6 +4,10 @@ description: >-
   Terraform Enterprise runs Terraform operations remotely through the UI, API,
   or CLI. Learn how HCP Terraform manages runs.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Remote operations

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/run/run-environment.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/run/run-environment.mdx
@@ -5,6 +5,10 @@ description: >-
   network access, concurrency for runs, state access authentication, and
   environment variables.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # HCP Terraform's run environment

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/run/states.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/run/states.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn the run stages of Terraform operations. Understanding run stages and
   their states can help you follow a run's progress.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Run states and stages

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/run/ui.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/run/ui.mdx
@@ -5,6 +5,10 @@ description: >-
   queue runs when merging new commits to the VCS repository branch associated
   with a workspace.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # UI and VCS-driven run workflow

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/settings/access.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/settings/access.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how to manage access to workspaces by adding teams and configuring their
   permissions.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Manage access to workspaces

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/settings/deletion.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/settings/deletion.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how to clean up resources by destroying a workspace's infrastructure and
   deleting a workspace in Terraform Enterprise.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Destroy infrastructure resources and delete workspaces

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/settings/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/settings/index.mdx
@@ -5,6 +5,10 @@ description: >-
   health, locking, policies, run triggers, SSH keys, team access, version
   control, and deletion.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 # Workspace settings

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/settings/notifications.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/settings/notifications.mdx
@@ -4,6 +4,10 @@ description: >-
   Use webhooks to notify external systems about run progress and other events in
   Terraform Enterprise. Learn to create and enable workspace notifications.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:55:25Z
+# END AUTO GENERATED METADATA
 ---
 
 # Workspace notifications

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/settings/run-tasks.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/settings/run-tasks.mdx
@@ -4,6 +4,10 @@ description: >-
   Run tasks integrate third-party tools into the run lifecycle. Learn how to
   create, delete, and associate run tasks with workspaces.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 [entitlement]: /terraform/enterprise/api-docs#feature-entitlements

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/settings/run-triggers.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/settings/run-triggers.mdx
@@ -4,6 +4,10 @@ description: >-
   Use run triggers to connect workspaces within your organization. Learn how to
   view, create, and manage run triggers.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Run triggers

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/settings/ssh-keys.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/settings/ssh-keys.mdx
@@ -4,6 +4,10 @@ description: >-
   Learn how to configure the SSH keys that Terraform uses to pull modules from
   private Git repositories. Learn to add, delete, and assign keys to workspaces.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Use SSH Keys for cloning modules

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/settings/vcs.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/settings/vcs.mdx
@@ -5,6 +5,10 @@ description: >-
   version control system (VCS) repository that contains a Terraform
   configuration.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Configure workspace VCS connections

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/state.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/state.mdx
@@ -4,6 +4,10 @@ description: >-
   Workspaces have their own separate state data. Learn how Terraform Enterprise
   uses state and how to access state from across workspaces.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Manage workspace state

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/tags.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/workspaces/tags.mdx
@@ -5,6 +5,10 @@ description: >-
   workspaces. Tagging workspaces also lets you sort and filter workspaces in the
   UI.
 source: terraform-docs-common
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-02-02T17:54:50Z
+last_modified: 2026-02-02T17:54:50Z
+# END AUTO GENERATED METADATA
 ---
 
 # Create workspace tags


### PR DESCRIPTION
### Description

This PR adds date metadata to v1.2.x of the terraform-enterprise documentation. This change should not affect the developer site as it is a change to the frontmatter. This change will help to keep our sitemap more accurate for SEO and LLMs. The date frontmatter was generated using the add-date-metadata.mjs script. To keep this information up to date, there will be a github action to handle all updates to date metadata: https://github.com/hashicorp/web-unified-docs/pull/1715.
