### PR TITLE
Improve doc to add Proxy Configuration to the Sentinel http import

### DIFF
--- a/content/sentinel/v0.40.x/content/sentinel/docs/imports/http.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/imports/http.mdx
@@ -292,6 +292,22 @@ http.without_certificate_verification().get(url)
 
 Returns true if the client requires TLS certificates to be verifiable.
 
+### Proxy Configuration
+
+The HTTP client supports routing requests through an HTTP or HTTPS proxy.
+
+Proxy settings are configured at the plugin level and apply to all requests using the client.
+
+**Global configuration** is set in a `sentinel.hcl` file:
+
+```hcl
+import "plugin" "http" {
+  config = {
+    proxy_address = "http://proxy.example.com:3128"
+  }
+}
+```
+
 ## Type: request
 
 ### request.url

--- a/content/sentinel/v0.40.x/content/sentinel/docs/imports/http.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/imports/http.mdx
@@ -298,7 +298,9 @@ The HTTP client supports routing requests through an HTTP or HTTPS proxy.
 
 Proxy settings are configured at the plugin level and apply to all requests using the client.
 
-**Global configuration** is set in a `sentinel.hcl` file:
+Configure proxy settings at the plugin level. Settings apply to all requests from the client.
+
+Configure global settings in an `sentinel.hcl` file:
 
 ```hcl
 import "plugin" "http" {

--- a/content/sentinel/v0.40.x/content/sentinel/docs/imports/http.mdx
+++ b/content/sentinel/v0.40.x/content/sentinel/docs/imports/http.mdx
@@ -292,7 +292,7 @@ http.without_certificate_verification().get(url)
 
 Returns true if the client requires TLS certificates to be verifiable.
 
-### Proxy Configuration
+### Proxy configuration
 
 The HTTP client supports routing requests through an HTTP or HTTPS proxy.
 


### PR DESCRIPTION
### What
This PR adds a new subsection titled **Proxy Configuration** to the Sentinel `http` import documentation, positioned under **Type: client** (after the `client.certificate_verification` method).

The added content documents the existing ( previously undocumented) proxy support via `sentinel.hcl` plugin configuration.

### Why
Proxy routing is supported in the `http` import for use in proxied environments (e.g., corporate networks or Terraform Cloud/Enterprise runs behind HTTP/HTTPS proxies), but it is not mentioned in the current documentation. Explicitly documenting this feature improves discoverability and helps users avoid connectivity issues in restricted networks.

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] You added redirects to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages **across all affected versions**. Refer to [Redirects](https://github.com/hashicorp/web-unified-docs/blob/main/docs/content-guide/redirects.md#example-redirects) for examples and guidance. 
- [ ] Links to related content where appropriate (e.g., CLI, language, API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
