### PR TITLE
Known issue: explorer not beta [TF-33981]

### DIFF
--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/1.2.x/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/1.2.x/index.mdx
@@ -72,6 +72,10 @@ Last required release: [v202406-1 (776)](/terraform/enterprise/releases/2024/v20
 
 Flexible Deployment Options `terraform-enterprise` container digest: amd64/linux sha256:ee07999aad4f865a71fd556be8eb8362e62a61cdf7dbdb9fd88b7057f2c527e0, arm64/linux sha256:9b0a7b502b17385a8ecd86e4959cb49ffacc915e970d513075af6b7ce8e723da
 
+## Known Issues
+
+1. (Updated 12 Feb 2026) Explorer is GA as of 1.2.0. Explorer is incorrectly identified as a beta feature in the navigation sidebar and page header.
+
 ## Deprecations
 
 1. The following Terraform Enterprise admin CLI subcommands are deprecated. HashiCorp plans to remove these commands in the next major release:


### PR DESCRIPTION
# Terraform Enterprise <!-- RELEASE_SHORT_TMPL (e.g. vYYYYMM-X) -->

- **Release Branch:** main
- **Release Slack Channel:** #proj-tfe-releases

Explorer is GA as of 1.2.0. The "Beta" badges and headers were not removed, see [JIRA](https://hashicorp.atlassian.net/browse/TF-33981).  This adds a "Known Issue" for the 1.2.0 release.

