### PR TITLE
fix: update version of changed-files in add-date-metadata to fix bug

### DIFF
--- a/.github/workflows/add-date-metadata.yml
+++ b/.github/workflows/add-date-metadata.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@dcc7a0cba800f454d79fff4b993e8c3555bcc0a8 # v45.0.7
+        uses: tj-actions/changed-files@8cba46e29c11878d930bca7870bb54394d3e8b21 # v47.0.2
         with:
           files: |
             content/**/*.mdx


### PR DESCRIPTION
### Description

This PR upgrades the version of changed-files to fix a bug with fetching github history (https://github.com/tj-actions/changed-files/issues/2546)
