### PR TITLE
HCP Terraform Docs

### DIFF
--- a/content/terraform-docs-agents/v1.24.x/docs/cloud-docs/agents/agent-pools.mdx
+++ b/content/terraform-docs-agents/v1.24.x/docs/cloud-docs/agents/agent-pools.mdx
@@ -92,7 +92,7 @@ The workspace begins using the agent for Terraform runs. Runs involving an agent
 
 <Note>
 
-Your agents must use v1.25.0 or above to execute Stack deployment runs. To learn more about agent versioning, refer to [Updates](/terraform/cloud-docs/agents/agents#updates).
+Your agents must use v1.25.2 or above to execute Stack deployment runs. To learn more about agent versioning, refer to [Updates](/terraform/cloud-docs/agents/agents#updates).
 
 </Note>
 

--- a/content/terraform-docs-agents/v1.25.x/docs/cloud-docs/agents/agent-pools.mdx
+++ b/content/terraform-docs-agents/v1.25.x/docs/cloud-docs/agents/agent-pools.mdx
@@ -94,7 +94,7 @@ The workspace begins using the agent for Terraform runs. Runs involving an agent
 
 <Note>
 
-Your agents must use v1.25.0 or above to execute Stack deployment runs. To learn more about agent versioning, refer to [Updates](/terraform/cloud-docs/agents/agents#updates).
+Your agents must use v1.25.2 or above to execute Stack deployment runs. To learn more about agent versioning, refer to [Updates](/terraform/cloud-docs/agents/agents#updates).
 
 </Note>
 

--- a/content/terraform-docs-agents/v1.26.x/docs/cloud-docs/agents/agent-pools.mdx
+++ b/content/terraform-docs-agents/v1.26.x/docs/cloud-docs/agents/agent-pools.mdx
@@ -94,7 +94,7 @@ The workspace begins using the agent for Terraform runs. Runs involving an agent
 
 <Note>
 
-Your agents must use v1.25.0 or above to execute Stack deployment runs. To learn more about agent versioning, refer to [Updates](/terraform/cloud-docs/agents/agents#updates).
+Your agents must use v1.25.2 or above to execute Stack deployment runs. To learn more about agent versioning, refer to [Updates](/terraform/cloud-docs/agents/agents#updates).
 
 </Note>
 

--- a/content/terraform-docs-agents/v1.27.x/docs/cloud-docs/agents/agent-pools.mdx
+++ b/content/terraform-docs-agents/v1.27.x/docs/cloud-docs/agents/agent-pools.mdx
@@ -94,7 +94,7 @@ The workspace begins using the agent for Terraform runs. Runs involving an agent
 
 <Note>
 
-Your agents must use v1.25.0 or above to execute Stack deployment runs. To learn more about agent versioning, refer to [Updates](/terraform/cloud-docs/agents/agents#updates).
+Your agents must use v1.25.2 or above to execute Stack deployment runs. To learn more about agent versioning, refer to [Updates](/terraform/cloud-docs/agents/agents#updates).
 
 </Note>
 

--- a/content/terraform-docs-agents/v1.28.x/docs/cloud-docs/agents/agent-pools.mdx
+++ b/content/terraform-docs-agents/v1.28.x/docs/cloud-docs/agents/agent-pools.mdx
@@ -94,7 +94,7 @@ The workspace begins using the agent for Terraform runs. Runs involving an agent
 
 <Note>
 
-Your agents must use v1.25.0 or above to execute Stack deployment runs. To learn more about agent versioning, refer to [Updates](/terraform/cloud-docs/agents/agents#updates).
+Your agents must use v1.25.2 or above to execute Stack deployment runs. To learn more about agent versioning, refer to [Updates](/terraform/cloud-docs/agents/agents#updates).
 
 </Note>
 


### PR DESCRIPTION
### What

Pages: terraform-docs-agents/VERSION/docs/cloud-docs/agents/agent-pools, for versions 1.24.x through 1.28.x.

Changed the required agent version for Stacks workloads (1.25.0 -> 1.25.2).

### Why

We are updating atlas to expect and require a minor fix that was shipped back in November 2025 with agent version 1.25.2. This change allows the agent to skip a redundant re-upload step in stack_prepare jobs if atlas chooses not to send a URL for that upload. Atlas is no longer sending that upload URL.

This is related to https://hashicorp.atlassian.net/browse/TF-33728.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] Description links to related pull requests or issues, if any.

#### Content

- [x] The Vercel website preview successfully deployed.

##### N/A
- [x] Redirects have been added to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages.
- [x] API documentation and the API Changelog have been updated.
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] New pages have metadata (page name and description) at the top.
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
