### PR TITLE
Fix a typo in the title

### DIFF
--- a/content/hcp-docs/data/docs-nav-data.json
+++ b/content/hcp-docs/data/docs-nav-data.json
@@ -617,7 +617,7 @@
             "path": "vault/reporting/secrets-inventory-reporting"
           },
           {
-            "title": "Certificate inventory reporting",
+            "title": "Certificates inventory reporting",
             "path": "vault/reporting/certificates-inventory-reporting"
           }
         ]


### PR DESCRIPTION
The title on the side-nav is missing `s`. 

This PR fixes the side-nav title from "Certificate inventory reporting" to "Certificate**s** inventory reporting"

<img width="1122" height="518" alt="image" src="https://github.com/user-attachments/assets/645cc4b1-9202-462a-aa5f-1abc307d42e6" />
