### PR TITLE
Fix longstanding errors in kmip docs re connection_timeout and cert format

### DIFF
--- a/content/vault/v1.10.x/content/api-docs/secret/kmip.mdx
+++ b/content/vault/v1.10.x/content/api-docs/secret/kmip.mdx
@@ -37,10 +37,6 @@ is enabled.
   KMIP server should listen on. Can be given as a JSON list or a
   comma-separated string list. If multiple values are given, all will be
   listened on.
-- `connection_timeout` (`int: 1 || string:"1s"`) - Duration in either an integer
-  number of seconds (10) or an integer time unit (10s) within which connections
-  must become ready.
-
 - `server_hostnames` (`list: ["localhost"] || string`) - Hostnames to include in
   the server's TLS certificate as SAN DNS names. The first will be used as the
   common name (CN).
@@ -68,7 +64,6 @@ is enabled.
 ```json
 {
   "listen_addrs": "127.0.0.1:5696,192.168.1.2:9000",
-  "connection_timeout": "1s",
   "server_hostnames": "myhostname1,myhostname2",
   "server_ips": "192.168.1.2",
   "tls_ca_key_type": "ec",
@@ -111,7 +106,6 @@ $ curl \
 {
   "data": {
     "listen_addrs": ["127.0.0.1:5696", "192.168.1.2:9000"],
-    "connection_timeout": "1s",
     "server_hostnames": ["myhostname1", "myhostname2"],
     "server_ips": ["192.168.1.2"],
     "tls_ca_key_type": "ec",
@@ -415,7 +409,7 @@ if entropy augmentation is enabled.
 
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 
 ### Sample Request
@@ -457,7 +451,7 @@ The key type and key bits used in the CSR must match those of the role.
 
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 - `csr` (`string`) - CSR in PEM format.
 
@@ -500,7 +494,7 @@ at generation time.
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
 - `serial_number` (`string: <required>`) - Serial number of certificate to revoke.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 
 ### Sample Request

--- a/content/vault/v1.11.x/content/api-docs/secret/kmip.mdx
+++ b/content/vault/v1.11.x/content/api-docs/secret/kmip.mdx
@@ -39,10 +39,6 @@ is enabled.
   KMIP server should listen on. Can be given as a JSON list or a
   comma-separated string list. If multiple values are given, all will be
   listened on.
-- `connection_timeout` (`int: 1 || string:"1s"`) - Duration in either an integer
-  number of seconds (10) or an integer time unit (10s) within which connections
-  must become ready.
-
 - `server_hostnames` (`list: ["localhost"] || string`) - Hostnames to include in
   the server's TLS certificate as SAN DNS names. The first will be used as the
   common name (CN).
@@ -70,7 +66,6 @@ is enabled.
 ```json
 {
   "listen_addrs": "127.0.0.1:5696,192.168.1.2:9000",
-  "connection_timeout": "1s",
   "server_hostnames": "myhostname1,myhostname2",
   "server_ips": "192.168.1.2",
   "tls_ca_key_type": "ec",
@@ -113,7 +108,6 @@ $ curl \
 {
   "data": {
     "listen_addrs": ["127.0.0.1:5696", "192.168.1.2:9000"],
-    "connection_timeout": "1s",
     "server_hostnames": ["myhostname1", "myhostname2"],
     "server_ips": ["192.168.1.2"],
     "tls_ca_key_type": "ec",
@@ -433,7 +427,7 @@ if entropy augmentation is enabled.
 
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 
 ### Sample request
@@ -475,7 +469,7 @@ The key type and key bits used in the CSR must match those of the role.
 
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 - `csr` (`string`) - CSR in PEM format.
 
@@ -518,7 +512,7 @@ at generation time.
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
 - `serial_number` (`string: <required>`) - Serial number of certificate to revoke.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 
 ### Sample request

--- a/content/vault/v1.12.x/content/api-docs/secret/kmip.mdx
+++ b/content/vault/v1.12.x/content/api-docs/secret/kmip.mdx
@@ -39,10 +39,6 @@ is enabled.
   KMIP server should listen on. Can be given as a JSON list or a
   comma-separated string list. If multiple values are given, all will be
   listened on.
-- `connection_timeout` (`int: 1 || string:"1s"`) - Duration in either an integer
-  number of seconds (10) or an integer time unit (10s) within which connections
-  must become ready.
-
 - `server_hostnames` (`list: ["localhost"] || string`) - Hostnames to include in
   the server's TLS certificate as SAN DNS names. The first will be used as the
   common name (CN).
@@ -70,7 +66,6 @@ is enabled.
 ```json
 {
   "listen_addrs": "127.0.0.1:5696,192.168.1.2:9000",
-  "connection_timeout": "1s",
   "server_hostnames": "myhostname1,myhostname2",
   "server_ips": "192.168.1.2",
   "tls_ca_key_type": "ec",
@@ -113,7 +108,6 @@ $ curl \
 {
   "data": {
     "listen_addrs": ["127.0.0.1:5696", "192.168.1.2:9000"],
-    "connection_timeout": "1s",
     "server_hostnames": ["myhostname1", "myhostname2"],
     "server_ips": ["192.168.1.2"],
     "tls_ca_key_type": "ec",
@@ -433,7 +427,7 @@ if entropy augmentation is enabled.
 
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 
 ### Sample request
@@ -475,7 +469,7 @@ The key type and key bits used in the CSR must match those of the role.
 
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 - `csr` (`string`) - CSR in PEM format.
 
@@ -518,7 +512,7 @@ at generation time.
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
 - `serial_number` (`string: <required>`) - Serial number of certificate to revoke.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 
 ### Sample request

--- a/content/vault/v1.13.x/content/api-docs/secret/kmip.mdx
+++ b/content/vault/v1.13.x/content/api-docs/secret/kmip.mdx
@@ -39,10 +39,6 @@ is enabled.
   KMIP server should listen on. Can be given as a JSON list or a
   comma-separated string list. If multiple values are given, all will be
   listened on.
-- `connection_timeout` (`int: 1 || string:"1s"`) - Duration in either an integer
-  number of seconds (10) or an integer time unit (10s) within which connections
-  must become ready.
-
 - `server_hostnames` (`list: ["localhost"] || string`) - Hostnames to include in
   the server's TLS certificate as SAN DNS names. The first will be used as the
   common name (CN).
@@ -70,7 +66,6 @@ is enabled.
 ```json
 {
   "listen_addrs": "127.0.0.1:5696,192.168.1.2:9000",
-  "connection_timeout": "1s",
   "server_hostnames": "myhostname1,myhostname2",
   "server_ips": "192.168.1.2",
   "tls_ca_key_type": "ec",
@@ -113,7 +108,6 @@ $ curl \
 {
   "data": {
     "listen_addrs": ["127.0.0.1:5696", "192.168.1.2:9000"],
-    "connection_timeout": "1s",
     "server_hostnames": ["myhostname1", "myhostname2"],
     "server_ips": ["192.168.1.2"],
     "tls_ca_key_type": "ec",
@@ -433,7 +427,7 @@ if entropy augmentation is enabled.
 
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 
 ### Sample request
@@ -475,7 +469,7 @@ The key type and key bits used in the CSR must match those of the role.
 
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 - `csr` (`string`) - CSR in PEM format.
 
@@ -518,7 +512,7 @@ at generation time.
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
 - `serial_number` (`string: <required>`) - Serial number of certificate to revoke.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 
 ### Sample request

--- a/content/vault/v1.14.x/content/api-docs/secret/kmip.mdx
+++ b/content/vault/v1.14.x/content/api-docs/secret/kmip.mdx
@@ -39,10 +39,6 @@ is enabled.
   KMIP server should listen on. Can be given as a JSON list or a
   comma-separated string list. If multiple values are given, all will be
   listened on.
-- `connection_timeout` (`int: 1 || string:"1s"`) - Duration in either an integer
-  number of seconds (10) or an integer time unit (10s) within which connections
-  must become ready.
-
 - `server_hostnames` (`list: ["localhost"] || string`) - Hostnames to include in
   the server's TLS certificate as SAN DNS names. The first will be used as the
   common name (CN).
@@ -70,7 +66,6 @@ is enabled.
 ```json
 {
   "listen_addrs": "127.0.0.1:5696,192.168.1.2:9000",
-  "connection_timeout": "1s",
   "server_hostnames": "myhostname1,myhostname2",
   "server_ips": "192.168.1.2",
   "tls_ca_key_type": "ec",
@@ -113,7 +108,6 @@ $ curl \
 {
   "data": {
     "listen_addrs": ["127.0.0.1:5696", "192.168.1.2:9000"],
-    "connection_timeout": "1s",
     "server_hostnames": ["myhostname1", "myhostname2"],
     "server_ips": ["192.168.1.2"],
     "tls_ca_key_type": "ec",
@@ -433,7 +427,7 @@ if entropy augmentation is enabled.
 
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 
 ### Sample request
@@ -475,7 +469,7 @@ The key type and key bits used in the CSR must match those of the role.
 
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 - `csr` (`string`) - CSR in PEM format.
 
@@ -518,7 +512,7 @@ at generation time.
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
 - `serial_number` (`string: <required>`) - Serial number of certificate to revoke.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 
 ### Sample request

--- a/content/vault/v1.15.x/content/api-docs/secret/kmip.mdx
+++ b/content/vault/v1.15.x/content/api-docs/secret/kmip.mdx
@@ -39,10 +39,6 @@ is enabled.
   KMIP server should listen on. Can be given as a JSON list or a
   comma-separated string list. If multiple values are given, all will be
   listened on.
-- `connection_timeout` (`int: 1 || string:"1s"`) - Duration in either an integer
-  number of seconds (10) or an integer time unit (10s) within which connections
-  must become ready.
-
 - `server_hostnames` (`list: ["localhost"] || string`) - Hostnames to include in
   the server's TLS certificate as SAN DNS names. The first will be used as the
   common name (CN).
@@ -70,7 +66,6 @@ is enabled.
 ```json
 {
   "listen_addrs": "127.0.0.1:5696,192.168.1.2:9000",
-  "connection_timeout": "1s",
   "server_hostnames": "myhostname1,myhostname2",
   "server_ips": "192.168.1.2",
   "tls_ca_key_type": "ec",
@@ -113,7 +108,6 @@ $ curl \
 {
   "data": {
     "listen_addrs": ["127.0.0.1:5696", "192.168.1.2:9000"],
-    "connection_timeout": "1s",
     "server_hostnames": ["myhostname1", "myhostname2"],
     "server_ips": ["192.168.1.2"],
     "tls_ca_key_type": "ec",
@@ -433,7 +427,7 @@ if entropy augmentation is enabled.
 
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 
 ### Sample request
@@ -475,7 +469,7 @@ The key type and key bits used in the CSR must match those of the role.
 
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 - `csr` (`string`) - CSR in PEM format.
 
@@ -518,7 +512,7 @@ at generation time.
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
 - `serial_number` (`string: <required>`) - Serial number of certificate to revoke.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 
 ### Sample request

--- a/content/vault/v1.16.x/content/api-docs/secret/kmip.mdx
+++ b/content/vault/v1.16.x/content/api-docs/secret/kmip.mdx
@@ -39,10 +39,6 @@ is enabled.
   KMIP server should listen on. Can be given as a JSON list or a
   comma-separated string list. If multiple values are given, all will be
   listened on.
-- `connection_timeout` (`int: 1 || string:"1s"`) - Duration in either an integer
-  number of seconds (10) or an integer time unit (10s) within which connections
-  must become ready.
-
 - `server_hostnames` (`list: ["localhost"] || string`) - Hostnames to include in
   the server's TLS certificate as SAN DNS names. The first will be used as the
   common name (CN).
@@ -70,7 +66,6 @@ is enabled.
 ```json
 {
   "listen_addrs": "127.0.0.1:5696,192.168.1.2:9000",
-  "connection_timeout": "1s",
   "server_hostnames": "myhostname1,myhostname2",
   "server_ips": "192.168.1.2",
   "tls_ca_key_type": "ec",
@@ -113,7 +108,6 @@ $ curl \
 {
   "data": {
     "listen_addrs": ["127.0.0.1:5696", "192.168.1.2:9000"],
-    "connection_timeout": "1s",
     "server_hostnames": ["myhostname1", "myhostname2"],
     "server_ips": ["192.168.1.2"],
     "tls_ca_key_type": "ec",
@@ -433,7 +427,7 @@ if entropy augmentation is enabled.
 
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 
 ### Sample request
@@ -475,7 +469,7 @@ The key type and key bits used in the CSR must match those of the role.
 
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 - `csr` (`string`) - CSR in PEM format.
 
@@ -518,7 +512,7 @@ at generation time.
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
 - `serial_number` (`string: <required>`) - Serial number of certificate to revoke.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 
 ### Sample request

--- a/content/vault/v1.17.x/content/api-docs/secret/kmip.mdx
+++ b/content/vault/v1.17.x/content/api-docs/secret/kmip.mdx
@@ -39,10 +39,6 @@ is enabled.
   KMIP server should listen on. Can be given as a JSON list or a
   comma-separated string list. If multiple values are given, all will be
   listened on.
-- `connection_timeout` (`int: 1 || string:"1s"`) - Duration in either an integer
-  number of seconds (10) or an integer time unit (10s) within which connections
-  must become ready.
-
 - `server_hostnames` (`list: ["localhost"] || string`) - Hostnames to include in
   the server's TLS certificate as SAN DNS names. The first will be used as the
   common name (CN).
@@ -70,7 +66,6 @@ is enabled.
 ```json
 {
   "listen_addrs": "127.0.0.1:5696,192.168.1.2:9000",
-  "connection_timeout": "1s",
   "server_hostnames": "myhostname1,myhostname2",
   "server_ips": "192.168.1.2",
   "tls_ca_key_type": "ec",
@@ -113,7 +108,6 @@ $ curl \
 {
   "data": {
     "listen_addrs": ["127.0.0.1:5696", "192.168.1.2:9000"],
-    "connection_timeout": "1s",
     "server_hostnames": ["myhostname1", "myhostname2"],
     "server_ips": ["192.168.1.2"],
     "tls_ca_key_type": "ec",
@@ -433,7 +427,7 @@ if entropy augmentation is enabled.
 
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 
 ### Sample request
@@ -475,7 +469,7 @@ The key type and key bits used in the CSR must match those of the role.
 
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 - `csr` (`string`) - CSR in PEM format.
 
@@ -518,7 +512,7 @@ at generation time.
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
 - `serial_number` (`string: <required>`) - Serial number of certificate to revoke.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 
 ### Sample request

--- a/content/vault/v1.18.x/content/api-docs/secret/kmip.mdx
+++ b/content/vault/v1.18.x/content/api-docs/secret/kmip.mdx
@@ -39,10 +39,6 @@ is enabled.
   KMIP server should listen on. Can be given as a JSON list or a
   comma-separated string list. If multiple values are given, all will be
   listened on.
-- `connection_timeout` (`int: 1 || string:"1s"`) - Duration in either an integer
-  number of seconds (10) or an integer time unit (10s) within which connections
-  must become ready.
-
 - `server_hostnames` (`list: ["localhost"] || string`) - Hostnames to include in
   the server's TLS certificate as SAN DNS names. The first will be used as the
   common name (CN).
@@ -70,7 +66,6 @@ is enabled.
 ```json
 {
   "listen_addrs": "127.0.0.1:5696,192.168.1.2:9000",
-  "connection_timeout": "1s",
   "server_hostnames": "myhostname1,myhostname2",
   "server_ips": "192.168.1.2",
   "tls_ca_key_type": "ec",
@@ -113,7 +108,6 @@ $ curl \
 {
   "data": {
     "listen_addrs": ["127.0.0.1:5696", "192.168.1.2:9000"],
-    "connection_timeout": "1s",
     "server_hostnames": ["myhostname1", "myhostname2"],
     "server_ips": ["192.168.1.2"],
     "tls_ca_key_type": "ec",
@@ -433,7 +427,7 @@ if entropy augmentation is enabled.
 
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 
 ### Sample request
@@ -475,7 +469,7 @@ The key type and key bits used in the CSR must match those of the role.
 
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 - `csr` (`string`) - CSR in PEM format.
 
@@ -518,7 +512,7 @@ at generation time.
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
 - `serial_number` (`string: <required>`) - Serial number of certificate to revoke.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 
 ### Sample request

--- a/content/vault/v1.19.x/content/api-docs/secret/kmip.mdx
+++ b/content/vault/v1.19.x/content/api-docs/secret/kmip.mdx
@@ -39,10 +39,6 @@ is enabled.
   KMIP server should listen on. Can be given as a JSON list or a
   comma-separated string list. If multiple values are given, all will be
   listened on.
-- `connection_timeout` (`int: 1 || string:"1s"`) - Duration in either an integer
-  number of seconds (10) or an integer time unit (10s) within which connections
-  must become ready.
-
 - `server_hostnames` (`list: ["localhost"] || string`) - Hostnames to include in
   the server's TLS certificate as SAN DNS names. The first will be used as the
   common name (CN).
@@ -70,7 +66,6 @@ is enabled.
 ```json
 {
   "listen_addrs": "127.0.0.1:5696,192.168.1.2:9000",
-  "connection_timeout": "1s",
   "server_hostnames": "myhostname1,myhostname2",
   "server_ips": "192.168.1.2",
   "tls_ca_key_type": "ec",
@@ -113,7 +108,6 @@ $ curl \
 {
   "data": {
     "listen_addrs": ["127.0.0.1:5696", "192.168.1.2:9000"],
-    "connection_timeout": "1s",
     "server_hostnames": ["myhostname1", "myhostname2"],
     "server_ips": ["192.168.1.2"],
     "tls_ca_key_type": "ec",
@@ -433,7 +427,7 @@ if entropy augmentation is enabled.
 
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 
 ### Sample request
@@ -475,7 +469,7 @@ The key type and key bits used in the CSR must match those of the role.
 
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 - `csr` (`string`) - CSR in PEM format.
 
@@ -518,7 +512,7 @@ at generation time.
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
 - `serial_number` (`string: <required>`) - Serial number of certificate to revoke.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 
 ### Sample request

--- a/content/vault/v1.20.x/content/api-docs/secret/kmip.mdx
+++ b/content/vault/v1.20.x/content/api-docs/secret/kmip.mdx
@@ -39,10 +39,6 @@ is enabled.
   KMIP server should listen on. Can be given as a JSON list or a
   comma-separated string list. If multiple values are given, all will be
   listened on.
-- `connection_timeout` (`int: 1 || string:"1s"`) - Duration in either an integer
-  number of seconds (10) or an integer time unit (10s) within which connections
-  must become ready.
-
 - `server_hostnames` (`list: ["localhost"] || string`) - Hostnames to include in
   the server's TLS certificate as SAN DNS names. The first will be used as the
   common name (CN).
@@ -70,7 +66,6 @@ is enabled.
 ```json
 {
   "listen_addrs": "127.0.0.1:5696,192.168.1.2:9000",
-  "connection_timeout": "1s",
   "server_hostnames": "myhostname1,myhostname2",
   "server_ips": "192.168.1.2",
   "tls_ca_key_type": "ec",
@@ -113,7 +108,6 @@ $ curl \
 {
   "data": {
     "listen_addrs": ["127.0.0.1:5696", "192.168.1.2:9000"],
-    "connection_timeout": "1s",
     "server_hostnames": ["myhostname1", "myhostname2"],
     "server_ips": ["192.168.1.2"],
     "tls_ca_key_type": "ec",
@@ -433,7 +427,7 @@ if entropy augmentation is enabled.
 
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 
 ### Sample request
@@ -475,7 +469,7 @@ The key type and key bits used in the CSR must match those of the role.
 
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 - `csr` (`string`) - CSR in PEM format.
 
@@ -518,7 +512,7 @@ at generation time.
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
 - `serial_number` (`string: <required>`) - Serial number of certificate to revoke.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 
 ### Sample request

--- a/content/vault/v1.21.x/content/api-docs/secret/kmip.mdx
+++ b/content/vault/v1.21.x/content/api-docs/secret/kmip.mdx
@@ -39,10 +39,6 @@ is enabled.
   KMIP server should listen on. Can be given as a JSON list or a
   comma-separated string list. If multiple values are given, all will be
   listened on.
-- `connection_timeout` (`int: 1 || string:"1s"`) - Duration in either an integer
-  number of seconds (10) or an integer time unit (10s) within which connections
-  must become ready.
-
 - `server_hostnames` (`list: ["localhost"] || string`) - Hostnames to include in
   the server's TLS certificate as SAN DNS names. The first will be used as the
   common name (CN).
@@ -70,7 +66,6 @@ is enabled.
 ```json
 {
   "listen_addrs": "127.0.0.1:5696,192.168.1.2:9000",
-  "connection_timeout": "1s",
   "server_hostnames": "myhostname1,myhostname2",
   "server_ips": "192.168.1.2",
   "tls_ca_key_type": "ec",
@@ -113,7 +108,6 @@ $ curl \
 {
   "data": {
     "listen_addrs": ["127.0.0.1:5696", "192.168.1.2:9000"],
-    "connection_timeout": "1s",
     "server_hostnames": ["myhostname1", "myhostname2"],
     "server_ips": ["192.168.1.2"],
     "tls_ca_key_type": "ec",
@@ -433,7 +427,7 @@ if entropy augmentation is enabled.
 
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 
 ### Sample request
@@ -475,7 +469,7 @@ The key type and key bits used in the CSR must match those of the role.
 
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 - `csr` (`string`) - CSR in PEM format.
 
@@ -518,7 +512,7 @@ at generation time.
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
 - `serial_number` (`string: <required>`) - Serial number of certificate to revoke.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 
 ### Sample request

--- a/content/vault/v1.7.x/content/api-docs/secret/kmip.mdx
+++ b/content/vault/v1.7.x/content/api-docs/secret/kmip.mdx
@@ -38,10 +38,6 @@ is enabled.
   KMIP server should listen on. Can be given as a JSON list or a
   comma-separated string list. If multiple values are given, all will be
   listened on.
-- `connection_timeout` (`int: 1 || string:"1s"`) - Duration in either an integer
-  number of seconds (10) or an integer time unit (10s) within which connections
-  must become ready.
-
 - `server_hostnames` (`list: ["localhost"] || string`) - Hostnames to include in
   the server's TLS certificate as SAN DNS names. The first will be used as the
   common name (CN).
@@ -69,7 +65,6 @@ is enabled.
 ```json
 {
   "listen_addrs": "127.0.0.1:5696,192.168.1.2:9000",
-  "connection_timeout": "1s",
   "server_hostnames": "myhostname1,myhostname2",
   "server_ips": "192.168.1.2",
   "tls_ca_key_type": "ec",
@@ -112,7 +107,6 @@ $ curl \
 {
   "data": {
     "listen_addrs": ["127.0.0.1:5696", "192.168.1.2:9000"],
-    "connection_timeout": "1s",
     "server_hostnames": ["myhostname1", "myhostname2"],
     "server_ips": ["192.168.1.2"],
     "tls_ca_key_type": "ec",
@@ -416,7 +410,7 @@ if entropy augmentation is enabled.
 
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 
 ### Sample Request
@@ -458,7 +452,7 @@ The key type and key bits used in the CSR must match those of the role.
 
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 - `csr` (`string`) - CSR in PEM format.
 
@@ -501,7 +495,7 @@ at generation time.
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
 - `serial_number` (`string: <required>`) - Serial number of certificate to revoke.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 
 ### Sample Request

--- a/content/vault/v1.8.x/content/api-docs/secret/kmip.mdx
+++ b/content/vault/v1.8.x/content/api-docs/secret/kmip.mdx
@@ -37,10 +37,6 @@ is enabled.
   KMIP server should listen on. Can be given as a JSON list or a
   comma-separated string list. If multiple values are given, all will be
   listened on.
-- `connection_timeout` (`int: 1 || string:"1s"`) - Duration in either an integer
-  number of seconds (10) or an integer time unit (10s) within which connections
-  must become ready.
-
 - `server_hostnames` (`list: ["localhost"] || string`) - Hostnames to include in
   the server's TLS certificate as SAN DNS names. The first will be used as the
   common name (CN).
@@ -68,7 +64,6 @@ is enabled.
 ```json
 {
   "listen_addrs": "127.0.0.1:5696,192.168.1.2:9000",
-  "connection_timeout": "1s",
   "server_hostnames": "myhostname1,myhostname2",
   "server_ips": "192.168.1.2",
   "tls_ca_key_type": "ec",
@@ -111,7 +106,6 @@ $ curl \
 {
   "data": {
     "listen_addrs": ["127.0.0.1:5696", "192.168.1.2:9000"],
-    "connection_timeout": "1s",
     "server_hostnames": ["myhostname1", "myhostname2"],
     "server_ips": ["192.168.1.2"],
     "tls_ca_key_type": "ec",
@@ -415,7 +409,7 @@ if entropy augmentation is enabled.
 
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 
 ### Sample Request
@@ -457,7 +451,7 @@ The key type and key bits used in the CSR must match those of the role.
 
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 - `csr` (`string`) - CSR in PEM format.
 
@@ -500,7 +494,7 @@ at generation time.
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
 - `serial_number` (`string: <required>`) - Serial number of certificate to revoke.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 
 ### Sample Request

--- a/content/vault/v1.9.x/content/api-docs/secret/kmip.mdx
+++ b/content/vault/v1.9.x/content/api-docs/secret/kmip.mdx
@@ -37,10 +37,6 @@ is enabled.
   KMIP server should listen on. Can be given as a JSON list or a
   comma-separated string list. If multiple values are given, all will be
   listened on.
-- `connection_timeout` (`int: 1 || string:"1s"`) - Duration in either an integer
-  number of seconds (10) or an integer time unit (10s) within which connections
-  must become ready.
-
 - `server_hostnames` (`list: ["localhost"] || string`) - Hostnames to include in
   the server's TLS certificate as SAN DNS names. The first will be used as the
   common name (CN).
@@ -68,7 +64,6 @@ is enabled.
 ```json
 {
   "listen_addrs": "127.0.0.1:5696,192.168.1.2:9000",
-  "connection_timeout": "1s",
   "server_hostnames": "myhostname1,myhostname2",
   "server_ips": "192.168.1.2",
   "tls_ca_key_type": "ec",
@@ -111,7 +106,6 @@ $ curl \
 {
   "data": {
     "listen_addrs": ["127.0.0.1:5696", "192.168.1.2:9000"],
-    "connection_timeout": "1s",
     "server_hostnames": ["myhostname1", "myhostname2"],
     "server_ips": ["192.168.1.2"],
     "tls_ca_key_type": "ec",
@@ -415,7 +409,7 @@ if entropy augmentation is enabled.
 
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 
 ### Sample Request
@@ -457,7 +451,7 @@ The key type and key bits used in the CSR must match those of the role.
 
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 - `csr` (`string`) - CSR in PEM format.
 
@@ -500,7 +494,7 @@ at generation time.
 - `scope` (`string: <required>`) - Name of scope. This is part of the request URL.
 - `role` (`string: <required>`) - Name of role. This is part of the request URL.
 - `serial_number` (`string: <required>`) - Serial number of certificate to revoke.
-- `format` (`string: "pem"`) - Format to return the certificate, private key,
+- `format` (`string: "pem_bundle"`) - Format to return the certificate, private key,
   and CA chain in. One of `pem`, `pem_bundle`, or `der`.
 
 ### Sample Request


### PR DESCRIPTION
connection_timeout was removed prior to the first kmip release, and the default format for cert data was also changed from pem to pem_bundle.

Please go to the `Preview` tab and select the appropriate template:

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
