### PR TITLE
remove value arg

### DIFF
--- a/content/terraform/v1.12.x/docs/language/block/variable.mdx
+++ b/content/terraform/v1.12.x/docs/language/block/variable.mdx
@@ -2,8 +2,8 @@
 page_title: variable block reference for the Terraform configuration language
 description: Use variables to parameterize your configuration, making your modules dynamic, reusable, and flexible by intaking values at run time.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2023-01-01T00:00:00.000Z
-last_modified: 2023-01-01T00:00:00.000Z
+created_at: 2025-09-05T15:51:39-04:00
+last_modified: 2026-02-18T17:48:10.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -144,8 +144,6 @@ The `validation` block lets you enforce that a variable value meets your specifi
 
 ```hcl
 variable "unique_name" {
-  value  = <expression-to-evaluate>
-
   validation {
     condition     = <expression-to-verify>
     error_message = "<error message string>"

--- a/content/terraform/v1.13.x/docs/language/block/variable.mdx
+++ b/content/terraform/v1.13.x/docs/language/block/variable.mdx
@@ -3,7 +3,7 @@ page_title: variable block reference for the Terraform configuration language
 description: Use variables to parameterize your configuration, making your modules dynamic, reusable, and flexible by intaking values at run time.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-09-05T15:51:39-04:00
-last_modified: 2025-11-17T12:04:37-08:00
+last_modified: 2026-02-18T17:48:11.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -144,8 +144,6 @@ The `validation` block lets you enforce that a variable value meets your specifi
 
 ```hcl
 variable "unique_name" {
-  value  = <expression-to-evaluate>
-
   validation {
     condition     = <expression-to-verify>
     error_message = "<error message string>"

--- a/content/terraform/v1.14.x/docs/language/block/variable.mdx
+++ b/content/terraform/v1.14.x/docs/language/block/variable.mdx
@@ -3,7 +3,7 @@ page_title: variable block reference for the Terraform configuration language
 description: Use variables to parameterize your configuration, making your modules dynamic, reusable, and flexible by intaking values at run time.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-11-19T13:27:46Z
-last_modified: 2025-12-03T16:22:47-08:00
+last_modified: 2026-02-18T17:48:12.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -142,8 +142,6 @@ The `validation` block lets you enforce that a variable value meets your specifi
 
 ```hcl
 variable "unique_name" {
-  value  = <expression-to-evaluate>
-
   validation {
     condition     = <expression-to-verify>
     error_message = "<error message string>"

--- a/content/terraform/v1.15.x (alpha)/docs/language/block/variable.mdx
+++ b/content/terraform/v1.15.x (alpha)/docs/language/block/variable.mdx
@@ -3,7 +3,7 @@ page_title: variable block reference for the Terraform configuration language
 description: Use variables to parameterize your configuration, making your modules dynamic, reusable, and flexible by intaking values at run time.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-11-19T19:11:19Z
-last_modified: 2025-11-19T19:11:19Z
+last_modified: 2026-02-18T17:48:12.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -144,8 +144,6 @@ The `validation` block lets you enforce that a variable value meets your specifi
 
 ```hcl
 variable "unique_name" {
-  value  = <expression-to-evaluate>
-
   validation {
     condition     = <expression-to-verify>
     error_message = "<error message string>"


### PR DESCRIPTION
The `variable` block does not support the `value` argument. This PR removes the `value` argument from an example on the `variable` reference page. 
