### PR TITLE
Consul duration formatting validation examples

### DIFF
--- a/content/consul/v1.22.x/content/docs/reference/agent/configuration-file/index.mdx
+++ b/content/consul/v1.22.x/content/docs/reference/agent/configuration-file/index.mdx
@@ -5,7 +5,7 @@ description: >-
   This section contains reference information for individual agent configuration files. Configure multiple agents at once. Assign attributes to agents. Learn about agent configuration file parameters and formatting. Review example configuration.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-11-05T11:02:51-05:00
-last_modified: 2025-11-05T11:02:51-05:00
+last_modified: 2026-02-19T23:00:04.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -71,7 +71,7 @@ telemetry {
 
 </CodeTabs>
 
-### Time-to-live values
+## Time-to-live values
 
 Consul uses the Go `time` package to parse all time-to-live (TTL) values used in Consul agent configuration files. Specify integer and float values as a string and include one or more of the following units of time:
 
@@ -90,6 +90,27 @@ Examples:
 - `'2h45m'`
 
 Refer to the [formatting specification](https://golang.org/pkg/time/#ParseDuration) for additional information.
+
+## Duration formatting validation
+
+When you configure timeout and duration values, Consul validates the formatting and enforces minimum values where applicable. When you use invalid duration strings, the agent will fail to start and the output will include a descriptive error message.
+
+**Examples of valid duration formatting**:
+
+- `"10s"` - 10 seconds
+- `"1.5m"` - 1.5 minutes, equivalent to 90 seconds (`90s`)
+- `"2h30m45s"` - Complex duration with hours, minutes, and seconds
+- `"0s"` - Zero duration, although not all fields support this value.
+
+**Examples of invalid formatting that produce errors**:
+
+- `"10"` - Missing unit specification
+- `"10x"` - Invalid unit, as `x` is not a recognized duration
+- `""` - Empty string
+- `"abc"` - Non-numeric string
+- `"-5s"` - Negative durations are not accepted for timeout configurations
+
+Some timeout configurations enforce minimum values to prevent connection issues or security vulnerabilities. For example, handshake timeouts typically require a minimum of 1 second. When a configured value is below the minimum, Consul reports a validation error during startup.
 
 ## Examples
 


### PR DESCRIPTION
## Description

Ports https://github.com/hashicorp/consul/pull/22739 to the web-unified docs.

[Preview link](https://unified-docs-frontend-preview-a4nk8p4f1-hashicorp.vercel.app/consul/docs/reference/agent/configuration-file#duration-formatting-validation)