### PR TITLE
Introducing WIF in Secret Sync for AWS Destination

### DIFF
--- a/content/vault/v2.x (rc)/content/api-docs/system/secrets-sync.mdx
+++ b/content/vault/v2.x (rc)/content/api-docs/system/secrets-sync.mdx
@@ -262,7 +262,7 @@ authentication fallbacks on the AWS credentials provider chain and tries to infe
 
 - `role_arn` `(string: "")` - Specifies a role to assume when connecting to AWS. When assuming a role, Vault uses temporary
 STS credentials to authenticate. An initial session with the proper trust relationship must exist for Vault to be able to
-assume this role. The role can be in a different account. Must be provided with `identity_token_audience` for WIF authentication.
+assume the provided role. The role can be in a different account. Must be provided with `identity_token_audience` for WIF authentication.
 
 - `external_id` `(string: "")` - Optional extra protection that must match the trust policy granting access to the AWS IAM
 role ARN. We recommend using a different random UUID per destination.

--- a/content/vault/v2.x (rc)/content/docs/sync/awssm.mdx
+++ b/content/vault/v2.x (rc)/content/docs/sync/awssm.mdx
@@ -25,7 +25,7 @@ Prerequisites:
 ## Setup
 
 1. Navigate to the [AWS Identity and Access Management (IAM) console](https://us-east-1.console.aws.amazon.com/iamv2/home#/home)
-  to configure an IAM user or role with access to the Secrets Manager. The following is an example policy outlining the required
+  to configure an IAM user or role with access to the Secrets Manager. The following example policy outlines the required
   permissions to use secrets syncing.
 
   ```json
@@ -72,7 +72,7 @@ Prerequisites:
 
 	</CodeBlockConfig>
 
-   [Workload identity federation (WIF)](#workload-identity-federation-wif) authentication: Configure a trust relationship
+   **Workload identity federation (WIF) authentication**: Configure a trust relationship
      between Vault and AWS. Use WIF to eliminate the need to manage long-lived
      access keys.
 
@@ -174,13 +174,13 @@ the secret or the association in Vault will delete the secret in your AWS accoun
 
 
 The AWS Secrets Manager sync destination supports the WIF workflow, and has a source of identity called
-an identity token. The identity token is a JWT that is internally signed by Vault's
+an identity token. The identity token is a JWT that Vault signs internally using the
 [secrets sync identity token issuer](/vault/api-docs/secret/identity/tokens#read-openid-configuration-for-secret-sync-identity-token-issuer).
 
-If there is a trust relationship configured between Vault and AWS through
-[workload identity federation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc.html),
-the sync destination can exchange its identity token for short-lived STS credentials needed to
-perform its actions.
+The sync destination can exchange identity tokens for short-lived STS credentials
+needed to perform the requested actions as long as you have configured a trust
+relationship between Vault and AWS using
+[workload identity federation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc.html)
 
 Exchanging identity tokens for STS credentials lets the AWS Secrets Manager sync destination
 operate without configuring explicit access to sensitive IAM security
@@ -209,7 +209,7 @@ To configure the sync destination to use WIF:
 1. Create a [web identity role](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-idp_oidc.html#idp_oidc_Create)
    in AWS with the same audience used for your IAM OIDC identity provider.
 
-   - The subject identifier **must** match the unique `sub` claim issued by identity tokens and have the form `secrets-sync:<NAMESPACE_PATH>:<STORE_TYPE>:<STORE_NAME>`.
+   - The subject identifier **must** match the unique `sub` claim issued by identity tokens and have the form `secrets-sync:<namespace_path>:<store_type>:<store_name>`.
 
    - Attach the IAM policy granting the required Secrets Manager permissions
      to the web identity role, as shown in the [Setup](#setup) section.


### PR DESCRIPTION
Updates the AWS Secrets Manager Secrets Sync destination documentation to incorporate the new Workload Identity Federation (WIF) support. This includes adding the new WIF fields (identity_token_audience, identity_token_ttl, identity_token_key), updating sample requests/responses, revising CLI examples, and updating the corresponding API documentation to reflect these changes.

Jira: https://hashicorp.atlassian.net/browse/VAULT-41615

Related RFC: [Vault_Secrets_Sync_WIF_Support.docx](https://ibm.sharepoint.com/:w:/r/sites/hermes/_layouts/15/Doc.aspx?sourcedoc=%7B173AFEB8-E39D-44D6-B7D9-452EE7404B35%7D&file=VLT-383_-_Vault_Secrets_Sync_WIF_Support.docx&action=default&mobileredirect=true) 

This PR is dependent on [PR #1816 ](https://github.com/hashicorp/web-unified-docs/pull/1816)



Please go to the `Preview` tab and select the appropriate template:

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
