### PR TITLE
Fix syntax error in List function diagnostics

### DIFF
--- a/content/terraform-plugin-framework/v1.16.x/docs/plugin/framework/list-resources/list.mdx
+++ b/content/terraform-plugin-framework/v1.16.x/docs/plugin/framework/list-resources/list.mdx
@@ -49,7 +49,7 @@ func (r *ThingListResource) List(ctx context.Context, req list.ListRequest, stre
 	var data ThingListResourceModel
 
 	// Read list config data into the model
-	diags := req.Config.Get(ctx, &data)...
+	diags := req.Config.Get(ctx, &data)
 	if diags.HasError() {
 		stream.Results = list.ListResultsStreamDiagnostics(diags)
 		return


### PR DESCRIPTION
Please go to the `Preview` tab and select the appropriate template:

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
