### PR TITLE
nomad: Update metric reference to detail new TLS telemetry

### DIFF
--- a/content/nomad/v1.11.x/content/docs/reference/metrics.mdx
+++ b/content/nomad/v1.11.x/content/docs/reference/metrics.mdx
@@ -125,6 +125,8 @@ signals.
 | `nomad.raft.leader.lastContact`              | Time since last contact to leader. General indicator of Raft latency                                                                                                                                              | ms / Leader Contact            | Timer   |
 | `nomad.raft.replication.appendEntries`       | Raft transaction commit time                                                                                                                                                                                      | ms / Raft Log Append           | Timer   |
 | `nomad.license.expiration_time_epoch`        | Time as epoch (seconds since Jan 1 1970) at which license will expire                                                                                                                                             | Seconds                        | Gauge   |
+| `nomad.agent.tls.cert.expiration_seconds`    | Time until the agent TLS certificate expires in seconds. This metric is only emitted if TLS is enabled      | Seconds                        | Gauge   |
+| `nomad.agent.tls.ca.expiration_seconds`      | Time until the agent TLS CA certificate expires in seconds. This metric is only emitted if TLS is enabled   | Seconds                        | Gauge   |
 
 ## Client metrics
 


### PR DESCRIPTION
## Description
Updates Nomad's reference metrics to include the new TLS agent metrics. These will be available in the next release of the Nomad 1.11.x release chain.

## Links
Jira: [NMD-1234](https://hashicorp.atlassian.net/browse/NMD-1055)
Github: https://github.com/hashicorp/nomad/pull/27538

## Contributor checklists

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [x] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [x] Verify that all status checks passed
- [x] Verify that the preview environment deployed successfully
- [x] Add additional reviewers if they are not part of assigned groups

Content:

- [x] I added redirects for any moved or removed pages
- [x] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [x] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [ ] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.


[NMD-1234]: https://hashicorp.atlassian.net/browse/NMD-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ