### PR TITLE
Add environment variable name for Docker -e arguments [IPE-1402]

### DIFF
--- a/content/terraform-mcp-server/v0.3.x/docs/mcp-server/deploy.mdx
+++ b/content/terraform-mcp-server/v0.3.x/docs/mcp-server/deploy.mdx
@@ -4,7 +4,7 @@ description: |-
  Learn how to deploy the Terraform MCP server, which helps you write configuration using LLM responses sourced from the Terraform registry.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-10-03T12:52:08-07:00
-last_modified: 2026-01-02T09:52:24-05:00
+last_modified: 2026-02-23T18:38:00.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -72,8 +72,8 @@ Set the `TFE_TOKEN` environment variable to your HCP Terraform or Terraform Ente
             "run",
             "-i",
             "--rm",
-            "-e", "${input:tfe_token}",
-            "-e", "${input:tfe_address}",
+            "-e", "TFE_TOKEN=${input:tfe_token}",
+            "-e", "TFE_ADDRESS=${input:tfe_address}",
             "hashicorp/terraform-mcp-server"
           ]
         }
@@ -107,8 +107,8 @@ Set the `TFE_TOKEN` environment variable to your HCP Terraform or Terraform Ente
           "run",
           "-i",
           "--rm",
-          "-e", "${input:tfe_token}",
-          "-e", "${input:tfe_address}",
+          "-e", "TFE_TOKEN=${input:tfe_token}",
+          "-e", "TFE_ADDRESS=${input:tfe_address}",
           "hashicorp/terraform-mcp-server"
         ]
       }
@@ -148,8 +148,8 @@ Set the `TFE_TOKEN` environment variable to your HCP Terraform or Terraform Ente
             "run",
             "-i",
             "--rm",
-            "-e", "<<TFE_ADDRESS_HERE>>",
-            "-e", "<<TFE_TOKEN_HERE>>",
+            "-e", "TFE_ADDRESS=<<TFE_ADDRESS_HERE>>",
+            "-e", "TFE_TOKEN=<<TFE_TOKEN_HERE>>",
             "hashicorp/terraform-mcp-server"
           ]
         }
@@ -180,8 +180,8 @@ Set the `TFE_TOKEN` environment variable to your HCP Terraform or Terraform Ente
             "run",
             "-i",
             "--rm",
-            "-e", "<<TFE_ADDRESS_HERE>>",
-            "-e", "<<TFE_TOKEN_HERE>>",
+            "-e", "TFE_ADDRESS=<<TFE_ADDRESS_HERE>>",
+            "-e", "TFE_TOKEN=<<TFE_TOKEN_HERE>>",
             "hashicorp/terraform-mcp-server"
           ]
         }
@@ -211,8 +211,8 @@ Set the `TFE_TOKEN` environment variable to your HCP Terraform or Terraform Ente
             "run",
             "-i",
             "--rm",
-            "-e", "<<TFE_ADDRESS_HERE>>",
-            "-e", "<<TFE_TOKEN_HERE>>",
+            "-e", "TFE_ADDRESS=<<TFE_ADDRESS_HERE>>",
+            "-e", "TFE_TOKEN=<<TFE_TOKEN_HERE>>",
             "hashicorp/terraform-mcp-server"
           ]
         }

--- a/content/terraform-mcp-server/v0.4.x/docs/mcp-server/deploy.mdx
+++ b/content/terraform-mcp-server/v0.4.x/docs/mcp-server/deploy.mdx
@@ -4,7 +4,7 @@ description: |-
  Learn how to deploy the Terraform MCP server, which helps you write configuration using LLM responses sourced from the Terraform registry.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2026-01-22T23:00:02-07:00
-last_modified: 2026-01-22T23:00:02-07:00
+last_modified: 2026-02-23T18:38:01.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -72,8 +72,8 @@ Set the `TFE_TOKEN` environment variable to your HCP Terraform or Terraform Ente
             "run",
             "-i",
             "--rm",
-            "-e", "${input:tfe_token}",
-            "-e", "${input:tfe_address}",
+            "-e", "TFE_TOKEN=${input:tfe_token}",
+            "-e", "TFE_ADDRESS=${input:tfe_address}",
             "hashicorp/terraform-mcp-server"
           ]
         }
@@ -107,8 +107,8 @@ Set the `TFE_TOKEN` environment variable to your HCP Terraform or Terraform Ente
           "run",
           "-i",
           "--rm",
-          "-e", "${input:tfe_token}",
-          "-e", "${input:tfe_address}",
+          "-e", "TFE_TOKEN=${input:tfe_token}",
+          "-e", "TFE_ADDRESS=${input:tfe_address}",
           "hashicorp/terraform-mcp-server"
         ]
       }
@@ -148,8 +148,8 @@ Set the `TFE_TOKEN` environment variable to your HCP Terraform or Terraform Ente
             "run",
             "-i",
             "--rm",
-            "-e", "<<TFE_ADDRESS_HERE>>",
-            "-e", "<<TFE_TOKEN_HERE>>",
+            "-e", "TFE_ADDRESS=<<TFE_ADDRESS_HERE>>",
+            "-e", "TFE_TOKEN=<<TFE_TOKEN_HERE>>",
             "hashicorp/terraform-mcp-server"
           ]
         }
@@ -180,8 +180,8 @@ Set the `TFE_TOKEN` environment variable to your HCP Terraform or Terraform Ente
             "run",
             "-i",
             "--rm",
-            "-e", "<<TFE_ADDRESS_HERE>>",
-            "-e", "<<TFE_TOKEN_HERE>>",
+            "-e", "TFE_ADDRESS=<<TFE_ADDRESS_HERE>>",
+            "-e", "TFE_TOKEN=<<TFE_TOKEN_HERE>>",
             "hashicorp/terraform-mcp-server"
           ]
         }
@@ -211,8 +211,8 @@ Set the `TFE_TOKEN` environment variable to your HCP Terraform or Terraform Ente
             "run",
             "-i",
             "--rm",
-            "-e", "<<TFE_ADDRESS_HERE>>",
-            "-e", "<<TFE_TOKEN_HERE>>",
+            "-e", "TFE_ADDRESS=<<TFE_ADDRESS_HERE>>",
+            "-e", "TFE_TOKEN=<<TFE_TOKEN_HERE>>",
             "hashicorp/terraform-mcp-server"
           ]
         }


### PR DESCRIPTION
Based on a conversation in Slack, it was found that the configuration samples to set up the MCP server to run in Docker did not include the environment variable name with each `-e` flag used in the `args` list.