### PR TITLE
Speed up get-changed-files job

### DIFF
--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -2,8 +2,6 @@ name: Build Preview
 run-name: 'Build Preview for "${{ github.event.pull_request.title }}" (#${{ github.event.pull_request.number }})'
 
 on:
-  # only used for testing, pull out when done
-  pull_request:
   # 1: Change this to `pull_request` to see changes while testing this file in a PR.
   # 2: This is because `pull_request_target` only works from the context of the base branch
   #    https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target


### PR DESCRIPTION
## Description

Changes the `get-changed-files` job to no longer us the action `tj-actions/changed-files`, as it took on average 1:30 mins and plus required a checkout. And replaced it with a call to the `gh api` command line tool and used `jq` to count the files changed in a PR.

## Testing

1. Check the `pull_request` versus `pull_request_target` builds for the following commits:
    1. 3973917 - Make sure that `pull_request` matches `pull_request_target`, except it runs quicker.
        1. [pull_request](https://github.com/hashicorp/web-unified-docs/actions/runs/22416657946)
        1. [pull_request_target](https://github.com/hashicorp/web-unified-docs/actions/runs/22416657136)
    1. 8e4bcef - Correctly lists the number of changed files in the PR
        1. [Changed files in /content](https://github.com/hashicorp/web-unified-docs/actions/runs/22418004015/job/64908535847#step:2:19)
        1. [Changed files outside of /content](https://github.com/hashicorp/web-unified-docs/actions/runs/22418004015/job/64908535881#step:2:32)
