### PR TITLE
Update documentation of sys/seal-backend-status

### DIFF
--- a/content/vault/v1.21.x/content/api-docs/system/seal-backend-status.mdx
+++ b/content/vault/v1.21.x/content/api-docs/system/seal-backend-status.mdx
@@ -23,11 +23,11 @@ endpoint.
 | `GET`  | `/sys/seal-backend-status` |
 
 For each seal backend, the following information is returned:
-  * `name` - The identifier of the seal backend
-  * `configured` - Boolean indicating whether the backend was successfully initialized
-  * `disabled` - Boolean indicating whether the backend is disabled
-  * `healthy` - Boolean indicating the current health status of the backend
-  * `unhealthy_since` - Timestamp (RFC3339 format) indicating when the backend became unhealthy (only present if unhealthy)
+  - `name` `(string: "")` - Specifies the identifier of the seal backend.
+  - `configured` `(bool: true)` - Indicates whether the backend was successfully initialized.
+  - `disabled` `(bool: false)` - Indicates whether the backend is disabled.
+  - `healthy` `(bool: false)` - Indicates the current health status of the backend.
+  - `unhealthy_since` `(string: "")` - Timestamp (RFC3339 format) indicating when the backend became unhealthy (only present if unhealthy).
 
 ### Sample request
 


### PR DESCRIPTION
Add missing fully_wrapped response field.

Add new seal backend fields.

See https://github.com/hashicorp/vault-enterprise/pull/12575.