### PR TITLE
vault(license): fix license behaviors

### DIFF
--- a/content/vault/v1.16.x/content/docs/enterprise/license/index.mdx
+++ b/content/vault/v1.16.x/content/docs/enterprise/license/index.mdx
@@ -49,8 +49,9 @@ normally until they restart or have to unseal again.
 | Trial      | Any                   | On, or one day after, expiration              |
 
 To review the dates on a license key, run
-[`vault license inspect`](/vault/docs/commands/license/inspect) (for a local key) or
-[`vault license get`](/vault/docs/commands/license/get) (to query a Vault cluster's API).
+[`vault license inspect`](/vault/docs/commands/license/inspect) for a local key,
+or [`vault license get`](/vault/docs/commands/license/get) to query the license
+key of a Vault cluster.
 
 You must comply with the terms of your Vault Enterprise license agreement,
 regardless of any automated license key enforcement behaviors. Continued use of

--- a/content/vault/v1.17.x/content/docs/enterprise/license/index.mdx
+++ b/content/vault/v1.17.x/content/docs/enterprise/license/index.mdx
@@ -49,8 +49,9 @@ normally until they restart or have to unseal again.
 | Trial      | Any                   | On, or one day after, expiration              |
 
 To review the dates on a license key, run
-[`vault license inspect`](/vault/docs/commands/license/inspect) (for a local key) or
-[`vault license get`](/vault/docs/commands/license/get) (to query a Vault cluster's API).
+[`vault license inspect`](/vault/docs/commands/license/inspect) for a local key,
+or [`vault license get`](/vault/docs/commands/license/get) to query the license
+key of a Vault cluster.
 
 You must comply with the terms of your Vault Enterprise license agreement,
 regardless of any automated license key enforcement behaviors. Continued use of

--- a/content/vault/v1.18.x/content/docs/enterprise/license/index.mdx
+++ b/content/vault/v1.18.x/content/docs/enterprise/license/index.mdx
@@ -51,8 +51,9 @@ normally until they restart or have to unseal again.
 | Trial      | Any                   | On, or one day after, expiration              |
 
 To review the dates on a license key, run
-[`vault license inspect`](/vault/docs/commands/license/inspect) (for a local key) or
-[`vault license get`](/vault/docs/commands/license/get) (to query a Vault cluster's API).
+[`vault license inspect`](/vault/docs/commands/license/inspect) for a local key,
+or [`vault license get`](/vault/docs/commands/license/get) to query the license
+key of a Vault cluster.
 
 You must comply with the terms of your Vault Enterprise license agreement,
 regardless of any automated license key enforcement behaviors. Continued use of

--- a/content/vault/v1.19.x/content/docs/license/index.mdx
+++ b/content/vault/v1.19.x/content/docs/license/index.mdx
@@ -52,8 +52,9 @@ normally until they restart or have to unseal again.
 | Trial      | Any                   | On, or one day after, expiration              |
 
 To review the dates on a license key, run
-[`vault license inspect`](/vault/docs/commands/license/inspect) (for a local key) or
-[`vault license get`](/vault/docs/commands/license/get) (to query a Vault cluster's API).
+[`vault license inspect`](/vault/docs/commands/license/inspect) for a local key,
+or [`vault license get`](/vault/docs/commands/license/get) to query the license
+key of a Vault cluster.
 
 You must comply with the terms of your Vault Enterprise license agreement,
 regardless of any automated license key enforcement behaviors. Continued use of

--- a/content/vault/v1.20.x/content/docs/license/index.mdx
+++ b/content/vault/v1.20.x/content/docs/license/index.mdx
@@ -52,8 +52,9 @@ normally until they restart or have to unseal again.
 | Trial      | Any                   | On, or one day after, expiration              |
 
 To review the dates on a license key, run
-[`vault license inspect`](/vault/docs/commands/license/inspect) (for a local key) or
-[`vault license get`](/vault/docs/commands/license/get) (to query a Vault cluster's API).
+[`vault license inspect`](/vault/docs/commands/license/inspect) for a local key,
+or [`vault license get`](/vault/docs/commands/license/get) to query the license
+key of a Vault cluster.
 
 You must comply with the terms of your Vault Enterprise license agreement,
 regardless of any automated license key enforcement behaviors. Continued use of

--- a/content/vault/v1.21.x/content/docs/license/index.mdx
+++ b/content/vault/v1.21.x/content/docs/license/index.mdx
@@ -52,8 +52,9 @@ normally until they restart or have to unseal again.
 | Trial      | Any                   | On, or one day after, expiration              |
 
 To review the dates on a license key, run
-[`vault license inspect`](/vault/docs/commands/license/inspect) (for a local key) or
-[`vault license get`](/vault/docs/commands/license/get) (to query a Vault cluster's API).
+[`vault license inspect`](/vault/docs/commands/license/inspect) for a local key,
+or [`vault license get`](/vault/docs/commands/license/get) to query the license
+key of a Vault cluster.
 
 You must comply with the terms of your Vault Enterprise license agreement,
 regardless of any automated license key enforcement behaviors. Continued use of


### PR DESCRIPTION
Update the documentation on Vault license key behaviors for versions 1.16 through 1.21. Also note that license keys issued since September 2025 have termination dates on them.