### PR TITLE
Root-Rotation: Documentation update

### DIFF
--- a/content/vault/v1.21.x/content/api-docs/auth/ldap.mdx
+++ b/content/vault/v1.21.x/content/api-docs/auth/ldap.mdx
@@ -205,7 +205,7 @@ $ curl \
 ## Rotate root password
 
 The `rotate-root` endpoint offers password rotation for the `binddn` entry used to manage LDAP.
-The root password becomes irretrievable and only known to Vault once you rotate it.
+After rotation, only Vault knows the generated password, and you cannot retrieve it.
 
 | Method | Path                     |
 | :----- | :----------------------- |


### PR DESCRIPTION
This document is updated as part of the main Ticket: 
https://hashicorp.atlassian.net/browse/VAULT-42182

Description:
Added new section at `api-docs/auth/ldap.mdx` for root rotation.

Changes:
Document before update:
<img width="3426" height="1854" alt="image" src="https://github.com/user-attachments/assets/1454a088-5214-4498-b9c6-ae5ea1b98eb1" />

Document after update (Root Rotation section is added before the List LDAP Group):
<img width="3426" height="1642" alt="image" src="https://github.com/user-attachments/assets/5d3c6336-191f-4675-89ca-7c887a0c9c7b" />

