### PR TITLE
Update snowflake.mdx

### DIFF
--- a/content/vault/v1.21.x/content/docs/secrets/databases/snowflake.mdx
+++ b/content/vault/v1.21.x/content/docs/secrets/databases/snowflake.mdx
@@ -127,6 +127,7 @@ enable generating credentials.
         creation_statements="CREATE USER {{name}} PASSWORD = '{{password}}'
             DAYS_TO_EXPIRY = {{expiration}} DEFAULT_ROLE=myrole;
             GRANT ROLE myrole TO USER {{name}};" \
+        revocation_statements="DROP USER IF EXISTS {{name}};"
         default_ttl="1h" \
         max_ttl="24h"
     Success! Data written to: database/roles/my-password-role
@@ -156,6 +157,7 @@ enable generating credentials.
         creation_statements="CREATE USER {{name}} RSA_PUBLIC_KEY='{{public_key}}'
           DAYS_TO_EXPIRY = {{expiration}} DEFAULT_ROLE=myrole;
           GRANT ROLE myrole TO USER {{name}};" \
+        revocation_statements="DROP USER IF EXISTS {{name}};"
         credential_type="rsa_private_key" \
         credential_config=key_bits=2048 \
         default_ttl="1h" \


### PR DESCRIPTION
Adding revocation_statements to dynamic role creation statement. Without it dynamic credential will never expire off Snowflake.

Please go to the `Preview` tab and select the appropriate template:

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
