### PR TITLE
VAULT-43031: add warning about incorrect assignment to group alias name

### DIFF
--- a/content/vault/v1.21.x/content/docs/auth/jwt/oidc-providers/azuread.mdx
+++ b/content/vault/v1.21.x/content/docs/auth/jwt/oidc-providers/azuread.mdx
@@ -106,11 +106,13 @@ You should set up a [Vault policy](/vault/tutorials/policies/policies) for the A
       canonical_id="vault_external_group_id"
    ```
 
-<note>
+<Note title="Always use Azure object ID as group alias">
 
-If the Azure AD **objectId** is not used as the group alias name, Vault will not raise an error, but identity policies associated with the group will not be applied.
+You must use the Azure AD objectId as the group alias name for Vault to 
+correctly apply identity policies associated with the group. Vault does not log errors
+if you misconfigure the group alias.
 
-</note>
+</Note>
 
 ### Optional azure-specific configuration
 


### PR DESCRIPTION
## Description
Adds a documentation clarification for **Azure AD OIDC** configuration when creating Vault external group aliases.

During investigation of the Home Depot escalation (VAULT-40643), we reproduced a scenario where users authenticated successfully but only received the default policy. The root cause was that the Vault group alias had been created using the **Azure AD group display name** instead of the Object **ID.**

Vault matches external groups using the Azure AD group Object ID returned in the token. If the alias name is configured using the display name, the alias will not match and identity policies will not be applied. Vault does not raise an error in this scenario, which can make the misconfiguration difficult to detect.

## Change
Adds a clarification to the Azure AD OIDC provider documentation below the group alias creation example:

>If the display name is used, Vault will not raise an error, but identity policies associated with the group will not be applied.

## Result
This documentation update helps prevent configuration issues where authentication succeeds but the expected identity policies are not attached to the resulting Vault token.