### PR TITLE
vault: updating vault-k8s default for the v1.7.3 injector release

### DIFF
--- a/content/vault/v1.21.x/content/docs/deploy/kubernetes/injector/annotations.mdx
+++ b/content/vault/v1.21.x/content/docs/deploy/kubernetes/injector/annotations.mdx
@@ -4,7 +4,7 @@ page_title: Vault Agent Injector annotations
 description: Learn about the configurable annotations for the Vault Agent Injector.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-07-22T12:58:23-07:00
-last_modified: 2025-12-01T17:33:11-08:00
+last_modified: 2026-03-05T23:57:19.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -32,7 +32,7 @@ them, optional commands to run, etc.
 
 - `vault.hashicorp.com/agent-image` - name of the Vault docker image to use. This
   value overrides the default image configured in the injector and is usually
-  not needed. Defaults to `hashicorp/vault:1.21.1`.
+  not needed. Defaults to `hashicorp/vault:1.21.4`.
 
 - `vault.hashicorp.com/agent-init-first` - configures the pod to run the Vault Agent
   init container first if `true` (last if `false`). This is useful when other init


### PR DESCRIPTION
Updating the Vault Agent default for the injector from the [v1.7.3](https://github.com/hashicorp/vault-k8s/releases/tag/v1.7.3) release.