### PR TITLE
Fix the documentation for POST /sys/managed-keys/:type/:name

### DIFF
--- a/content/vault/v1.21.x/content/api-docs/system/managed-keys.mdx
+++ b/content/vault/v1.21.x/content/api-docs/system/managed-keys.mdx
@@ -104,7 +104,7 @@ $ curl \
   grant usage.
 
 - `usages` `(comma-delimited string: "sign,verify")` - A comma-delimited list of the allowed usages of this key. Valid values
-  are encrypt, decrypt, sign, verify, wrap, unwrap, mac, and random.
+  are encrypt, decrypt, sign, verify, wrap, unwrap, mac, and generate_random.
 
 #### PKCS#11 backend parameters
 
@@ -309,7 +309,11 @@ $ curl \
   "pin": "redacted",
   "slot": 1,
   "token_label": "",
-  "type": "pkcs11"
+  "type": "pkcs11",
+  "usages": [
+    "sign",
+    "verify"
+  ]
 }
 ```
 


### PR DESCRIPTION
Change key usage values from `random` to `generate_random`.

Update the sample output of GET /sys/managed-keys/:type/:name to include key usages.

See https://github.com/hashicorp/vault-enterprise/pull/12769.

Please go to the `Preview` tab and select the appropriate template:

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
