### PR TITLE
fix complete conf examples for providers in module ref

### DIFF
--- a/content/terraform/v1.12.x/docs/language/block/module.mdx
+++ b/content/terraform/v1.12.x/docs/language/block/module.mdx
@@ -2,8 +2,8 @@
 page_title: module block reference
 description: Learn how to configure a `module` block, which instructs Terraform to create resources defined in a local or remote module.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2023-01-01T00:00:00.000Z
-last_modified: 2023-01-01T00:00:00.000Z
+created_at: 2025-09-05T15:51:39-04:00
+last_modified: 2026-03-06T22:48:32.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -49,7 +49,9 @@ module "<LABEL>" {
     "<VALUE>",
     "<VALUE>"
    ]
-  provider = "<alias.provider-configuration>"
+  providers = {
+    "<provider-name-in-child-module>" = "<provider-name-from-parent-module>"
+  }
   depends_on = [ <resource.address.reference> ]
 }
 ```

--- a/content/terraform/v1.13.x/docs/language/block/module.mdx
+++ b/content/terraform/v1.13.x/docs/language/block/module.mdx
@@ -3,7 +3,7 @@ page_title: module block reference
 description: Learn how to configure a `module` block, which instructs Terraform to create resources defined in a local or remote module.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-09-05T15:51:39-04:00
-last_modified: 2025-10-30T10:04:04-07:00
+last_modified: 2026-03-06T22:48:34.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -49,7 +49,9 @@ module "<LABEL>" {
     "<VALUE>",
     "<VALUE>"
    ]
-  provider = "<alias.provider-configuration>"
+  providers = {
+    "<provider-name-in-child-module>" = "<provider-name-from-parent-module>"
+  }
   depends_on = [ <resource.address.reference> ]
 }
 ```

--- a/content/terraform/v1.14.x/docs/language/block/module.mdx
+++ b/content/terraform/v1.14.x/docs/language/block/module.mdx
@@ -3,7 +3,7 @@ page_title: module block reference
 description: Learn how to configure a `module` block, which instructs Terraform to create resources defined in a local or remote module.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-11-19T13:27:46Z
-last_modified: 2025-12-03T16:22:47-08:00
+last_modified: 2026-03-06T22:48:35.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -45,7 +45,9 @@ module "<LABEL>" {
     "<VALUE>",
     "<VALUE>"
    ]
-  provider = "<alias.provider-configuration>"
+  providers = {
+    "<provider-name-in-child-module>" = "<provider-name-from-parent-module>"
+  }
   depends_on = [ <resource.address.reference> ]
 }
 ```

--- a/content/terraform/v1.15.x (alpha)/docs/language/block/module.mdx
+++ b/content/terraform/v1.15.x (alpha)/docs/language/block/module.mdx
@@ -3,7 +3,7 @@ page_title: module block reference
 description: Learn how to configure a `module` block, which instructs Terraform to create resources defined in a local or remote module.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-11-19T19:11:19Z
-last_modified: 2025-11-19T19:11:19Z
+last_modified: 2026-03-06T22:48:35.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -49,7 +49,9 @@ module "<LABEL>" {
     "<VALUE>",
     "<VALUE>"
    ]
-  provider = "<alias.provider-configuration>"
+  providers = {
+    "<provider-name-in-child-module>" = "<provider-name-from-parent-module>"
+  }
   depends_on = [ <resource.address.reference> ]
 }
 ```


### PR DESCRIPTION
The PR fixes the sample `providers` argument in the complete configuration sections of the `module` reference page. The complete configuration listed the `provider` (singular)  meta-argument instead of the `providers` meta-argument. The `provider` argument takes string, whereas the `providers` argument takes a map of strings. 