### PR TITLE
Corrected type error in configuration.mdx

### DIFF
--- a/content/terraform/v1.14.x/docs/language/modules/configuration.mdx
+++ b/content/terraform/v1.14.x/docs/language/modules/configuration.mdx
@@ -114,16 +114,16 @@ Refer to [Select an alternate provider configuration](/terraform/language/block/
 
 The resources defined in a module form a self-contained group of resources. Module authors commonly define outputs that expose attribute values for the resources created by the module. You can reference the values in the parent module using the [`module.<MODULE-NAME>.<OUTPUT-NAME>` expression](/terraform/language/expressions/references#child-module-outputs). Refer to the module documentation for information about its outputs. 
 
-In the following example, the `aws_subnet` resource references the value of the VCP ID output by the `vcp` module:
+In the following example, the `aws_subnet` resource references the value of the VPC ID output by the `vpc` module:
 
 ```hcl
-module "vcp" {
+module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "6.0.1"
 }
 
 resource "aws_subnet" "main" {
-  vpc_id     = module.vcp.vpc_id
+  vpc_id     = module.vpc.vpc_id
   cidr_block = "10.0.1.0/24"
 
   tags = {


### PR DESCRIPTION
Document has type error 'vcp' instead of 'vpc'.

Please go to the `Preview` tab and select the appropriate template:

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
