### PR TITLE
Fixing precommit deleted file bug

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -18,7 +18,7 @@ fi
 echo "No .env files detected in commit"
 
 # Add date metadata to changed markdown files
-MDX_FILES=$(git diff --cached --name-only | grep '^content/.*\.mdx$' || true)
+MDX_FILES=$(git diff --cached --name-only --diff-filter=d | grep '^content/.*\.mdx$' || true)
 if [ -n "$MDX_FILES" ]; then
     echo "Adding date metadata to changed .mdx files..."
     echo "$MDX_FILES" | while read -r FILE; do


### PR DESCRIPTION
# Description
This commit fixes a bug with the precommit hook that wouldn't allow deleted files to get committed, this is because `add-date-metadata.mjs ` assumes that it will be given files it can write to, but it obviously can't do that for a deleted file. The bug was initially reported [here](https://ibm-hashicorp.slack.com/archives/C09LU1THDDE/p1773075273949459)

Very interesting how this bug went a few weeks without being picked up or reported earlier.

## Testing
- Before checking out this branch, just delete an `.mdx` file within the `/content` folder and see if you can commit it. It should fail
- Include this change and you should be able to successfully commit a deleted file
- You can test various other edge cases, renaming files should work (it was working before)
- Can look at my commits on this branch to see if the test commits I did earlier would suffice

