### PR TITLE
Fix typo in module documentation

### DIFF
--- a/content/terraform/v1.13.x/docs/language/block/module.mdx
+++ b/content/terraform/v1.13.x/docs/language/block/module.mdx
@@ -496,7 +496,7 @@ module "vpc" {
 }
 ```
 
-In the following example, Terraform gets a version of the module tagged as `v1.2.0` form the `modules/vpc` directory in a Git repository:
+In the following example, Terraform gets a version of the module tagged as `v1.2.0` from the `modules/vpc` directory in a Git repository:
 
 ```hcl
 module "vpc" {


### PR DESCRIPTION
Please go to the `Preview` tab and select the appropriate template:

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
