### PR TITLE
HCP Terraform Docs: Project exclusions on policy sets

### DIFF
--- a/content/terraform-docs-common/docs/cloud-docs/workspaces/policy-enforcement/manage-policy-sets/configure.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/workspaces/policy-enforcement/manage-policy-sets/configure.mdx
@@ -43,7 +43,7 @@ This page contains all of the policy sets available in the organization, includi
 1. Specify a unique and descriptive name for the policy set. You can use any combination of letters, numbers, `-`, and `_`. A name is required.
 1. It is optional, but you can add a description. We recommend adding a description so that the purpose of the policy set is clear to team members.
 1. Choose a policy set scope:
-   - Enable the **Policies enforced globally** option to automatically enforce this policy set on all of the organization's existing and future workspaces. You can optionally click **Add exclusions** and choose workspaces to exempt from the policy set. 
+   - Enable the **Policies enforced globally** option to automatically enforce this policy set on all of the organization's existing and future workspaces. You can optionally click **Add exclusions** and choose projects or workspaces to exempt from the policy set.
    - Enable the **Policies enforced on selected projects and workspaces** option to enforce the policy set on specific workspaces or all workspaces in project. This affects all current and future workspaces for any projects you choose.  
 1. For Sentinal policy sets, choose a policy execution mode. Refer to [Policy set execution modes](#policy-set-execution-modes) for details about each option. For OPA policy sets, configure the following settings:
    - Choose an OPA version from the **Runtime version** drop-down menu.

--- a/content/terraform-docs-common/docs/cloud-docs/workspaces/policy-enforcement/manage-policy-sets/index.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/workspaces/policy-enforcement/manage-policy-sets/index.mdx
@@ -18,7 +18,7 @@ Policies are rules that HCP Terraform enforces on Terraform runs. You can define
 
 <!-- END: TFC:only name:pnp-callout -->
 
-Policy sets are collections of policies you can apply globally or to specific [projects](/terraform/cloud-docs/projects/manage) and workspaces in your organization. For each run in the applicable workspaces, HCP Terraform checks the Terraform plan against the policy set. Depending on the [enforcement level](#policy-enforcement-levels), failed policies can stop a run in a workspace. If you do not want to enforce a policy set on a specific workspace, you can exclude the workspace from that set.
+Policy sets are collections of policies you can apply globally or to specific [projects](/terraform/cloud-docs/projects/manage) and workspaces in your organization. For each run in the applicable workspaces, HCP Terraform checks the Terraform plan against the policy set. Depending on the [enforcement level](#policy-enforcement-levels), failed policies can stop a run in a workspace. If you do not want to enforce a policy set on a specific project or workspace, you can exclude the project or workspace from that set.
 
 ## Policy checks versus policy evaluations
 


### PR DESCRIPTION
Policy sets can now be excluded when selecting the scope of a policy set. This is part of Phase 1 of Flexible targeting of policy sets: https://hashicorp.atlassian.net/browse/TF-34825
