### PR TITLE
Fixed redirect that was too general and picked up api-docs (IPE-1422)

### DIFF
--- a/content/terraform-enterprise/1.2.x/redirects.jsonc
+++ b/content/terraform-enterprise/1.2.x/redirects.jsonc
@@ -1250,7 +1250,8 @@
   },
   // the url is in cloud-docs
   {
-    "source": "/terraform/enterprise/:version/agents",
+    // Avoid matching enterprise/api-docs/agents, so match only versions made up of digits/dots/dashes/v/x
+    "source": "/terraform/enterprise/:version([v0-9.x-]+)/agents",
     "destination": "/terraform/cloud-docs/agents",
     "permanent": true
   },


### PR DESCRIPTION
### What
In the Terraform Enterprise navigation, API → Agent Pools incorrectly redirects to https://developer.hashicorp.com/terraform/cloud-docs/agents, which is not API documentation and is about HCP TF.  It should go to  https://developer.hashicorp.com/terraform/enterprise/api-docs/agents. 

[IPE-1422](https://hashicorp.atlassian.net/browse/IPE-1422)

### Alternatives Considered

Could have moved `api-docs/agents.mdx` to `api-docs/agent-pools.mdx` - decided not to because then we'd need to add more redirects and would likely have ended up with a similar issue.

Could have used a different regex (e.g., with a negative lookahead/behind to fail the match if `api-docs` is found) - decided not to because test cycles took a while and the regexes aren't fully-featured so I was having some difficulties.  It'd be more expressive, but more complex.

Could have used a simpler regex (e.g., ...`:version([^s]+)/agents`) - decided not to because the regex would be less expressive and make it harder to understand the intent.

### Testing

To make sure nothing broke while trying to fix things, "test cases" on Vercel are listed below.

These SHOULD redirect to `cloud-docs/agents`.  Prior to this change, they all did so.  After this change, they continue to do so.

https://unified-docs-frontend-preview-l8jlmj97h-hashicorp.vercel.app/terraform/enterprise/agents 
https://unified-docs-frontend-preview-l8jlmj97h-hashicorp.vercel.app/terraform/enterprise/1.2.x/agents 
https://unified-docs-frontend-preview-l8jlmj97h-hashicorp.vercel.app/terraform/enterprise/1.1.x/agents 
https://unified-docs-frontend-preview-l8jlmj97h-hashicorp.vercel.app/terraform/enterprise/1.0.x/agents 
https://unified-docs-frontend-preview-l8jlmj97h-hashicorp.vercel.app/terraform/enterprise/v202506-1/agents  
https://unified-docs-frontend-preview-l8jlmj97h-hashicorp.vercel.app/terraform/enterprise/v202307-1/agents 
https://unified-docs-frontend-preview-l8jlmj97h-hashicorp.vercel.app/terraform/enterprise/v202206-1/agents 

These SHOULD NOT redirect.  Prior to this change, the [first one](https://developer.hashicorp.com/terraform/enterprise/api-docs/agents) _did_ redirect.  The rest did not.  (i.e., first = broken, rest worked).  After this change, all correctly do not redirect.

https://unified-docs-frontend-preview-l8jlmj97h-hashicorp.vercel.app/terraform/enterprise/api-docs/agents 
https://unified-docs-frontend-preview-l8jlmj97h-hashicorp.vercel.app/terraform/enterprise/1.2.x/api-docs/agents 
https://unified-docs-frontend-preview-l8jlmj97h-hashicorp.vercel.app/terraform/enterprise/1.1.x/api-docs/agents 
https://unified-docs-frontend-preview-l8jlmj97h-hashicorp.vercel.app/terraform/enterprise/1.0.x/api-docs/agents 
https://unified-docs-frontend-preview-l8jlmj97h-hashicorp.vercel.app/terraform/enterprise/v202506-1/api-docs/agents 
https://unified-docs-frontend-preview-l8jlmj97h-hashicorp.vercel.app/terraform/enterprise/v202307-1/api-docs/agents 
https://unified-docs-frontend-preview-l8jlmj97h-hashicorp.vercel.app/terraform/enterprise/v202206-1/api-docs/agents 

#### Local Testing

(If you want)

These SHOULD redirect to `cloud-docs/agents`.  Prior to this change, they all did so.  After this change, they continue to do so.
http://localhost:3000/terraform/enterprise/agents 
http://localhost:3000/terraform/enterprise/1.2.x/agents
http://localhost:3000/terraform/enterprise/1.1.x/agents 
http://localhost:3000/terraform/enterprise/1.0.x/agents 
http://localhost:3000/terraform/enterprise/v202506-1/agents 
http://localhost:3000/terraform/enterprise/v202307-1/agents 
http://localhost:3000/terraform/enterprise/v202206-1/agents 

These SHOULD NOT redirect.  Prior to this change, the first one _did_ redirect.  The rest did not.  (i.e., first = broken, rest worked).  After this change, all correctly do not redirect.
http://localhost:3000/terraform/enterprise/api-docs/agents
http://localhost:3000/terraform/enterprise/1.2.x/api-docs/agents
http://localhost:3000/terraform/enterprise/1.1.x/api-docs/agents 
http://localhost:3000/terraform/enterprise/1.0.x/api-docs/agents
http://localhost:3000/terraform/enterprise/v202506-1/api-docs/agents
http://localhost:3000/terraform/enterprise/v202307-1/api-docs/agents
http://localhost:3000/terraform/enterprise/v202206-1/api-docs/agents

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [X] Description links to related pull requests or issues, if any.

#### Content
- [X] You added redirects to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages **across all affected versions**. Refer to [Redirects](https://github.com/hashicorp/web-unified-docs/blob/main/docs/content-guide/redirects.md#example-redirects) for examples and guidance. 
- [X] The Vercel website preview successfully deployed.
- [X] All other checklist items N/A

#### Reviews
- [X] I or someone else reviewed the content for technical accuracy.
- [X] I or someone else reviewed the content for typos, punctuation, spelling, and grammar. (N/A)


[IPE-1422]: https://hashicorp.atlassian.net/browse/IPE-1422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ