### PR TITLE
add aws kms multi-region docs

### DIFF
--- a/content/vault/v2.x (rc)/content/docs/secrets/key-management/awskms.mdx
+++ b/content/vault/v2.x (rc)/content/docs/secrets/key-management/awskms.mdx
@@ -60,7 +60,7 @@ You must have the following permissions to use
 
 The following is an example of how to configure the KMS provider resource using the Vault CLI:
 
-```text
+```shell-session
 $ vault write keymgmt/kms/example-kms \
     provider="awskms" \
     key_collection="us-west-1" \
@@ -99,39 +99,46 @@ Vault currently limits multi-region support to `aes256-gcm96` keys with the
 `awskms` provider, and sets the primary region based on the `key_collection`
 parameter on the KMS provider resource.
 
-### Multi-region key lifecycle
+### Multi-region key replication
 
-Distributing a key as a multi-region key is a two-step process:
+Use the same API workflow for single-region and multi-region keys, with two differences:
 
-**Step 1 — Create the key with replica regions**
+1. When you create a multi-region key, set `replica_regions`.
+2. After you distribute the key, call the `/replicate` endpoint.
 
-When creating the key in Vault, specify the `replica_regions` parameter with the AWS
-regions to replicate to. This parameter is immutable after key creation.
+All other key operations use the same API endpoints and behavior.
 
-```text
+Use this workflow to replicate a key across AWS regions:
+
+**Create the key with replica regions**
+
+When you create the key in Vault, set the `replica_regions` parameter to the AWS
+regions where you want replicas. You cannot change this parameter after key creation.
+
+```shell-session
 $ vault write keymgmt/key/example-key \
     type="aes256-gcm96" \
     replica_regions="us-east-1,eu-west-1"
 ```
 
-**Step 2 — Distribute the key to the primary KMS region**
+**Distribute the key to the primary KMS region**
 
-Distributing the key to the KMS provider creates a multi-region primary CMK in the
-primary region (set by `key_collection`) and imports the key material.
+When you distribute the key to the KMS provider, Vault creates a multi-region primary
+CMK in the primary region (set by `key_collection`) and imports the key material.
 
-```text
+```shell-session
 $ vault write keymgmt/kms/example-kms/key/example-key \
     purpose="encrypt,decrypt" \
     protection="hsm"
 ```
 
-**Step 3 — Replicate the key to replica regions**
+**Replicate the key to replica regions**
 
-After distribution, trigger replication to copy the key material into each configured
-replica region. All replica regions configured during key creation are replicated in
-a single call.
+After distribution, call the replication endpoint to copy key material into each
+configured replica region. Vault replicates all regions that you configured during
+key creation in a single call.
 
-```text
+```shell-session
 $ vault write -f keymgmt/kms/example-kms/key/example-key/replicate
 ```
 

--- a/content/vault/v2.x (rc)/content/docs/secrets/key-management/awskms.mdx
+++ b/content/vault/v2.x (rc)/content/docs/secrets/key-management/awskms.mdx
@@ -101,14 +101,7 @@ parameter on the KMS provider resource.
 
 ### Multi-region key replication
 
-Use the same API workflow for single-region and multi-region keys, with two differences:
-
-1. When you create a multi-region key, set `replica_regions`.
-2. After you distribute the key, call the `/replicate` endpoint.
-
-All other key operations use the same API endpoints and behavior.
-
-Use this workflow to replicate a key across AWS regions:
+When you create a multi-region key, you must set `replica_regions` and call the `/replicate` endpoint after distributing the key:
 
 **Create the key with replica regions**
 
@@ -121,35 +114,15 @@ $ vault write keymgmt/key/example-key \
     replica_regions="us-east-1,eu-west-1"
 ```
 
-**Distribute the key to the primary KMS region**
+1. Distribute the key to the primary KMS region. Distributing the key creates a
+   multi-region primary CMK in the primary region and imports the key material:
 
-When you distribute the key to the KMS provider, Vault creates a multi-region primary
-CMK in the primary region (set by `key_collection`) and imports the key material.
+  
 
-```shell-session
-$ vault write keymgmt/kms/example-kms/key/example-key \
-    purpose="encrypt,decrypt" \
-    protection="hsm"
-```
+1. Call the `/replicate` endpoint to replicate the key to the regions
+   set in `replica_regions` during key creation:
 
-**Replicate the key to replica regions**
-
-After distribution, call the replication endpoint to copy key material into each
-configured replica region. Vault replicates all regions that you configured during
-key creation in a single call.
-
-```shell-session
-$ vault write -f keymgmt/kms/example-kms/key/example-key/replicate
-```
-
-### Rotate a multi-region key
-
-Use the `/rotate` endpoint and the key name to rotate a multi-region key:
-
-
-### Delete a multi-region key
-
-Use `vault delete` the key name to delete a multi-region key:
+  
 
 
 ## Key purpose compatibility

--- a/content/vault/v2.x (rc)/content/docs/secrets/key-management/awskms.mdx
+++ b/content/vault/v2.x (rc)/content/docs/secrets/key-management/awskms.mdx
@@ -50,7 +50,7 @@ The IAM principal associated with the provided credentials must have the followi
 - `kms:ListAliases`
 - `kms:TagResource`
 
-The following additional permissions are required when using
+You must have the following permissions to use
 [multi-region keys](#multi-region-keys):
 
 - `kms:ReplicateKey`

--- a/content/vault/v2.x (rc)/content/docs/secrets/key-management/awskms.mdx
+++ b/content/vault/v2.x (rc)/content/docs/secrets/key-management/awskms.mdx
@@ -103,16 +103,14 @@ parameter on the KMS provider resource.
 
 When you create a multi-region key, you must set `replica_regions` and call the `/replicate` endpoint after distributing the key:
 
-**Create the key with replica regions**
+1. Create the key with explicit replica regions. You cannot change the assigned
+   regions after key creation:
 
-When you create the key in Vault, set the `replica_regions` parameter to the AWS
-regions where you want replicas. You cannot change this parameter after key creation.
-
-```shell-session
-$ vault write keymgmt/key/example-key \
-    type="aes256-gcm96" \
-    replica_regions="us-east-1,eu-west-1"
-```
+  ```shell-session
+  $ vault write keymgmt/key/example-key \
+      type="aes256-gcm96"               \
+      replica_regions="us-east-1,eu-west-1"
+  ```
 
 1. Distribute the key to the primary KMS region. Distributing the key creates a
    multi-region primary CMK in the primary region and imports the key material:

--- a/content/vault/v2.x (rc)/content/docs/secrets/key-management/awskms.mdx
+++ b/content/vault/v2.x (rc)/content/docs/secrets/key-management/awskms.mdx
@@ -50,6 +50,12 @@ The IAM principal associated with the provided credentials must have the followi
 - `kms:ListAliases`
 - `kms:TagResource`
 
+The following additional permissions are required when using
+[multi-region keys](#multi-region-keys):
+
+- `kms:ReplicateKey`
+- `kms:DescribeKey`
+
 ## Configuration
 
 The following is an example of how to configure the KMS provider resource using the Vault CLI:
@@ -79,6 +85,75 @@ within AWS KMS. As such, key rotations performed by the secrets engine use the
 [manual key rotation](https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html#rotate-keys-manually)
 process. Applications should refer to the [alias](https://docs.aws.amazon.com/kms/latest/developerguide/kms-alias.html)
 associated with imported keys. Aliases will always have the form: `hashicorp/<key_name>-<unix_timestamp>`.
+
+## Multi-region keys
+
+The Key Management secrets engine supports distributing keys as
+[AWS KMS multi-region keys](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html),
+which allow the same key material to be available in multiple AWS regions. This is useful
+for applications that require low-latency cryptographic operations across regions or need
+cross-region disaster recovery.
+
+Multi-region support is only available for the `aes256-gcm96` key type and the `awskms`
+provider. The primary region is determined by the `key_collection` parameter on the KMS
+provider resource.
+
+### Multi-region key lifecycle
+
+Distributing a key as a multi-region key is a two-step process:
+
+**Step 1 — Create the key with replica regions**
+
+When creating the key in Vault, specify the `replica_regions` parameter with the AWS
+regions to replicate to. This parameter is immutable after key creation.
+
+```text
+$ vault write keymgmt/key/example-key \
+    type="aes256-gcm96" \
+    replica_regions="us-east-1,eu-west-1"
+```
+
+**Step 2 — Distribute the key to the primary KMS region**
+
+Distributing the key to the KMS provider creates a multi-region primary CMK in the
+primary region (set by `key_collection`) and imports the key material.
+
+```text
+$ vault write keymgmt/kms/example-kms/key/example-key \
+    purpose="encrypt,decrypt" \
+    protection="hsm"
+```
+
+**Step 3 — Replicate the key to replica regions**
+
+After distribution, trigger replication to copy the key material into each configured
+replica region. All replica regions configured during key creation are replicated in
+a single call.
+
+```text
+$ vault write -f keymgmt/kms/example-kms/key/example-key/replicate
+```
+
+### Multi-region key rotation
+
+Rotating a multi-region key is a single operation. The secrets engine creates a new
+multi-region primary CMK in the primary region, replicates it to all configured replica
+regions, imports the new key material into every replica, and updates the aliases in all
+regions atomically.
+
+```text
+$ vault write -f keymgmt/key/example-key/rotate
+```
+
+### Multi-region key deletion
+
+Deleting a multi-region key from the KMS provider removes the key from all replica
+regions before scheduling deletion of the primary. The deletion order is enforced by
+the secrets engine to comply with AWS KMS requirements.
+
+```text
+$ vault delete keymgmt/kms/example-kms/key/example-key
+```
 
 ## Key purpose compatibility
 

--- a/content/vault/v2.x (rc)/content/docs/secrets/key-management/awskms.mdx
+++ b/content/vault/v2.x (rc)/content/docs/secrets/key-management/awskms.mdx
@@ -88,15 +88,16 @@ associated with imported keys. Aliases will always have the form: `hashicorp/<ke
 
 ## Multi-region keys
 
-The Key Management secrets engine supports distributing keys as
-[AWS KMS multi-region keys](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html),
-which allow the same key material to be available in multiple AWS regions. This is useful
-for applications that require low-latency cryptographic operations across regions or need
-cross-region disaster recovery.
+You can use the Key Management secrets engine to distribute keys as
+[AWS KMS multi-region keys](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html)
+to make the same key material available in multiple AWS regions. Multi-region
+keys can improve performance for applications that operate across regions by
+lowering latency on cryptographic operations and helping with cross-region
+disaster recovery.
 
-Multi-region support is only available for the `aes256-gcm96` key type and the `awskms`
-provider. The primary region is determined by the `key_collection` parameter on the KMS
-provider resource.
+Vault currently limits multi-region support to `aes256-gcm96` keys with the
+`awskms` provider, and sets the primary region based on the `key_collection`
+parameter on the KMS provider resource.
 
 ### Multi-region key lifecycle
 
@@ -134,26 +135,15 @@ a single call.
 $ vault write -f keymgmt/kms/example-kms/key/example-key/replicate
 ```
 
-### Multi-region key rotation
+### Rotate a multi-region key
 
-Rotating a multi-region key is a single operation. The secrets engine creates a new
-multi-region primary CMK in the primary region, replicates it to all configured replica
-regions, imports the new key material into every replica, and updates the aliases in all
-regions atomically.
+Use the `/rotate` endpoint and the key name to rotate a multi-region key:
 
-```text
-$ vault write -f keymgmt/key/example-key/rotate
-```
 
-### Multi-region key deletion
+### Delete a multi-region key
 
-Deleting a multi-region key from the KMS provider removes the key from all replica
-regions before scheduling deletion of the primary. The deletion order is enforced by
-the secrets engine to comply with AWS KMS requirements.
+Use `vault delete` the key name to delete a multi-region key:
 
-```text
-$ vault delete keymgmt/kms/example-kms/key/example-key
-```
 
 ## Key purpose compatibility
 

--- a/content/vault/v2.x (rc)/content/docs/secrets/key-management/awskms.mdx
+++ b/content/vault/v2.x (rc)/content/docs/secrets/key-management/awskms.mdx
@@ -115,8 +115,6 @@ When you create a multi-region key, you must set `replica_regions` and call the 
 1. Distribute the key to the primary KMS region. Distributing the key creates a
    multi-region primary CMK in the primary region and imports the key material:
 
-  
-
 1. Call the `/replicate` endpoint to replicate the key to the regions
    set in `replica_regions` during key creation:
 


### PR DESCRIPTION
This pull request adds comprehensive documentation for AWS KMS multi-region key support in the Vault Key Management secrets engine. It introduces a new section explaining how to create, replicate, rotate, and delete multi-region keys, and updates the required IAM permissions for using this feature.

Enhancements for AWS KMS multi-region key support:

**Documentation updates:**

* Added a new section describing multi-region keys, including their purpose, lifecycle, and usage instructions for creating, replicating, rotating, and deleting keys across regions.

**Permissions updates:**

* Updated the IAM permissions requirements to include `kms:ReplicateKey` and `kms:DescribeKey` for multi-region key operations.