### PR TITLE
Update docs to set up dynamic credentials for Terraform queries

### DIFF
--- a/content/terraform-docs-common/docs/cloud-docs/dynamic-provider-credentials/index.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/dynamic-provider-credentials/index.mdx
@@ -50,7 +50,7 @@ You can also use Vault to generate credentials for AWS, GCP, or Azure by setting
 
 To use dynamic credentials for queries, complete the steps for [configuring dynamic credentials for workspaces](#configure-dynamic-credentials-for-workspaces). 
 
-Query runs will use the dynamic credentials configuration specified for Terraform plans.
+Query runs use the dynamic credentials configuration for Terraform plans. For example, when the same role is configured for both plans and applies, query runs use that shared role. When separate roles are configured, query runs use the plan role.
 
 The following variables are examples of environment variables you can use to configure dynamic provider credentials for queries:
 - [Amazon Web Services](/terraform/cloud-docs/dynamic-provider-credentials/aws-configuration#required-environment-variables): `TFC_AWS_PLAN_ROLE_ARN`

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/dynamic-provider-credentials/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/dynamic-provider-credentials/index.mdx
@@ -55,7 +55,7 @@ You can also use Vault to generate credentials for AWS, GCP, or Azure by setting
 
 To use dynamic credentials for queries, complete the steps for [configuring dynamic credentials for workspaces](#configure-dynamic-credentials-for-workspaces). 
 
-Query runs will use the dynamic credentials configuration specified for Terraform plans.
+Query runs use the dynamic credentials configuration for Terraform plans. For example, when the same role is configured for both plans and applies, query runs use that shared role. When separate roles are configured, query runs use the plan role.
 
 The following variables are examples of environment variables you can use to configure dynamic provider credentials for queries:
 


### PR DESCRIPTION
### What
<!-- Explain what you changed and provide a list of changed page names. -->
Update setting up dynamic credentials for terraform queries to specify plan roles will be used instead of a run role, if it is specified.

### Why
<!-- Explain why this change is necessary and how it benefits users. -->
`query` runs using dynamic credentials use run roles. However, since these runs only require read permissions, it would be best to use plan roles when they are available. Run roles are only used as fallback when a plan role is unspecified.

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->
<img width="1556" height="1104" alt="image" src="https://github.com/user-attachments/assets/63fb9446-893a-485c-991d-a0858993a2af" />

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] https://github.com/hashicorp/atlas/pull/27376

#### Content
- [x]  (N/A) Redirects have been added to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages.
- [ ] API documentation and the API Changelog have been updated.
- [x]  (N/A) Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x]  (N/A) Pages with related content are updated and link to this content when appropriate.
- [x]  (N/A) Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] (N/A)  New pages have metadata (page name and description) at the top.
- [x]  (N/A) New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x]  (N/A) New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x]  (N/A) UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
