### PR TITLE
 Nomad: document nil checks in filter expressions

### DIFF
--- a/content/nomad/v1.11.x/content/api-docs/index.mdx
+++ b/content/nomad/v1.11.x/content/api-docs/index.mdx
@@ -192,6 +192,10 @@ those endpoints.
 // Regular Expression Matching
 <Selector> matches "<Value>"
 <Selector> not matches "<Value>"
+
+// Nil checks
+<Selector> is nil
+<Selector> is not nil
 ```
 
 #### Selectors


### PR DESCRIPTION
We've added "is nil" and "is not nil" to the `bexpr` filter expression language, and shipped this in Nomad 1.11.3.

## Links

Ref: https://github.com/hashicorp/nomad/pull/27631
Ref: https://hashicorp.atlassian.net/browse/NMD-941
Ref: https://github.com/hashicorp/go-bexpr/pull/129

Preview: https://unified-docs-frontend-preview-epd4dtekb-hashicorp.vercel.app/nomad/api-docs#matching-operators

## Contributor checklists

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [x] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [x] Verify that all status checks passed
- [x] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [ ] I added redirects for any moved or removed pages
- [ ] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [x] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [ ] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.
