### PR TITLE
Add new PKI External CA metrics and SPIFFE mount count metrics

### DIFF
--- a/content/vault/v2.x (rc)/content/docs/license/product-usage-reporting.mdx
+++ b/content/vault/v2.x (rc)/content/docs/license/product-usage-reporting.mdx
@@ -150,6 +150,7 @@ All of these metrics are numerical, and contain no sensitive values or additiona
 | `vault.auth.method.pcf.count`                                       | The total number of PCF auth mounts in Vault.                                                                    |
 | `vault.auth.method.radius.count`                                    | The total number of Radius auth mounts in Vault.                                                                 |
 | `vault.auth.method.saml.count`                                      | The total number of SAML auth mounts in Vault.                                                                   |
+| `vault.auth.method.spiffe.count`                                    | The total number of SPIFFE auth mounts in Vault.                                                                 |
 | `vault.auth.method.cert.count`                                      | The total number of Cert auth mounts in Vault.                                                                   |
 | `vault.auth.method.oidc.count`                                      | The total number of OIDC auth mounts in Vault.                                                                   |
 | `vault.auth.method.token.count`                                     | The total number of Token auth mounts in Vault.                                                                  |
@@ -197,7 +198,9 @@ All of these metrics are numerical, and contain no sensitive values or additiona
 | `vault.secret.engine.ldap.count`                                    | The total number of LDAP secret engines in Vault.                                                                |
 | `vault.secret.engine.openldap.count`                                | The total number of OpenLDAP secret engines in Vault.                                                            |
 | `vault.secret.engine.pki.count`                                     | The total number of PKI secret engines in Vault.                                                                 |
+| `vault.secret.engine.pki-external-ca.count`                         | The total number of PKI External CA secret engines in Vault.                                                     |
 | `vault.secret.engine.rabbitmq.count`                                | The total number of RabbitMQ secret engines in Vault.                                                            |
+| `vault.secret.engine.spiffe.count`                                  | The total number of SPIFFE secret engines in Vault.                                                              |
 | `vault.secret.engine.ssh.count`                                     | The total number of SSH secret engines in Vault.                                                                 |
 | `vault.secret.engine.terraform.count`                               | The total number of Terraform secret engines in Vault.                                                           |
 | `vault.secret.engine.totp.count`                                    | The total number of TOTP secret engines in Vault.                                                                |
@@ -270,6 +273,7 @@ All of these metrics are numerical, and contain no sensitive values or additiona
 | `vault.autosnapshots.azure-blob.count`                              | The total number of automated snapshot configurations with storage type Azure Blob.                              |
 | `vault.pki.cert.stored.count.current_month`                         | The number of certificates stored in built-in PKI backends in the current month.                                 |
 | `vault.pki.cert.stored.count.previous_month`                        | The number of certificates stored in built-in PKI backends in the previous month.                                |
+| `vault.pki-external-ca.acme_accounts.count`                         | The total number of ACME accounts across all PKI External CA secret engines in Vault.                            |
 | `vault.secret.engine.keymgmt.kms.key.count`                         | The total number of KMS keys across all namespaces from keymgmt secret engine.                                   |
 | `vault.secret.engine.keymgmt.awskms.provider.kms.key.count`         | The total number of KMS keys across all namespaces from keymgmt secret engine mapped with AWS provider.          |
 | `vault.secret.engine.keymgmt.gcpckms.provider.kms.key.count`        | The total number of KMS keys across all namespaces from keymgmt secret engine mapped with GCP provider.          |


### PR DESCRIPTION
Update the existing table of metrics we collect, adding the new ones for SPIFFE auth/secrets engine as well as the PKI External CA plugin 
