### PR TITLE
Document acme_account_name cannot be changed on a role

### DIFF
--- a/content/vault/v2.x (rc)/content/api-docs/secret/pki-external-ca.mdx
+++ b/content/vault/v2.x (rc)/content/api-docs/secret/pki-external-ca.mdx
@@ -370,7 +370,7 @@ Roles define policies for certificate issuance, including which domains you can 
 
 ### Create/update role
 
-Create or update a role. The acme_account_name field cannot be changed after role creation.
+Create or update a role. You cannot modify `acme_account_name` after role creation.
 
 | Method | Path                              |
 |:-------|:----------------------------------|
@@ -380,7 +380,7 @@ Create or update a role. The acme_account_name field cannot be changed after rol
 
 - `name` `(string: <required>)` - The name of the role.
 
-- `acme_account_name` `(string: <required>)` - The name of the ACME account to use for certificate requests. Cannot be changed after role creation.
+- `acme_account_name` `(string: <required>)` - The name of the ACME account to use for certificate requests. You cannot change the account name after role creation.
 
 - `allowed_domains` `(array<string>: [])` - List of domains the role accepts for certificates. You can use templates with ACL Path Templating (e.g., `{{identity.entity.name}}.example.com`).
 


### PR DESCRIPTION
Update api docs for PKI External CA plugin, documenting the fact that the `acme_account_name` field cannot be updated after role creation.
