### PR TITLE
docs(consul-k8s): add note about config entries requiring transparent proxy on both downstream and upstream

### DIFF
--- a/content/consul/v1.18.x/content/docs/connect/config-entries/proxy-defaults.mdx
+++ b/content/consul/v1.18.x/content/docs/connect/config-entries/proxy-defaults.mdx
@@ -380,7 +380,7 @@ Specifies a mode for how proxies direct inbound and outbound traffic. You can sp
 
 Contains configurations for proxies that are running in transparent proxy mode. This mode enables permissive mTLS for Consul so that you can use your Kubernetes cluster's DNS service instead of Consul DNS. Refer to [Transparent proxy mode](/consul/docs/k8s/connect/transparent-proxy) for additional information.
 
-**Note**: If you plan to use config entries to define a call path (for example, `ServiceDefaults` or `ProxyDefaults` that affect upstream routing), enable transparent proxy on both the downstream and upstream services. If an upstream must bypass the mesh, do NOT apply config entries that assume a mesh-based call path to that upstream.
+When you use configuration entries to define a call path that affects upstream routing, you must enable transparent proxy on both the downstream and upstream services. If an upstream must bypass the mesh, do not apply configuration entries such as `ServiceDefaults` or `ProxyDefaults`, which assume a mesh-based call path to that upstream.
 
 #### Values
 

--- a/content/consul/v1.18.x/content/docs/k8s/connect/transparent-proxy/enable-transparent-proxy.mdx
+++ b/content/consul/v1.18.x/content/docs/k8s/connect/transparent-proxy/enable-transparent-proxy.mdx
@@ -224,7 +224,7 @@ Kubernetes annotation to the service pods. The annotation overrides the Consul s
 Consul configures redirection for each Pod bound to the Kubernetes Service using  `iptables` rules. The rules redirect all inbound and outbound traffic through an inbound and outbound listener on the sidecar proxy. Consul configures the proxy to route traffic to the appropriate upstream services based on [service
 intentions](/consul/docs/connect/config-entries/service-intentions), which address the upstream services using KubeDNS.
 
-**Note**: If you plan to use config entries for a call path, enable transparent proxy on both the downstream (caller) and upstream (callee) services. If an upstream must bypass the mesh, do NOT apply config entries to that upstream — instead exclude it from transparent proxy or use direct dialing.
+When you use configuration entries to define a call path, you must enable transparent proxy on both the downstream and upstream services. If an upstream must bypass the mesh, do not apply configuration entries. Instead, exclude it from the transparent proxy or use direct dialing.
 
 In the following example, the Kubernetes service selects `sample-app` application Pods so that they can be reached within the mesh.
 

--- a/content/consul/v1.19.x/content/docs/connect/config-entries/proxy-defaults.mdx
+++ b/content/consul/v1.19.x/content/docs/connect/config-entries/proxy-defaults.mdx
@@ -380,7 +380,7 @@ Specifies a mode for how proxies direct inbound and outbound traffic. You can sp
 
 Contains configurations for proxies that are running in transparent proxy mode. This mode enables permissive mTLS for Consul so that you can use your Kubernetes cluster's DNS service instead of Consul DNS. Refer to [Transparent proxy mode](/consul/docs/k8s/connect/transparent-proxy) for additional information.
 
-**Note**: If you plan to use config entries to define a call path (for example, `ServiceDefaults` or `ProxyDefaults` that affect upstream routing), enable transparent proxy on both the downstream and upstream services. If an upstream must bypass the mesh, do NOT apply config entries that assume a mesh-based call path to that upstream.
+When you use configuration entries to define a call path that affects upstream routing, you must enable transparent proxy on both the downstream and upstream services. If an upstream must bypass the mesh, do not apply configuration entries such as `ServiceDefaults` or `ProxyDefaults`, which assume a mesh-based call path to that upstream.
 
 #### Values
 

--- a/content/consul/v1.19.x/content/docs/k8s/connect/transparent-proxy/enable-transparent-proxy.mdx
+++ b/content/consul/v1.19.x/content/docs/k8s/connect/transparent-proxy/enable-transparent-proxy.mdx
@@ -224,7 +224,7 @@ Kubernetes annotation to the service pods. The annotation overrides the Consul s
 Consul configures redirection for each Pod bound to the Kubernetes Service using  `iptables` rules. The rules redirect all inbound and outbound traffic through an inbound and outbound listener on the sidecar proxy. Consul configures the proxy to route traffic to the appropriate upstream services based on [service
 intentions](/consul/docs/connect/config-entries/service-intentions), which address the upstream services using KubeDNS.
 
-**Note**: If you plan to use config entries for a call path, enable transparent proxy on both the downstream (caller) and upstream (callee) services. If an upstream must bypass the mesh, do NOT apply config entries to that upstream — instead exclude it from transparent proxy or use direct dialing.
+When you use configuration entries to define a call path, you must enable transparent proxy on both the downstream and upstream services. If an upstream must bypass the mesh, do not apply configuration entries. Instead, exclude it from the transparent proxy or use direct dialing.
 
 In the following example, the Kubernetes service selects `sample-app` application Pods so that they can be reached within the mesh.
 

--- a/content/consul/v1.20.x/content/docs/k8s/connect/transparent-proxy/enable-transparent-proxy.mdx
+++ b/content/consul/v1.20.x/content/docs/k8s/connect/transparent-proxy/enable-transparent-proxy.mdx
@@ -224,7 +224,7 @@ Kubernetes annotation to the service pods. The annotation overrides the Consul s
 Consul configures redirection for each Pod bound to the Kubernetes Service using  `iptables` rules. The rules redirect all inbound and outbound traffic through an inbound and outbound listener on the sidecar proxy. Consul configures the proxy to route traffic to the appropriate upstream services based on [service
 intentions](/consul/docs/connect/config-entries/service-intentions), which address the upstream services using KubeDNS.
 
-**Note**: If you plan to use config entries for a call path, enable transparent proxy on both the downstream (caller) and upstream (callee) services. If an upstream must bypass the mesh, do NOT apply config entries to that upstream — instead exclude it from transparent proxy or use direct dialing.
+When you use configuration entries to define a call path, you must enable transparent proxy on both the downstream and upstream services. If an upstream must bypass the mesh, do not apply configuration entries. Instead, exclude it from the transparent proxy or use direct dialing.
 
 In the following example, the Kubernetes service selects `sample-app` application Pods so that they can be reached within the mesh.
 

--- a/content/consul/v1.21.x/content/docs/connect/proxy/transparent-proxy/k8s.mdx
+++ b/content/consul/v1.21.x/content/docs/connect/proxy/transparent-proxy/k8s.mdx
@@ -243,7 +243,7 @@ Kubernetes annotation to the service pods. The annotation overrides the Consul s
 Consul configures redirection for each Pod bound to the Kubernetes Service using  `iptables` rules. The rules redirect all inbound and outbound traffic through an inbound and outbound listener on the sidecar proxy. Consul configures the proxy to route traffic to the appropriate upstream services based on [service
 intentions](/consul/docs/reference/config-entry/service-intentions), which address the upstream services using KubeDNS.
 
-**Note**: If you plan to use config entries for a call path, enable transparent proxy on both the downstream (caller) and upstream (callee) services. If an upstream must bypass the mesh, do NOT apply config entries to that upstream — instead exclude it from transparent proxy or use direct dialing.
+When you use configuration entries to define a call path, you must enable transparent proxy on both the downstream and upstream services. If an upstream must bypass the mesh, do not apply configuration entries. Instead, exclude it from the transparent proxy or use direct dialing.
 
 In the following example, the Kubernetes service selects `sample-app` application Pods so that they can be reached within the mesh.
 

--- a/content/consul/v1.21.x/content/docs/reference/config-entry/proxy-defaults.mdx
+++ b/content/consul/v1.21.x/content/docs/reference/config-entry/proxy-defaults.mdx
@@ -380,7 +380,7 @@ Specifies a mode for how proxies direct inbound and outbound traffic. You can sp
 
 Contains configurations for proxies that are running in transparent proxy mode. This mode enables permissive mTLS for Consul so that you can use your Kubernetes cluster's DNS service instead of Consul DNS. Refer to [Transparent proxy mode](/consul/docs/connect/proxy/transparent-proxy) for additional information.
 
-**Note**: If you plan to use config entries to define a call path (for example, `ServiceDefaults` or `ProxyDefaults` that affect upstream routing), enable transparent proxy on both the downstream and upstream services. If an upstream must bypass the mesh, do NOT apply config entries that assume a mesh-based call path to that upstream.
+When you use configuration entries to define a call path that affects upstream routing, you must enable transparent proxy on both the downstream and upstream services. If an upstream must bypass the mesh, do not apply configuration entries such as `ServiceDefaults` or `ProxyDefaults`, which assume a mesh-based call path to that upstream.
 
 #### Values
 

--- a/content/consul/v1.22.x/content/docs/connect/proxy/transparent-proxy/k8s.mdx
+++ b/content/consul/v1.22.x/content/docs/connect/proxy/transparent-proxy/k8s.mdx
@@ -243,7 +243,7 @@ Kubernetes annotation to the service pods. The annotation overrides the Consul s
 Consul configures redirection for each Pod bound to the Kubernetes Service using  `iptables` rules. The rules redirect all inbound and outbound traffic through an inbound and outbound listener on the sidecar proxy. Consul configures the proxy to route traffic to the appropriate upstream services based on [service
 intentions](/consul/docs/reference/config-entry/service-intentions), which address the upstream services using KubeDNS.
 
-**Note**: If you plan to use config entries for a call path, enable transparent proxy on both the downstream (caller) and upstream (callee) services. If an upstream must bypass the mesh, do NOT apply config entries to that upstream — instead exclude it from transparent proxy.
+When you use configuration entries to define a call path, you must enable transparent proxy on both the downstream and upstream services. If an upstream must bypass the mesh, do not apply configuration entries. Instead, exclude it from the transparent proxy or use direct dialing.
 
 In the following example, the Kubernetes service selects `sample-app` application Pods so that they can be reached within the mesh.
 

--- a/content/consul/v1.22.x/content/docs/reference/config-entry/proxy-defaults.mdx
+++ b/content/consul/v1.22.x/content/docs/reference/config-entry/proxy-defaults.mdx
@@ -380,7 +380,7 @@ Specifies a mode for how proxies direct inbound and outbound traffic. You can sp
 
 Contains configurations for proxies that are running in transparent proxy mode. This mode enables permissive mTLS for Consul so that you can use your Kubernetes cluster's DNS service instead of Consul DNS. Refer to [Transparent proxy mode](/consul/docs/connect/proxy/transparent-proxy) for additional information.
 
-**Note**: If you plan to use config entries to define a call path (for example, `ServiceDefaults` or `ProxyDefaults` that affect upstream routing), enable transparent proxy on both the downstream and upstream services. If an upstream must bypass the mesh, do NOT apply config entries that assume a mesh-based call path to that upstream.
+When you use configuration entries to define a call path that affects upstream routing, you must enable transparent proxy on both the downstream and upstream services. If an upstream must bypass the mesh, do not apply configuration entries such as `ServiceDefaults` or `ProxyDefaults`, which assume a mesh-based call path to that upstream.
 
 #### Values
 


### PR DESCRIPTION
## Description
- Add a note to the Kubernetes transparent-proxy guides and ProxyDefaults config-entry reference that config entries for call paths require transparent proxy enabled on both caller and callee, and must not be applied to upstreams that bypass the mesh.
- Users disabled transparent proxy on an upstream (last hop) and assumed it wasn't required as per their understanding. To prevent such issues, we are adding this note to avoid such misunderstandings

<!--
**Merge branch**

Make sure you create your PR against the correct **base** branch. For instructions, refer to
GitHub's **Change the branch range and destination repository guide** (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request).

If your content is an update to:

- Currently published content

  Choose **base: main** when you are updating published documentation, and you
  want your changes published when the PR is merged. We publish Consul content
  from the `main` branch.

- Upcoming Consul release

  Choose the branch for the Consul release that your content is for. Consul
  release branches use the `consul/<exact-release-number>` format. If you are not
  able to find the upcoming Consul release branch that you are looking for,
  contact the tech writer that works with the Consul team.

**Backports**

This repo stores previous version docs in folders instead of branches. There are
no backport labels.  If you backported your code PR to previous branches, update
the docs content in the corresponding folders. For example, if the current
release is 1.22.x and you backported your code to 1.21.x and 1.20.x, update the docs content
in the v1.22.x, v1.21.x, and v1.20.x folders.
-->


## Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.

Jira: [<jira-ticket-number>]  // for example, Jira: [CE-1001] GH-Jira integration generates the link and updates the Jira ticket.
GitHub Issue: <issue-link>

The bot does publish a root-level link to the deploy preview. The link changes with each build.
-->
[Jira ticket ](https://hashicorp.atlassian.net/browse/CSL-13458)

## Contributor checklists

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [x] 3 days: Small changes, easy reviews
- [ ] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [x] Verify that all status checks passed
- [x] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [ ] I added redirects for any moved or removed pages
- [ ] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [x] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [ ] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.

[CE-1001]: https://hashicorp.atlassian.net/browse/CE-1001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ