### PR TITLE
Add new PKI ACME config fields for challenge validation ip ranges

### DIFF
--- a/content/vault/v1.19.x/content/api-docs/secret/pki/issuance.mdx
+++ b/content/vault/v1.19.x/content/api-docs/secret/pki/issuance.mdx
@@ -341,6 +341,17 @@ mount.
    string duration with time suffix. Hour is the largest suffix. If not set,
    defaults to the previous hard-coded behavior of 90 days (2160 hours).
 
+ - `challenge_permitted_ip_ranges` `(list: [])` - List of CIDR blocks that are
+   permitted for ACME challenge validation. If set, only IPs within these ranges
+   will be allowed for validation. Can be individual IPs or CIDR notation. When
+   empty (default), all IPs are permitted unless excluded by
+   `challenge_excluded_ip_ranges`.
+
+ - `challenge_excluded_ip_ranges` `(list: [])` - List of CIDR blocks that are
+   excluded from ACME challenge validation. IPs within these ranges will be
+   rejected for validation. Can be individual IPs or CIDR notation. This list
+   takes precedence over `challenge_permitted_ip_ranges`.
+
 #### Sample payload
 
 ```

--- a/content/vault/v1.20.x/content/api-docs/secret/pki/issuance.mdx
+++ b/content/vault/v1.20.x/content/api-docs/secret/pki/issuance.mdx
@@ -345,6 +345,17 @@ mount.
    string duration with time suffix. Hour is the largest suffix. If not set,
    defaults to the previous hard-coded behavior of 90 days (2160 hours).
 
+ - `challenge_permitted_ip_ranges` `(list: [])` - List of CIDR blocks that are
+   permitted for ACME challenge validation. If set, only IPs within these ranges
+   will be allowed for validation. Can be individual IPs or CIDR notation. When
+   empty (default), all IPs are permitted unless excluded by
+   `challenge_excluded_ip_ranges`.
+
+ - `challenge_excluded_ip_ranges` `(list: [])` - List of CIDR blocks that are
+   excluded from ACME challenge validation. IPs within these ranges will be
+   rejected for validation. Can be individual IPs or CIDR notation. This list
+   takes precedence over `challenge_permitted_ip_ranges`.
+
 #### Sample payload
 
 ```

--- a/content/vault/v1.21.x/content/api-docs/secret/pki/issuance.mdx
+++ b/content/vault/v1.21.x/content/api-docs/secret/pki/issuance.mdx
@@ -345,6 +345,17 @@ mount.
    string duration with time suffix. Hour is the largest suffix. If not set,
    defaults to the previous hard-coded behavior of 90 days (2160 hours).
 
+ - `challenge_permitted_ip_ranges` `(list: [])` - List of CIDR blocks that are
+   permitted for ACME challenge validation. If set, only IPs within these ranges
+   will be allowed for validation. Can be individual IPs or CIDR notation. When
+   empty (default), all IPs are permitted unless excluded by
+   `challenge_excluded_ip_ranges`.
+
+ - `challenge_excluded_ip_ranges` `(list: [])` - List of CIDR blocks that are
+   excluded from ACME challenge validation. IPs within these ranges will be
+   rejected for validation. Can be individual IPs or CIDR notation. This list
+   takes precedence over `challenge_permitted_ip_ranges`.
+
 #### Sample payload
 
 ```


### PR DESCRIPTION
The new fields are callenge_permitted_ip_ranges and callenge_excluded_ip_ranges.

Please go to the `Preview` tab and select the appropriate template:

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
