### PR TITLE
Consul: Remove repeated Node Health Info

### DIFF
--- a/content/consul/v1.21.x/content/commands/lock.mdx
+++ b/content/consul/v1.21.x/content/commands/lock.mdx
@@ -7,7 +7,7 @@ description: >-
   services running at once across a cluster.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-11-04T10:42:51-06:00
-last_modified: 2025-11-04T10:42:51-06:00
+last_modified: 2026-03-13T19:58:55.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -90,7 +90,7 @@ Windows has no POSIX compatible notion for `SIGTERM`.
 
 ## Node health checks and TTL behavior
 
-When you run `consul lock`, Consul automatically creates an _ephemeral session_ that attaches one or more node checks, such as the `serfHealth` check, by default. These checks keep the node “healthy” from Consul’s perspective. This session automatically renews as long as the agent passes these health checks. For sessions with a a TTL configured, that TTL never reaches zero as long as the node remains healthy.
+When you run `consul lock`, Consul automatically creates an _ephemeral session_ that attaches one or more node checks, such as the `serfHealth` check, by default. These checks keep the node “healthy” from Consul’s perspective. This session automatically renews as long as the agent passes these health checks. For sessions with a TTL configured, that TTL never reaches zero as long as the node remains healthy.
 
 This design ensures the lock is not lost as long as the local Consul agent is up and healthy. However, emphemeral sessions run indefinitely when:
 
@@ -104,30 +104,3 @@ To strictly enforce the TTL and prevent auto-renewed by node checks, you must cr
 1. **Manage renewals** and releases yourself as needed.
 
 When you remove node checks, the TTL-based session expires after the specified time if you do not renew it. Consul releases the lock automatically when the session expires.
-
-## Node health checks and TTL behavior
-
-When you run `consul lock`, Consul automatically creates an _ephemeral session_ that attaches one or more node checks, such as the `serfHealth` check, by default. These checks keep the node “healthy” from Consul’s perspective. This session automatically renews as long as the agent passes these health checks. For sessions with a a TTL configured, that TTL never reaches zero as long as the node remains healthy.
-
-This design ensures the lock is not lost as long as the local Consul agent is up and healthy. However, emphemeral sessions run indefinitely when:
-
-- **The node remains healthy**, including in partial networks where at least one Consul server still reads the node as online.  
-- **No explicit session destroy** or forced release occurs.
-
-To strictly enforce the TTL and prevent auto-renewed by node checks, you must create or manage your own session separately. In that scenario:
-
-1. **Manually create a session** with the HTTP API that either excludes node checks or uses custom service checks.  
-1. **Acquire the lock** on that custom session using the raw KV API (`?acquire=<sessionID>`).  
-1. **Manage renewals** and releases yourself as needed.
-
-When you remove node checks, the TTL-based session expires after the specified time if you do not renew it. Consul releases the lock automatically when the session expires.
-
-## SHELL
-
-Consul lock launches its children in a shell. By default, Consul will use the shell
-defined in the environment variable `SHELL`. If `SHELL` is not defined, it will
-default to `/bin/sh`. It should be noted that not all shells terminate child
-processes when they receive `SIGTERM`. Under Ubuntu, `/bin/sh` is linked to `dash`,
-which does **not** terminate its children. In order to ensure that child processes
-are killed when the lock is lost, be sure to set the `SHELL` environment variable
-appropriately, or run without a shell by setting `-shell=false`.

--- a/content/consul/v1.22.x/content/commands/lock.mdx
+++ b/content/consul/v1.22.x/content/commands/lock.mdx
@@ -7,7 +7,7 @@ description: >-
   services running at once across a cluster.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-11-05T11:02:51-05:00
-last_modified: 2025-11-05T11:02:51-05:00
+last_modified: 2026-03-13T19:58:57.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -90,7 +90,7 @@ Windows has no POSIX compatible notion for `SIGTERM`.
 
 ## Node health checks and TTL behavior
 
-When you run `consul lock`, Consul automatically creates an _ephemeral session_ that attaches one or more node checks, such as the `serfHealth` check, by default. These checks keep the node “healthy” from Consul’s perspective. This session automatically renews as long as the agent passes these health checks. For sessions with a a TTL configured, that TTL never reaches zero as long as the node remains healthy.
+When you run `consul lock`, Consul automatically creates an _ephemeral session_ that attaches one or more node checks, such as the `serfHealth` check, by default. These checks keep the node “healthy” from Consul’s perspective. This session automatically renews as long as the agent passes these health checks. For sessions with a TTL configured, that TTL never reaches zero as long as the node remains healthy.
 
 This design ensures the lock is not lost as long as the local Consul agent is up and healthy. However, emphemeral sessions run indefinitely when:
 
@@ -104,30 +104,3 @@ To strictly enforce the TTL and prevent auto-renewed by node checks, you must cr
 1. **Manage renewals** and releases yourself as needed.
 
 When you remove node checks, the TTL-based session expires after the specified time if you do not renew it. Consul releases the lock automatically when the session expires.
-
-## Node health checks and TTL behavior
-
-When you run `consul lock`, Consul automatically creates an _ephemeral session_ that attaches one or more node checks, such as the `serfHealth` check, by default. These checks keep the node “healthy” from Consul’s perspective. This session automatically renews as long as the agent passes these health checks. For sessions with a a TTL configured, that TTL never reaches zero as long as the node remains healthy.
-
-This design ensures the lock is not lost as long as the local Consul agent is up and healthy. However, emphemeral sessions run indefinitely when:
-
-- **The node remains healthy**, including in partial networks where at least one Consul server still reads the node as online.  
-- **No explicit session destroy** or forced release occurs.
-
-To strictly enforce the TTL and prevent auto-renewed by node checks, you must create or manage your own session separately. In that scenario:
-
-1. **Manually create a session** with the HTTP API that either excludes node checks or uses custom service checks.  
-1. **Acquire the lock** on that custom session using the raw KV API (`?acquire=<sessionID>`).  
-1. **Manage renewals** and releases yourself as needed.
-
-When you remove node checks, the TTL-based session expires after the specified time if you do not renew it. Consul releases the lock automatically when the session expires.
-
-## SHELL
-
-Consul lock launches its children in a shell. By default, Consul will use the shell
-defined in the environment variable `SHELL`. If `SHELL` is not defined, it will
-default to `/bin/sh`. It should be noted that not all shells terminate child
-processes when they receive `SIGTERM`. Under Ubuntu, `/bin/sh` is linked to `dash`,
-which does **not** terminate its children. In order to ensure that child processes
-are killed when the lock is lost, be sure to set the `SHELL` environment variable
-appropriately, or run without a shell by setting `-shell=false`.


### PR DESCRIPTION
<!--
**Merge branch**

Make sure you create your PR against the correct **base** branch. For instructions, refer to
GitHub's **Change the branch range and destination repository guide** (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request).

If your content is an update to:

- Currently published content

  Choose **base: main** when you are updating published documentation, and you
  want your changes published when the PR is merged. We publish Consul content
  from the `main` branch.

- Upcoming Consul release

  Choose the branch for the Consul release that your content is for. Consul
  release branches use the `consul/<exact-release-number>` format. If you are not
  able to find the upcoming Consul release branch that you are looking for,
  contact the tech writer that works with the Consul team.

**Backports**

This repo stores previous version docs in folders instead of branches. There are
no backport labels.  If you backported your code PR to previous branches, update
the docs content in the corresponding folders. For example, if the current
release is 1.22.x and you backported your code to 1.21.x and 1.20.x, update the docs content
in the v1.22.x, v1.21.x, and v1.20.x folders.
-->

## Description

<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of. 

Include the target release as well as prior versions if applicable.
-->

This PR removes one of the "Node Health checks and TTL behavior" sections on the `lock` CLI page. This section was repeated on accident.

## Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.

Jira: [<jira-ticket-number>]  // for example, Jira: [CE-1001] GH-Jira integration generates the link and updates the Jira ticket.
GitHub Issue: <issue-link>

The bot does publish a root-level link to the deploy preview. The link changes with each build.
-->
[Deployment preview link](https://unified-docs-frontend-preview-26c8h2r8k-hashicorp.vercel.app/consul/commands/lock)

## Contributor checklists

Review urgency:

- [x] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [ ] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [x] Verify that all status checks passed
- [x] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [x] I added redirects for any moved or removed pages
- [x] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [x] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [ ] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.


[CE-1001]: https://hashicorp.atlassian.net/browse/CE-1001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ