### PR TITLE
Propagate typo fix from #1964 to other docs versions 

### DIFF
--- a/content/terraform/v1.12.x/docs/language/modules/configuration.mdx
+++ b/content/terraform/v1.12.x/docs/language/modules/configuration.mdx
@@ -114,16 +114,16 @@ Refer to [Select an alternate provider configuration](/terraform/language/block/
 
 The resources defined in a module form a self-contained group of resources. Module authors commonly define outputs that expose attribute values for the resources created by the module. You can reference the values in the parent module using the [`module.<MODULE-NAME>.<OUTPUT-NAME>` expression](/terraform/language/expressions/references#child-module-outputs). Refer to the module documentation for information about its outputs. 
 
-In the following example, the `aws_subnet` resource references the value of the VCP ID output by the `vcp` module:
+In the following example, the `aws_subnet` resource references the value of the VPC ID output by the `vpc` module:
 
 ```hcl
-module "vcp" {
+module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "6.0.1"
 }
 
 resource "aws_subnet" "main" {
-  vpc_id     = module.vcp.vpc_id
+  vpc_id     = module.vpc.vpc_id
   cidr_block = "10.0.1.0/24"
 
   tags = {

--- a/content/terraform/v1.13.x/docs/language/modules/configuration.mdx
+++ b/content/terraform/v1.13.x/docs/language/modules/configuration.mdx
@@ -114,16 +114,16 @@ Refer to [Select an alternate provider configuration](/terraform/language/block/
 
 The resources defined in a module form a self-contained group of resources. Module authors commonly define outputs that expose attribute values for the resources created by the module. You can reference the values in the parent module using the [`module.<MODULE-NAME>.<OUTPUT-NAME>` expression](/terraform/language/expressions/references#child-module-outputs). Refer to the module documentation for information about its outputs. 
 
-In the following example, the `aws_subnet` resource references the value of the VCP ID output by the `vcp` module:
+In the following example, the `aws_subnet` resource references the value of the VPC ID output by the `vpc` module:
 
 ```hcl
-module "vcp" {
+module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "6.0.1"
 }
 
 resource "aws_subnet" "main" {
-  vpc_id     = module.vcp.vpc_id
+  vpc_id     = module.vpc.vpc_id
   cidr_block = "10.0.1.0/24"
 
   tags = {

--- a/content/terraform/v1.15.x (alpha)/docs/language/modules/configuration.mdx
+++ b/content/terraform/v1.15.x (alpha)/docs/language/modules/configuration.mdx
@@ -113,16 +113,16 @@ Refer to [Select an alternate provider configuration](/terraform/language/block/
 
 The resources defined in a module form a self-contained group of resources. Module authors commonly define outputs that expose attribute values for the resources created by the module. You can reference the values in the parent module using the [`module.<MODULE-NAME>.<OUTPUT-NAME>` expression](/terraform/language/expressions/references#child-module-outputs). Refer to the module documentation for information about its outputs. 
 
-In the following example, the `aws_subnet` resource references the value of the VCP ID output by the `vcp` module:
+In the following example, the `aws_subnet` resource references the value of the VPC ID output by the `vpc` module:
 
 ```hcl
-module "vcp" {
+module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "6.0.1"
 }
 
 resource "aws_subnet" "main" {
-  vpc_id     = module.vcp.vpc_id
+  vpc_id     = module.vpc.vpc_id
   cidr_block = "10.0.1.0/24"
 
   tags = {


### PR DESCRIPTION
### What
See https://github.com/hashicorp/web-unified-docs/pull/1964

Makes fix apply to all versions of docs


### Why
Avoiding confusion or future PRs

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] (N/A) You added redirects to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages **across all affected versions**. Refer to [Redirects](https://github.com/hashicorp/web-unified-docs/blob/main/docs/content-guide/redirects.md#example-redirects) for examples and guidance. 
- [x] (N/A) Links to related content where appropriate (e.g., CLI, language, API endpoints, permissions, etc.).
- [x] (N/A) Pages with related content are updated and link to this content when appropriate.
- [x] (N/A) Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] (N/A) New pages have metadata (page name and description) at the top.
- [x] (N/A) New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] (N/A) New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] (N/A) UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
