### PR TITLE
Typo correction vcp to vpc

### DIFF
--- a/content/terraform/v1.15.x (alpha)/docs/language/modules/configuration.mdx
+++ b/content/terraform/v1.15.x (alpha)/docs/language/modules/configuration.mdx
@@ -113,16 +113,16 @@ Refer to [Select an alternate provider configuration](/terraform/language/block/
 
 The resources defined in a module form a self-contained group of resources. Module authors commonly define outputs that expose attribute values for the resources created by the module. You can reference the values in the parent module using the [`module.<MODULE-NAME>.<OUTPUT-NAME>` expression](/terraform/language/expressions/references#child-module-outputs). Refer to the module documentation for information about its outputs. 
 
-In the following example, the `aws_subnet` resource references the value of the VCP ID output by the `vcp` module:
+In the following example, the `aws_subnet` resource references the value of the VPC ID output by the `vpc` module:
 
 ```hcl
-module "vcp" {
+module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "6.0.1"
 }
 
 resource "aws_subnet" "main" {
-  vpc_id     = module.vcp.vpc_id
+  vpc_id     = module.vpc.vpc_id
   cidr_block = "10.0.1.0/24"
 
   tags = {


### PR DESCRIPTION
Following up on the typo corrections from https://github.com/hashicorp/web-unified-docs/pull/1964

### What
<!-- Explain what you changed and provide a list of changed page names. -->
Changing typo vcp to vpc.

### Why
<!-- Explain why this change is necessary and how it benefits users. -->
Bringing docs inline with experiential reality. 

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->
(image of neon boxes within boxes, with neon arrows pointing at other boxes within boxes)

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] You added redirects to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages **across all affected versions**. Refer to [Redirects](https://github.com/hashicorp/web-unified-docs/blob/main/docs/content-guide/redirects.md#example-redirects) for examples and guidance. 
- [ ] Links to related content where appropriate (e.g., CLI, language, API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
