### PR TITLE
Run additional link checker for external links

### DIFF
--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -385,6 +385,7 @@ jobs:
             -b ${{ needs.deploy-dev-portal-preview.outputs.preview_url }}
             --exclude-all-private
             --exclude '\.(svg|gif|jpg|png)'
+            --exclude 'gnu\.org'
             --exclude ${{ needs.deploy-dev-portal-preview.outputs.preview_url }}
             --exclude 'https?://(www\.)?developer\.hashicorp\.com'
             --accept 200,408,429


### PR DESCRIPTION
## :question:  What

Updates the "Build PR Preview" workflow to run two separate lychee link scanners. The first scans _internal_ links for internal sites that we control (i.e: `*developer.hashicorp.com/*` & the preview URL) and passes the authentication bypass header along with each request. The second runs only for _external_ links to servers that we do not control and runs without the auth bypass header to avoid leaking this secret to external web servers via the request header

## :man_shrugging: Why
Security reached out to alert us to the fact that a secret (albeit a non-sensitive one) was being leaked via the request header meaning someone could open a pull request with a link to their own web server. Our lychee process would then reach out to that web server and include the auth bypass token in the request header.

## :test_tube:  Testing

1. Create a new branch based on this branch (`git fetch origin; git checkout rm/run-additional-link-checker-for-external-links`)
2. Duplicate the workflow (`cp .github/workflows/build-pr-preview.yml .github/workflows/build-pr-preview2.yml`) making sure to change the run name to something you can easily find later
3. Change the workflow trigger to `pull_request` instead of `pull_request_target`
4. Add a known good _external_ link (i.e: `http://www.google.com`), a known bad _external_ link (`http://www.google.com/bad-link-not-found`), a known good _internal_ link (i.e: `http://developer.hashicorp.com`), a known bad _internal_ link (i.e: `http://developer.hashicorp.com/bad-link-not-found`) and push the changes to the draft PR.
5. The link checker comment should update in your PR with internal and external bad links flagged
6. Remove the links you added before. The PR comment should be updated again to say "No bad links! :tada: "

## :cloud: Anything Else?
- Don't use `www.developer.hashicorp.com` to test good links. It will fail. This is a known issue and is outside of the scope of this PR.
  <img width="1203" height="906" alt="image" src="https://github.com/user-attachments/assets/9958bad9-44a6-4812-b1e0-54bbbfd01711" />
