### PR TITLE
Service mesh configuration options

### DIFF
--- a/content/consul/v1.21.x/content/docs/reference/agent/configuration-file/service-mesh.mdx
+++ b/content/consul/v1.21.x/content/docs/reference/agent/configuration-file/service-mesh.mdx
@@ -5,7 +5,7 @@ description: >-
   Use agent configuration files to assign attributes to agents and configure multiple agents at once. Learn about agent configuration file parameters and formatting with this reference page and sample code.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-11-04T10:42:51-06:00
-last_modified: 2026-03-13T21:41:41.000Z
+last_modified: 2026-03-16T22:54:16.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -79,16 +79,16 @@ subsystem that provides Consul's service mesh capabilities.
       CA**. The Vault token given above must have `write` access to this backend,
       as well as permission to mount the backend at this path if it is not already
       mounted.
-    
-    - `root_pki_namespace` The Vault namespace that the Root PKI Path is in. Setting this parameter overrides the Namespace option for Consul's RootPKIPath.
-    - `intermediate_pki_namespace` The Vault namespace that the Intermediate PKI Path is in. Setting this parameter overrides the Namespace option for Consul's IntermediatePKIPath. 
+
+    - `root_pki_namespace` ((#vault_root_pki_namespace)) The Vault namespace that the Root PKI Path is in. Setting this parameter overrides the Namespace option for Consul's RootPKIPath.
+    - `intermediate_pki_namespace` ((#vault_intermediate_pki_namespace)) The Vault namespace that the Intermediate PKI Path is in. Setting this parameter overrides the Namespace option for Consul's IntermediatePKIPath.
 
     - `ca_path` ((#vault_ca_path)) Specifies an optional path to a folder containing CA certificates to be used for Vault communication. If unspecified, this will fallback to the default system CA bundle, which varies by OS and version.
     - `ca_file`  ((#vault_ca_file)) Specifies an optional path to the CA certificate used for Vault communication. If unspecified, this will fallback to the default system CA bundle, which varies by OS and version.
     - `cert_file` ((#vault_cert_file))  Specifies the path to the certificate used for Vault communication. If this is set, then you also need to set `key_file`.
     - `key_file` ((#vault_key_file))  Specifies the path to the private key used for Vault communication. If this is set, then you also need to set `cert_file`.
-    - `tls_server_name` ((#vault_tls_server_name)) - Specifies an optional string used to set the SNI host when connecting to Vault with TLS.
-    - `tls_skip_verify` ((#vault_tls_skip_verify)) - Specifies if SSL peer validation should be enforced. Defaults to `false`.
+    - `tls_server_name` ((#vault_tls_server_name)) Specifies an optional string used to set the SNI host when connecting to Vault with TLS.
+    - `tls_skip_verify` ((#vault_tls_skip_verify)) Specifies if SSL peer validation should be enforced. Defaults to `false`.
   
     - `auth_method` ((#vault_ca_auth_method))
       Vault auth method to use for logging in to Vault.

--- a/content/consul/v1.22.x/content/docs/reference/agent/configuration-file/service-mesh.mdx
+++ b/content/consul/v1.22.x/content/docs/reference/agent/configuration-file/service-mesh.mdx
@@ -5,7 +5,7 @@ description: >-
   Use agent configuration files to assign attributes to agents and configure multiple agents at once. Learn about agent configuration file parameters and formatting with this reference page and sample code.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-11-05T11:02:51-05:00
-last_modified: 2026-03-13T21:41:42.000Z
+last_modified: 2026-03-16T22:54:18.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -80,15 +80,15 @@ subsystem that provides Consul's service mesh capabilities.
       as well as permission to mount the backend at this path if it is not already
       mounted.
 
-    - `root_pki_namespace` The Vault namespace that the Root PKI Path is in. Setting this parameter overrides the Namespace option for Consul's RootPKIPath.
-    - `intermediate_pki_namespace` The Vault namespace that the Intermediate PKI Path is in. Setting this parameter overrides the Namespace option for Consul's IntermediatePKIPath. 
+    - `root_pki_namespace` ((#vault_root_pki_namespace)) The Vault namespace that the Root PKI Path is in. Setting this parameter overrides the Namespace option for Consul's RootPKIPath.
+    - `intermediate_pki_namespace` ((#vault_intermediate_pki_namespace)) The Vault namespace that the Intermediate PKI Path is in. Setting this parameter overrides the Namespace option for Consul's IntermediatePKIPath.
 
     - `ca_path` ((#vault_ca_path)) Specifies an optional path to a folder containing CA certificates to be used for Vault communication. If unspecified, this will fallback to the default system CA bundle, which varies by OS and version.
     - `ca_file`  ((#vault_ca_file)) Specifies an optional path to the CA certificate used for Vault communication. If unspecified, this will fallback to the default system CA bundle, which varies by OS and version.
     - `cert_file` ((#vault_cert_file))  Specifies the path to the certificate used for Vault communication. If this is set, then you also need to set `key_file`.
     - `key_file` ((#vault_key_file))  Specifies the path to the private key used for Vault communication. If this is set, then you also need to set `cert_file`.
-    - `tls_server_name` ((#vault_tls_server_name)) - Specifies an optional string used to set the SNI host when connecting to Vault with TLS.
-    - `tls_skip_verify` ((#vault_tls_skip_verify)) - Specifies if SSL peer validation should be enforced. Defaults to `false`.
+    - `tls_server_name` ((#vault_tls_server_name)) Specifies an optional string used to set the SNI host when connecting to Vault with TLS.
+    - `tls_skip_verify` ((#vault_tls_skip_verify)) Specifies if SSL peer validation should be enforced. Defaults to `false`.
   
     - `auth_method` ((#vault_ca_auth_method))
       Vault auth method to use for logging in to Vault.


### PR DESCRIPTION
<!--
**Merge branch**

Make sure you create your PR against the correct **base** branch. For instructions, refer to
GitHub's **Change the branch range and destination repository guide** (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request).

If your content is an update to:

- Currently published content

  Choose **base: main** when you are updating published documentation, and you
  want your changes published when the PR is merged. We publish Consul content
  from the `main` branch.

- Upcoming Consul release

  Choose the branch for the Consul release that your content is for. Consul
  release branches use the `consul/<exact-release-number>` format. If you are not
  able to find the upcoming Consul release branch that you are looking for,
  contact the tech writer that works with the Consul team.

**Backports**

This repo stores previous version docs in folders instead of branches. There are
no backport labels.  If you backported your code PR to previous branches, update
the docs content in the corresponding folders. For example, if the current
release is 1.22.x and you backported your code to 1.21.x and 1.20.x, update the docs content
in the v1.22.x, v1.21.x, and v1.20.x folders.
-->

## Description

<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of. 

Include the target release as well as prior versions if applicable.
-->
This PR adds available configuration options that were not listed on the agent configuration reference. Entries adapted from the [Vault Consul configuration reference in the Vault docs](https://developer.hashicorp.com/vault/docs/configuration/service-registration/consul#consul-parameters).

## Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.

Jira: [<jira-ticket-number>]  // for example, Jira: [CE-1001] GH-Jira integration generates the link and updates the Jira ticket.
GitHub Issue: <issue-link>

The bot does publish a root-level link to the deploy preview. The link changes with each build.
-->
[Preview link](https://unified-docs-frontend-preview-mvpjzrmj2-hashicorp.vercel.app/consul/docs/reference/agent/configuration-file/service-mesh#vault-ca-provider-ca_provider-vault)

## Contributor checklists

Review urgency:

- [x] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [ ] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [x] Verify that all status checks passed
- [x] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [x] I added redirects for any moved or removed pages
- [x] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [x] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [ ] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.


[CE-1001]: https://hashicorp.atlassian.net/browse/CE-1001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ