### PR TITLE
Framework: update resource identity documentation to recommend setting identity during `Update`

### DIFF
--- a/content/terraform-plugin-framework/v1.16.x/docs/plugin/framework/resources/identity.mdx
+++ b/content/terraform-plugin-framework/v1.16.x/docs/plugin/framework/resources/identity.mdx
@@ -90,16 +90,17 @@ func (r ThingResource) IdentitySchema(_ context.Context, _ resource.IdentitySche
 
 Identity data, similar to resource state data, can be set or retrieved during the resource [`Create`](/terraform/plugin/framework/resources/create),
 [`Read`](/terraform/plugin/framework/resources/read), [`Update`](/terraform/plugin/framework/resources/update), [`Delete`](/terraform/plugin/framework/resources/delete)
-and [`ImportState`](/terraform/plugin/framework/resources/import) methods. Unlike resource state data, identity data is expected to be immutable after it is set during
-[`Create`](/terraform/plugin/framework/resources/create), so typically the only locations a provider should need to write identity data is during [`Create`](/terraform/plugin/framework/resources/create) and
-[`Read`](/terraform/plugin/framework/resources/read).
+and [`ImportState`](/terraform/plugin/framework/resources/import) methods. To avoid validation errors, any resource that defines an identity schema should
+set identity data during the [`Create`](/terraform/plugin/framework/resources/create), [`Read`](/terraform/plugin/framework/resources/read)
+and [`Update`](/terraform/plugin/framework/resources/update) methods.
 
 [`Read`](/terraform/plugin/framework/resources/read) should return identity data so that the managed resource can support [importing](/terraform/plugin/framework/resources/import),
 especially if not all of the identity attributes are provided by the practitioner during import (like provider configuration values and remote API data).
 
 ### Writing Identity
 
-Typically, identity data should be set during [`Create`](/terraform/plugin/framework/resources/create) and [`Read`](/terraform/plugin/framework/resources/read).
+Typically, identity data should be set during [`Create`](/terraform/plugin/framework/resources/create), [`Read`](/terraform/plugin/framework/resources/read)
+and [`Update`](/terraform/plugin/framework/resources/update).
 The same data model for [writing data](/terraform/plugin/framework/handling-data/writing-state) to state is used for identity, for example:
 
 ```go

--- a/content/terraform-plugin-framework/v1.16.x/docs/plugin/framework/resources/update.mdx
+++ b/content/terraform-plugin-framework/v1.16.x/docs/plugin/framework/resources/update.mdx
@@ -140,6 +140,10 @@ func (r ThingResource) Update(ctx context.Context, req resource.UpdateRequest, r
 }
 ```
 
+## Resource Identity
+
+Managed resources that support identity also need to set the identity data during `Update`, see the ["Identity" page](/terraform/plugin/framework/resources/identity#writing-identity) for more information.
+
 ## Caveats
 
 Note these caveats when implementing the `Update` method:

--- a/content/terraform-plugin-framework/v1.17.x/docs/plugin/framework/resources/identity.mdx
+++ b/content/terraform-plugin-framework/v1.17.x/docs/plugin/framework/resources/identity.mdx
@@ -90,16 +90,17 @@ func (r ThingResource) IdentitySchema(_ context.Context, _ resource.IdentitySche
 
 Identity data, similar to resource state data, can be set or retrieved during the resource [`Create`](/terraform/plugin/framework/resources/create),
 [`Read`](/terraform/plugin/framework/resources/read), [`Update`](/terraform/plugin/framework/resources/update), [`Delete`](/terraform/plugin/framework/resources/delete)
-and [`ImportState`](/terraform/plugin/framework/resources/import) methods. Unlike resource state data, identity data is expected to be immutable after it is set during
-[`Create`](/terraform/plugin/framework/resources/create), so typically the only locations a provider should need to write identity data is during [`Create`](/terraform/plugin/framework/resources/create) and
-[`Read`](/terraform/plugin/framework/resources/read).
+and [`ImportState`](/terraform/plugin/framework/resources/import) methods. To avoid validation errors, any resource that defines an identity schema should
+set identity data during the [`Create`](/terraform/plugin/framework/resources/create), [`Read`](/terraform/plugin/framework/resources/read)
+and [`Update`](/terraform/plugin/framework/resources/update) methods.
 
 [`Read`](/terraform/plugin/framework/resources/read) should return identity data so that the managed resource can support [importing](/terraform/plugin/framework/resources/import),
 especially if not all of the identity attributes are provided by the practitioner during import (like provider configuration values and remote API data).
 
 ### Writing Identity
 
-Typically, identity data should be set during [`Create`](/terraform/plugin/framework/resources/create) and [`Read`](/terraform/plugin/framework/resources/read).
+Typically, identity data should be set during [`Create`](/terraform/plugin/framework/resources/create), [`Read`](/terraform/plugin/framework/resources/read)
+and [`Update`](/terraform/plugin/framework/resources/update).
 The same data model for [writing data](/terraform/plugin/framework/handling-data/writing-state) to state is used for identity, for example:
 
 ```go

--- a/content/terraform-plugin-framework/v1.17.x/docs/plugin/framework/resources/update.mdx
+++ b/content/terraform-plugin-framework/v1.17.x/docs/plugin/framework/resources/update.mdx
@@ -140,6 +140,10 @@ func (r ThingResource) Update(ctx context.Context, req resource.UpdateRequest, r
 }
 ```
 
+## Resource Identity
+
+Managed resources that support identity also need to set the identity data during `Update`, see the ["Identity" page](/terraform/plugin/framework/resources/identity#writing-identity) for more information.
+
 ## Caveats
 
 Note these caveats when implementing the `Update` method:

--- a/content/terraform-plugin-framework/v1.18.x/docs/plugin/framework/resources/identity.mdx
+++ b/content/terraform-plugin-framework/v1.18.x/docs/plugin/framework/resources/identity.mdx
@@ -90,16 +90,17 @@ func (r ThingResource) IdentitySchema(_ context.Context, _ resource.IdentitySche
 
 Identity data, similar to resource state data, can be set or retrieved during the resource [`Create`](/terraform/plugin/framework/resources/create),
 [`Read`](/terraform/plugin/framework/resources/read), [`Update`](/terraform/plugin/framework/resources/update), [`Delete`](/terraform/plugin/framework/resources/delete)
-and [`ImportState`](/terraform/plugin/framework/resources/import) methods. Unlike resource state data, identity data is expected to be immutable after it is set during
-[`Create`](/terraform/plugin/framework/resources/create), so typically the only locations a provider should need to write identity data is during [`Create`](/terraform/plugin/framework/resources/create) and
-[`Read`](/terraform/plugin/framework/resources/read).
+and [`ImportState`](/terraform/plugin/framework/resources/import) methods. To avoid validation errors, any resource that defines an identity schema should
+set identity data during the [`Create`](/terraform/plugin/framework/resources/create), [`Read`](/terraform/plugin/framework/resources/read)
+and [`Update`](/terraform/plugin/framework/resources/update) methods.
 
 [`Read`](/terraform/plugin/framework/resources/read) should return identity data so that the managed resource can support [importing](/terraform/plugin/framework/resources/import),
 especially if not all of the identity attributes are provided by the practitioner during import (like provider configuration values and remote API data).
 
 ### Writing Identity
 
-Typically, identity data should be set during [`Create`](/terraform/plugin/framework/resources/create) and [`Read`](/terraform/plugin/framework/resources/read).
+Typically, identity data should be set during [`Create`](/terraform/plugin/framework/resources/create), [`Read`](/terraform/plugin/framework/resources/read)
+and [`Update`](/terraform/plugin/framework/resources/update).
 The same data model for [writing data](/terraform/plugin/framework/handling-data/writing-state) to state is used for identity, for example:
 
 ```go

--- a/content/terraform-plugin-framework/v1.18.x/docs/plugin/framework/resources/update.mdx
+++ b/content/terraform-plugin-framework/v1.18.x/docs/plugin/framework/resources/update.mdx
@@ -140,6 +140,10 @@ func (r ThingResource) Update(ctx context.Context, req resource.UpdateRequest, r
 }
 ```
 
+## Resource Identity
+
+Managed resources that support identity also need to set the identity data during `Update`, see the ["Identity" page](/terraform/plugin/framework/resources/identity#writing-identity) for more information.
+
 ## Caveats
 
 Note these caveats when implementing the `Update` method:

--- a/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/resources/identity.mdx
+++ b/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/resources/identity.mdx
@@ -79,16 +79,15 @@ func resourceThing() *schema.Resource {
 ## Handling Identity Data
 
 Identity data, similar to resource state data, can be set or retrieved during the resource `Create`, `Read`,
-`Update`, `Delete` and [`Importer`](/terraform/plugin/sdkv2/resources/import) functions. Unlike resource state data,
-identity data is expected to be immutable after it is set during `Create`, so typically the only locations a provider
-should need to write identity data is during `Create` and `Read`.
+`Update`, `Delete` and [`Importer`](/terraform/plugin/sdkv2/resources/import) functions. To avoid validation errors, any resource that defines an identity schema should
+set identity data during the `Create`, `Read`, and `Update` functions.
 
 `Read` should return identity data so that the managed resource can support [importing](/terraform/plugin/sdkv2/resources/import),
 especially if not all of the identity attributes are provided by the practitioner during import (like provider configuration values and remote API data).
 
 ### Writing Identity
 
-Typically, identity data should be set during `Create` and `Read`. The [`*schema.IdentityData`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema#IdentityData)
+Typically, identity data should be set during `Create`, `Read`, and `Update`. The [`*schema.IdentityData`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema#IdentityData)
 struct is used to write identity data and can be retrieved via the `*schema.ResourceData` struct, for example:
 
 ```go

--- a/content/terraform-plugin-sdk/v2.39.x/docs/plugin/sdkv2/resources/identity.mdx
+++ b/content/terraform-plugin-sdk/v2.39.x/docs/plugin/sdkv2/resources/identity.mdx
@@ -79,16 +79,15 @@ func resourceThing() *schema.Resource {
 ## Handling Identity Data
 
 Identity data, similar to resource state data, can be set or retrieved during the resource `Create`, `Read`,
-`Update`, `Delete` and [`Importer`](/terraform/plugin/sdkv2/resources/import) functions. Unlike resource state data,
-identity data is expected to be immutable after it is set during `Create`, so typically the only locations a provider
-should need to write identity data is during `Create` and `Read`.
+`Update`, `Delete` and [`Importer`](/terraform/plugin/sdkv2/resources/import) functions. To avoid validation errors, any resource that defines an identity schema should
+set identity data during the `Create`, `Read`, and `Update` functions.
 
 `Read` should return identity data so that the managed resource can support [importing](/terraform/plugin/sdkv2/resources/import),
 especially if not all of the identity attributes are provided by the practitioner during import (like provider configuration values and remote API data).
 
 ### Writing Identity
 
-Typically, identity data should be set during `Create` and `Read`. The [`*schema.IdentityData`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema#IdentityData)
+Typically, identity data should be set during `Create`, `Read`, and `Update`. The [`*schema.IdentityData`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema#IdentityData)
 struct is used to write identity data and can be retrieved via the `*schema.ResourceData` struct, for example:
 
 ```go


### PR DESCRIPTION
### What
<!-- Explain what you changed and provide a list of changed page names. -->
Framework v1.16.x, v1.17.x, v1.18.x:
- `resources/identity.mdx`
- `resources/update.mdx`

SDK v2.28.x, v2.29.x:
- `resources/identity.mdx`

### Why
<!-- Explain why this change is necessary and how it benefits users. -->
We've added validation in Framework `v1.16.1` and SDK `v2.38.0` to throw an error for null identities during create, read, and update. We're updating our guidance to include setting identity during update so that provider developers can avoid running into this error.

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] You added redirects to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages **across all affected versions**. Refer to [Redirects](https://github.com/hashicorp/web-unified-docs/blob/main/docs/content-guide/redirects.md#example-redirects) for examples and guidance. 
- [ ] Links to related content where appropriate (e.g., CLI, language, API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
