### PR TITLE
[CODEOWNER] Set codeowner for global partials

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,6 +4,9 @@
 # Content CODEOWNERS
 /docs @hashicorp/vault-education-approvers @hashicorp/education
 
+# Global partials
+/content/global/partials @hashicorp/education
+
 # Terraform documentation ownership
 /content/terraform-plugin-framework @hashicorp/terraform-core-plugins @hashicorp/terraform-education
 /content/terraform-plugin-log @hashicorp/terraform-core-plugins @hashicorp/terraform-education


### PR DESCRIPTION

When I created https://github.com/hashicorp/web-unified-docs/pull/1996, it added way too many reviewers. 

<img width="1189" height="636" alt="image" src="https://github.com/user-attachments/assets/cde9d9ab-1d8c-4e0b-93e8-601ddbfc7c1b" />


I need help setting reasonable list of teams who must approve whenever someone adds global partials. 