### PR TITLE
vault: events now forwarded to secondary clusters for 1.21 and 2.0

### DIFF
--- a/content/vault/v1.21.x/content/docs/concepts/events.mdx
+++ b/content/vault/v1.21.x/content/docs/concepts/events.mdx
@@ -178,7 +178,7 @@ For multi-node Vault deployments, Vault only accepts subscriptions on the active
 Vault reroutes subscription requests made to [non-performance standby nodes](/vault/docs/enterprise/performance-standby#disabling-performance-standbys) to the active node based on the [`api_addr`](/vault/docs/configuration#api_addr) configuration setting on the active node.
 
 Primary clusters forward events to secondary performance replica clusters for
-replicated mounts; secondary clusters do not forward events to the primary
+replicated mounts. Secondary clusters do not forward events to the primary
 cluster.
 
 Due to the [eventually consistent](/vault/docs/enterprise/consistency) nature of

--- a/content/vault/v2.x (rc)/content/docs/concepts/events.mdx
+++ b/content/vault/v2.x (rc)/content/docs/concepts/events.mdx
@@ -178,7 +178,7 @@ For multi-node Vault deployments, Vault only accepts subscriptions on the active
 Vault reroutes subscription requests made to [non-performance standby nodes](/vault/docs/enterprise/performance-standby#disabling-performance-standbys) to the active node based on the [`api_addr`](/vault/docs/configuration#api_addr) configuration setting on the active node.
 
 Primary clusters forward events to secondary performance replica clusters for
-replicated mounts; secondary clusters do not forward events to the primary
+replicated mounts. Secondary clusters do not forward events to the primary
 cluster.
 
 Due to the [eventually consistent](/vault/docs/enterprise/consistency) nature of


### PR DESCRIPTION
As of ENT Vault 1.21.5 and 2.0, events will now be forwarded from primary to secondary clusters. Updating the 1.21 and 2.0-rc docs to reflect that.