### PR TITLE
Specify url base64 encoding for EAB key within External CA

### DIFF
--- a/content/vault/v2.x (rc)/content/api-docs/secret/pki-external-ca.mdx
+++ b/content/vault/v2.x (rc)/content/api-docs/secret/pki-external-ca.mdx
@@ -65,7 +65,7 @@ Create a new ACME account by registering with the specified ACME directory serve
 - `eab_kid` `(string: "")` - External Account Binding (EAB) key identifier. Some
   ACME servers require an EAB key identifier for account registration.
 
-- `eab_key` `(string: "")` - External Account Binding (EAB) key (base64-encoded). Some ACME servers require an EAB key for account registration.
+- `eab_key` `(string: "")` - External Account Binding (EAB) key (urlbase64-encoded). Some ACME servers require an EAB key for account registration.
 
 - `trusted_ca` `(string: "")` - PEM-encoded trusted CA certificates for
   validating the TLS certificate provided by the ACME server. Use `trusted_ca`

--- a/content/vault/v2.x (rc)/content/docs/secrets/pki-external-ca/index.mdx
+++ b/content/vault/v2.x (rc)/content/docs/secrets/pki-external-ca/index.mdx
@@ -71,7 +71,7 @@ You can use the PKI external CA plugin to:
         directory_url="https://acme.example.com/v2/acme/directory"  \
         email_contacts="admin@example.com"                          \
         eab_kid="your-eab-key-id"                                   \
-        eab_key="base64-encoded-eab-key"                            \
+        eab_key="urlbase64-encoded-eab-key"                         \
         key_type="rsa-2048"
     ```
     </Tab>


### PR DESCRIPTION
Be a little more explicit in the type of base64 encoding we are expecting from the EAB key. Specifying base64 most people would assuming std base64 encoding.