### PR TITLE
Nomad: document that sometimes plugin_dir needs to be executable

### DIFF
--- a/content/nomad/v1.10.x/content/docs/configuration/index.mdx
+++ b/content/nomad/v1.10.x/content/docs/configuration/index.mdx
@@ -300,7 +300,9 @@ testing.
 - `plugin_dir` `(string: "")` - Specifies the directory to use for looking up
   plugins. When this parameter is empty, Nomad will generate the path using the
   [top-level `data_dir`](#data_dir) suffixed with `plugins`, like
-  `"/opt/nomad/plugins"`. This must be an absolute path.
+  `"/opt/nomad/plugins"`. This must be an absolute path. If you are using
+  plugins that execute as unprivileged users, such as `exec2`, you should set
+  the `plugin_dir` outside the `data_dir` and allow it to be executable.
 
 - `plugin` `(`[`Plugin`]`: nil)` - Specifies configuration for a
   specific plugin. The plugin block may be repeated, once for each plugin being

--- a/content/nomad/v1.10.x/content/plugins/drivers/exec2.mdx
+++ b/content/nomad/v1.10.x/content/plugins/drivers/exec2.mdx
@@ -26,10 +26,17 @@ Review the source on [GitHub][github].
 <Tabs>
 <Tab heading="Manual installation" group="manual">
 
-You can download a [precompiled binary](https://releases.hashicorp.com/nomad-driver-exec2/) and verify the binary using the
-available SHA-256 sums. After downloading nomad-driver-exec2 driver, unzip the package. Make sure
-that the `nomad-driver-exec2` binary is available on your [plugin_dir](/nomad/docs/configuration#plugin_dir) path, specified by the client's config file, before continuing with the
-other guides.
+You can download a [precompiled
+binary](https://releases.hashicorp.com/nomad-driver-exec2/) and verify the
+binary using the available SHA-256 sums. After downloading nomad-driver-exec2
+driver, unzip the package. Make sure that the `nomad-driver-exec2` binary is
+available on your [plugin_dir](/nomad/docs/configuration#plugin_dir) path,
+specified by the client's config file, before continuing with the other
+guides.
+
+Note that if you have followed the guidance in the [hardening guide][] you
+should set the `plugin_dir` to be outside the `data_dir` and executable so that
+the unprivileged user IDs used by this plugin can execute the plugin binary.
 
 </Tab>
 <Tab heading="Ubuntu/Debian" group="manual">
@@ -320,3 +327,4 @@ driver.exec2.unveil.tasks       = true
 [releases]: https://releases.hashicorp.com/nomad-driver-exec2
 [unshare]: https://www.man7.org/linux/man-pages/man1/unshare.1.html
 [unveil]: https://man.openbsd.org/unveil
+[hardening guide]: /nomad/docs/deploy/production/requirements#hardening-nomad

--- a/content/nomad/v1.11.x/content/docs/configuration/index.mdx
+++ b/content/nomad/v1.11.x/content/docs/configuration/index.mdx
@@ -304,7 +304,9 @@ testing.
 - `plugin_dir` `(string: "")` - Specifies the directory to use for looking up
   plugins. When this parameter is empty, Nomad will generate the path using the
   [top-level `data_dir`](#data_dir) suffixed with `plugins`, like
-  `"/opt/nomad/plugins"`. This must be an absolute path.
+  `"/opt/nomad/plugins"`. This must be an absolute path. If you are using
+  plugins that execute as unprivileged users, such as `exec2`, you should set
+  the `plugin_dir` outside the `data_dir` and allow it to be executable.
 
 - `plugin` `(`[`Plugin`]`: nil)` - Specifies configuration for a
   specific plugin. The plugin block may be repeated, once for each plugin being

--- a/content/nomad/v1.11.x/content/plugins/drivers/exec2.mdx
+++ b/content/nomad/v1.11.x/content/plugins/drivers/exec2.mdx
@@ -26,10 +26,17 @@ Review the source on [GitHub][github].
 <Tabs>
 <Tab heading="Manual installation" group="manual">
 
-You can download a [precompiled binary](https://releases.hashicorp.com/nomad-driver-exec2/) and verify the binary using the
-available SHA-256 sums. After downloading nomad-driver-exec2 driver, unzip the package. Make sure
-that the `nomad-driver-exec2` binary is available on your [plugin_dir](/nomad/docs/configuration#plugin_dir) path, specified by the client's config file, before continuing with the
-other guides.
+You can download a [precompiled
+binary](https://releases.hashicorp.com/nomad-driver-exec2/) and verify the
+binary using the available SHA-256 sums. After downloading nomad-driver-exec2
+driver, unzip the package. Make sure that the `nomad-driver-exec2` binary is
+available on your [plugin_dir](/nomad/docs/configuration#plugin_dir) path,
+specified by the client's config file, before continuing with the other
+guides.
+
+Note that if you have followed the guidance in the [hardening guide][] you
+should set the `plugin_dir` to be outside the `data_dir` and executable so that
+the unprivileged user IDs used by this plugin can execute the plugin binary.
 
 </Tab>
 <Tab heading="Ubuntu/Debian" group="manual">
@@ -320,3 +327,4 @@ driver.exec2.unveil.tasks       = true
 [releases]: https://releases.hashicorp.com/nomad-driver-exec2
 [unshare]: https://www.man7.org/linux/man-pages/man1/unshare.1.html
 [unveil]: https://man.openbsd.org/unveil
+[hardening guide]: /nomad/docs/deploy/production/requirements#hardening-nomad


### PR DESCRIPTION
If you follow the Nomad hardening guide, some external plugins like `exec2` run into trouble when they drop their privileges and re-exec themselves if you have the `plugin_dir` inside the Nomad datadir.

Fixes: https://github.com/hashicorp/nomad-driver-exec2/issues/85

## Contributor checklists

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [x] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [ ] Verify that all status checks passed
- [ ] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [ ] I added redirects for any moved or removed pages
- [ ] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [ ] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [ ] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.
