### PR TITLE
change http 204 to 202 for seal rewrap process start

### DIFF
--- a/content/vault/v1.21.x/content/api-docs/system/sealwrap-rewrap.mdx
+++ b/content/vault/v1.21.x/content/api-docs/system/sealwrap-rewrap.mdx
@@ -64,7 +64,7 @@ and progress updates.
 The default status codes are:
 
 - `200` if a seal rewrap process is already running
-- `204` if a seal rewrap process was started
+- `202` if a seal rewrap process was started
 
 ### Sample request
 


### PR DESCRIPTION
minor fix to reflect doc bug. Seal rewrap started is HTTP code 202 (not 204).
