### PR TITLE
Fix typo on `import` block documentation

### DIFF
--- a/content/terraform/v1.14.x/docs/language/block/import.mdx
+++ b/content/terraform/v1.14.x/docs/language/block/import.mdx
@@ -25,7 +25,7 @@ An `import` block supports the following configuration:
 
 ## Complete configuration
 
-The following `module` block includes all built-in arguments:
+The following `import` block includes all built-in arguments:
 
 ```hcl
 import {


### PR DESCRIPTION
### What
Corrected a single typo in the [import block](https://developer.hashicorp.com/terraform/language/block/import) documentation. 

### Why
An `import` block example was erroneously referred to as a `module` block example

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [N/A] You added redirects to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages **across all affected versions**. Refer to [Redirects](https://github.com/hashicorp/web-unified-docs/blob/main/docs/content-guide/redirects.md#example-redirects) for examples and guidance. 
- [N/A] Links to related content where appropriate (e.g., CLI, language, API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [N/A] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [N/A] New pages have metadata (page name and description) at the top.
- [N/A] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [N/A] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [N/A] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
