### PR TITLE
Nomad Docs:  Updated docs for nomad-pack release 0.4.2

### DIFF
--- a/content/nomad/v1.11.x/content/partials/tools/nomad-pack/options-nomad-cluster.mdx
+++ b/content/nomad/v1.11.x/content/partials/tools/nomad-pack/options-nomad-cluster.mdx
@@ -4,8 +4,10 @@
   environment variable if set.
 - `-namespace=<string>`: The target namespace for queries and actions bound to a
   namespace.	Overrides the NOMAD_NAMESPACE environment variable if set.
+  Namespace values can include hyphens.
 - `-region=<string>`: The region of the Nomad servers to forward commands to.
-  Overrides the NOMAD_REGION environment variable if set.
+  Overrides the NOMAD_REGION environment variable if set. Region values can
+  include hyphens.
 - `-ca-cert=<string>`: Path to a PEM encoded CA cert file to use to verify the
   Nomad server SSL certificate. Overrides the NOMAD_CACERT environment variable
   if set.

--- a/content/nomad/v1.11.x/content/tools/nomad-pack/advanced-usage.mdx
+++ b/content/nomad/v1.11.x/content/tools/nomad-pack/advanced-usage.mdx
@@ -66,6 +66,24 @@ To deploy the resources in a pack to Nomad, use the `run` command.
 $ nomad-pack run hello_world
 ```
 
+By default, `run` monitors evaluations and deployments after job submission. If
+you are running in automation and want the command to return immediately, use
+the `--detach` flag.
+
+```shell-session
+$ nomad-pack run hello_world --detach
+```
+
+If a target job already exists and was not deployed by Nomad Pack, you can use
+`--deploy-override`.
+
+```shell-session
+$ nomad-pack run hello_world --deploy-override
+```
+
+When you update a running deployment, Nomad Pack stops jobs that no longer
+exist in the updated pack definition.
+
 By passing a `--name` value into `run`, Nomad Pack deploys each resource in the
 pack with a metadata value for pack name. If no name is given, the pack name
 is used by default.
@@ -104,6 +122,19 @@ The `plan` command also takes the `--var` and `-f` flags like the `run` command.
 ```
 nomad-pack plan hello_world -f ./my-variables.hcl --var greeting=hallo
 ```
+
+The `plan` command also supports `--deploy-override` when you want to plan over
+an existing non-pack job.
+
+```
+nomad-pack plan hello_world --deploy-override
+```
+
+### Reading HCL diagnostics
+
+When Nomad Pack reports HCL parsing errors, the message includes filename,
+line, and column ranges. For example, `variables.hcl:3,3-7` identifies the
+exact location to inspect.
 
 ## Registry management
 
@@ -159,6 +190,8 @@ $ nomad-pack registry add community github.com/hashicorp/nomad-pack-community-re
 
 To download a single pack or an entire registry at a specific version/SHA, use the `--ref` flag.
 
+Refs can include slashes, such as `pack-name/v0.4.2`.
+
 ```shell-session
 $ nomad-pack registry add community github.com/hashicorp/nomad-pack-community-registry --ref=v0.0.1
 ```
@@ -174,10 +207,10 @@ $ nomad-pack registry delete community
 
 ### Updating a registry
 
-To update a registry, use the `add` command and Nomad Pack will re-download the registry and replace the contents.
+To update a registry, use the `registry update` command.
 
 ```shell-session
-$ nomad-pack registry add default github.com/hashicorp/nomad-pack-community-registry
+$ nomad-pack registry update default
 ```
 
 ## Next steps

--- a/content/nomad/v1.11.x/content/tools/nomad-pack/commands/destroy.mdx
+++ b/content/nomad/v1.11.x/content/tools/nomad-pack/commands/destroy.mdx
@@ -15,6 +15,8 @@ Use the `nomad-pack destroy` command to stop and delete the specified Nomad pack
 from the configured Nomad cluster. This is the same as using the command
 `nomad-pack stop <pack_name> --purge`.
 
+By default, `destroy` monitors evaluations and deployments after submitting job stop operations. Use `-detach` to return immediately.
+
 By default, the `nomad-pack destroy` command deletes all jobs in the pack
 deployment. If you ran a pack with var overrides to specify the job name, you
 must provide the var override when destroying the pack to guarantee this command
@@ -31,10 +33,13 @@ nomad-pack destroy <pack_name> [options]
 - `-registry=<string>`: Specific registry name containing the pack to be
 					destroyed.
 - `-ref=<string>`: Specific Git reference of the pack to destroy.
-					Supports tags, SHA, and latest. If no ref is specified,
-					defaults to latest.	Using `ref` with a file path is not supported.
+					Supports tags, SHA, refs with slashes (for example,
+					`pack-name/v0.4.2`), and `@latest`. If no ref is specified,
+					defaults to `@latest`. Using `ref` with a file path is not supported.
 - `-global`: Destroy multi-region pack in all its regions. By default,
 					 `destroy` only destroys a single region at a time. Ignored for single-region packs.
+- `-detach`: Return immediately instead of monitoring evaluations and
+  deployments.
 
 @include 'tools/nomad-pack/options-operations.mdx'
 

--- a/content/nomad/v1.11.x/content/tools/nomad-pack/commands/fmt.mdx
+++ b/content/nomad/v1.11.x/content/tools/nomad-pack/commands/fmt.mdx
@@ -1,0 +1,49 @@
+---
+layout: commands
+page_title: nomad-pack fmt command reference
+description: |-
+  Use the `nomad-pack fmt` command to format pack template and HCL files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-03-23T00:00:00-05:00
+last_modified: 2026-03-23T00:00:00-05:00
+# END AUTO GENERATED METADATA
+---
+
+# nomad-pack fmt command reference
+
+Use the `nomad-pack fmt` command to format pack files (`.tpl` templates and `.hcl` files).
+
+## Usage
+
+```plaintext
+nomad-pack fmt [options] [path...]
+```
+
+If you do not specify a path, the command formats files in the current directory.
+
+## Options
+
+- `-check`: Check whether files are formatted without modifying them. Returns exit code `1` if formatting is needed.
+- `-list`: List files that would be modified. Defaults to `true`.
+- `-write`: Write formatted content to files. Defaults to `true`.
+- `-recursive`: Process directories recursively.
+
+## Examples
+
+Format files in the current directory.
+
+```shell
+nomad-pack fmt
+```
+
+Format files in a specific pack directory.
+
+```shell
+nomad-pack fmt my-pack/
+```
+
+Check formatting without modifying files.
+
+```shell
+nomad-pack fmt -check .
+```

--- a/content/nomad/v1.11.x/content/tools/nomad-pack/commands/generate/var-file.mdx
+++ b/content/nomad/v1.11.x/content/tools/nomad-pack/commands/generate/var-file.mdx
@@ -24,8 +24,9 @@ nomad-pack generate var-file <pack_name> [options]
 - `-registry=<string>`: Specific registry name containing the target pack. If
   not specified, the default registry is used.
 - `-ref=<string>`: Specific Git reference of the target pack. Supports tags,
-  SHA, and `@latest`. If you do not specify a reference, the command defaults to
-  `@latest`.	Using `ref` with a file path is not supported.
+  SHA, refs with slashes (for example, `pack-name/v0.4.2`), and `@latest`.
+  If you do not specify a reference, the command defaults to `@latest`. Using
+  `ref` with a file path is not supported.
 - `-to-file=<string>`: Path to write generated variable override file to in
   addition to	standard output.
 

--- a/content/nomad/v1.11.x/content/tools/nomad-pack/commands/info.mdx
+++ b/content/nomad/v1.11.x/content/tools/nomad-pack/commands/info.mdx
@@ -13,6 +13,8 @@ last_modified: 2025-11-17T20:24:06-05:00
 
 Use the `nomad-pack info` command to fetch information on the given pack including name, description, and variable details.
 
+The output includes complex variable type details and default values for optional variables.
+
 ## Usage
 
 ```plaintext
@@ -24,8 +26,9 @@ nomad-pack info <pack_name>
 - `-registry=<string>`: Specific registry name containing the pack to retrieve
   info about. If not specified, this command targets the default registry.
 - `-ref=<string>`: Specific Git reference of the pack to retrieve info
-  about. Supports tags, SHA, and `@latest`. If you do not specify a reference,
-  the value defaults to `@latest`. Using `ref` with a file path is not supported.
+  about. Supports tags, SHA, refs with slashes (for example,
+  `pack-name/v0.4.2`), and `@latest`. If you do not specify a reference, the
+  value defaults to `@latest`. Using `ref` with a file path is not supported.
 
 @include 'tools/nomad-pack/options-operations.mdx'
 

--- a/content/nomad/v1.11.x/content/tools/nomad-pack/commands/list.mdx
+++ b/content/nomad/v1.11.x/content/tools/nomad-pack/commands/list.mdx
@@ -22,7 +22,8 @@ nomad-pack list
 ## Options
 
 - `-registry=<string>`: Registry name to filter packs by.
-- `-ref=<string>`: Registry ref to filter packs by.
+- `-ref=<string>`: Registry ref to filter packs by. Supports tags, SHA, refs
+  with slashes (for example, `pack-name/v0.4.2`), and `@latest`.
 
 @include 'tools/nomad-pack/options-operations.mdx'
 

--- a/content/nomad/v1.11.x/content/tools/nomad-pack/commands/plan.mdx
+++ b/content/nomad/v1.11.x/content/tools/nomad-pack/commands/plan.mdx
@@ -29,10 +29,13 @@ nomad-pack plan <pack_name> [options]
 
 - `-registry=<string>`: Specific registry name containing the pack.
 - `-ref=<string>`: Specific Git reference of the pack to retrieve info about.
-  Supports tags, SHA, and `@latest`. If you do not specify a reference, the
-  value defaults to `@latest`. Using `ref` with a file path is not supported.
+  Supports tags, SHA, refs with slashes (for example, `pack-name/v0.4.2`), and
+  `@latest`. If you do not specify a reference, the value defaults to
+  `@latest`. Using `ref` with a file path is not supported.
 - `-diff`: Determines whether to output the diff between the remote job and
   planned job. Defaults to true.
+- `-deploy-override`: Sets the flag to force deploy over currently deployed
+  jobs, including jobs that were not deployed by Nomad Pack.
 - `-policy-override`: Sets the flag to force override any soft mandatory
   Sentinel policies.
 - `-verbose`: Increase diff verbosity.
@@ -41,6 +44,14 @@ nomad-pack plan <pack_name> [options]
 - `-exit-code-makes-changes=<int>`: Override exit code returned when the plan
   shows changes.
 - `-exit-code-error=<int>`: Override exit code returned when there is an error.
+
+You can also set these exit codes with environment variables:
+
+- `NOMAD_PACK_PLAN_EXIT_CODE_NO_CHANGES`
+- `NOMAD_PACK_PLAN_EXIT_CODE_MAKES_CHANGES`
+- `NOMAD_PACK_PLAN_EXIT_CODE_ERROR`
+
+If you set both flags and environment variables, flag values take precedence.
 
 @include 'tools/nomad-pack/options-operations.mdx'
 

--- a/content/nomad/v1.11.x/content/tools/nomad-pack/commands/registry/add.mdx
+++ b/content/nomad/v1.11.x/content/tools/nomad-pack/commands/registry/add.mdx
@@ -23,7 +23,8 @@ nomad-pack registry add <name> <source> [options]
 
 - `-target=<string>`: A specific pack within the registry.
 - `-ref=<string>`: Specific Git reference of the registry or pack. Supports
-tags, SHA, and `latest`. If you do not specify a reference, the command defaults
+tags, SHA, refs with slashes (for example, `pack-name/v0.4.2`), and `latest`.
+If you do not specify a reference, the command defaults
 to `@latest`. Running `nomad registry add` multiple times for the same ref is
 idempotent. However, running`nomad-pack registry add` without specifying a
 reference or when specifying `@latest` is destructive and overwrites current

--- a/content/nomad/v1.11.x/content/tools/nomad-pack/commands/registry/add.mdx
+++ b/content/nomad/v1.11.x/content/tools/nomad-pack/commands/registry/add.mdx
@@ -23,7 +23,7 @@ nomad-pack registry add <name> <source> [options]
 
 - `-target=<string>`: A specific pack within the registry.
 - `-ref=<string>`: Specific Git reference of the registry or pack. Supports
-tags, SHA, refs with slashes (for example, `pack-name/v0.4.2`), and `latest`.
+tags, SHA, refs with slashes (for example, `pack-name/v0.4.2`), and `@latest`.
 If you do not specify a reference, the command defaults
 to `@latest`. Running `nomad registry add` multiple times for the same ref is
 idempotent. However, running`nomad-pack registry add` without specifying a

--- a/content/nomad/v1.11.x/content/tools/nomad-pack/commands/registry/delete.mdx
+++ b/content/nomad/v1.11.x/content/tools/nomad-pack/commands/registry/delete.mdx
@@ -24,7 +24,9 @@ nomad-pack registry delete <name> [options]
 - `-target=<string>`: A specific pack within the registry. If you add a
   reference flag, the command only deletes that reference of the target pack.
 - `-ref=<string>`: Specific Git reference of the registry or pack. Supports
-  tags, SHA, and `@latest`. If you do not specify a reference, the command defaults to `@latest`. Using `ref` with a file path is not supported.
+  tags, SHA, refs with slashes (for example, `pack-name/v0.4.2`), and
+  `@latest`. If you do not specify a reference, the command defaults to
+  `@latest`. Using `ref` with a file path is not supported.
 
 <Warning>
 

--- a/content/nomad/v1.11.x/content/tools/nomad-pack/commands/registry/update.mdx
+++ b/content/nomad/v1.11.x/content/tools/nomad-pack/commands/registry/update.mdx
@@ -1,0 +1,47 @@
+---
+layout: commands
+page_title: nomad-pack registry update command reference
+description: |-
+  Use the `nomad-pack registry update` command to update registries or packs in the local environment.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-03-23T00:00:00-05:00
+last_modified: 2026-03-23T00:00:00-05:00
+# END AUTO GENERATED METADATA
+---
+
+# nomad-pack registry update command reference
+
+Use the `nomad-pack registry update` command to update a previously added registry or a specific pack from a registry.
+
+The command uses the source URL from the cached registry metadata, so you only need the registry name.
+
+## Usage
+
+```plaintext
+nomad-pack registry update <name> [options]
+```
+
+## Options
+
+- `-target=<string>`: A specific pack within the registry to update.
+- `-ref=<string>`: Specific Git reference of the registry or pack to update. Supports tags, SHA, refs with slashes (for example, `pack-name/v0.4.2`), and `latest`. If you do not specify a reference, the command defaults to `@latest`. Running the command multiple times for the same ref is idempotent.
+
+## Examples
+
+Update a previously added registry to the latest ref.
+
+```shell
+nomad-pack registry update community
+```
+
+Update a specific pack from a previously added registry.
+
+```shell
+nomad-pack registry update community --target=nomad_example
+```
+
+Update a previously added registry at a specific tag, release, or SHA.
+
+```shell
+nomad-pack registry update community --ref=v0.1.0
+```

--- a/content/nomad/v1.11.x/content/tools/nomad-pack/commands/render.mdx
+++ b/content/nomad/v1.11.x/content/tools/nomad-pack/commands/render.mdx
@@ -24,8 +24,9 @@ nomad-pack render <pack_name> [options]
 - `-registry=<string>`: Specific registry name containing the pack. If not
   specified, the default registry is used.
 - `-ref=<string>`: Specific Git reference of the pack to retrieve info about.
-  Supports tags, SHA, and `@latest`. If you do not specify a reference, the
-  value defaults to `@latest`. Using `ref` with a file path is not supported.
+  Supports tags, SHA, refs with slashes (for example, `pack-name/v0.4.2`), and
+  `@latest`. If you do not specify a reference, the value defaults to
+  `@latest`. Using `ref` with a file path is not supported.
 - `-render-output-template`: Controls whether or not to render and display the
   output template file within the pack.
 - `-skip-aux-files`: Controls whether or not the rendered output contains

--- a/content/nomad/v1.11.x/content/tools/nomad-pack/commands/run.mdx
+++ b/content/nomad/v1.11.x/content/tools/nomad-pack/commands/run.mdx
@@ -13,6 +13,10 @@ last_modified: 2025-11-17T20:24:06-05:00
 
 Use the `nomad-pack run` command to install the specified Nomad Pack to a configured Nomad cluster.
 
+By default, `run` monitors evaluations and deployments after submitting jobs. Use `-detach` to return immediately after submission.
+
+When a pack update removes jobs from the pack definition, `run` stops those previously deployed jobs.
+
 ## Usage
 
 ```plaintext
@@ -23,8 +27,11 @@ nomad-pack run <pack_name> [options]
 
 - `-registry=<string>`: Specific registry name containing the pack to be run.
 - `-ref=<string>`: Specific Git reference of the pack to retrieve info about.
-  Supports tags, SHA, and `@latest`. If you do not specify a reference, the
-  value defaults to `@latest`. Using `ref` with a file path is not supported.
+  Supports tags, SHA, refs with slashes (for example, `pack-name/v0.4.2`), and
+  `@latest`. If you do not specify a reference, the value defaults to
+  `@latest`. Using `ref` with a file path is not supported.
+- `-deploy-override`: Sets the flag to force deploy over currently deployed
+  jobs, including jobs that were not deployed by Nomad Pack.
 - `-check-index=<uint>`: If set, the job is only registered or updated if the
   passed job modify index matches the server side version. If you pass a value
   of zero, the job is only registered if it does not yet exist.  Passing a
@@ -50,6 +57,8 @@ nomad-pack run <pack_name> [options]
   Sentinel policies.
 - `-preserve-counts`: If set, the existing task group count is preserved when
   updating a job.
+- `-detach`: Return immediately instead of monitoring evaluations and
+  deployments.
 
 @include 'tools/nomad-pack/options-operations.mdx'
 
@@ -80,6 +89,12 @@ Run an example pack with CLI variable overrides.
 ```shell
 nomad-pack run example --var="redis_image_version=latest" \
            --var="redis_resources={"cpu": "1000", "memory": "512"}"
+```
+
+Run a pack and return immediately without monitoring evaluations or deployments.
+
+```shell
+nomad-pack run example --detach
 ```
 
 Run a pack under development from the current filesystem.

--- a/content/nomad/v1.11.x/content/tools/nomad-pack/commands/status.mdx
+++ b/content/nomad/v1.11.x/content/tools/nomad-pack/commands/status.mdx
@@ -29,8 +29,9 @@ deployment names.
 - `-registry=<string>`: Specific registry name containing the pack to inspect.If
   not specified, the command uses the default registry.
 - `-ref=<string>`: Specific Git reference of the pack to retrieve info about.
-  Supports tags, SHA, and `@latest`. If you do not specify a reference, the
-  value defaults to `@latest`. Using `ref` with a file path is not supported.
+  Supports tags, SHA, refs with slashes (for example, `pack-name/v0.4.2`), and
+  `@latest`. If you do not specify a reference, the value defaults to
+  `@latest`. Using `ref` with a file path is not supported.
 
 @include 'tools/nomad-pack/options-operations.mdx'
 

--- a/content/nomad/v1.11.x/content/tools/nomad-pack/commands/stop.mdx
+++ b/content/nomad/v1.11.x/content/tools/nomad-pack/commands/stop.mdx
@@ -13,6 +13,8 @@ last_modified: 2025-11-17T20:24:06-05:00
 
 Use the `nomad-pack stop` command to stop the specified Nomad Pack in the configured Nomad cluster.
 
+By default, `stop` monitors evaluations and deployments after submitting job stop operations. Use `-detach` to return immediately.
+
 By default, the `stop` command stops all jobs in the pack deployment. If you ran
 a pack with variable overrides to specify the job name, you must provide the
 same variable overrides when stopping the pack to guarantee that this command
@@ -32,12 +34,15 @@ destroy` command](/nomad/tools/nomad-pack/commands/destroy).
 - `-registry=<string>`: Specific registry name containing the pack to be
   stopped.
 - `-ref=<string>`: Specific Git reference of the pack to retrieve info about.
-  Supports tags, SHA, and `@latest`. If you do not specify a reference, the
-  value defaults to `@latest`. Using `ref` with a file path is not supported.
+  Supports tags, SHA, refs with slashes (for example, `pack-name/v0.4.2`), and
+  `@latest`. If you do not specify a reference, the value defaults to
+  `@latest`. Using `ref` with a file path is not supported.
 - `-purge`: Purge is used to stop a pack and purge it from the system.	If not
   set, you can still query the pack until the garbage collector purges the pack.
 - `-global`: Stop a multi-region pack in all its regions. By default, `pack
   stop` only stops a single region at a time. Ignored for	single-region jobs.
+- `-detach`: Return immediately instead of monitoring evaluations and
+  deployments.
 
 @include 'tools/nomad-pack/options-operations.mdx'
 

--- a/content/nomad/v1.11.x/content/tools/nomad-pack/commands/version.mdx
+++ b/content/nomad/v1.11.x/content/tools/nomad-pack/commands/version.mdx
@@ -9,7 +9,7 @@ last_modified: 2025-11-17T20:24:06-05:00
 # END AUTO GENERATED METADATA
 ---
 
-# nomad-pack stop command reference
+# nomad-pack version command reference
 
 Use `nomad-pack version` to return the Nomad Pack version.
 

--- a/content/nomad/v1.11.x/content/tools/nomad-pack/create-packs.mdx
+++ b/content/nomad/v1.11.x/content/tools/nomad-pack/create-packs.mdx
@@ -89,6 +89,10 @@ The `metadata.hcl` file contains important key value information about the pack.
   - `alias` - Name to refer to this specific dependency instance. Helpful when importing multiple versions of the same dependency.
   - `source` - The source URL for this dependency. Dependencies with different names can refer to the same source pack.
 
+Nomad Pack also injects runtime metadata values, including `pack.path`, during
+template rendering. You can access these values with template metadata
+functions, for example `[[ meta "pack.path" . ]]`.
+
 Add a `metadata.hcl` file with the following contents:
 
 
@@ -112,6 +116,9 @@ Add a `metadata.hcl` file with the following contents:
 #### variables.hcl
 
 The `variables.hcl` file defines the variables required to fully render and deploy all the templates found within the "templates" directory.
+
+Variable definitions support `optional()` type constraints for object
+attributes.
 
 Add a `variables.hcl` file with the following contents:
 
@@ -151,6 +158,18 @@ variable "resources" {
 ```
 
 </CodeBlockConfig>
+
+The following example shows an `optional()` attribute in an object type
+constraint:
+
+```hcl
+variable "service" {
+  type = object({
+    name        = string
+    annotations = optional(map(string))
+  })
+}
+```
 
 #### outputs.tpl
 
@@ -256,6 +275,11 @@ Custom Nomad-specific and debugging functions are also provided:
 - `spewDump` dumps the entirety of the passed object as a string. The output includes the content types and values. This uses the `spew.SDump` function.
 - `spewPrintf` dumps the supplied arguments into a string according to the supplied format. This uses the `spew.Printf` function.
 - `fileContents` takes an argument to a file of the local host, reads its contents and provides this as a string.
+- `fileRelative` takes a file path relative to the current pack root and
+  returns the file content.
+- `packPath` returns the path to the current pack.
+- `tpl` evaluates a template string using the current template context. This is
+  useful when variables store template fragments.
 
 A custom function within a template is called like any other:
 

--- a/content/nomad/v1.11.x/data/tools-nav-data.json
+++ b/content/nomad/v1.11.x/data/tools-nav-data.json
@@ -293,6 +293,10 @@
             "path": "nomad-pack/commands/destroy"
           },
           {
+            "title": "fmt",
+            "path": "nomad-pack/commands/fmt"
+          },
+          {
             "title": "generate",
             "routes": [
               {
@@ -343,6 +347,10 @@
               {
                 "title": "list",
                 "path": "nomad-pack/commands/registry/list"
+              },
+              {
+                "title": "update",
+                "path": "nomad-pack/commands/registry/update"
               }
             ]
           },


### PR DESCRIPTION
<!--
**Merge branch**

Make sure you create your PR against the correct **base** branch. For instructions, refer to
GitHub's **Change the branch range and destination repository guide** (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request).

If your content is an update to:

- Currently published content

  Choose **base: main** when you are updating published documentation, and you
  want your changes published when the PR is merged. We publish Nomad content
  from the `main` branch.

- Upcoming Nomad release

  Choose the branch for the Nomad release that your content is for. Nomad
  release branches use the `nomad/<exact-release-number>` format. If you are not
  able to find the upcoming Nomad release branch that you are looking for,
  contact the tech writer that works with the Nomad team.

- Upcoming Nomad release but not sure which one

  - Choose the `main` branch.
  - Add the "do not merge" label.
  - Convert the PR to a DRAFT.
  - Put an explanation in the **Description** section.

  The tech writer coordinates with Nomad engineering and updates
  the docs PR base branch when the code is slotted into an upcoming release.

**Backports**

This repo stores previous version docs in folders instead of branches. There are
no backport labels.  If you backported your code PR to previous branches, update
the docs content in the corresponding folders. For example, if the current
release is 1.10.x and you backported your code to 1.9.x and 1.8.x, update the docs content
in the v1.10.x, v1.9.x, and v1.8.x folders. If you can't find the relevant files in previous versions,
add a note to your PR description. The tech writer will help ensure that the previous versions
receive the correct updates.
-->

## Description
Updated Nomad Pack docs for release 0.4.2 changes across command reference and authoring/usage guides.

1)Monitoring + detach for run/stop/destroy: ✅ present in **run.mdx, stop.mdx, destroy.mdx**
2)deploy-override for run/plan: ✅ present in run.mdx and **plan.mdx**
3)Plan exit-code env vars: ✅ present in **plan.mdx**
4)info output enhancements: ✅ present in **info.mdx**
5) HCL line/column diagnostics note: ✅ present in **advanced-usage.mdx**
6) New fmt command docs: ✅ page exists fmt.mdx and nav entry in **tools-nav-data.json**
7) pack.path metadata docs: ✅ present in **create-packs.mdx**
8) New registry update docs: ✅ page exists **update.mdx** and nav entry in **tools-nav-data.json**
9) Stop removed jobs on update: ✅ present in **run.mdx** and **advanced-usage.mdx**
10)Slash refs support docs: ✅ present across command pages (run/plan/info/render/status/registry add/delete/update/generate var-file)
11) Hyphen support for namespace/region: ✅ present in **options-nomad-cluster.mdx**
12) tpl function docs: ✅ present in **create-packs.mdx**
13) optional() type constraints docs: ✅ present in **create-packs.mdx**

<!-- 
Please describe why you're making this change and point out any important details the reviewers
should be aware of. A robust description helps the tech writer create a fabulous release note.
If your code PR has a splendid description, link to the code PR in the links section so that
the tech writer can update this PR's description. 

Include the target release as well as prior versions if applicable.
-->

## Links
<!--
**Please link to the related Nomad repo code PR!** if there is one. 
The tech writer does look at the code PR description, Jira ticket, and/or GH issue before reviewing docs content.

Include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a docs bug fix, please ensure related issues are linked so they will close when this PR is
merged.

// GH-Jira integration generates the link and updates the Jira ticket.
Jira: [<jira-ticket-number>]  // for example, Jira: [NMD-1234] 

GitHub Issue: <issue-link>

Deploy previews: The bot does publish a root-level link to the deploy preview, but the preview URL changes with each build.
-->

Nomad Code PR:
Jira:
GitHub Issue:

Nomad-pack 0.4.2 Changelog - https://github.com/hashicorp/nomad-pack/releases/tag/v0.4.2 
Nomad-pack 0.4.2 release Doc- https://ibm.sharepoint.com/:w:/s/DEPT-NomadEngineering-Core/IQD3R-57ygpUS7_NOUApBjUXAUs6SIiCL5K2gKPArC4OkKk?e=Qjnu6c

## Contributor checklists

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [ ] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [ ] Verify that all status checks passed
- [ ] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [ ] I added redirects for any moved or removed pages
- [x] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [x] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [x] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.


[NMD-1234]: https://hashicorp.atlassian.net/browse/NMD-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ