### PR TITLE
Migrate skill to prompt

### DIFF
--- a/.github/prompts/radar-doc-review-prompt.md
+++ b/.github/prompts/radar-doc-review-prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: ask
-model: gpt-4.0
+model: gpt-5.3-codex
 description: Reviews a documentation file for correct format, style guide compliance, and content quality. Attach the file you want reviewed using #file.
 ---
 


### PR DESCRIPTION
Migrate `.github/skills/radar-doc-review/SKILLS.md` to `.github/prompts/radar-doc-review-prompt.md`

- Models were not properly reading/using the skill, leading to hallucinations/bad feedback
- Tested prompt.md as an alternative with GPT 1x models and worked every time