### PR TITLE
Nomad: update API docs for fine-grained ACLs to make CLI

### DIFF
--- a/content/nomad/v1.11.x/content/api-docs/operator/keyring.mdx
+++ b/content/nomad/v1.11.x/content/api-docs/operator/keyring.mdx
@@ -133,9 +133,9 @@ HTTP API.
 The table below shows this endpoint's support for [blocking queries] and
 [required ACLs].
 
-| Blocking Queries | ACL Required |
-|------------------|--------------|
-| `YES`            | `management` |
+| Blocking Queries | ACL Required            |
+|------------------|-------------------------|
+| `YES`            | `operator:keyring-read` |
 
 ### Sample Request
 
@@ -186,9 +186,9 @@ This endpoint forces the server to rotate the active root key.
 The table below shows this endpoint's support for [blocking queries] and
 [required ACLs].
 
-| Blocking Queries | ACL Required |
-|------------------|--------------|
-| `NO`             | `management` |
+| Blocking Queries | ACL Required              |
+|------------------|---------------------------|
+| `NO`             | `operator:keyring-rotate` |
 
 
 ### Parameters
@@ -233,9 +233,9 @@ This endpoint deletes a root key in the `inactive` state.
 The table below shows this endpoint's support for [blocking queries] and
 [required ACLs].
 
-| Blocking Queries | ACL Required |
-|------------------|--------------|
-| `NO`             | `management` |
+| Blocking Queries | ACL Required              |
+|------------------|---------------------------|
+| `NO`             | `operator:keyring-delete` |
 
 ### Parameters
 

--- a/content/nomad/v1.11.x/content/api-docs/operator/license.mdx
+++ b/content/nomad/v1.11.x/content/api-docs/operator/license.mdx
@@ -25,9 +25,9 @@ The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
 [required ACLs](/nomad/api-docs#acls).
 
-| Blocking Queries | ACL Required    |
-| ---------------- | --------------- |
-| `NO`             | `operator:read` |
+| Blocking Queries | ACL Required                               |
+|------------------|--------------------------------------------|
+| `NO`             | `operator:read` or `operator:license-read` |
 
 ### Sample Request
 

--- a/content/nomad/v1.11.x/content/api-docs/operator/snapshot.mdx
+++ b/content/nomad/v1.11.x/content/api-docs/operator/snapshot.mdx
@@ -33,9 +33,9 @@ The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
 [required ACLs](/nomad/api-docs#acls).
 
-| Blocking Queries | ACL Required |
-| ---------------- | ------------ |
-| `NO`             | `management` |
+| Blocking Queries | ACL Required                                 |
+|------------------|----------------------------------------------|
+| `NO`             | `operator:write` or `operator:snapshot-save` |
 
 ### Parameters
 

--- a/content/nomad/v1.11.x/content/api-docs/sentinel-policies.mdx
+++ b/content/nomad/v1.11.x/content/api-docs/sentinel-policies.mdx
@@ -32,9 +32,10 @@ The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries), [consistency modes](/nomad/api-docs#consistency-modes) and
 [required ACLs](/nomad/api-docs#acls).
 
-| Blocking Queries | Consistency Modes | ACL Required |
-| ---------------- | ----------------- | ------------ |
-| `YES`            | `all`             | `management` |
+| Blocking Queries | Consistency Modes | ACL Required    |
+|------------------|-------------------|-----------------|
+| `YES`            | `all`             | `sentinel:read` |
+
 
 ### Sample Request
 
@@ -72,9 +73,9 @@ The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
 [required ACLs](/nomad/api-docs#acls).
 
-| Blocking Queries | ACL Required |
-| ---------------- | ------------ |
-| `NO`             | `management` |
+| Blocking Queries | ACL Required      |
+|------------------|-------------------|
+| `NO`             | `sentinel:submit` |
 
 ### Parameters
 
@@ -124,9 +125,9 @@ The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries), [consistency modes](/nomad/api-docs#consistency-modes) and
 [required ACLs](/nomad/api-docs#acls).
 
-| Blocking Queries | Consistency Modes | ACL Required |
-| ---------------- | ----------------- | ------------ |
-| `YES`            | `all`             | `management` |
+| Blocking Queries | Consistency Modes | ACL Required    |
+|------------------|-------------------|-----------------|
+| `YES`            | `all`             | `sentinel:read` |
 
 ### Sample Request
 
@@ -163,9 +164,9 @@ The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
 [required ACLs](/nomad/api-docs#acls).
 
-| Blocking Queries | ACL Required |
-| ---------------- | ------------ |
-| `NO`             | `management` |
+| Blocking Queries | ACL Required      |
+|------------------|-------------------|
+| `NO`             | `sentinel:delete` |
 
 ### Parameters
 


### PR DESCRIPTION
In #1853 we updated the command line docs to explain a bunch of new fine-grained ACL capabilities. But we forgot to update the HTTP API docs to match.

* https://unified-docs-frontend-preview-j2laxj7b2-hashicorp.vercel.app/nomad/api-docs/operator/snapshot
* https://unified-docs-frontend-preview-j2laxj7b2-hashicorp.vercel.app/nomad/api-docs/sentinel-policies

## Contributor checklists

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [x] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [x] Verify that all status checks passed
- [x] Verify that the preview environment deployed successfully
- [x] Add additional reviewers if they are not part of assigned groups

Content:

- [x] I added redirects for any moved or removed pages
- [x] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [x] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [ ] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.
