### PR TITLE
Consul: Fix otel reference path

### DIFF
--- a/content/consul/global/partials/text/descriptions/access-log.mdx
+++ b/content/consul/global/partials/text/descriptions/access-log.mdx
@@ -1,3 +1,3 @@
 Consul can emit access logs to record application connections and requests that pass through proxies in a service mesh, including sidecar proxies and gateways. When you enable access logs in your proxy defaults, you can use it to diagnose and troubleshoot network issues, detect threats to your network, and audit traffic for security compliance.
 
-You can also [configure the OpenTelemetry Envoy extension](/consul/docs/envoy-extension/otel-access-logging) to capture and stream access logs. Refer to [access logs](/consul/docs/observe/access-log) for more information on enabling access logs in Consul.
+You can also [configure the OpenTelemetry Envoy extension](/consul/docs/envoy-extension/otel) to capture and stream access logs. Refer to [access logs](/consul/docs/observe/access-log) for more information on enabling access logs in Consul.

--- a/content/consul/v1.21.x/content/docs/envoy-extension/index.mdx
+++ b/content/consul/v1.21.x/content/docs/envoy-extension/index.mdx
@@ -5,7 +5,7 @@ description: >-
   Envoy extensions are plugins that you can use to add support for additional Envoy features without modifying the Consul codebase.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-11-04T10:42:51-06:00
-last_modified: 2025-11-04T10:42:51-06:00
+last_modified: 2026-03-25T21:53:09.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -50,7 +50,7 @@ The `lua` Envoy extension enables HTTP Lua filters in your Consul Envoy proxies.
 
 ### OpenTelemetry Access Logging
 
-The `otel-access-logging` Envoy extension lets you configure Envoy proxies to send access logs to OpenTelemetry collector service. Refer to the [OpenTelemetry Access Logging extension documentation](/consul/docs/envoy-extension/otel-access-logging) for more information.
+The `otel-access-logging` Envoy extension lets you configure Envoy proxies to send access logs to OpenTelemetry collector service. Refer to the [OpenTelemetry Access Logging extension documentation](/consul/docs/envoy-extension/otel) for more information.
 
 ### Property override
 

--- a/content/consul/v1.21.x/content/docs/observe/access-log.mdx
+++ b/content/consul/v1.21.x/content/docs/observe/access-log.mdx
@@ -5,7 +5,7 @@ description: >-
   Consul can emit access logs for application connections and requests that pass through Envoy proxies in the service mesh. Learn how to configure access logs, including minimum configuration requirements and the default log format.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-11-04T10:42:51-06:00
-last_modified: 2025-11-04T10:42:51-06:00
+last_modified: 2026-03-25T21:53:10.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -18,7 +18,7 @@ You can use the application traffic records in access to logs to help you perfor
   - **Threat Detection**: Operators can review details about unauthorized attempts to access the service mesh and their origins.
   - **Audit Compliance**: Operators can use access less for security compliance requirements for traffic entering and exiting the service mesh through gateways.
 
-Consul supports access logs capture through Envoy proxies started through the [`consul connect envoy`](/consul/commands/connect/envoy) CLI command and [`consul-dataplane`](/consul/docs/architecture/control-plane/dataplane). Other proxies are not supported. You can also configure the [OpenTelemetry Envoy extension](/consul/docs/envoy-extension/otel-access-logging) to capture and stream access logs.
+Consul supports access logs capture through Envoy proxies started through the [`consul connect envoy`](/consul/commands/connect/envoy) CLI command and [`consul-dataplane`](/consul/docs/architecture/control-plane/dataplane). Other proxies are not supported. You can also configure the [OpenTelemetry Envoy extension](/consul/docs/envoy-extension/otel) to capture and stream access logs.
 
 ## Enable access logs
 

--- a/content/consul/v1.21.x/content/docs/reference/proxy/extensions/otel.mdx
+++ b/content/consul/v1.21.x/content/docs/reference/proxy/extensions/otel.mdx
@@ -4,13 +4,13 @@ page_title: OpenTelemetry Access Logging extension configuration reference
 description: Learn how to configure the otel-access-logging Envoy extension, which is a builtin Consul extension that configures Envoy proxies to send access logs to OpenTelemetry collector service.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-11-04T10:42:51-06:00
-last_modified: 2025-11-04T10:42:51-06:00
+last_modified: 2026-03-25T21:53:12.000Z
 # END AUTO GENERATED METADATA
 ---
 
 # OpenTelemetry Access Logging extension configuration reference
 
-This topic describes how to configure the OpenTelemetry access logging Envoy extension, which configures Envoy proxies to send access logs to OpenTelemetry collector service. Refer to [Send access logs to OpenTelemetry collector service](/consul/docs/envoy-extension/otel-access-logging) for usage information.
+This topic describes how to configure the OpenTelemetry access logging Envoy extension, which configures Envoy proxies to send access logs to OpenTelemetry collector service. Refer to [Send access logs to OpenTelemetry collector service](/consul/docs/envoy-extension/otel) for usage information.
 
 ## Configuration model
 

--- a/content/consul/v1.21.x/content/partials/text/descriptions/access-log.mdx
+++ b/content/consul/v1.21.x/content/partials/text/descriptions/access-log.mdx
@@ -1,3 +1,3 @@
 Consul can emit access logs to record application connections and requests that pass through proxies in a service mesh, including sidecar proxies and gateways. When you enable access logs in your proxy defaults, you can use it to diagnose and troubleshoot network issues, detect threats to your network, and audit traffic for security compliance.
 
-You can also [configure the OpenTelemetry Envoy extension](/consul/docs/envoy-extension/otel-access-logging) to capture and stream access logs. Refer to [access logs](/consul/docs/observe/access-log) for more information on enabling access logs in Consul.
+You can also [configure the OpenTelemetry Envoy extension](/consul/docs/envoy-extension/otel) to capture and stream access logs. Refer to [access logs](/consul/docs/observe/access-log) for more information on enabling access logs in Consul.

--- a/content/consul/v1.21.x/redirects.jsonc
+++ b/content/consul/v1.21.x/redirects.jsonc
@@ -950,7 +950,7 @@
   },
   {
     "source": "/consul/docs/connect/proxies/envoy-extensions/usage/otel-access-logging",
-    "destination": "/consul/docs/envoy-extension/otel-access-logging",
+    "destination": "/consul/docs/envoy-extension/otel",
     "permanent": true,
   },
   {

--- a/content/consul/v1.22.x/content/docs/envoy-extension/index.mdx
+++ b/content/consul/v1.22.x/content/docs/envoy-extension/index.mdx
@@ -5,7 +5,7 @@ description: >-
   Envoy extensions are plugins that you can use to add support for additional Envoy features without modifying the Consul codebase.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-11-05T11:02:51-05:00
-last_modified: 2025-11-05T11:02:51-05:00
+last_modified: 2026-03-25T21:53:13.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -50,7 +50,7 @@ The `lua` Envoy extension enables HTTP Lua filters in your Consul Envoy proxies.
 
 ### OpenTelemetry Access Logging
 
-The `otel-access-logging` Envoy extension lets you configure Envoy proxies to send access logs to OpenTelemetry collector service. Refer to the [OpenTelemetry Access Logging extension documentation](/consul/docs/envoy-extension/otel-access-logging) for more information.
+The `otel-access-logging` Envoy extension lets you configure Envoy proxies to send access logs to OpenTelemetry collector service. Refer to the [OpenTelemetry Access Logging extension documentation](/consul/docs/envoy-extension/otel) for more information.
 
 ### Property override
 

--- a/content/consul/v1.22.x/content/docs/observe/access-log.mdx
+++ b/content/consul/v1.22.x/content/docs/observe/access-log.mdx
@@ -5,7 +5,7 @@ description: >-
   Consul can emit access logs for application connections and requests that pass through Envoy proxies in the service mesh. Learn how to configure access logs, including minimum configuration requirements and the default log format.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-11-05T11:02:51-05:00
-last_modified: 2025-11-05T11:02:51-05:00
+last_modified: 2026-03-25T21:53:14.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -18,7 +18,7 @@ You can use the application traffic records in access to logs to help you perfor
   - **Threat Detection**: Operators can review details about unauthorized attempts to access the service mesh and their origins.
   - **Audit Compliance**: Operators can use access less for security compliance requirements for traffic entering and exiting the service mesh through gateways.
 
-Consul supports access logs capture through Envoy proxies started through the [`consul connect envoy`](/consul/commands/connect/envoy) CLI command and [`consul-dataplane`](/consul/docs/architecture/control-plane/dataplane). Other proxies are not supported. You can also configure the [OpenTelemetry Envoy extension](/consul/docs/envoy-extension/otel-access-logging) to capture and stream access logs.
+Consul supports access logs capture through Envoy proxies started through the [`consul connect envoy`](/consul/commands/connect/envoy) CLI command and [`consul-dataplane`](/consul/docs/architecture/control-plane/dataplane). Other proxies are not supported. You can also configure the [OpenTelemetry Envoy extension](/consul/docs/envoy-extension/otel) to capture and stream access logs.
 
 ## Enable access logs
 

--- a/content/consul/v1.22.x/content/docs/reference/proxy/extensions/otel.mdx
+++ b/content/consul/v1.22.x/content/docs/reference/proxy/extensions/otel.mdx
@@ -4,13 +4,13 @@ page_title: OpenTelemetry Access Logging extension configuration reference
 description: Learn how to configure the otel-access-logging Envoy extension, which is a builtin Consul extension that configures Envoy proxies to send access logs to OpenTelemetry collector service.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-11-05T11:02:51-05:00
-last_modified: 2025-11-05T11:02:51-05:00
+last_modified: 2026-03-25T21:53:14.000Z
 # END AUTO GENERATED METADATA
 ---
 
 # OpenTelemetry Access Logging extension configuration reference
 
-This topic describes how to configure the OpenTelemetry access logging Envoy extension, which configures Envoy proxies to send access logs to OpenTelemetry collector service. Refer to [Send access logs to OpenTelemetry collector service](/consul/docs/envoy-extension/otel-access-logging) for usage information.
+This topic describes how to configure the OpenTelemetry access logging Envoy extension, which configures Envoy proxies to send access logs to OpenTelemetry collector service. Refer to [Send access logs to OpenTelemetry collector service](/consul/docs/envoy-extension/otel) for usage information.
 
 ## Configuration model
 

--- a/content/consul/v1.22.x/content/partials/text/descriptions/access-log.mdx
+++ b/content/consul/v1.22.x/content/partials/text/descriptions/access-log.mdx
@@ -1,3 +1,3 @@
 Consul can emit access logs to record application connections and requests that pass through proxies in a service mesh, including sidecar proxies and gateways. When you enable access logs in your proxy defaults, you can use it to diagnose and troubleshoot network issues, detect threats to your network, and audit traffic for security compliance.
 
-You can also [configure the OpenTelemetry Envoy extension](/consul/docs/envoy-extension/otel-access-logging) to capture and stream access logs. Refer to [access logs](/consul/docs/observe/access-log) for more information on enabling access logs in Consul.
+You can also [configure the OpenTelemetry Envoy extension](/consul/docs/envoy-extension/otel) to capture and stream access logs. Refer to [access logs](/consul/docs/observe/access-log) for more information on enabling access logs in Consul.

--- a/content/consul/v1.22.x/redirects.jsonc
+++ b/content/consul/v1.22.x/redirects.jsonc
@@ -949,7 +949,7 @@
   },
   {
     "source": "/consul/docs/connect/proxies/envoy-extensions/usage/otel-access-logging",
-    "destination": "/consul/docs/envoy-extension/otel-access-logging",
+    "destination": "/consul/docs/envoy-extension/otel",
     "permanent": true,
   },
   {


### PR DESCRIPTION
<!--
**Merge branch**

Make sure you create your PR against the correct **base** branch. For instructions, refer to
GitHub's **Change the branch range and destination repository guide** (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request).

If your content is an update to:

- Currently published content

  Choose **base: main** when you are updating published documentation, and you
  want your changes published when the PR is merged. We publish Consul content
  from the `main` branch.

- Upcoming Consul release

  Choose the branch for the Consul release that your content is for. Consul
  release branches use the `consul/<exact-release-number>` format. If you are not
  able to find the upcoming Consul release branch that you are looking for,
  contact the tech writer that works with the Consul team.

**Backports**

This repo stores previous version docs in folders instead of branches. There are
no backport labels.  If you backported your code PR to previous branches, update
the docs content in the corresponding folders. For example, if the current
release is 1.22.x and you backported your code to 1.21.x and 1.20.x, update the docs content
in the v1.22.x, v1.21.x, and v1.20.x folders.
-->

## Description

<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of. 

Include the target release as well as prior versions if applicable.
-->

This PR updates the path to the OTEL Envoy Extension reference page, which should be `otel` not `otel-access-logging`.

## Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.

Jira: [<jira-ticket-number>]  // for example, Jira: [CE-1001] GH-Jira integration generates the link and updates the Jira ticket.
GitHub Issue: <issue-link>

The bot does publish a root-level link to the deploy preview. The link changes with each build.
-->
[Preview link](https://unified-docs-frontend-preview-n3u9iswll-hashicorp.vercel.app/consul/docs/reference/proxy/extensions/otel)

## Contributor checklists

Review urgency:

- [x] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [ ] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [x] Verify that all status checks passed
- [x] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [x] I added redirects for any moved or removed pages
- [x] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [x] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [ ] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.


[CE-1001]: https://hashicorp.atlassian.net/browse/CE-1001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ