### PR TITLE
Terraform Docs: fix typo `conditions` to `condition` in `action_trigger`

### DIFF
--- a/content/terraform/v1.14.x/docs/language/block/resource.mdx
+++ b/content/terraform/v1.14.x/docs/language/block/resource.mdx
@@ -287,7 +287,7 @@ resource "<TYPE>" "<LABEL>" {
   lifecycle {
     action_trigger {
       events     = [ <EVENT> ]
-      conditions = < true || false >
+      condition  = < true || false >
       actions    = [ action.<TYPE>.<LABEL> ]
     }
   }


### PR DESCRIPTION
### What
<!-- Explain what you changed and provide a list of changed page names. -->
Fixed a typo in the `action_trigger` block reference documentation.

- `content/terraform/v1.14.x/docs/language/block/resource.mdx`
### Why
<!-- Explain why this change is necessary and how it benefits users. -->
The `action_trigger` Specification section uses `conditions` (plural), but the correct attribute name is `condition` (singular).
### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->
N/A

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] Description links to related pull requests or issues, if any.
    - Fixes #2087

#### Content
- [x] (N/A) You added redirects to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages **across all affected versions**. Refer to [Redirects](https://github.com/hashicorp/web-unified-docs/blob/main/docs/content-guide/redirects.md#example-redirects) for examples and guidance. 
- [x] (N/A) Links to related content where appropriate (e.g., CLI, language, API endpoints, permissions, etc.).
- [x] (N/A) Pages with related content are updated and link to this content when appropriate.
- [x] (N/A) Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] (N/A) New pages have metadata (page name and description) at the top.
- [x] (N/A) New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] (N/A) New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] (N/A) UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
