### PR TITLE
TF-35068: update framework list rpc docs

### DIFF
--- a/content/terraform-plugin-framework/v1.16.x/docs/plugin/framework/list-resources/list.mdx
+++ b/content/terraform-plugin-framework/v1.16.x/docs/plugin/framework/list-resources/list.mdx
@@ -4,13 +4,15 @@ description: >-
   Learn how to list a resource in the Terraform plugin framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-09-23T14:09:33-05:00
-last_modified: 2025-11-18T22:58:26-05:00
+last_modified: 2026-04-09T15:49:38.000Z
 # END AUTO GENERATED METADATA
 ---
 
 # Listing resources
 
 List is called when a `terraform query` is executed, the `ListResource` RPC is called which in turn calls the [`list.ListResource` interface `List` method](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/list#ListResource.List). The request contains the configuration supplied to Terraform by the list block and the response contains a stream of the list results.
+
+The [`list.ListRequest` type](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/list#ListRequest) also includes the `IncludeResource` field. Terraform can set this field when the practitioner enables the `include_resource` argument in HCL or when the query is run with the `-generate-config-out` flag. Check this field early in the `List` method so the provider can avoid unnecessary requests or response processing when Terraform only needs resource identity data.
 
 ## Define List Method
 
@@ -19,6 +21,7 @@ Implement the `List` method by:
 1. [Accessing the `Config` data](/terraform/plugin/framework/handling-data/accessing-values) from the [`list.ListRequest` type](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/list#ListRequest).
 1. Performing external calls and logic for the list operation.
 1. For each list result instantiate a new result object using the [`list.ListRequest.NewListResult`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/list#ListRequest.NewListResult) method.
+1. Checking [`list.ListRequest.IncludeResource`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/list#ListRequest) early and using it to decide whether full resource data should be fetched and whether [`list.ListResult.Resource`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/list#ListResult) should be populated.
 1. Return an iterator function that pushes list results into the response stream.
 
 If the logic needs to return [warning or error diagnostics](/terraform/plugin/framework/diagnostics), they can be added into the [`list.ListResult.Diagnostics`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/list#ListResult.Diagnostics) field of an empty list result and pushed into the stream.
@@ -59,6 +62,18 @@ func (r *ThingListResource) List(ctx context.Context, req list.ListRequest, stre
 	// as input. For brevity, we assume the `things` slice below was returned by an
 	// API call here
 
+	// Check IncludeResource before making remote requests so the provider can
+	// avoid unnecessary work when Terraform only needs identity data.
+	var things []Thing
+
+	if req.IncludeResource {
+		// Fetch full resource data because Terraform requested it.
+		things = client.ListThingsWithResourceData(ctx, data.ResourceGroupName.ValueString())
+	} else {
+		// Fetch only the data needed to populate identities and display names.
+		things = client.ListThings(ctx, data.ResourceGroupName.ValueString())
+	}
+
 	// Define the function that will push results into the stream
 	stream.Results = func(push func(list.ListResult) bool) {
         for _, thing := range things {
@@ -71,8 +86,10 @@ func (r *ThingListResource) List(ctx context.Context, req list.ListRequest, stre
 		// Set resource identity data on the result
 		result.Diagnostics.Append(result.Identity.Set(ctx, thing.ID))
 
-		// Set the resource information on the result
-		result.Diagnostics.Append(result.Resource.Set(ctx, thing.Resource))
+		// Only set full resource data when Terraform requested it.
+		if req.IncludeResource {
+			result.Diagnostics.Append(result.Resource.Set(ctx, thing.Resource))
+		}
 
 		// Send the result to the stream.
 		if !push(result) {
@@ -85,4 +102,4 @@ func (r *ThingListResource) List(ctx context.Context, req list.ListRequest, stre
 ## Caveats
 
 * An error is returned if a list result in the stream contains a null identity unless it contains a warning in the diagnostics.
-* An error is returned if `include_resource` is set to `true` and a list result in the stream has a null resource.
+* An error is returned if `req.IncludeResource` is `true` (for example, because the practitioner set `include_resource = true` or Terraform is using `-generate-config-out`) and a list result in the stream has a null resource.

--- a/content/terraform-plugin-framework/v1.16.x/docs/plugin/framework/list-resources/list.mdx
+++ b/content/terraform-plugin-framework/v1.16.x/docs/plugin/framework/list-resources/list.mdx
@@ -102,4 +102,4 @@ func (r *ThingListResource) List(ctx context.Context, req list.ListRequest, stre
 ## Caveats
 
 * An error is returned if a list result in the stream contains a null identity unless it contains a warning in the diagnostics.
-* An error is returned if `req.IncludeResource` is `true` (for example, because the practitioner set `include_resource = true` or Terraform is using `-generate-config-out`) and a list result in the stream has a null resource.
+* An error is returned if `req.IncludeResource` is `true`, for example the practitioner set `include_resource = true` or Terraform is using `-generate-config-out`, and a list result in the stream has a null resource.

--- a/content/terraform-plugin-framework/v1.17.x/docs/plugin/framework/list-resources/list.mdx
+++ b/content/terraform-plugin-framework/v1.17.x/docs/plugin/framework/list-resources/list.mdx
@@ -3,14 +3,16 @@ page_title: Listing resources
 description: >-
   Learn how to list a resource in the Terraform plugin framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2026-03-05T16:11:36.000Z
-last_modified: 2026-03-05T16:11:36.000Z
+created_at: 2026-03-11T10:18:18-04:00
+last_modified: 2026-04-09T15:49:39.000Z
 # END AUTO GENERATED METADATA
 ---
 
 # Listing resources
 
 List is called when a `terraform query` is executed, the `ListResource` RPC is called which in turn calls the [`list.ListResource` interface `List` method](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/list#ListResource.List). The request contains the configuration supplied to Terraform by the list block and the response contains a stream of the list results.
+
+The [`list.ListRequest` type](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/list#ListRequest) also includes the `IncludeResource` field. Terraform can set this field when the practitioner enables the `include_resource` argument in HCL or when the query is run with the `-generate-config-out` flag. Check this field early in the `List` method so the provider can avoid unnecessary requests or response processing when Terraform only needs resource identity data.
 
 ## Define List Method
 
@@ -19,6 +21,7 @@ Implement the `List` method by:
 1. [Accessing the `Config` data](/terraform/plugin/framework/handling-data/accessing-values) from the [`list.ListRequest` type](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/list#ListRequest).
 1. Performing external calls and logic for the list operation.
 1. For each list result instantiate a new result object using the [`list.ListRequest.NewListResult`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/list#ListRequest.NewListResult) method.
+1. Checking [`list.ListRequest.IncludeResource`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/list#ListRequest) early and using it to decide whether full resource data should be fetched and whether [`list.ListResult.Resource`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/list#ListResult) should be populated.
 1. Return an iterator function that pushes list results into the response stream.
 
 If the logic needs to return [warning or error diagnostics](/terraform/plugin/framework/diagnostics), they can be added into the [`list.ListResult.Diagnostics`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/list#ListResult.Diagnostics) field of an empty list result and pushed into the stream.
@@ -59,6 +62,18 @@ func (r *ThingListResource) List(ctx context.Context, req list.ListRequest, stre
 	// as input. For brevity, we assume the `things` slice below was returned by an
 	// API call here
 
+	// Check IncludeResource before making remote requests so the provider can
+	// avoid unnecessary work when Terraform only needs identity data.
+	var things []Thing
+
+	if req.IncludeResource {
+		// Fetch full resource data because Terraform requested it.
+		things = client.ListThingsWithResourceData(ctx, data.ResourceGroupName.ValueString())
+	} else {
+		// Fetch only the data needed to populate identities and display names.
+		things = client.ListThings(ctx, data.ResourceGroupName.ValueString())
+	}
+
 	// Define the function that will push results into the stream
 	stream.Results = func(push func(list.ListResult) bool) {
         for _, thing := range things {
@@ -71,8 +86,10 @@ func (r *ThingListResource) List(ctx context.Context, req list.ListRequest, stre
 		// Set resource identity data on the result
 		result.Diagnostics.Append(result.Identity.Set(ctx, thing.ID))
 
-		// Set the resource information on the result
-		result.Diagnostics.Append(result.Resource.Set(ctx, thing.Resource))
+		// Only set full resource data when Terraform requested it.
+		if req.IncludeResource {
+			result.Diagnostics.Append(result.Resource.Set(ctx, thing.Resource))
+		}
 
 		// Send the result to the stream.
 		if !push(result) {
@@ -85,4 +102,4 @@ func (r *ThingListResource) List(ctx context.Context, req list.ListRequest, stre
 ## Caveats
 
 * An error is returned if a list result in the stream contains a null identity unless it contains a warning in the diagnostics.
-* An error is returned if `include_resource` is set to `true` and a list result in the stream has a null resource.
+* An error is returned if `req.IncludeResource` is `true` (for example, because the practitioner set `include_resource = true` or Terraform is using `-generate-config-out`) and a list result in the stream has a null resource.

--- a/content/terraform-plugin-framework/v1.17.x/docs/plugin/framework/list-resources/list.mdx
+++ b/content/terraform-plugin-framework/v1.17.x/docs/plugin/framework/list-resources/list.mdx
@@ -102,4 +102,4 @@ func (r *ThingListResource) List(ctx context.Context, req list.ListRequest, stre
 ## Caveats
 
 * An error is returned if a list result in the stream contains a null identity unless it contains a warning in the diagnostics.
-* An error is returned if `req.IncludeResource` is `true` (for example, because the practitioner set `include_resource = true` or Terraform is using `-generate-config-out`) and a list result in the stream has a null resource.
+* An error is returned if `req.IncludeResource` is `true`, for example the practitioner set `include_resource = true` or Terraform is using `-generate-config-out`, and a list result in the stream has a null resource.

--- a/content/terraform-plugin-framework/v1.18.x/docs/plugin/framework/list-resources/list.mdx
+++ b/content/terraform-plugin-framework/v1.18.x/docs/plugin/framework/list-resources/list.mdx
@@ -4,7 +4,7 @@ description: >-
   Learn how to list a resource in the Terraform plugin framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2026-03-11T10:18:18-04:00
-last_modified: 2026-03-30T20:52:50.000Z
+last_modified: 2026-03-30T21:17:21.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -59,6 +59,10 @@ func (r *ThingListResource) List(ctx context.Context, req list.ListRequest, stre
 		stream.Results = list.ListResultsStreamDiagnostics(diags)
 		return
 	}
+
+	// Typically lists will make external calls here using data from the config
+	// as input. For brevity, we assume the `things` slice below was returned by an
+	// API call here
 
 	// Check IncludeResource before making remote requests so the provider can
 	// avoid unnecessary work when Terraform only needs identity data.

--- a/content/terraform-plugin-framework/v1.18.x/docs/plugin/framework/list-resources/list.mdx
+++ b/content/terraform-plugin-framework/v1.18.x/docs/plugin/framework/list-resources/list.mdx
@@ -4,7 +4,7 @@ description: >-
   Learn how to list a resource in the Terraform plugin framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2026-03-11T10:18:18-04:00
-last_modified: 2026-03-30T21:17:21.000Z
+last_modified: 2026-03-31T23:07:23.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -25,8 +25,6 @@ Implement the `List` method by:
 1. Return an iterator function that pushes list results into the response stream.
 
 If the logic needs to return [warning or error diagnostics](/terraform/plugin/framework/diagnostics), they can be added into the [`list.ListResult.Diagnostics`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/list#ListResult.Diagnostics) field of an empty list result and pushed into the stream.
-
--> `IncludeResource` is easy to overlook, but it directly controls whether Terraform expects full resource data in each list result. This can be `true` because the practitioner set `include_resource = true` or because Terraform is generating configuration output. Check `req.IncludeResource` before making remote requests so providers can choose a lighter identity-only lookup when `false` and only perform heavier fetches when `true`.
 
 In this example, the list method on the resource `examplecloud_thing` is defined:
 

--- a/content/terraform-plugin-framework/v1.18.x/docs/plugin/framework/list-resources/list.mdx
+++ b/content/terraform-plugin-framework/v1.18.x/docs/plugin/framework/list-resources/list.mdx
@@ -3,14 +3,16 @@ page_title: Listing resources
 description: >-
   Learn how to list a resource in the Terraform plugin framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2026-03-05T16:12:45.000Z
-last_modified: 2026-03-05T16:12:45.000Z
+created_at: 2026-03-11T10:18:18-04:00
+last_modified: 2026-03-30T20:52:50.000Z
 # END AUTO GENERATED METADATA
 ---
 
 # Listing resources
 
 List is called when a `terraform query` is executed, the `ListResource` RPC is called which in turn calls the [`list.ListResource` interface `List` method](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/list#ListResource.List). The request contains the configuration supplied to Terraform by the list block and the response contains a stream of the list results.
+
+The [`list.ListRequest` type](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/list#ListRequest) also includes the `IncludeResource` field. Terraform can set this field when the practitioner enables the `include_resource` argument in HCL or when the query is run with the `-generate-config-out` flag. Check this field early in the `List` method so the provider can avoid unnecessary requests or response processing when Terraform only needs resource identity data.
 
 ## Define List Method
 
@@ -19,9 +21,12 @@ Implement the `List` method by:
 1. [Accessing the `Config` data](/terraform/plugin/framework/handling-data/accessing-values) from the [`list.ListRequest` type](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/list#ListRequest).
 1. Performing external calls and logic for the list operation.
 1. For each list result instantiate a new result object using the [`list.ListRequest.NewListResult`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/list#ListRequest.NewListResult) method.
+1. Checking [`list.ListRequest.IncludeResource`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/list#ListRequest) early and using it to decide whether full resource data should be fetched and whether [`list.ListResult.Resource`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/list#ListResult) should be populated.
 1. Return an iterator function that pushes list results into the response stream.
 
 If the logic needs to return [warning or error diagnostics](/terraform/plugin/framework/diagnostics), they can be added into the [`list.ListResult.Diagnostics`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/list#ListResult.Diagnostics) field of an empty list result and pushed into the stream.
+
+-> `IncludeResource` is easy to overlook, but it directly controls whether Terraform expects full resource data in each list result. This can be `true` because the practitioner set `include_resource = true` or because Terraform is generating configuration output. Check `req.IncludeResource` before making remote requests so providers can choose a lighter identity-only lookup when `false` and only perform heavier fetches when `true`.
 
 In this example, the list method on the resource `examplecloud_thing` is defined:
 
@@ -55,9 +60,17 @@ func (r *ThingListResource) List(ctx context.Context, req list.ListRequest, stre
 		return
 	}
 
-	// Typically lists will make external calls here using data from the config
-	// as input. For brevity, we assume the `things` slice below was returned by an
-	// API call here
+	// Check IncludeResource before making remote requests so the provider can
+	// avoid unnecessary work when Terraform only needs identity data.
+	var things []Thing
+
+	if req.IncludeResource {
+		// Fetch full resource data because Terraform requested it.
+		things = client.ListThingsWithResourceData(ctx, data.ResourceGroupName.ValueString())
+	} else {
+		// Fetch only the data needed to populate identities and display names.
+		things = client.ListThings(ctx, data.ResourceGroupName.ValueString())
+	}
 
 	// Define the function that will push results into the stream
 	stream.Results = func(push func(list.ListResult) bool) {
@@ -71,8 +84,10 @@ func (r *ThingListResource) List(ctx context.Context, req list.ListRequest, stre
 		// Set resource identity data on the result
 		result.Diagnostics.Append(result.Identity.Set(ctx, thing.ID))
 
-		// Set the resource information on the result
-		result.Diagnostics.Append(result.Resource.Set(ctx, thing.Resource))
+		// Only set full resource data when Terraform requested it.
+		if req.IncludeResource {
+			result.Diagnostics.Append(result.Resource.Set(ctx, thing.Resource))
+		}
 
 		// Send the result to the stream.
 		if !push(result) {
@@ -85,4 +100,4 @@ func (r *ThingListResource) List(ctx context.Context, req list.ListRequest, stre
 ## Caveats
 
 * An error is returned if a list result in the stream contains a null identity unless it contains a warning in the diagnostics.
-* An error is returned if `include_resource` is set to `true` and a list result in the stream has a null resource.
+* An error is returned if `req.IncludeResource` is `true` (for example, because the practitioner set `include_resource = true` or Terraform is using `-generate-config-out`) and a list result in the stream has a null resource.

--- a/content/terraform-plugin-framework/v1.18.x/docs/plugin/framework/list-resources/list.mdx
+++ b/content/terraform-plugin-framework/v1.18.x/docs/plugin/framework/list-resources/list.mdx
@@ -102,4 +102,4 @@ func (r *ThingListResource) List(ctx context.Context, req list.ListRequest, stre
 ## Caveats
 
 * An error is returned if a list result in the stream contains a null identity unless it contains a warning in the diagnostics.
-* An error is returned if `req.IncludeResource` is `true` (for example, because the practitioner set `include_resource = true` or Terraform is using `-generate-config-out`) and a list result in the stream has a null resource.
+* An error is returned if `req.IncludeResource` is `true`, for example the practitioner set `include_resource = true` or Terraform is using `-generate-config-out`, and a list result in the stream has a null resource.

--- a/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/resources/list.mdx
+++ b/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/resources/list.mdx
@@ -3,7 +3,7 @@ page_title: Resources - List
 description: Implementing List on an SDKv2 resource.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-09-23T21:34:11+02:00
-last_modified: 2025-12-10T09:29:12+01:00
+last_modified: 2026-04-09T15:49:40.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -47,6 +47,8 @@ func (r *ThingListResource) RawV5Schemas(ctx context.Context, req list.RawV5Sche
 
 The [`list.ListResource` interface `List` method](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/list#ListResource.List) is where the actual list API call is made and the resulting resource state is returned to the framework.
 
+The [`list.ListRequest` type](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/list#ListRequest) also includes the `IncludeResource` field. Terraform can set this field when the practitioner enables the `include_resource` argument in HCL or when the query is run with the `-generate-config-out` flag. Check this field early in the `List` method so the provider can avoid unnecessary requests or response processing when Terraform only needs resource identity data.
+
 The results that are returned must be framework types. To simplify the conversion of identity and resource data on SDKv2 objects to framework types, the following two methods were added on `schema.ResourceData`:
 
 - [`TfTypeIdentityState()`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema#ResourceData.TfTypeIdentityState) - Converts the identity data on the `ResourceData` to a `tftypes.Value`.
@@ -82,7 +84,7 @@ func (r *ThingListResource) List(ctx context.Context, req list.ListRequest, stre
 	var data ThingListResourceModel
 
 	// Read list config data into the model
-	diags := request.Config.Get(ctx, &data)
+	diags := req.Config.Get(ctx, &data)
 	if diags.HasError() {
 		stream.Results = list.ListResultsStreamDiagnostics(diags)
 		return
@@ -91,6 +93,18 @@ func (r *ThingListResource) List(ctx context.Context, req list.ListRequest, stre
 	// Typically lists will make external calls here using data from the config
 	// as input. For brevity, we assume the `things` slice below was returned by an
 	// API call here
+
+	// Check IncludeResource before making remote requests so the provider can
+	// avoid unnecessary work when Terraform only needs identity data.
+	var things []Thing
+
+	if req.IncludeResource {
+		// Fetch full resource data because Terraform requested it.
+		things = client.ListThingsWithResourceData(ctx)
+	} else {
+		// Fetch only the data needed to populate identities and display names.
+		things = client.ListThings(ctx)
+	}
 
 	// Define the function that will push results into the stream
 	stream.Results = func(push func(list.ListResult) bool) {
@@ -121,11 +135,6 @@ func (r *ThingListResource) List(ctx context.Context, req list.ListRequest, stre
 
 			identity.Set("an_identity_attribute", thing.IdentityAttribute)
 
-			// Set the attributes of interest into the resource state
-			rd.Set("name", thing.Name)
-			rd.Set("attribute_one", thing.AttributeOne)
-			rd.Set("attribute_two", thing.AttributeTwo)
-
 			// Convert and set the identity and resource state into the result
 			tfTypeIdentity, err := rd.TfTypeIdentityState()
 			if err != nil {
@@ -139,23 +148,31 @@ func (r *ThingListResource) List(ctx context.Context, req list.ListRequest, stre
 				result.Diagnostics.AddError(
                     "Setting identity data",
                     "An error was encountered when setting the identity data: "+err.Error(),
-                )
+				)
 			}
 
-			// Convert and set the resource state into the result
-			tfTypeResource, err := rd.TfTypeResourceState()
-			if err != nil {
-				result.Diagnostics.AddError(
+			// Only set full resource data when Terraform requested it.
+			if req.IncludeResource {
+				// Set the attributes of interest into the resource state.
+				rd.Set("name", thing.Name)
+				rd.Set("attribute_one", thing.AttributeOne)
+				rd.Set("attribute_two", thing.AttributeTwo)
+
+				// Convert and set the resource state into the result.
+				tfTypeResource, err := rd.TfTypeResourceState()
+				if err != nil {
+					result.Diagnostics.AddError(
                     "Converting resource state",
                     "An error was encountered when converting the resource state: "+err.Error(),
                 )
-			}
+				}
 
-			if err := result.Resource.Set(ctx, *tfTypeResource); err != nil {
-				result.Diagnostics.AddError(
+				if err := result.Resource.Set(ctx, *tfTypeResource); err != nil {
+					result.Diagnostics.AddError(
                     "Setting resource state",
                     "An error was encountered when setting the resource state: "+err.Error(),
                 )
+				}
 			}
 
             // Send the result to the stream.

--- a/content/terraform-plugin-sdk/v2.39.x/docs/plugin/sdkv2/resources/list.mdx
+++ b/content/terraform-plugin-sdk/v2.39.x/docs/plugin/sdkv2/resources/list.mdx
@@ -2,8 +2,8 @@
 page_title: Resources - List
 description: Implementing List on an SDKv2 resource.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2026-03-05T16:17:41.000Z
-last_modified: 2026-03-05T16:17:41.000Z
+created_at: 2026-03-11T10:18:18-04:00
+last_modified: 2026-04-03T02:52:08.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -47,6 +47,8 @@ func (r *ThingListResource) RawV5Schemas(ctx context.Context, req list.RawV5Sche
 
 The [`list.ListResource` interface `List` method](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/list#ListResource.List) is where the actual list API call is made and the resulting resource state is returned to the framework.
 
+The [`list.ListRequest` type](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/list#ListRequest) also includes the `IncludeResource` field. Terraform can set this field when the practitioner enables the `include_resource` argument in HCL or when the query is run with the `-generate-config-out` flag. Check this field early in the `List` method so the provider can avoid unnecessary requests or response processing when Terraform only needs resource identity data.
+
 The results that are returned must be framework types. To simplify the conversion of identity and resource data on SDKv2 objects to framework types, the following two methods were added on `schema.ResourceData`:
 
 - [`TfTypeIdentityState()`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema#ResourceData.TfTypeIdentityState) - Converts the identity data on the `ResourceData` to a `tftypes.Value`.
@@ -82,7 +84,7 @@ func (r *ThingListResource) List(ctx context.Context, req list.ListRequest, stre
 	var data ThingListResourceModel
 
 	// Read list config data into the model
-	diags := request.Config.Get(ctx, &data)
+	diags := req.Config.Get(ctx, &data)
 	if diags.HasError() {
 		stream.Results = list.ListResultsStreamDiagnostics(diags)
 		return
@@ -91,6 +93,18 @@ func (r *ThingListResource) List(ctx context.Context, req list.ListRequest, stre
 	// Typically lists will make external calls here using data from the config
 	// as input. For brevity, we assume the `things` slice below was returned by an
 	// API call here
+
+	// Check IncludeResource before making remote requests so the provider can
+	// avoid unnecessary work when Terraform only needs identity data.
+	var things []Thing
+
+	if req.IncludeResource {
+		// Fetch full resource data because Terraform requested it.
+		things = client.ListThingsWithResourceData(ctx)
+	} else {
+		// Fetch only the data needed to populate identities and display names.
+		things = client.ListThings(ctx)
+	}
 
 	// Define the function that will push results into the stream
 	stream.Results = func(push func(list.ListResult) bool) {
@@ -121,11 +135,6 @@ func (r *ThingListResource) List(ctx context.Context, req list.ListRequest, stre
 
 			identity.Set("an_identity_attribute", thing.IdentityAttribute)
 
-			// Set the attributes of interest into the resource state
-			rd.Set("name", thing.Name)
-			rd.Set("attribute_one", thing.AttributeOne)
-			rd.Set("attribute_two", thing.AttributeTwo)
-
 			// Convert and set the identity and resource state into the result
 			tfTypeIdentity, err := rd.TfTypeIdentityState()
 			if err != nil {
@@ -139,23 +148,31 @@ func (r *ThingListResource) List(ctx context.Context, req list.ListRequest, stre
 				result.Diagnostics.AddError(
                     "Setting identity data",
                     "An error was encountered when setting the identity data: "+err.Error(),
-                )
+				)
 			}
 
-			// Convert and set the resource state into the result
-			tfTypeResource, err := rd.TfTypeResourceState()
-			if err != nil {
-				result.Diagnostics.AddError(
+			// Only set full resource data when Terraform requested it.
+			if req.IncludeResource {
+				// Set the attributes of interest into the resource state.
+				rd.Set("name", thing.Name)
+				rd.Set("attribute_one", thing.AttributeOne)
+				rd.Set("attribute_two", thing.AttributeTwo)
+
+				// Convert and set the resource state into the result.
+				tfTypeResource, err := rd.TfTypeResourceState()
+				if err != nil {
+					result.Diagnostics.AddError(
                     "Converting resource state",
                     "An error was encountered when converting the resource state: "+err.Error(),
                 )
-			}
+				}
 
-			if err := result.Resource.Set(ctx, *tfTypeResource); err != nil {
-				result.Diagnostics.AddError(
+				if err := result.Resource.Set(ctx, *tfTypeResource); err != nil {
+					result.Diagnostics.AddError(
                     "Setting resource state",
                     "An error was encountered when setting the resource state: "+err.Error(),
                 )
+				}
 			}
 
             // Send the result to the stream.


### PR DESCRIPTION
## Description
Updates Terraform Provider List RPC documentation to highlight he importance of checking `IncludeResource` attribute on the ListRequest.

Please go to the `Preview` tab and select the appropriate template:

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
