### PR TITLE
Terraform Docs: Updates for dynamic module sources

### DIFF
--- a/content/terraform/v1.15.x (rc)/docs/cli/commands/get.mdx
+++ b/content/terraform/v1.15.x (rc)/docs/cli/commands/get.mdx
@@ -41,3 +41,12 @@ module, aside from the `-var` and `-var-file` options. Refer to
 [Assign values to input variables](/terraform/language/values/variables#assign-values-to-input-variables) for more information.
 
 * `-no-color` - Disable text coloring in the output.
+
+### Variable lifecycle
+
+Terraform evaluates most input variables when it creates a plan, so their values
+are not be available during a get operation. Any input variable referenced in a
+module block's `source` or `version` arguments must declare `const = true`.
+Refer to the [variable block
+reference](/terraform/language/block/variable#const) documentation for more
+information.

--- a/content/terraform/v1.15.x (rc)/docs/cli/commands/get.mdx
+++ b/content/terraform/v1.15.x (rc)/docs/cli/commands/get.mdx
@@ -20,9 +20,24 @@ The modules are downloaded into a `.terraform` subdirectory of the current
 working directory. Don't commit this directory to your version control
 repository.
 
-The `get` command supports the following option:
+The `get` command supports the following options:
 
 * `-update` - If specified, modules that are already downloaded will be
   checked for updates and the updates will be downloaded if present.
+
+* `-var 'NAME=VALUE'` - Sets a value for a single
+  [input variable](/terraform/language/block/variable) declared in the
+  root module of the configuration. Use this option multiple times to set
+  more than one variable. Refer to
+  [Input Variables on the Command Line](/terraform/cli/commands/plan#input-variables-on-the-command-line) for more information.
+
+* `-var-file=FILENAME` - Sets values for potentially many
+  [input variables](/terraform/language/block/variable) declared in the
+  root module of the configuration, using definitions from a
+  [`.tfvars` file](/terraform/language/values/variables#variable-definition-files).
+  Use this option multiple times to include values from more than one file.
+There are several other ways to set values for input variables in the root
+module, aside from the `-var` and `-var-file` options. Refer to
+[Assign values to input variables](/terraform/language/values/variables#assign-values-to-input-variables) for more information.
 
 * `-no-color` - Disable text coloring in the output.

--- a/content/terraform/v1.15.x (rc)/docs/cli/commands/graph.mdx
+++ b/content/terraform/v1.15.x (rc)/docs/cli/commands/graph.mdx
@@ -37,6 +37,21 @@ Options:
   of the default resources-only simplified graph.
   Can be: `plan`, `plan-refresh-only`, `plan-destroy`, or `apply`.
 
+* `-var 'NAME=VALUE'` - Sets a value for a single
+  [input variable](/terraform/language/block/variable) declared in the
+  root module of the configuration. Use this option multiple times to set
+  more than one variable. Refer to
+  [Input Variables on the Command Line](/terraform/cli/commands/plan#input-variables-on-the-command-line) for more information.
+
+* `-var-file=FILENAME` - Sets values for potentially many
+  [input variables](/terraform/language/block/variable) declared in the
+  root module of the configuration, using definitions from a
+  [`.tfvars` file](/terraform/language/values/variables#variable-definition-files).
+  Use this option multiple times to include values from more than one file.
+There are several other ways to set values for input variables in the root
+module, aside from the `-var` and `-var-file` options. Refer to
+[Assign values to input variables](/terraform/language/values/variables#assign-values-to-input-variables) for more information.
+
 ## Generating Images
 
 The graph output uses

--- a/content/terraform/v1.15.x (rc)/docs/cli/commands/init.mdx
+++ b/content/terraform/v1.15.x (rc)/docs/cli/commands/init.mdx
@@ -110,12 +110,13 @@ be statically specified in the configuration file.
 
 ## Child Module Installation
 
-During init, the configuration is searched for `module` blocks, and the source
-code for referenced [modules](/terraform/language/modules/develop) is retrieved from the locations
-given in their `source` arguments.
+During init, Terraform searches the configuration for `module` blocks, and
+retrieves the source code for referenced
+[modules](/terraform/language/modules/develop) from the locations given in their
+`source` arguments.
 
-Re-running init with modules already installed will install the sources for
-any modules that were added to configuration since the last init, but will not
+Re-running init with modules already installed will install the sources for any
+modules that were added to configuration since the last init, but will not
 change any already-installed modules. Use `-upgrade` to override this behavior,
 updating all modules to the latest available source code.
 

--- a/content/terraform/v1.15.x (rc)/docs/cli/commands/init.mdx
+++ b/content/terraform/v1.15.x (rc)/docs/cli/commands/init.mdx
@@ -124,6 +124,12 @@ steps can complete only when the module tree is complete, so it's recommended
 to use this flag only when the working directory was already previously
 initialized with its child modules.
 
+Terraform evaluates most input variables when it creates a plan, so their values
+are not be available during init. Any input variable referenced in a module
+block's `source` or `version` arguments must declare `const = true`. Refer to
+the [variable block reference](/terraform/language/block/variable#const)
+documentation for more information.
+
 ## Plugin Installation
 
 Most Terraform providers are published separately from Terraform as plugins.

--- a/content/terraform/v1.15.x (rc)/docs/cli/commands/modules.mdx
+++ b/content/terraform/v1.15.x (rc)/docs/cli/commands/modules.mdx
@@ -26,6 +26,19 @@ Usage: `terraform modules [options]`
 The following optional flags are available:
 
 - `-json` - Displays the module declarations in a machine-readable, JSON format.
+- `-var 'NAME=VALUE'` - Sets a value for a single
+  [input variable](/terraform/language/block/variable) declared in the
+  root module of the configuration. Use this option multiple times to set
+  more than one variable. Refer to
+  [Input Variables on the Command Line](/terraform/cli/commands/plan#input-variables-on-the-command-line) for more information.
+- `-var-file=FILENAME` - Sets values for potentially many
+  [input variables](/terraform/language/block/variable) declared in the
+  root module of the configuration, using definitions from a
+  [`.tfvars` file](/terraform/language/values/variables#variable-definition-files).
+  Use this option multiple times to include values from more than one file.
+There are several other ways to set values for input variables in the root
+module, aside from the `-var` and `-var-file` options. Refer to
+[Assign values to input variables](/terraform/language/values/variables#assign-values-to-input-variables) for more information.
 
 The output of `terraform modules -json` includes a `format_version` key, which is set to the value of `"1.0"` in Terraform 1.10.0. The semantics of this version are:
 

--- a/content/terraform/v1.15.x (rc)/docs/cli/commands/providers.mdx
+++ b/content/terraform/v1.15.x (rc)/docs/cli/commands/providers.mdx
@@ -20,4 +20,20 @@ This command also has several subcommands with different purposes.
 
 ## Usage
 
-Usage: `terraform providers`
+Usage: `terraform providers [options]`
+
+The `terraform providers` command also accepts the following options:
+
+- `-var 'NAME=VALUE'` - Sets a value for a single
+  [input variable](/terraform/language/block/variable) declared in the
+  root module of the configuration. Use this option multiple times to set
+  more than one variable. Refer to
+  [Input Variables on the Command Line](/terraform/cli/commands/plan#input-variables-on-the-command-line) for more information.
+- `-var-file=FILENAME` - Sets values for potentially many
+  [input variables](/terraform/language/block/variable) declared in the
+  root module of the configuration, using definitions from a
+  [`.tfvars` file](/terraform/language/values/variables#variable-definition-files).
+  Use this option multiple times to include values from more than one file.
+There are several other ways to set values for input variables in the root
+module, aside from the `-var` and `-var-file` options. Refer to
+[Assign values to input variables](/terraform/language/values/variables#assign-values-to-input-variables) for more information.

--- a/content/terraform/v1.15.x (rc)/docs/cli/commands/providers/lock.mdx
+++ b/content/terraform/v1.15.x (rc)/docs/cli/commands/providers/lock.mdx
@@ -68,7 +68,7 @@ If you list one or more provider source addresses on the command line then
 `terraform providers lock` will restrict its work only to those providers,
 leaving the lock entries for other providers (if any) unchanged.
 
-You can customize the default behavior using the following additional option:
+You can customize the default behavior using the following additional options:
 
 * `-fs-mirror=PATH` - Direct Terraform to look for provider packages in the
   given local filesystem mirror directory, instead of in upstream registries.
@@ -98,6 +98,21 @@ You can customize the default behavior using the following additional option:
   the plugin cache is not an authoritative source. As the
   `terraform provider lock` command is used to ensure no untrusted provider
   versions can be used installing the plugins from the cache is considered risky.
+
+* `-var 'NAME=VALUE'` - Sets a value for a single
+  [input variable](/terraform/language/block/variable) declared in the
+  root module of the configuration. Use this option multiple times to set
+  more than one variable. Refer to
+  [Input Variables on the Command Line](/terraform/cli/commands/plan#input-variables-on-the-command-line) for more information.
+
+* `-var-file=FILENAME` - Sets values for potentially many
+  [input variables](/terraform/language/block/variable) declared in the
+  root module of the configuration, using definitions from a
+  [`.tfvars` file](/terraform/language/values/variables#variable-definition-files).
+  Use this option multiple times to include values from more than one file.
+There are several other ways to set values for input variables in the root
+module, aside from the `-var` and `-var-file` options. Refer to
+[Assign values to input variables](/terraform/language/values/variables#assign-values-to-input-variables) for more information.
 
 
 ## Specifying Target Platforms

--- a/content/terraform/v1.15.x (rc)/docs/cli/commands/providers/mirror.mdx
+++ b/content/terraform/v1.15.x (rc)/docs/cli/commands/providers/mirror.mdx
@@ -48,7 +48,7 @@ if you upload the resulting directory to a static website host. Terraform
 ignores those index files when using the directory as a filesystem mirror,
 because the directory entries themselves are authoritative in that case.
 
-This command supports the following additional option:
+This command supports the following additional options:
 
 * `-platform=OS_ARCH` - Choose which target platform to build a mirror for.
   By default Terraform will obtain plugin packages suitable for the platform
@@ -62,6 +62,21 @@ This command supports the following additional option:
 * `-lock-file=true` - Set to `false` to ignore the provider lock file when fetching
 providers. By default (`true`) the mirror command will use the version info in the
 lock file if the configuration directory has been previously initialized.
+
+* `-var 'NAME=VALUE'` - Sets a value for a single
+  [input variable](/terraform/language/block/variable) declared in the
+  root module of the configuration. Use this option multiple times to set
+  more than one variable. Refer to
+  [Input Variables on the Command Line](/terraform/cli/commands/plan#input-variables-on-the-command-line) for more information.
+
+* `-var-file=FILENAME` - Sets values for potentially many
+  [input variables](/terraform/language/block/variable) declared in the
+  root module of the configuration, using definitions from a
+  [`.tfvars` file](/terraform/language/values/variables#variable-definition-files).
+  Use this option multiple times to include values from more than one file.
+There are several other ways to set values for input variables in the root
+module, aside from the `-var` and `-var-file` options. Refer to
+[Assign values to input variables](/terraform/language/values/variables#assign-values-to-input-variables) for more information.
 
 You can run `terraform providers mirror` again on an existing mirror directory
 to update it with new packages. For example, you can add packages for a new

--- a/content/terraform/v1.15.x (rc)/docs/cli/commands/providers/schema.mdx
+++ b/content/terraform/v1.15.x (rc)/docs/cli/commands/providers/schema.mdx
@@ -18,7 +18,7 @@ The `terraform providers schema` command print detailed schemas for the provider
 $ terraform providers schema [options]
 ```
 
-The following flags are available:
+This command also accepts the following options:
 
 - `-json` - Displays the schemas in a machine-readable JSON format. The `-json` flag is required.
 

--- a/content/terraform/v1.15.x (rc)/docs/cli/commands/providers/schema.mdx
+++ b/content/terraform/v1.15.x (rc)/docs/cli/commands/providers/schema.mdx
@@ -20,9 +20,24 @@ $ terraform providers schema [options]
 
 The following flags are available:
 
-- `-json` - Displays the schemas in a machine-readable JSON format. The `-json` flag is required. 
+- `-json` - Displays the schemas in a machine-readable JSON format. The `-json` flag is required.
 
-  The output includes a `format_version` key, which has a default value of `"1.0"`. The semantics of this version are:
+- `-var 'NAME=VALUE'` - Sets a value for a single
+  [input variable](/terraform/language/block/variable) declared in the
+  root module of the configuration. Use this option multiple times to set
+  more than one variable. Refer to
+  [Input Variables on the Command Line](/terraform/cli/commands/plan#input-variables-on-the-command-line) for more information.
+
+- `-var-file=FILENAME` - Sets values for potentially many
+  [input variables](/terraform/language/block/variable) declared in the
+  root module of the configuration, using definitions from a
+  [`.tfvars` file](/terraform/language/values/variables#variable-definition-files).
+  Use this option multiple times to include values from more than one file.
+There are several other ways to set values for input variables in the root
+module, aside from the `-var` and `-var-file` options. Refer to
+[Assign values to input variables](/terraform/language/values/variables#assign-values-to-input-variables) for more information.
+
+The output includes a `format_version` key, which has a default value of `"1.0"`. The semantics of this version are:
 
   - Versions between `1.0` and `2.0` are backward-compatible. You should ignore any object properties with unrecognized names to
   remain forward-compatible with future minor versions.

--- a/content/terraform/v1.15.x (rc)/docs/cli/commands/state/mv.mdx
+++ b/content/terraform/v1.15.x (rc)/docs/cli/commands/state/mv.mdx
@@ -57,6 +57,20 @@ This command also accepts the following options:
 - `-dry-run` - Report all of the resource instances that match the given
   address without actually "forgetting" any of them.
 
+- `-var 'NAME=VALUE'` - Sets a value for a single
+  [input variable](/terraform/language/block/variable) declared in the
+  root module of the configuration. Use this option multiple times to set
+  more than one variable. Refer to
+  [Input Variables on the Command Line](/terraform/cli/commands/plan#input-variables-on-the-command-line) for more information.
+- `-var-file=FILENAME` - Sets values for potentially many
+  [input variables](/terraform/language/block/variable) declared in the
+  root module of the configuration, using definitions from a
+  [`.tfvars` file](/terraform/language/values/variables#variable-definition-files).
+  Use this option multiple times to include values from more than one file.
+There are several other ways to set values for input variables in the root
+module, aside from the `-var` and `-var-file` options. Refer to
+[Assign values to input variables](/terraform/language/values/variables#assign-values-to-input-variables) for more information.
+
 - `-lock=false` - Don't hold a state lock during the operation. This is
   dangerous if others might concurrently run commands against the same
   workspace.

--- a/content/terraform/v1.15.x (rc)/docs/cli/commands/state/pull.mdx
+++ b/content/terraform/v1.15.x (rc)/docs/cli/commands/state/pull.mdx
@@ -14,11 +14,28 @@ The `terraform state pull` downloads and outputs state information from a [remot
 
 ## Usage
 
-Usage: `terraform state pull`
+Usage: `terraform state pull [options]`
 
 This command downloads the state from its current location, upgrades the
 local copy to the latest state file version that is compatible with
 locally-installed Terraform, and outputs the raw format to stdout.
+
+This command also accepts the following options:
+
+- `-var 'NAME=VALUE'` - Sets a value for a single
+  [input variable](/terraform/language/block/variable) declared in the
+  root module of the configuration. Use this option multiple times to set
+  more than one variable. Refer to
+  [Input Variables on the Command Line](/terraform/cli/commands/plan#input-variables-on-the-command-line) for more information.
+
+- `-var-file=FILENAME` - Sets values for potentially many
+  [input variables](/terraform/language/block/variable) declared in the
+  root module of the configuration, using definitions from a
+  [`.tfvars` file](/terraform/language/values/variables#variable-definition-files).
+  Use this option multiple times to include values from more than one file.
+There are several other ways to set values for input variables in the root
+module, aside from the `-var` and `-var-file` options. Refer to
+[Assign values to input variables](/terraform/language/values/variables#assign-values-to-input-variables) for more information.
 
 This is useful for reading values out of state (potentially pairing this
 command with something like [jq](https://stedolan.github.io/jq/)). It is

--- a/content/terraform/v1.15.x (rc)/docs/cli/commands/state/push.mdx
+++ b/content/terraform/v1.15.x (rc)/docs/cli/commands/state/push.mdx
@@ -41,6 +41,24 @@ Both of these safety checks can be disabled with the `-force` flag.
 **This is not recommended.** If you disable the safety checks and are
 pushing state, the destination state will be overwritten.
 
+This command also accepts the following options:
+
+- `-force` - Disable the safety checks for differing lineage and higher remote serial.
+
+- `-var 'NAME=VALUE'` - Sets a value for a single
+  [input variable](/terraform/language/block/variable) declared in the
+  root module of the configuration. Use this option multiple times to set
+  more than one variable. Refer to
+  [Input Variables on the Command Line](/terraform/cli/commands/plan#input-variables-on-the-command-line) for more information.
+- `-var-file=FILENAME` - Sets values for potentially many
+  [input variables](/terraform/language/block/variable) declared in the
+  root module of the configuration, using definitions from a
+  [`.tfvars` file](/terraform/language/values/variables#variable-definition-files).
+  Use this option multiple times to include values from more than one file.
+There are several other ways to set values for input variables in the root
+module, aside from the `-var` and `-var-file` options. Refer to
+[Assign values to input variables](/terraform/language/values/variables#assign-values-to-input-variables) for more information.
+
 For configurations using the [HCP Terraform CLI integration](/terraform/cli/cloud) or the [`remote` backend](/terraform/language/backend/remote)
 only, `terraform state push`
 also accepts the option

--- a/content/terraform/v1.15.x (rc)/docs/cli/commands/state/replace-provider.mdx
+++ b/content/terraform/v1.15.x (rc)/docs/cli/commands/state/replace-provider.mdx
@@ -30,6 +30,21 @@ This command also accepts the following options:
 
 - `-auto-approve` - Skip interactive approval.
 
+- `-var 'NAME=VALUE'` - Sets a value for a single
+  [input variable](/terraform/language/block/variable) declared in the
+  root module of the configuration. Use this option multiple times to set
+  more than one variable. Refer to
+  [Input Variables on the Command Line](/terraform/cli/commands/plan#input-variables-on-the-command-line) for more information.
+
+- `-var-file=FILENAME` - Sets values for potentially many
+  [input variables](/terraform/language/block/variable) declared in the
+  root module of the configuration, using definitions from a
+  [`.tfvars` file](/terraform/language/values/variables#variable-definition-files).
+  Use this option multiple times to include values from more than one file.
+There are several other ways to set values for input variables in the root
+module, aside from the `-var` and `-var-file` options. Refer to
+[Assign values to input variables](/terraform/language/values/variables#assign-values-to-input-variables) for more information.
+
 - `-lock=false` - Don't hold a state lock during the operation. This is
   dangerous if others might concurrently run commands against the same
   workspace.

--- a/content/terraform/v1.15.x (rc)/docs/cli/commands/state/rm.mdx
+++ b/content/terraform/v1.15.x (rc)/docs/cli/commands/state/rm.mdx
@@ -46,6 +46,21 @@ This command also accepts the following options:
   returning an error. The duration syntax is a number followed by a time
   unit letter, such as "3s" for three seconds.
 
+- `-var 'NAME=VALUE'` - Sets a value for a single
+  [input variable](/terraform/language/block/variable) declared in the
+  root module of the configuration. Use this option multiple times to set
+  more than one variable. Refer to
+  [Input Variables on the Command Line](/terraform/cli/commands/plan#input-variables-on-the-command-line) for more information.
+
+- `-var-file=FILENAME` - Sets values for potentially many
+  [input variables](/terraform/language/block/variable) declared in the
+  root module of the configuration, using definitions from a
+  [`.tfvars` file](/terraform/language/values/variables#variable-definition-files).
+  Use this option multiple times to include values from more than one file.
+There are several other ways to set values for input variables in the root
+module, aside from the `-var` and `-var-file` options. Refer to
+[Assign values to input variables](/terraform/language/values/variables#assign-values-to-input-variables) for more information.
+
 For configurations using the [HCP Terraform CLI integration](/terraform/cli/cloud) or the [`remote` backend](/terraform/language/backend/remote)
 only, `terraform state rm`
 also accepts the option

--- a/content/terraform/v1.15.x (rc)/docs/cli/commands/taint.mdx
+++ b/content/terraform/v1.15.x (rc)/docs/cli/commands/taint.mdx
@@ -55,6 +55,20 @@ This command accepts the following options:
   returning an error. The duration syntax is a number followed by a time
   unit letter, such as "3s" for three seconds.
 
+- `-var 'NAME=VALUE'` - Sets a value for a single
+  [input variable](/terraform/language/block/variable) declared in the
+  root module of the configuration. Use this option multiple times to set
+  more than one variable. Refer to
+  [Input Variables on the Command Line](/terraform/cli/commands/plan#input-variables-on-the-command-line) for more information.
+- `-var-file=FILENAME` - Sets values for potentially many
+  [input variables](/terraform/language/block/variable) declared in the
+  root module of the configuration, using definitions from a
+  [`.tfvars` file](/terraform/language/values/variables#variable-definition-files).
+  Use this option multiple times to include values from more than one file.
+There are several other ways to set values for input variables in the root
+module, aside from the `-var` and `-var-file` options. Refer to
+[Assign values to input variables](/terraform/language/values/variables#assign-values-to-input-variables) for more information.
+
 For configurations using the [HCP Terraform CLI integration](/terraform/cli/cloud) or the [`remote` backend](/terraform/language/backend/remote) only, `terraform taint`
 also accepts the option
 [`-ignore-remote-version`](/terraform/cli/cloud/command-line-arguments#ignore-remote-version).

--- a/content/terraform/v1.15.x (rc)/docs/cli/commands/validate.mdx
+++ b/content/terraform/v1.15.x (rc)/docs/cli/commands/validate.mdx
@@ -40,6 +40,22 @@ Usage: `terraform validate [options]`
 
 This command accepts the following options:
 
+* `-var 'NAME=VALUE'` - Sets a value for a single
+  [input variable](/terraform/language/block/variable) declared in the
+  root module of the configuration. Use this option multiple times to set
+  more than one variable. Refer to
+  [Input Variables on the Command Line](/terraform/cli/commands/plan#input-variables-on-the-command-line) for more information.
+
+* `-var-file=FILENAME` - Sets values for potentially many
+  [input variables](/terraform/language/block/variable) declared in the
+  root module of the configuration, using definitions from a
+  [`.tfvars` file](/terraform/language/values/variables#variable-definition-files).
+  Use this option multiple times to include values from more than one file.
+
+There are several other ways to set values for input variables in the root
+module, aside from the `-var` and `-var-file` options. Refer to
+[Assign values to input variables](/terraform/language/values/variables#assign-values-to-input-variables) for more information.
+
 * `-json` - Produce output in a machine-readable JSON format, suitable for
   use in text editor integrations and other automated systems. Always disables
   color.

--- a/content/terraform/v1.15.x (rc)/docs/language/block/module.mdx
+++ b/content/terraform/v1.15.x (rc)/docs/language/block/module.mdx
@@ -25,8 +25,8 @@ A `module` block supports the following configuration:
 
 - [`module "<LABEL>"`](#module) &nbsp block
   - [module-specific inputs](#module-specific-inputs) &nbsp some inputs may be required
-  - [`source`](#source) &nbsp string | required
-  - [`version`](#version) &nbsp string
+  - [`source`](#source) &nbsp expression | required
+  - [`version`](#version) &nbsp expression
   - [`count`](#count) &nbsp number | mutually exclusive with `for_each`
   - [`depends_on`](#depends_on) &nbsp list of references
   - [`for_each`](#for_each): &nbsp map or set of strings | mutually exclusive with `count`
@@ -94,6 +94,8 @@ You can specify the same source address in two or more separate `module` blocks,
 Module source code stored in a version control repository or archive file, referred to as a **package**, may be in a sub-directory relative to the root of the package. Add `//` to the source path to indicate that the rest of the path after that point is a sub-directory within the package. Place any query parameters, such as the `ref` argument supported for the version control sources, after the sub-directory segment. Refer to [Specify sources in subdirectories](#specify-sources-in-subdirectories) for examples.
 
 Terraform extracts the entire package to local disk, but reads the module from the subdirectory. As a result, modules in a sub-directory of a package can use a [local path](#local-paths) to reference another module in the same package.
+
+The `source` attribute can reference constant input variables and local values. Any input variable referenced in `source` must declare `const = true`.
 
 You can configure Terraform to install modules from the following types of sources.
 
@@ -373,8 +375,8 @@ Refer to [Install a module from a GCS bucket](#install-a-module-from-a-gcs-bucke
 
 #### Summary
 
-- Data type: String.
-- Default: None.
+- Data type: Expression
+- Default: None
 - Examples: [Specify the location of module source files](#specify-the-location-of-module-source-files)
 
 ### `version`
@@ -394,11 +396,13 @@ or [HCP Terraform's private module registry](/terraform/cloud-docs/registry).
 
 You must run [`terraform init`](/terraform/cli/commands/init) after modifying the `version` argument so that Terraform can update the local code.
 
+The `version` attribute can reference constant input variables and local values. Any input variable referenced in `version` must declare `const = true`.
+
 Refer to the documentation for the module for versioning mechanisms specific to the module. Modules sourced from local file paths do not support `version` because they're loaded from the same source repository and always share the same version as their caller.
 
 #### Summary
 
-- Data type: String
+- Data type: Expression
 - Default: Defaults to latest version available from the source
 - Example: [Specify a module version from a registry](#specify-a-module-version-from-a-registryl)
 

--- a/content/terraform/v1.15.x (rc)/docs/language/block/variable.mdx
+++ b/content/terraform/v1.15.x (rc)/docs/language/block/variable.mdx
@@ -257,7 +257,7 @@ If another expression references a variable with the `ephemeral` argument, that 
 
 ### `const`
 
-Enabling the `const` argument allows the variable to be used during early Terraform operations, like configuration loading.
+Enabling the `const` argument allows the variable to be used when Terraform loads configuration, such as during a Terraform init operation.
 
 ```hcl
 variable "example" {

--- a/content/terraform/v1.15.x (rc)/docs/language/block/variable.mdx
+++ b/content/terraform/v1.15.x (rc)/docs/language/block/variable.mdx
@@ -37,6 +37,7 @@ The `variable` block supports the following arguments:
   - [`sensitive`](#sensitive) &nbsp; boolean
   - [`nullable`](#nullable) &nbsp; boolean
   - [`ephemeral`](#ephemeral) &nbsp; boolean
+  - [`const`](#ephemeral) &nbsp; boolean
 
 ## Complete configuration
 
@@ -50,6 +51,7 @@ variable "<LABEL>" {
   sensitive   = <true|false>
   nullable    = <true|false>
   ephemeral   = <true|false>
+  const       = <true|false>
 
   validation {
     condition     = <EXPRESSION>
@@ -77,6 +79,7 @@ The following arguments are supported in a `variable` block:
 | `sensitive` | Specifies if Terraform hides this value in CLI output. | Boolean | Optional |
 | `nullable` | Specifies if the value of a variable can be `null`. | Boolean | Optional |
 | `ephemeral` | Specifies whether to prevent storing this value in state or plan files. | Boolean | Optional |
+| `const` | Specifies whether the variable can be references during configuration loading. | Boolean | Optional |
 
 ### `type`
 
@@ -251,6 +254,24 @@ If another expression references a variable with the `ephemeral` argument, that 
 - Data type: Boolean
 - Default: `false`
 - Example: [Ephemeral variable](#ephemeral-variable)
+
+### `const`
+
+Enabling the `const` argument allows the variable to be used during early Terraform operations, like configuration loading.
+
+```hcl
+variable "example" {
+  type     = string
+  const    = true
+}
+```
+
+If `const` is `true` in a variable block, then that variable can only contain a known, constant value. It can't depend on dynamic results from a plan operation. These variables can then be using in module `source` and `version` attributes.
+
+#### Summary
+
+- Data type: Boolean
+- Default: `false`
 
 ## Examples
 

--- a/content/terraform/v1.15.x (rc)/docs/language/block/variable.mdx
+++ b/content/terraform/v1.15.x (rc)/docs/language/block/variable.mdx
@@ -266,7 +266,7 @@ variable "example" {
 }
 ```
 
-If `const` is `true` in a variable block, then that variable can only contain a known, constant value. It can't depend on dynamic results from a plan operation. These variables can then be using in module `source` and `version` attributes.
+If `const` is `true` in a variable block, then that variable can only contain a known, constant value. It cannot depend on dynamic results from a plan operation. These variables may then be used in module `source` and `version` attributes.
 
 #### Summary
 

--- a/content/terraform/v1.15.x (rc)/docs/language/block/variable.mdx
+++ b/content/terraform/v1.15.x (rc)/docs/language/block/variable.mdx
@@ -79,7 +79,7 @@ The following arguments are supported in a `variable` block:
 | `sensitive` | Specifies if Terraform hides this value in CLI output. | Boolean | Optional |
 | `nullable` | Specifies if the value of a variable can be `null`. | Boolean | Optional |
 | `ephemeral` | Specifies whether to prevent storing this value in state or plan files. | Boolean | Optional |
-| `const` | Specifies whether the variable can be references during configuration loading. | Boolean | Optional |
+| `const` | allows the variable to be used during early Terraform operations, such as initialization. | Boolean | Optional |
 
 ### `type`
 

--- a/content/terraform/v1.15.x (rc)/docs/language/modules/configuration.mdx
+++ b/content/terraform/v1.15.x (rc)/docs/language/modules/configuration.mdx
@@ -184,3 +184,67 @@ removed {
 ```
 
 Refer to [`moved` block reference](/terraform/language/block/removed) for more information.
+
+## Source and Version Expressions
+
+A module `source` can be an expression, which allows you to build a source address from constant input variables and local values.
+
+When a `source` expression refers to an input variable, that variable must set `const = true`. Terraform requires this so it can fully determine the module source during `terraform init`.
+
+For example, you can select a module source using a constant variable:
+
+```hcl
+module "consul" {
+  source = var.module_source
+}
+```
+
+```hcl
+variable "module_source" {
+  type  = string
+  const = true
+}
+```
+
+You can also compose a source from constant variables and local values:
+
+```hcl
+module "vpc" {
+  source = local.vpc_source
+}
+```
+
+```hcl
+variable "module_repo" {
+  type  = string
+  const = true
+}
+
+variable "module_ref" {
+  type  = string
+  const = true
+}
+
+locals {
+  vpc_source = "git::https://example.com/${var.module_repo}.git?ref=${var.module_ref}"
+}
+```
+
+The `version` argument also accepts expressions. If a `version` expression
+refers to an input variable, that variable must also set `const = true`.
+
+```hcl
+module "consul" {
+  source  = "hashicorp/consul/aws"
+  version = var.consul_version
+}
+```
+
+```hcl
+variable "consul_version" {
+  type  = string
+  const = true
+}
+```
+
+The `source` and `version` expressions can only reference things that are known during configuration loading. Terraform will show an error if they reference something that is only known after a plan.

--- a/content/terraform/v1.15.x (rc)/docs/language/modules/configuration.mdx
+++ b/content/terraform/v1.15.x (rc)/docs/language/modules/configuration.mdx
@@ -216,7 +216,8 @@ variable "module_source" {
 }
 ```
 
-You can also compose a source from constant variables and local values:
+You can also compose a source from constant variables and local values that
+refer to constant variables:
 
 ```hcl
 module "vpc" {

--- a/content/terraform/v1.15.x (rc)/docs/language/modules/configuration.mdx
+++ b/content/terraform/v1.15.x (rc)/docs/language/modules/configuration.mdx
@@ -62,6 +62,16 @@ Refer to the following topics for more information:
 - [Git documentation](https://git-scm.com/book/en/v2/Git-Tools-Revision-Selection#_single_revisions) on selecting revisions.
 - [`source` argument](/terraform/language/block/module#source) in the `module` block reference.
 
+### Variables in module source and versions
+
+Terraform evaluates the value of most variables when it creates a Terraform
+plan. Since Terraform installs modules when a workspace is initialized or during
+a "Get" operation, those variable's values will not be available. Any input
+variable referenced in a module block's `source` or `version` arguments must
+declare `const = true`. Refer to the [variable block
+reference](/terraform/language/block/variable#const) documentation for more
+information.
+
 ## Use a shallow clone
 
 When retrieving module sources from large repositories, you may prefer to make a shallow clone to reduce how long it takes for Terraform to download the files.

--- a/content/terraform/v1.15.x (rc)/docs/language/values/variables.mdx
+++ b/content/terraform/v1.15.x (rc)/docs/language/values/variables.mdx
@@ -268,8 +268,7 @@ Terraform handles setting values for undeclared variables differently depending 
 
 ### Variable lifecycle
 
-Terraform evaluates the value of most variables when it creates a Terraform plan. Terraform will evaluate variables with the `const` attribute set during earlier operations such as when initializing a workspace.
-
-Use variables with the `const` attribute set in module and provider source and
-version attributes, since Terraform evaluates those values when it initializes a
-workspace and installs modules and providers.
+Terraform evaluates the value of most variables when it creates a Terraform
+plan. To use variables in module and provider source and version attributes, the
+const attribute must be set so that Terraform will evaluate those variables
+during initialization.

--- a/content/terraform/v1.15.x (rc)/docs/language/values/variables.mdx
+++ b/content/terraform/v1.15.x (rc)/docs/language/values/variables.mdx
@@ -265,3 +265,11 @@ Terraform handles setting values for undeclared variables differently depending 
 - Terraform ignores any assigned [environment variables](#environment-variables) that do not have a matching `variable` block.
 - Terraform warns you if you assign an undeclared variable in a [variable definition file](#variable-definition-files), letting you catch accidental misspellings in your configuration or definition files.
 - Terraform errors if you attempt to assign a value for an undeclared variable with `-var` on the command line.
+
+### Variable lifecycle
+
+Terraform evaluates the value of most variables when it creates a Terraform plan. Terraform will evaluate variables with the `const` attribute set during earlier operations such as when initializing a workspace.
+
+Use variables with the `const` attribute set in module and provider source and
+version attributes, since Terraform evaluates those values when it initializes a
+workspace and installs modules and providers.


### PR DESCRIPTION
### What
This PR updates the documentation around module `source` and `version` attributes. Starting with Terraform 1.15 they now can be an expression that references variables and locals.

As soon as someone starts using dynamic module sources, Terraform will need values for these variables to load the full configuration. Because of that, most commands now accept variables via the CLI.

### Why
Terraform 1.15 will ship with dynamic module sources and versions.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- https://github.com/hashicorp/terraform/pull/38217
- https://github.com/hashicorp/terraform/pull/38276

#### Content
- [x] You added redirects to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages **across all affected versions**. Refer to [Redirects](https://github.com/hashicorp/web-unified-docs/blob/main/docs/content-guide/redirects.md#example-redirects) for examples and guidance. 
- [x] Links to related content where appropriate (e.g., CLI, language, API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] New pages have metadata (page name and description) at the top.
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
