### PR TITLE
Add minimum NPM package release age

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7d


### PR DESCRIPTION
In order to add some time buffer for supply chain NPM attacks, require that package releases be older than 7 days (since these compromises are often found in a few hours)