### PR TITLE
terraform_data store block

### DIFF
--- a/content/terraform/v1.16.x (beta)/docs/language/resources/terraform-data.mdx
+++ b/content/terraform/v1.16.x (beta)/docs/language/resources/terraform-data.mdx
@@ -23,13 +23,20 @@ You can use the following arguments in the `terraform_data` resource type:
 
 - `triggers_replace`: (Optional) Specifies a value to store in the instance state. Terraform replaces the resource when the value changes.
 
+- `store`: The `store` block has 4 possible arguments, `input`, `replace`, `sensitive`,  and `version`.
+ - `input`: (Optional, write-only) This argument can accept any type, and is write-only hence can also accept ephemeral values. The value supplied here during apply will be copied to either of the `store` block's `output` or `sensitive_output` attributes and stored in the resource's state.
+ - `replace`: (Optional) If `replace` is `true`, any change in a `store` block output value will trigger a replacement of the resource rather than an update.
+ - `sensitive`: (Optional) If `sensitive` is set to `true`, the `input` value will be stored in `sensitive_output`.
+ - `version`: (Optional) If version is set, changes to the `input` value won't be reflected in `output` unless there is also a change to the `version` argument.
+
 ## Attributes
 
 The `terraform_data` resource exports the following attributes:
 
 - `id`: A string value unique to the resource instance.
 - `output`: The computed value derived from the `input` argument. In plans where `output` is unknown, Terraform returns the same type of value used in the `input` argument.
-
+- `store`: The `store` block has 2 possible outputs, `output` or `sensitive_output`.
+  - `output`, `sensitive_output`: These attribute are mutually exclusive and set depending on the value of the `sensitive` `store` argument. They work like the top level `output` attribute, and capture their value from the `store` block `input` argumnet.
 
 
 ## Examples
@@ -55,6 +62,26 @@ resource "example_database" "test" {
   lifecycle {
     replace_triggered_by = [terraform_data.replacement]
   }
+}
+```
+
+Here we capture the result of the ephemeral password value during the initial apply, and store it in the state of terraform_data.test.
+```
+ephemeral "random_password" "test" {
+  length = 16
+}
+
+resource "terraform_data" "test" {
+  store {
+    input     = ephemeral.random_password.test.result
+    sensitive = true
+    version   = 1
+  }
+}
+
+output "password" {
+  sensitive = true
+  value     = terraform_data.test.store.sensitive_output
 }
 ```
 

--- a/content/terraform/v1.16.x (rc)/docs/language/resources/terraform-data.mdx
+++ b/content/terraform/v1.16.x (rc)/docs/language/resources/terraform-data.mdx
@@ -23,13 +23,20 @@ You can use the following arguments in the `terraform_data` resource type:
 
 - `triggers_replace`: (Optional) Specifies a value to store in the instance state. Terraform replaces the resource when the value changes.
 
+- `store`: The `store` block has 4 possible arguments, `input`, `replace`, `sensitive`,  and `version`.
+ - `input`: (Optional, write-only) This argument can accept any type, and is write-only hence can also accept ephemeral values. The value supplied here during apply will be copied to either of the `store` block's `output` or `sensitive_output` attributes and stored in the resource's state.
+ - `replace`: (Optional) If `replace` is `true`, any change in a `store` block output value will trigger a replacement of the resource rather than an update.
+ - `sensitive`: (Optional) If `sensitive` is set to `true`, the `input` value will be stored in `sensitive_output`.
+ - `version`: (Optional) If version is set, changes to the `input` value won't be reflected in `output` unless there is also a change to the `version` argument.
+
 ## Attributes
 
 The `terraform_data` resource exports the following attributes:
 
 - `id`: A string value unique to the resource instance.
 - `output`: The computed value derived from the `input` argument. In plans where `output` is unknown, Terraform returns the same type of value used in the `input` argument.
-
+- `store`: The `store` block has 2 possible outputs, `output` or `sensitive_output`.
+  - `output`, `sensitive_output`: These attribute are mutually exclusive and set depending on the value of the `sensitive` `store` argument. They work like the top level `output` attribute, and capture their value from the `store` block `input` argumnet.
 
 
 ## Examples
@@ -55,6 +62,26 @@ resource "example_database" "test" {
   lifecycle {
     replace_triggered_by = [terraform_data.replacement]
   }
+}
+```
+
+Here we capture the result of the ephemeral password value during the initial apply, and store it in the state of terraform_data.test.
+```
+ephemeral "random_password" "test" {
+  length = 16
+}
+
+resource "terraform_data" "test" {
+  store {
+    input     = ephemeral.random_password.test.result
+    sensitive = true
+    version   = 1
+  }
+}
+
+output "password" {
+  sensitive = true
+  value     = terraform_data.test.store.sensitive_output
 }
 ```
 


### PR DESCRIPTION
### What
Add docs for the new `terraform_data` `store` block.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] You added redirects to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages **across all affected versions**. Refer to [Redirects](https://github.com/hashicorp/web-unified-docs/blob/main/docs/content-guide/redirects.md#example-redirects) for examples and guidance. 
- [x] Links to related content where appropriate (e.g., CLI, language, API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] New pages have metadata (page name and description) at the top.
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.