### PR TITLE
Add docs for Terraform MCP Server 0.5.x

### DIFF
--- a/content/terraform-mcp-server/v0.5.x/data/mcp-server-nav-data.json
+++ b/content/terraform-mcp-server/v0.5.x/data/mcp-server-nav-data.json
@@ -1,0 +1,25 @@
+[
+    {
+        "heading": "Terraform MCP Server"
+    },
+    {
+        "title": "Overview",
+        "path": ""
+    },
+    {
+        "title": "Deploy",
+        "path": "deploy"
+    },
+    {
+        "title": "Prompt",
+        "path": "prompt"
+    },
+    {
+        "title": "Security",
+        "path": "security"
+    },
+    {
+        "title": "Reference",
+        "path": "reference"
+    }
+]

--- a/content/terraform-mcp-server/v0.5.x/docs/mcp-server/deploy.mdx
+++ b/content/terraform-mcp-server/v0.5.x/docs/mcp-server/deploy.mdx
@@ -1,0 +1,536 @@
+---
+page_title: Deploy the Terraform model context protocol (MCP) server 
+description: |-
+ Learn how to deploy the Terraform MCP server, which helps you write configuration using LLM responses sourced from the Terraform registry.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-01-22T23:00:02-07:00
+last_modified: 2026-02-23T18:38:01.000Z
+# END AUTO GENERATED METADATA
+---
+
+# Deploy the Terraform MCP server
+
+The Terraform Model Context Protocol (MCP) server enables AI models to generate Terraform configuration using up-to-date information from the Terraform Registry. This page explains how to install, configure, and integrate the MCP server with your AI client.
+
+## Overview
+
+The Terraform MCP server is a specialized service that provides AI models with access to current Terraform provider documentation and module information. You can deploy the server to the following environments:
+
+- **Local deployment**: Run the server on your workstation using `stdio` mode for direct communication through standard input/output
+- **Remote deployment**: Run the server on a remote instance using `streamable-http` mode for network-based communication
+
+### Secure configuration
+
+Implement the following recommendations to securely deploy the MCP server:
+
+- **Hosting**: We recommend running the MCP Server locally at `127.0.0.1` through the STDIO or HTTP Streamable transport protocol to limit publicly exposing your Terraform environment. The default transport is set to STDIO. If you host the service remotely, we recommend implementing additional security controls at the application and network layers.
+- **CORS**: By default, Terraform MCP server runs in `strict` CORS (cross-origin request) mode and the allowed origins are empty. As a result, all cross-origin requests are blocked unless the server is explicitly configured to allow them. Exercise caution when you need to change allowed origins list.
+- **Terraform authentication**: The `TFE_SKIP_VERIFY` option is enabled by default. We recommend keeping the option enabled so that communication with your Terraform environment is encrypted. We also recommend limiting the permissions of the `TFE_TOKEN` used to authenticate as described in the Terraform documentation. Refer to [API tokens](/terraform/cloud-docs/users-teams-organizations/api-tokens) for more information.
+- **Rate limiting**: We recommend setting up global and per-session rate limits to prevent the server or dependent resources from becoming overloaded through excessive requests. 
+- **TLS**: When making your MCP server accessible remotely, we recommend adding a TLS certificate to protect in-transit communication through the wire.
+
+### Installation methods
+
+Choose from three installation options based on your environment and preferences:
+
+| Method | Best for | Requirements |
+|--------|----------|--------------|
+| [Docker](#run-in-docker) | Most users, consistent environments | Docker Engine v20.10.21+ or Docker Desktop v4.14.0+. Refer to the [Docker documentation](https://docs.docker.com/desktop) for installation instructions. |
+| [Compiled binary](#run-the-compiled-binary) | Lightweight deployments, specific OS needs | Compatible operating system |
+| [Source installation](#install-from-source) | Development, customization | Go development environment |
+
+## Requirements
+
+Terraform MCP server v0.3.0 or newer is required to authenticate Terraform MCP server with the registry. You must also obtain an authentication token from HCP Terraform or your Terraform Enterprise deployment so that the MCP server can present it. Refer to [API tokens](/terraform/cloud-docs/users-teams-organizations/api-tokens) for instructions.
+
+We recommend authenticating the server with the registry to ensure that communication in your Terraform environment is encrypted. Refer to [Secure configuration](#secure-configuration) for more information.
+
+## Run in Docker
+
+Docker provides the most reliable and consistent way to run the Terraform MCP server across different environments. To run the server in Docker, start Docker on your system, then integrate with your AI assistant. 
+
+### Enable authentication
+
+Set the `TFE_TOKEN` environment variable to your HCP Terraform or Terraform Enteprise API token. Set the `TFE_HOSTNAME` environment variable to the URL of your Terraform Enteprise deployment. Refer to the [environment variables reference](/terraform/docs/tools/mcp-server/reference#environment-variables) for more information.
+
+<Tabs>
+
+<Tab heading="Visual Studio Code">
+
+1. Verify [Visual Studio Code](https://code.visualstudio.com/docs) is installed.
+1. Verify the [GitHub Copilot extension](https://code.visualstudio.com/docs/copilot/overview) is installed and chats are configured to `Agent` mode.
+1. Verify MCP support enabled, refer to the [VS Code MCP documentation](https://code.visualstudio.com/docs/copilot/chat/mcp-servers) for more information.
+1. To use the MCP server in all workspaces, add the following configuration to your user settings JSON file:
+
+  ```json
+  {
+    "mcp": {
+      "servers": {
+        "terraform": {
+          "command": "docker",
+          "args": [
+            "run",
+            "-i",
+            "--rm",
+            "-e", "TFE_TOKEN=${input:tfe_token}",
+            "-e", "TFE_ADDRESS=${input:tfe_address}",
+            "hashicorp/terraform-mcp-server"
+          ]
+        }
+      },
+      "inputs": [
+        {
+          "type": "promptString",
+          "id": "tfe_token",
+          "description": "Terraform API Token",
+          "password": true
+        },
+        {
+          "type": "promptString",
+          "id": "tfe_address",
+          "description": "Terraform Address",
+          "password": false
+        }
+      ]
+    }
+  }
+  ```
+
+  Alternatively, to use the server in a specific workspace, create an `mcp.json` file with the following configuration in your workspace's `.vscode` directory:
+
+  ```json
+  {
+    "servers": {
+      "terraform": {
+        "command": "docker",
+        "args": [
+          "run",
+          "-i",
+          "--rm",
+          "-e", "TFE_TOKEN=${input:tfe_token}",
+          "-e", "TFE_ADDRESS=${input:tfe_address}",
+          "hashicorp/terraform-mcp-server"
+        ]
+      }
+    },
+    "inputs": [
+      {
+        "type": "promptString",
+        "id": "tfe_token",
+        "description": "Terraform API Token",
+        "password": true
+      },
+      {
+        "type": "promptString",
+        "id": "tfe_address",
+        "description": "Terraform Address",
+        "password": false
+      }
+    ]
+  }
+  ```
+
+</Tab>
+
+<Tab heading="Cursor">
+
+1. Verify [Cursor](https://www.cursor.com) is installed.
+1. Verify the MCP support configured, refer to [Cursor's MCP documentation](https://docs.cursor.com/context/model-context-protocol#configuring-mcp-servers) for more information.    
+1. To use the MCP server in all workspaces, add the following configuration to your user settings JSON file:
+
+  ```json
+  {
+    "mcp": {
+      "servers": {
+        "terraform": {
+          "command": "docker",
+          "args": [
+            "run",
+            "-i",
+            "--rm",
+            "-e", "TFE_ADDRESS=<<TFE_ADDRESS_HERE>>",
+            "-e", "TFE_TOKEN=<<TFE_TOKEN_HERE>>",
+            "hashicorp/terraform-mcp-server"
+          ]
+        }
+      }
+    }
+  }
+  ```
+
+1. Verify the installation by opening the chat pane and selecting **Chat Settings** from the ellipses menu.
+1. Choose **Agent** from the **Default new chat mode** drop-down menu.
+1. Select **MCP** from the **Cursor Settings** sidebar to verify that Terraform MCP server tools are enabled. Refer to the [tools reference](/terraform/docs/tools/mcp-server/reference#available-tools) for more information.
+  
+</Tab>
+
+<Tab heading="Claude Desktop">
+
+1. Verify [Claude Desktop](https://support.anthropic.com/en/articles/10065433-installing-claude-for-desktop) is installed.
+1. Verify MCP support is configured, refer to [Claude Desktop's MCP documentation](https://modelcontextprotocol.io/quickstart/user) for more information.    
+1. Create or edit the `mcp.json` file and add the following configuration:
+
+  ```json
+  {
+    "mcpServers": {
+      "servers": {
+        "terraform": {
+          "command": "docker",
+          "args": [
+            "run",
+            "-i",
+            "--rm",
+            "-e", "TFE_ADDRESS=<<TFE_ADDRESS_HERE>>",
+            "-e", "TFE_TOKEN=<<TFE_TOKEN_HERE>>",
+            "hashicorp/terraform-mcp-server"
+          ]
+        }
+      }
+    }
+  }
+  ```
+
+1. Verify the integration by opening the chat pane and clicking the **search and tools** slider icon.
+1. Click **terraform-mcp-server** to verify that all tools are enabled and accessible. Refer to the [tools reference](/terraform/docs/tools/mcp-server/reference#available-tools) for more information.
+
+</Tab>
+
+<Tab heading="Amazon Q">
+
+1. Verify [Amazon Q](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line-installing.html) is installed.
+1. Verify MCP support is configured, refer to [Amazon Q's MCP documentation](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/qdev-mcp.html) for more information.    
+1. Create or edit the `mcp.json` file with the following configuration:
+
+  ```json
+  {
+    "mcpServers": {
+      "servers": {
+        "terraform": {
+          "command": "docker",
+          "args": [
+            "run",
+            "-i",
+            "--rm",
+            "-e", "TFE_ADDRESS=<<TFE_ADDRESS_HERE>>",
+            "-e", "TFE_TOKEN=<<TFE_TOKEN_HERE>>",
+            "hashicorp/terraform-mcp-server"
+          ]
+        }
+      }
+    }
+  }
+  ```
+
+</Tab>
+
+<Tab heading="Bob Shell / Bob IDE">
+
+1. Verify [Bob Shell or Bob IDE](https://bob.ibm.com) is installed.
+1. Verify MCP support is configured, refer to [Bob's MCP documentation](https://bob.ibm.com/docs/ide) for more information.
+1. To use the MCP server, add the following configuration to `~/.bob/settings/mcp_settings.json` for global configuration or `.bob/mcp.json` for local projects:
+
+  ```json
+  {
+    "mcpServers": {
+      "terraform": {
+        "command": "docker",
+        "args": [
+          "run",
+          "-i",
+          "--rm",
+          "-e", "TFE_ADDRESS=<<PASTE_TFE_ADDRESS_HERE>>",
+          "-e", "TFE_TOKEN=<<PASTE_TFE_TOKEN_HERE>>",
+          "hashicorp/terraform-mcp-server"
+        ],
+        "disabled": false
+      }
+    }
+  }
+  ```
+
+1. Load the server configuration using either the Bob shell or IDE:
+   - Shell: Run the `bob /mcp refresh` command.
+   - IDE: Open settings and navigate to the MCP tab to load the configuration.
+
+</Tab>
+
+</Tabs>
+
+### Run without authentication
+
+Set the `tfe_token` environment variable to your HCP Terraform or Terraform Enteprise API token. Set the `tfe_hostname` environment variable to the URL of your Terraform Enteprise deployment. Refer to the [environment variables reference](/terraform/docs/tools/mcp-server/reference#environment-variables) for more information. 
+
+<Tabs>
+
+<Tab heading="Visual Studio Code">
+
+1. Verify [Visual Studio Code](https://code.visualstudio.com/docs) is installed.
+1. Verify the [GitHub Copilot extension](https://code.visualstudio.com/docs/copilot/overview) is installed and chats are configured to `Agent` mode.
+1. Verify MCP support enabled, refer to the [VS Code MCP documentation](https://code.visualstudio.com/docs/copilot/chat/mcp-servers) for more information.
+1. To use the MCP server in all workspaces, add the following configuration to your user settings JSON file:
+
+  ```json
+  {
+    "mcp": {
+      "servers": {
+        "terraform": {
+          "command": "docker",
+          "args": [
+            "run",
+            "-i",
+            "--rm",
+            "hashicorp/terraform-mcp-server"
+          ]
+        }
+      }
+    }
+  }
+  ```
+
+  Alternatively, to use the server in a specific workspace, create an `mcp.json` file with the following configuration in your workspace's `.vscode` directory:
+
+  ```json
+  {
+    "servers": {
+      "terraform": {
+        "command": "docker",
+        "args": [
+          "run",
+          "-i",
+          "--rm",
+          "hashicorp/terraform-mcp-server"
+        ]
+      }
+    }
+  }
+  ```
+
+1. Verify the integration by opening the chat interface and selecting **Agent** from the mode settings.
+1. Click the tools icon to verify that Terraform MCP server tools appear in the available tools list.
+
+</Tab>
+
+<Tab heading="Cursor">
+
+1. Verify [Cursor](https://www.cursor.com) is installed.
+1. Verify the MCP support configured, refer to [Cursor's MCP documentation](https://docs.cursor.com/context/model-context-protocol#configuring-mcp-servers) for more information.    
+1. To use the MCP server in all workspaces, add the following configuration to your user settings JSON file:
+
+  ```json
+  {
+    "mcp": {
+      "servers": {
+        "terraform": {
+          "command": "docker",
+          "args": [
+            "run",
+            "-i",
+            "--rm",
+            "hashicorp/terraform-mcp-server"
+          ]
+        }
+      }
+    }
+  }
+  ```
+
+1. Verify the installation by opening the chat pane and selecting **Chat Settings** from the ellipses menu.
+1. Choose **Agent** from the **Default new chat mode** drop-down menu.
+1. Select **MCP** from the **Cursor Settings** sidebar to verify that Terraform MCP server tools are enabled. Refer to the [tools reference](/terraform/docs/tools/mcp-server/reference#available-tools) for more information.
+  
+</Tab>
+
+<Tab heading="Claude Desktop">
+
+1. Verify [Claude Desktop](https://support.anthropic.com/en/articles/10065433-installing-claude-for-desktop) is installed.
+1. Verify MCP support is configured, refer to [Claude Desktop's MCP documentation](https://modelcontextprotocol.io/quickstart/user) for more information.    
+1. Create or edit the `mcp.json` file and add the following configuration:
+
+  ```json
+  {
+    "mcpServers": {
+      "servers": {
+        "terraform": {
+          "command": "docker",
+          "args": [
+            "run",
+            "-i",
+            "--rm",
+            "hashicorp/terraform-mcp-server"
+          ]
+        }
+      }
+    }
+  }
+  ```
+
+1. Verify the integration by opening the chat pane and clicking the **search and tools** slider icon.
+1. Click **terraform-mcp-server** to verify that all tools are enabled and accessible. Refer to the [tools reference](/terraform/docs/tools/mcp-server/reference#available-tools) for more information.
+
+</Tab>
+
+<Tab heading="Amazon Q">
+
+1. Verify [Amazon Q](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line-installing.html) is installed.
+1. Verify MCP support is configured, refer to [Amazon Q's MCP documentation](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/qdev-mcp.html) for more information.    
+1. Create or edit the `mcp.json` file with the following configuration:
+
+  ```json
+  {
+    "mcpServers": {
+      "servers": {
+        "terraform": {
+          "command": "docker",
+          "args": [
+            "run",
+            "-i",
+            "--rm",
+            "hashicorp/terraform-mcp-server"
+          ]
+        }
+      }
+    }
+  }
+  ```
+  
+</Tab>
+
+<Tab heading="Bob Shell / Bob IDE">
+
+1. Verify [Bob Shell or Bob IDE](https://bob.ibm.com) is installed.
+1. Verify MCP support is configured, refer to [Bob's MCP documentation](https://bob.ibm.com/docs/ide) for more information.
+1. To use the MCP server, add the following configuration to `~/.bob/settings/mcp_settings.json` for global configuration or `.bob/mcp.json` for local projects:
+
+  ```json
+  {
+    "mcpServers": {
+      "terraform": {
+        "command": "docker",
+        "args": [
+          "run",
+          "-i",
+          "--rm",
+          "hashicorp/terraform-mcp-server"
+        ],
+        "disabled": false
+      }
+    }
+  }
+  ```
+
+1. Load the server configuration:
+   - **Bob Shell**: Run `/mcp refresh` command
+   - **Bob IDE**: Open settings and navigate to the MCP tab to load the configuration
+
+</Tab>
+
+</Tabs>
+
+## Run the compiled binary
+
+The compiled binary option provides a lightweight installation without Docker dependencies. This method is ideal when you want to minimize resource usage or work in environments with restricted container access.
+
+Download the binary for your operating system and architecture from the [release library](https://releases.hashicorp.com/terraform-mcp-server). Then, add the configure your client settings. 
+
+If you downloaded a supported version of the binary, you can enable authentication in the configuration. Otherwise, you can run the server without authentication. 
+
+### Enable authentication
+
+Set the `tfe_token` environment variable to your HCP Terraform or Terraform Enteprise API token. Set the `tfe_hostname` environment variable to the URL of your Terraform Enteprise deployment. Refer to the [environment variables reference](/terraform/docs/tools/mcp-server/reference#environment-variables) for more information.
+
+Replace `/path/to/terraform-mcp-server` with the path to your downloaded binary.
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "terraform": {
+        "type": "stdio",
+        "command": "/path/to/terraform-mcp-server",
+        "env": {
+          "TFE_TOKEN": "<tfe-token>"
+        },
+      }
+    }
+  }
+}
+```
+
+### Run without authentication
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "terraform": {
+        "type": "stdio",
+        "command": "/path/to/terraform-mcp-server"
+      }
+    }
+  }
+}
+```
+
+## Install from source
+
+Installing from source gives you access to the latest features and allows for customization. This method requires a Go development environment.
+
+1. Install the latest stable release.
+
+  ```shell-session
+  $ go install github.com/hashicorp/terraform-mcp-server/cmd/terraform-mcp-server@latest
+  ```
+
+  Alternatively, you can install the development version on `main`.
+
+  ```shell-session
+  $ go install github.com/hashicorp/terraform-mcp-server/cmd/terraform-mcp-server@main
+  ```
+
+1. After installation, add the following configuration to your client.
+
+  ```json
+  {
+    "mcp": {
+      "servers": {
+        "terraform": {
+          "command": "/path/to/terraform-mcp-server",
+          "args": ["stdio"]
+        }
+      }
+    }
+  }
+  ```
+
+  Replace `/path/to/terraform-mcp-server` with the actual path to your downloaded binary. The binary location depends on your Go installation and `GOPATH` configuration. 
+  
+Use `which terraform-mcp-server` to find the installed binary path.
+
+## Start the server
+
+You can use the `terraform-mcp-server` CLI and specify the transport protocol you want to use to start the server. Refer to the [transport protocols reference](/terraform/docs/tools/mcp-server/reference#transport-protocols) for more information.
+
+Start the server in `stdio` mode. 
+
+```shell-session
+$ terraform-mcp-server stdio [--log-file /path/to/log]
+```
+
+Run the following command on the local instance to start the server in `streamable-http` mode:
+
+```shell-session
+$ terraform-mcp-server streamable-http \
+  [--transport-port 8080] \
+  [--transport-host 127.0.0.1] \
+  [--mcp-endpoint /mcp] \
+  [--log-file /path/to/log]
+```
+
+Instead of setting values manually, you can also use the supported environment variables. Refer to the [environment variables reference](/terraform/docs/tools/mcp-server/reference#environment-variables) for details.
+
+## Next steps
+
+- Begin prompting your AI model about Terraform configurations. Refer to [Prompt an AI model](/terraform/docs/tools/mcp-server/prompt) for guidance on effective prompting techniques.
+- The server provides access to up-to-date provider documentation.
+- Ask for help with specific Terraform resources and modules. 
+- Explore advanced configuration options for your specific deployment needs.

--- a/content/terraform-mcp-server/v0.5.x/docs/mcp-server/index.mdx
+++ b/content/terraform-mcp-server/v0.5.x/docs/mcp-server/index.mdx
@@ -1,0 +1,54 @@
+---
+page_title: Terraform MCP server overview
+description: Learn about the Terraform model context protocol (MCP) server and how it can help you write Terraform configuration using AI.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-01-22T23:00:02-07:00
+last_modified: 2026-01-22T23:00:02-07:00
+# END AUTO GENERATED METADATA
+---
+
+# Terraform MCP server overview
+
+The Terraform Model Context Protocol (MCP) server enhances AI models with real-time access to current Terraform provider documentation, modules, and policies from the [Terraform registry](https://registry.terraform.io). This ensures AI-generated Terraform configurations use accurate, up-to-date information rather than potentially outdated training data.
+
+@include 'beta.mdx'
+
+## What is the Terraform MCP server?
+
+The Model Context Protocol (MCP) is an open standard that enables AI models to securely connect with external tools, applications, and data sources. MCP allows AI models to access information beyond their training data, providing more current and accurate responses.
+
+The Terraform MCP server implements this protocol specifically for Terraform development, offering several key benefits:
+
+- **Real-time accuracy**: Access current provider documentation instead of relying on potentially outdated training data
+- **Terraform Registry Integration**: Direct integration with public Terraform Registry APIs for providers, modules, and policies
+- **HCP Terraform & Terraform Enterprise Support**: Full workspace management, organization/project listing, and private registry access
+- **Workspace Operations**: Create, update, delete workspaces with support for variables, tags, and run management
+- **AI enhancement**: Enables more accurate and actionable Terraform configuration generation
+
+## How it works
+
+When you connect an AI model to the Terraform MCP server, the model gains access to specialized tools that can perform the following actions:
+
+1. Search and retrieve current provider documentation
+1. Access module information, including inputs, outputs, and examples  
+1. Find Sentinel policies for governance and compliance
+1. HCP Terraform or TFE organization and workspace lists
+1. HCP Terraform or TFE workspace, variables, tags, variable set create, read, update and delete operations
+
+The AI model uses these tools automatically when you ask questions about Terraform configuration, ensuring responses are based on the most current information available.
+
+## Deployment architecture
+
+The deployment architecture for running an MCP server includes the following components:
+
+- **AI model**: A trained algorithm and large dataset that recognizes patterns, makes predictions, and performs tasks with minimal human intervention.
+- **MCP host**: AI application or environment in a language model performs AI-driven tasks that operate the MCP client, such as Claude Desktop.
+- **MCP client**: An interface that discovers MCP server tools and translates model prompts into executable actions so that the MCP host can communicate with the MCP server.
+- **MCP server**: A service that the MCP client calls to execute various tools, resources, and prompts. It provides a server or tool manifest for allowing the model to dynamically discover available capabilities.
+- **MCP tool**: A server-defined executable function or operation, such as plan or apply operations in Terraform, with defined inputs and outputs callable by clients.
+- **MCP transport**: Handles the underlying communication of how messages are sent and received over the JSON-RPC 2.0 protocol. The stdio transport allows the MCP server to invoke tools directly using the standard input/output pipe. The streamable HTTP transport exposes a local server, such as `127.0.0.1:8080`, to receive and respond to MCP tool calls.
+
+## Additional resources
+
+- [Terraform MCP server repository](https://github.com/hashicorp/terraform-mcp-server/releases): For source code, issues and contributions.
+- [Terraform MCP server releases](https://releases.hashicorp.com/terraform-mcp-server): Provides links for downloading prebuilt binaries.

--- a/content/terraform-mcp-server/v0.5.x/docs/mcp-server/prompt.mdx
+++ b/content/terraform-mcp-server/v0.5.x/docs/mcp-server/prompt.mdx
@@ -1,0 +1,207 @@
+---
+page_title: Prompt an AI model connected to the Terraform MCP server   
+description: |-
+ Learn how to prompt your AI model connected to the Terraform MCP server to answer questions about Terraform configuration using code stored in the Terraform registry
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-01-22T23:00:02-07:00
+last_modified: 2026-01-22T23:00:02-07:00
+# END AUTO GENERATED METADATA
+---
+
+# Prompt a model connected to the Terraform MCP server 
+
+This topic provides example prompts for helping you write Terraform configuration after installing the Terraform model context protocol (MCP) server. Refer to [Deploy the Terraform MCP server](/terraform/docs/tools/mcp-server/deploy) for instructions on how to deploy the server.
+
+## Overview
+
+To trigger the MCP server tools, ask your LLM questions about your provider configuration or general questions about Terraform providers and modules. Note that for your LLM to use the server, your questions must pertain to provider configuration from the registry. The LLM uses other sources, such as content from the internet, to respond to general questions about Terraform configuration or requests to generate code.  
+
+## Requirements
+
+Verify that you have deployed the Terraform MCP server and configured your client. Refer to [Deploy the Terraform MCP server](/terraform/docs/tools/mcp-server/deploy) for instructions.
+
+## Prompt your MCP client
+
+Your model may still decide to use other resources to formulate responses, but you can use the following guidelines to help you create prompts that are more likely to be routed through the server:
+ 
+- Include the names of specific providers or provider modules. For example, use `google_compute_disk` in your prompt instead of `the compute disk`.
+- Use the full Terraform resource address in your query. Refer to [Resource Address Reference](/terraform/cli/state/resource-addressing) in the Terraform CLI documentation for additional information about resource addresses.
+- Ask for the latest information about the provider or module.
+
+## Examples     
+
+You can use the following set of prompts as a guide to help you write your own configuration. The following responses are returned from the server using ChatGPT 4.1 in GitHub Copilot on VS Code. Your responses may vary.
+
+### Get AI-related resources from the Google provider
+
+In the following example, the server obtains a list of Google provider document IDs so that you can decide which resources to create:
+
+#### Prompt
+
+```
+I need help understanding what resources are available 
+in the Google provider that are for AI
+```
+
+#### Request
+
+The server sends the following request payload to the registry: 
+
+```json
+{
+  "provider_Data_Type": "resources",
+  "provider_Name": "google",
+  "provider_Namespace": "hashicorp",
+  "providerVersion": "latest",
+  "serviceSlug": "ai"
+}
+```
+
+#### Response
+
+```
+The Google Terraform provider offers several resources related to AI, primarily under the Vertex AI and Document AI services. Here are the main AI-related resources available:
+
+**Vertex AI Resources**
+
+- `vertex_ai_dataset`
+- `vertex_ai_deployment_resource_pool`
+- `vertex_ai_endpoint`
+- `vertex_ai_endpoint_iam`
+- `vertex_ai_feature_group`
+- `vertex_ai_featurestore`
+- `vertex_ai_index`
+- `vertex_ai_metadata_store`
+- `vertex_ai_tensorboard`
+- `document_ai_processor`
+- `document_ai_warehouse_document_schema`
+ 
+These resources allow you to manage datasets, endpoints, feature stores, indexes, metadata, and more for AI/ML workflows on Google Cloud, as well as Document AI processors and schemas.
+```
+
+### Get information about storage buckets in Azure
+
+The following prompt gets a list of provider documentation IDs. Then, it calls the appropriate documentation for the use case:
+
+```
+I need help setting up storage buckets in the azure provider
+```
+
+#### Request
+
+The server sends the following request payloads to the registry:
+
+```json
+{
+  "providerDataType": "resources",
+  "providerName": "azurerm",
+  "providerNamespace": "hashicorp",
+  "providerVersion": "latest",
+  "serviceSlug": "storage_account"
+}
+```
+
+```json
+{
+  "providerDocID": "8957547"
+}
+```
+
+```json
+{
+  "providerDocID": "8957555"
+}
+```
+
+#### Response
+
+The server retrieves several responses from each tool, including example configurations from the registry. The following response is one of the examples:
+
+````
+Available Documentation (top matches) for resources in Terraform provider hashicorp/azurerm version: 4.29.0
+
+# azurerm_storage_account
+
+Manages an Azure Storage Account.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_storage_account" "example" {
+  name                     = "storageaccountname"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+
+  tags = {
+    environment = "staging"
+  }
+}
+```
+
+To set up storage buckets in Azure using the Terraform azurerm provider, you need to use the azurerm_storage_account resource. Here’s a quick guide and example configuration:
+
+1. Terraform Resource for Azure Storage Account
+ 
+```hcl
+ resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_storage_account" "example" {
+  name                     = "storageaccountname" # must be globally unique, lowercase
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_tier             = "Standard"           # or "Premium"
+  account_replication_type = "GRS"                # or "LRS", "RAGRS", "ZRS", etc.
+
+  tags = {
+   environment = "staging"
+  }
+}
+```
+````
+
+### Get help creating an IBM VM
+
+The following prompt gets a list of modules:
+
+```
+Is there a module to help with setting up an IBM VM?
+```
+
+#### Request
+
+The server sends the following request payload: 
+
+```json
+{
+  "moduleQuery": "ibm vm"
+}
+```
+
+#### Response
+
+The client prints the following response using the context acquired from the MCP server:
+
+```
+Yes, there is a Terraform module to help with setting up an IBM VM:
+
+- IBM VM Module
+- ID: intel/ibm-vm/intel/1.2.2
+- Description: Intel Cloud Optimization Module - IBM VM
+- Module Version: 1.2.2
+- Namespace: intel
+- Source: GitHub - intel/terraform-intel-ibm-vm
+
+You can use this module to set up and manage IBM VMs with Terraform. 
+
+If you need more details or usage examples, let me know.
+```

--- a/content/terraform-mcp-server/v0.5.x/docs/mcp-server/reference.mdx
+++ b/content/terraform-mcp-server/v0.5.x/docs/mcp-server/reference.mdx
@@ -1,0 +1,214 @@
+---
+page_title: Terraform MCP server reference
+description: Learn about the configuration options and tools available for the Terraform MCP server.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-01-22T23:00:02-07:00
+last_modified: 2026-01-28T10:45:26-07:00
+# END AUTO GENERATED METADATA
+---
+
+# Terraform MCP server reference
+
+This page contains reference information about the Terraform MCP server, including configuration options and tools.
+
+## Available tools
+
+The Terraform MCP server provides specialized tools that AI models can use to access current Terraform registry information. These tools work automatically when you ask relevant questions—you don't need to invoke them manually.
+
+## Toolsets 
+
+The server includes the following toolsets:
+
+| Toolset | Description |
+| --- | --- |
+| `registry` | Tools for accessing the public registry |
+| `registry-private` | Tools for accessing private registries |
+| `terraform` | Tools for interacting with HCP Terraform and Terraform Enterprise |
+
+You can add the `--toolsets` flag to enable or disable these tools when starting the binary.
+
+
+### Provider tools
+
+Access comprehensive provider documentation for resources, data sources, functions, and configuration guides.
+
+| Tool | Purpose | What it returns |
+|------|---------|-----------------|
+| `search_providers` | Find provider documentation by service name | List of available documentation with IDs, titles, and categories |
+| `get_provider_details` | Retrieve complete documentation for a specific provider component | Full documentation content in markdown format |
+| `get_latest_provider_version` | Retrieve the latest version of a specifc provider | The latest version of a provider |
+
+Example prompt: "How do I configure an AWS S3 bucket with versioning enabled?"
+
+### Module tools
+
+Discover and explore community and verified modules from the Terraform registry.
+
+| Tool | Purpose | What it returns |
+|------|---------|-----------------|
+| `search_modules` | Find modules by name or functionality | Module details including names, descriptions, download counts, and verification status |
+| `get_module_details` | Get comprehensive module information | Complete documentation with inputs, outputs, examples, and submodules |
+| `get_latest_module_version` | Retrieve the latest version of a specifc module | The latest version of a module |
+
+Example prompt: "Show me modules for deploying a Kubernetes cluster on AWS."
+
+### Policy tools
+
+Access Sentinel policies for governance and compliance requirements.
+
+| Tool | Purpose | What it returns |
+|------|---------|-----------------|
+| `search_policies` | Find Sentinel policies by topic or requirement | Policy listings with IDs, names, and download statistics |
+| `get_policy_details` | Retrieve detailed policy documentation | Policy implementation details and usage instructions |
+
+Example prompt: "What Sentinel policies are available for enforcing security best practices?"
+
+### Terraform Cloud/Enterprise tools
+
+Manage Terraform Cloud/Enterprise resources including workspaces, runs, variables, and private modules. Some tools require the `ENABLE_TF_OPERATIONS` environment variable for destructive operations.
+
+| Tool | Purpose | What it returns |
+|------|---------|-----------------|
+| `list_terraform_orgs` | Fetch all Terraform organizations | List of organizations with their details |
+| `list_terraform_projects` | Fetch all Terraform projects | List of projects with their metadata |
+| `list_workspaces` | Search and list workspaces in an organization | Workspace details including configuration and status |
+| `get_workspace_details` | Get comprehensive workspace information | Complete workspace configuration, variables, and state information |
+| `create_workspace` | Create a new Terraform workspace | Confirmation of workspace creation (destructive operation) |
+| `update_workspace` | Update workspace configuration | Updated workspace configuration (potentially destructive) |
+| `delete_workspace_safely` | Delete workspace if it manages no resources | Confirmation of deletion (requires `ENABLE_TF_OPERATIONS`) |
+| `list_runs` | List or search runs in a workspace | Run details with optional filtering |
+| `get_run_details` | Get detailed information about a specific run | Complete run information including logs and status |
+| `create_run` | Create a new Terraform run | Run creation confirmation with available run types |
+| `action_run` | Perform actions on runs (apply, discard, cancel) | Action confirmation (requires `ENABLE_TF_OPERATIONS`) |
+| `search_private_modules` | Find private modules in your organization | List of private modules matching search criteria |
+| `get_private_module_details` | Get detailed private module information | Complete module details including inputs, outputs, and examples |
+| `search_private_providers` | Find private providers in your organization | List of private providers matching search criteria |
+| `get_private_provider_details` | Get detailed private provider information | Provider details including usage and version information |
+| `get_workspace_policy_sets` | Get the policy sets attached to a particular workspace | A list of policy sets |
+| `attach_policy_set_to_workspace` | Attach a policy set to a workspace | Confirmation of attachment |
+| `get_token_permissions` | Get the permissions for the `TFE_TOKEN` | A list of actions you can take |
+| `get_plan_json_output` | Retrieves the structured JSON output of a Terraform plan, providing detailed resource changes in a machine-readable format that is easier to parse than plain logs |
+| `get_plan_details` | Fetches detailed metadata about a specific Terraform plan |
+| `get_plan_logs` | Retrieves the execution logs of a specific Terraform plan |
+| `get_apply_details` | Fetches detailed metadata about a specific Terraform apply |
+| `get_apply_logs` | Retrieves the execution logs of a specific Terraform apply |
+
+### Variable management tools
+
+Manage variables and variable sets across workspaces and organizations.
+
+| Tool | Purpose | What it returns |
+|------|---------|-----------------|
+| `list_variable_sets` | List all variable sets in an organization | Variable set details and configurations |
+| `create_variable_set` | Create a new variable set | Confirmation of variable set creation |
+| `create_variable_in_variable_set` | Add a variable to a variable set | Variable creation confirmation |
+| `delete_variable_in_variable_set` | Remove a variable from a variable set | Variable deletion confirmation |
+| `attach_variable_set_to_workspaces` | Attach variable set to workspaces | Attachment confirmation |
+| `detach_variable_set_from_workspaces` | Detach variable set from workspaces | Detachment confirmation |
+| `list_workspace_variables` | List all variables in a workspace | Workspace variable details |
+| `create_workspace_variable` | Create a variable in a workspace | Variable creation confirmation |
+| `update_workspace_variable` | Update an existing workspace variable | Updated variable configuration |
+
+### Workspace tagging tools
+
+Manage tags for Terraform workspaces to organize and categorize resources.
+
+| Tool | Purpose | What it returns |
+|------|---------|-----------------|
+| `create_workspace_tags` | Add tags to a workspace | Tag creation confirmation |
+| `read_workspace_tags` | Read all tags from a workspace | List of workspace tags |
+
+Example prompts:
+- "Create a new workspace called 'production-app' in my organization"
+- "Show me all runs for the staging workspace"
+- "List all private modules related to AWS"
+- "Create a variable set for database configuration"
+
+### Stacks tools
+
+Manage Terraform Stacks in an organization.
+
+| Tool | Purpose | What it returns |
+|------|---------|-----------------|
+| `list_stacks` | Retrieve list of stacks | List of stacks with high level summary |
+| `get_stack_details` | Read full details for a specific stack | Full stack configuration |
+
+Example prompts:
+- "List all the stacks in my organization"
+- "Show me the details for the `dev-environment` stack"
+
+
+## Available resources
+
+The Terraform MCP server provides several static read-only guides to the MCP clients to retrieve structured, contextual data. It helps generate standardized Terraform code. 
+
+| Resource URI | Kind | Description |
+|--------------|------|-------------|
+| `/terraform/style-guide` | Resource | Terraform Style Guide - Provides access to the official Terraform style guide documentation in markdown format |
+| `/terraform/module-development` | Resource | Terraform Module Development Guide - Comprehensive guide covering module composition, structure, providers, publishing, and refactoring best practices |
+| `/terraform/providers/{namespace}/name/{name}/version/{version}` | Resource Template | Provider Resource Template - Dynamically retrieves detailed documentation and overview for any Terraform provider by namespace, name, and version |
+
+## Transport protocols
+
+You can set one of the following transport protocols when starting the MCP server so that it operates correctly for your environment. 
+
+|   Transport      |   Best for                                                      |   How it works                                                                                |   Usage                                                          |
+|------------------|-----------------------------------------------------------------|-----------------------------------------------------------------------------------------------|------------------------------------------------------------------|
+| `stdio`          | Local development and direct integration with MCP clients       | Uses standard input/output for JSON-RPC message communication                                 | Automatically used when no specific transport mode is configured |
+| `streamableHTTP` | Remote deployments, distributed setups, production environments | HTTP-based transport with support for both direct HTTP requests                               | Enable by setting `TRANSPORT_MODE=streamable-http`               |
+
+
+## Environment variables
+
+You can set the following environment variables to configure the server behavior.
+
+| Variable                       | Description                                                                  | Default                      |
+|--------------------------------|------------------------------------------------------------------------------|------------------------------|
+| `TFE_ADDRESS`                  | HCP Terraform or Terraform Enterprise address                                | `"https://app.terraform.io"` |
+| `TFE_TOKEN`                    | Terraform Enterprise API token                                               | `""` (empty)                 |
+| `TFE_SKIP_TLS_VERIFY`          | Skip HCP Terraform or Terraform Enterprise TLS verification                  | `false`                      |
+| `TRANSPORT_MODE`               | Set to `streamable-http` to enable HTTP transport (legacy `http`)            | `stdio`                      |
+| `TRANSPORT_HOST`               | Host to bind the HTTP server                                                 | `127.0.0.1`                  |
+| `TRANSPORT_PORT`               | HTTP server port                                                             | `8080`                       |
+| `MCP_ENDPOINT`                 | HTTP server endpoint path                                                    | `/mcp`                       |
+| `MCP_SESSION_MODE`             | Session mode: `stateful` or `stateless`                                      | `stateful`                   |
+| `MCP_ALLOWED_ORIGINS`          | Comma-separated list of allowed origins for CORS                             | `""` (empty)                 |
+| `MCP_CORS_MODE`                | CORS mode: `strict`, `development`, or `disabled`                            | `strict`                     |
+| `MCP_RATE_LIMIT_GLOBAL`        | Global rate limit (format: `rps:burst`)                                      | `10:20`                      |
+| `MCP_RATE_LIMIT_SESSION`       | Per-session rate limit (format: `rps:burst`)                                 | `5:10`                       |
+| `ENABLE_TF_OPERATIONS`         | Enable destructive Terraform operations                                      | `false`                      |
+| `MCP_HEARTBEAT_INTERVAL`       | Keep-alive long lived streamable HTTP connections (`0` to disable)           | `0`                          |
+| `OTEL_METRICS_ENABLED`         | Enable tools metrics using OpenTelemtry                                      | `false`                      |
+| `OTEL_METRICS_SERVICE_NAME`    | Identifies the source of the metrics                                         | `terraform-mcp-server`       |
+| `OTEL_METRICS_EXPORT_INTERVAL` | Controls the frequency of metric flushes                                     | `2`                          |
+| `OTEL_METRICS_ENDPOINT`        | OpenTelemetry collector endpoint                                             | `localhost:4318`             |
+| `LOG_LEVEL`                    | Logging level: `trace`, `debug`, `info`, `warn`, `error`, `fatal`, `panic`   | `info`                       |
+| `LOG_FORMAT`                   | Logging format: `text` or `json` (overrides `--log-format` flag)             | `text`                       |
+
+## Run type options
+
+The `create_run` tool supports the following run types by default:
+
+- `plan_and_apply`: Creates a plan and applies it if approved
+- `refresh_state`: Refreshes the state without making changes
+- `plan_only`: Creates a plan without applying
+- `allow_empty_apply`: Allows applying when no changes are detected
+
+When `ENABLE_TF_OPERATIONS` is set to `true`, the following additional options become available:
+
+- `auto_approve`: Automatically approves and applies the plan
+- `is_destroy`: Creates a destroy plan to remove infrastructure
+
+### Destructive operations
+
+Several tools perform destructive operations that can modify or delete infrastructure resources. These tools are disabled by default and require setting `ENABLE_TF_OPERATIONS=true`:
+
+- `action_run`: Can apply or destroy infrastructure
+- `delete_workspace_safely`: Permanently deletes workspaces
+- Additional run type options in `create_run`
+
+<Warning>
+
+When enabled, use these tools with caution as they can permanently modify or destroy infrastructure resources.
+
+</Warning>

--- a/content/terraform-mcp-server/v0.5.x/docs/mcp-server/security.mdx
+++ b/content/terraform-mcp-server/v0.5.x/docs/mcp-server/security.mdx
@@ -1,0 +1,54 @@
+---
+page_title: Security model for Terraform MCP server
+description: Learn about potential security threats to Terraform Model Context Protocol (MCP) server when operating the server locally if you do not take proper precations.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-01-22T23:00:02-07:00
+last_modified: 2026-01-22T23:00:02-07:00
+# END AUTO GENERATED METADATA
+---
+
+# Security model for Terraform MCP server
+
+This document explains the security model for the Terraform Model Context Protocol (MCP) server when operating the server locally. Understanding this model helps you safely integrate local AI agents with Terraform tooling. This ensures the following outcomes, even in local environments:
+
+- Tool execution is safe and controlled
+- Sensitive operations are protected from accidental misuse or injection
+- LLM behavior is constrained and auditable prior to application.
+
+Refer to the [Terraform MCP server overview](/terraform/docs/tools/mcp-server) for additional information. 
+
+## Threat model
+
+You should be aware of the following potential threats to the Terraform MCP server.
+
+### Hallucinations
+
+AI hallucinations, or the generation of false information, stem from insufficient training data, flawed model assumptions, and biased datasets. They pose serious risks in critical applications where accuracy is vital for correct diagnoses and sound decisions. We recommend always validating the data prior to applying any changes to your infrastructure.
+
+### Prompt injection
+
+Improperly validating or sanitizing inputs can allow attackers to inject malicious instructions for the MCP server to execute. This can lead to code execution, server side request forgery (SSRF), and other kinds of security breaches. To mitigate this risk, we've implemented input validation for all user-sourced data entering the MCP server.
+
+### Tool poisoning 
+
+Tool poisoning is when the MCP server inadvertently executes hidden instructions within comprehensive tool descriptions, which lets attackers instigate unwanted or damaging outcomes. To mitigate tool poisoning, the MCP server uses static tool descriptions that don't allow poisoning.
+
+### Rug pull attack 
+
+Deploying a remotely accessible MCP server changes its available tools and descriptions after deployment. This enables malicious behavior that isn't present when the tool was initially approved.
+
+### Tool shadowing 
+
+When multiple MCP servers are connected, a compromised server can override tools from trusted servers, leading to potential security breaches. You should take precautions when operating several MCP servers.
+
+## Threat model exclusions
+
+The following are not part of the threat model for the Terraform MCP Server:
+
+- **Foundational model**: Concerns related to the underlying AI models, training data, and inherent vulnerabilities.
+- **Infrastructure deployment**: Concerns related to the security of infrastructure, network and software environments configuration and deployment through the output of the model should always be reviewed prior to any change application.
+
+## Recommendations for secure use
+
+- Always validate before doing any write changes. 
+- Follow the instructions for securely deploying the MCP server. Refer to [Secure configuration](/terraform/docs/tools/mcp-server/deploy#secure-configuration).

--- a/content/terraform-mcp-server/v0.5.x/docs/partials/beta.mdx
+++ b/content/terraform-mcp-server/v0.5.x/docs/partials/beta.mdx
@@ -1,0 +1,6 @@
+<!-- Use this partial for general beta callouts -->
+<Note>
+
+This feature is currently in beta. Do not use beta functionality in production environments.
+
+</Note>


### PR DESCRIPTION
### What

This adds the docs pages for Terraform MCP 0.5.x

### Why

Documentation is updated with a set of new MCP tools and environment variables for configuring the server for release 0.5.x. 

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] You added redirects to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages **across all affected versions**. Refer to [Redirects](https://github.com/hashicorp/web-unified-docs/blob/main/docs/content-guide/redirects.md#example-redirects) for examples and guidance. 
- [ ] Links to related content where appropriate (e.g., CLI, language, API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
