### PR TITLE
Consul: Certificate expiration telemetry

### DIFF
--- a/content/consul/v2.0.x/content/api-docs/agent/metrics.mdx
+++ b/content/consul/v2.0.x/content/api-docs/agent/metrics.mdx
@@ -1,39 +1,53 @@
 ---
 layout: api
-page_title: Certificates - Metrics - Agent - HTTP API
+page_title: Metrics - Agent - HTTP API
 description: |-
   The /agent/metrics/certificates endpoint returns certificate expiration information for monitoring scenarios.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2026-04-01T22:39:20.000Z
-last_modified: 2026-04-01T22:39:20.000Z
+created_at: 2026-04-01T15:39:20-07:00
+last_modified: 2026-04-01T22:55:40.000Z
 # END AUTO GENERATED METADATA
 ---
 
-# Certificates - Metrics - Agent HTTP API
+# Metrics - Agent HTTP API
+
+The `/agent/metrics` endpoints return telemetry data from the agent for both Consul agent and service mesh operations.
+
+## Certificate expiration
 
 The `/agent/metrics/certificates` endpoint returns detailed information about certificate expiration status across the Consul infrastructure, including CA roots, intermediates, leaf certificates, and agent TLS certificates.
+
+This endpoint requires Consul v2.0.0 or later.
+
+Certificate telemetry is enabled by default. Responses are cached for 5 minutes, but this duration is configurable. The endpoint gathers metrics from Prometheus and processes them. It determines security levels by configurable thresholds.
+
+@include 'legacy/http_api_results_filtered_by_acls.mdx'
 
 | Method | Path                              | Produces           |
 | ------ | --------------------------------- | ------------------ |
 | `GET`  | `/agent/metrics/certificates`     | `application/json` |
 
-The table below shows this endpoint's support by ACL token:
+The table below shows this endpoint's support for
+[blocking queries](/consul/api-docs/features/blocking),
+[consistency modes](/consul/api-docs/features/consistency),
+[agent caching](/consul/api-docs/features/caching), and
+[required ACLs](/consul/api-docs/api-structure#authentication).
 
-| ACL Required |
-| ------------ |
-| `agent:read` |
+| Blocking Queries | Consistency Modes | Agent Caching | ACL Required   |
+| ---------------- | ----------------- | ------------- | -------------- |
+| `NO`             | `none`            | `none`        | `agent:read` |
 
-## Query Parameters
+### Query Parameters
 
 This endpoint does not accept query parameters.
 
-## Sample Request
+### Sample Request
 
 ```shell-session
 $ curl http://127.0.0.1:8500/v1/agent/metrics/certificates
 ```
 
-## Sample Response
+### Sample Response
 
 ```json
 {
@@ -104,14 +118,16 @@ $ curl http://127.0.0.1:8500/v1/agent/metrics/certificates
 }
 ```
 
-## Response Fields
+### JSON Response Schemas
 
-### Certificate Object
+The JSON response includes the following information.
+
+#### Certificate Object
 
 - `id` `(string)` - Unique identifier for the certificate
 - `name` `(string)` - Human-readable name
 - `type` `(string)` - Certificate type: `ca`, `agent`, `leaf`, or `gateway`
-- `subtype` `(string)` - Certificate subtype (e.g., `root`, `intermediate`, `service`, `mesh`)
+- `subtype` `(string)` - Certificate subtype: `root`, `intermediate`, `service`, or `mesh`
 - `subject` `(string)` - Certificate subject (optional)
 - `issuer` `(string)` - Certificate issuer (optional)
 - `not_after` `(string)` - Expiration timestamp (optional)
@@ -131,7 +147,7 @@ $ curl http://127.0.0.1:8500/v1/agent/metrics/certificates
   - `last_attempt` `(string)` - Timestamp of last renewal attempt
   - `consecutive_rate_limits` `(int)` - Number of consecutive rate limit errors
 
-### Summary Object
+#### Summary Object
 
 - `total` `(int)` - Total number of certificates
 - `by_severity` `(map)` - Count of certificates by severity level
@@ -140,19 +156,12 @@ $ curl http://127.0.0.1:8500/v1/agent/metrics/certificates
 - `expiring_soon_with_failures` `(int)` - Number of expiring certificates with failures
 - `failures_by_reason` `(map)` - Count of failures by reason
 
-### Thresholds Object
+#### Thresholds Object
 
 - `critical_days` `(int)` - Days threshold for critical severity
 - `warning_days` `(int)` - Days threshold for warning severity
 
-### Response Metadata
+#### Response Metadata
 
 - `cached` `(bool)` - Whether the response was served from cache
 - `cache_expires_at` `(string)` - When the cached response expires
-
-## Notes
-
-- This endpoint requires certificate telemetry to be enabled (default: enabled)
-- Responses are cached for 5 minutes by default (configurable)
-- The endpoint gathers metrics from Prometheus and processes them
-- Severity levels are determined by configurable thresholds

--- a/content/consul/v2.0.x/content/api-docs/agent/metrics.mdx
+++ b/content/consul/v2.0.x/content/api-docs/agent/metrics.mdx
@@ -5,7 +5,7 @@ description: |-
   The /agent/metrics/certificates endpoint returns certificate expiration information for monitoring scenarios.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2026-04-01T15:39:20-07:00
-last_modified: 2026-04-02T18:16:43.000Z
+last_modified: 2026-04-02T20:49:23.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -17,9 +17,9 @@ The `/agent/metrics` endpoints return a node's telemetry data for both Consul ag
 
 The `/agent/metrics/certificates` endpoint returns detailed information about certificate expiration status across the Consul infrastructure, including CA roots, intermediates, leaf certificates, and agent TLS certificates.
 
-This endpoint requires Consul v2.0.0 or later.
-
 Certificate telemetry is enabled by default. Responses are cached for 5 minutes, but this duration is configurable. The endpoint gathers metrics from Prometheus and processes them. It determines security levels by configurable thresholds.
+
+For more information about enabling and configuring agent behavior, refer to [the Consul agent `telemetry` configuration parameters](/consul/docs/reference/agent/configuration-file/telemetry#certificate-expiration). To learn about the other workflows for returning certificate expiration metrics, including Prometheus integration, refer to [Monitor certificate expiration](/consul/docs/monitor/telemetry/certificate-expiration).
 
 @include 'legacy/http_api_results_filtered_by_acls.mdx'
 

--- a/content/consul/v2.0.x/content/api-docs/agent/metrics.mdx
+++ b/content/consul/v2.0.x/content/api-docs/agent/metrics.mdx
@@ -1,15 +1,15 @@
 ---
 layout: api
-page_title: Agent Metrics Certificates - Agent - HTTP API
+page_title: Certificates - Metrics - Agent - HTTP API
 description: |-
-  The /agent/metrics/certificates endpoint returns certificate expiry information for monitoring.
+  The /agent/metrics/certificates endpoint returns certificate expiration information for monitoring scenarios.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2026-04-01T22:02:50.000Z
-last_modified: 2026-04-01T22:02:50.000Z
+created_at: 2026-04-01T22:39:20.000Z
+last_modified: 2026-04-01T22:39:20.000Z
 # END AUTO GENERATED METADATA
 ---
 
-# Agent Metrics Certificates
+# Certificates - Metrics - Agent HTTP API
 
 The `/agent/metrics/certificates` endpoint returns detailed information about certificate expiration status across the Consul infrastructure, including CA roots, intermediates, leaf certificates, and agent TLS certificates.
 

--- a/content/consul/v2.0.x/content/api-docs/agent/metrics.mdx
+++ b/content/consul/v2.0.x/content/api-docs/agent/metrics.mdx
@@ -5,13 +5,13 @@ description: |-
   The /agent/metrics/certificates endpoint returns certificate expiration information for monitoring scenarios.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2026-04-01T15:39:20-07:00
-last_modified: 2026-04-01T22:55:40.000Z
+last_modified: 2026-04-02T18:16:43.000Z
 # END AUTO GENERATED METADATA
 ---
 
 # Metrics - Agent HTTP API
 
-The `/agent/metrics` endpoints return telemetry data from the agent for both Consul agent and service mesh operations.
+The `/agent/metrics` endpoints return a node's telemetry data for both Consul agent and service mesh operations.
 
 ## Certificate expiration
 

--- a/content/consul/v2.0.x/content/api-docs/agent/metrics.mdx
+++ b/content/consul/v2.0.x/content/api-docs/agent/metrics.mdx
@@ -27,7 +27,7 @@ For more information about enabling and configuring agent behavior, refer to [th
 | ------ | --------------------------------- | ------------------ |
 | `GET`  | `/agent/metrics/certificates`     | `application/json` |
 
-The table below shows this endpoint's support for
+This table shows this endpoint's support for
 [blocking queries](/consul/api-docs/features/blocking),
 [consistency modes](/consul/api-docs/features/consistency),
 [agent caching](/consul/api-docs/features/caching), and

--- a/content/consul/v2.0.x/content/api-docs/agent/metrics/certificates.mdx
+++ b/content/consul/v2.0.x/content/api-docs/agent/metrics/certificates.mdx
@@ -1,0 +1,158 @@
+---
+layout: api
+page_title: Agent Metrics Certificates - Agent - HTTP API
+description: |-
+  The /agent/metrics/certificates endpoint returns certificate expiry information for monitoring.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-04-01T22:02:50.000Z
+last_modified: 2026-04-01T22:02:50.000Z
+# END AUTO GENERATED METADATA
+---
+
+# Agent Metrics Certificates
+
+The `/agent/metrics/certificates` endpoint returns detailed information about certificate expiration status across the Consul infrastructure, including CA roots, intermediates, leaf certificates, and agent TLS certificates.
+
+| Method | Path                              | Produces           |
+| ------ | --------------------------------- | ------------------ |
+| `GET`  | `/agent/metrics/certificates`     | `application/json` |
+
+The table below shows this endpoint's support by ACL token:
+
+| ACL Required |
+| ------------ |
+| `agent:read` |
+
+## Query Parameters
+
+This endpoint does not accept query parameters.
+
+## Sample Request
+
+```shell-session
+$ curl http://127.0.0.1:8500/v1/agent/metrics/certificates
+```
+
+## Sample Response
+
+```json
+{
+  "certificates": [
+    {
+      "id": "ca-root-primary",
+      "name": "Root CA",
+      "type": "ca",
+      "subtype": "root",
+      "days_remaining": 3650,
+      "seconds_remaining": 315360000,
+      "severity": "INFO",
+      "severity_score": 10,
+      "color": "green"
+    },
+    {
+      "id": "ca-signing-active",
+      "name": "Active Signing CA",
+      "type": "ca",
+      "subtype": "intermediate",
+      "days_remaining": 365,
+      "seconds_remaining": 31536000,
+      "severity": "INFO",
+      "severity_score": 10,
+      "color": "green"
+    },
+    {
+      "id": "web",
+      "name": "web",
+      "type": "leaf",
+      "subtype": "service",
+      "days_remaining": 2,
+      "seconds_remaining": 172800,
+      "severity": "CRITICAL",
+      "severity_score": 90,
+      "color": "red",
+      "renewal_failure": {
+        "failure_reason": "rate_limited",
+        "failure_count": 3,
+        "last_attempt": "2026-01-30T07:00:00Z",
+        "consecutive_rate_limits": 2
+      }
+    }
+  ],
+  "summary": {
+    "total": 3,
+    "by_severity": {
+      "critical": 1,
+      "warning": 0,
+      "info": 2
+    },
+    "by_type": {
+      "ca": 2,
+      "leaf": 1
+    },
+    "total_with_failures": 1,
+    "expiring_soon_with_failures": 1,
+    "failures_by_reason": {
+      "rate_limited": 1
+    }
+  },
+  "thresholds": {
+    "critical_days": 7,
+    "warning_days": 30
+  },
+  "cached": false,
+  "cache_expires_at": "2026-01-30T07:05:00Z"
+}
+```
+
+## Response Fields
+
+### Certificate Object
+
+- `id` `(string)` - Unique identifier for the certificate
+- `name` `(string)` - Human-readable name
+- `type` `(string)` - Certificate type: `ca`, `agent`, `leaf`, or `gateway`
+- `subtype` `(string)` - Certificate subtype (e.g., `root`, `intermediate`, `service`, `mesh`)
+- `subject` `(string)` - Certificate subject (optional)
+- `issuer` `(string)` - Certificate issuer (optional)
+- `not_after` `(string)` - Expiration timestamp (optional)
+- `days_remaining` `(int)` - Days until expiration
+- `seconds_remaining` `(int64)` - Seconds until expiration
+- `severity` `(string)` - Severity level: `CRITICAL`, `WARNING`, or `INFO`
+- `severity_score` `(int)` - Numeric severity score (90=critical, 50=warning, 10=info)
+- `color` `(string)` - Color indicator: `red`, `yellow`, or `green`
+- `auto_renewable` `(bool)` - Whether the certificate auto-renews (optional)
+- `requires_manual_rotation` `(bool)` - Whether manual rotation is required (optional)
+- `ca_provider` `(string)` - CA provider name (optional)
+- `path` `(string)` - File path for agent TLS certificates (optional)
+- `node_name` `(string)` - Node name for agent TLS certificates (optional)
+- `renewal_failure` `(object)` - Renewal failure information (optional)
+  - `failure_reason` `(string)` - Reason for renewal failure
+  - `failure_count` `(int)` - Number of consecutive failures
+  - `last_attempt` `(string)` - Timestamp of last renewal attempt
+  - `consecutive_rate_limits` `(int)` - Number of consecutive rate limit errors
+
+### Summary Object
+
+- `total` `(int)` - Total number of certificates
+- `by_severity` `(map)` - Count of certificates by severity level
+- `by_type` `(map)` - Count of certificates by type
+- `total_with_failures` `(int)` - Number of certificates with renewal failures
+- `expiring_soon_with_failures` `(int)` - Number of expiring certificates with failures
+- `failures_by_reason` `(map)` - Count of failures by reason
+
+### Thresholds Object
+
+- `critical_days` `(int)` - Days threshold for critical severity
+- `warning_days` `(int)` - Days threshold for warning severity
+
+### Response Metadata
+
+- `cached` `(bool)` - Whether the response was served from cache
+- `cache_expires_at` `(string)` - When the cached response expires
+
+## Notes
+
+- This endpoint requires certificate telemetry to be enabled (default: enabled)
+- Responses are cached for 5 minutes by default (configurable)
+- The endpoint gathers metrics from Prometheus and processes them
+- Severity levels are determined by configurable thresholds

--- a/content/consul/v2.0.x/content/docs/monitor/telemetry/certificate-expiration.mdx
+++ b/content/consul/v2.0.x/content/docs/monitor/telemetry/certificate-expiration.mdx
@@ -86,22 +86,22 @@ Consul logs certificate expiration warnings at different severity levels:
 - `WARNING`
 - `INFO`
 
-Use the `consul monitor` CLI command to return an agent's logs. You can configure log behavior in [the Consul agent's configuration file](/consul/docs/reference/agent/configuration-file/log).
+Use the [`consul monitor` CLI command](/consul/commands/monitor) to return an agent's logs. You can configure log behavior in [the Consul agent's configuration file](/consul/docs/reference/agent/configuration-file/log).
 
 ### Prometheus Metrics
 
 Consul emits the following Prometheus metrics for certificate expiration:
 
 - `consul_mesh_active_root_ca_expiry`: Root CA expiration, in seconds
-- `consul_mesh_active_signing_ca_expiry`: Signing CA expiry (seconds)
-- `consul_agent_tls_cert_expiry{node="server-1"}`: Agent TLS certificate expiry (seconds, labeled by node)
-- `consul_leaf_certs_cert_expiry{service="web",kind="service"}`: Leaf certificate expiry (seconds, labeled by service and kind)
+- `consul_mesh_active_signing_ca_expiry`: Signing CA expiry, in seconds
+- `consul_agent_tls_cert_expiry{node="server-1"}`: Agent TLS certificate expiry in seconds, labeled by node
+- `consul_leaf_certs_cert_expiry{service="web",kind="service"}`: Leaf certificate expiry in seconds, labeled by service and kind
 - `consul_leaf_certs_cert_renewal_failure{service="web",kind="service",reason="rate_limited"}`: Certificate renewal failures
 
 You can configure certificate expiration alerts in Prometheus using these metrics. The following configuration example alerts you in the following scenarios:
 
-- there is a signing that CA expires in less than 7 days
-- leaf certificate renewal failed for a service
+- There is a signing that CA expires in less than 7 days
+- Leaf certificate renewal failed for a service
 
 ```yaml
 groups:

--- a/content/consul/v2.0.x/content/docs/monitor/telemetry/certificate-expiration.mdx
+++ b/content/consul/v2.0.x/content/docs/monitor/telemetry/certificate-expiration.mdx
@@ -1,0 +1,220 @@
+---
+layout: docs
+page_title: Monitor certificate expiration
+description: >-
+  Learn how to monitor certificate expiration in Consul service mesh to prevent service disruptions.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-04-01T22:15:12.000Z
+last_modified: 2026-04-01T22:15:12.000Z
+# END AUTO GENERATED METADATA
+---
+
+# Monitor certificate expiration
+
+This topic describes how to monitor certificate expiration in Consul to prevent service disruptions caused by expired certificates.
+
+## Overview
+
+Consul manages several types of certificates in a service mesh deployment:
+
+- **CA Root Certificates** - The primary root certificate authority
+- **Intermediate Certificates** - Signing certificates used to issue leaf certificates
+- **Leaf Certificates** - Service identity certificates for workloads
+- **Agent TLS Certificates** - Certificates for secure agent communication
+
+Certificate expiration can cause service disruptions if not monitored and renewed in time. Consul provides built-in certificate telemetry to help you track certificate expiration and take proactive action.
+
+## Configuration
+
+Certificate telemetry is enabled by default. You can customize thresholds and behavior in your agent configuration:
+
+```hcl
+telemetry {
+  certificate {
+    enabled = true
+    cache_duration = "5m"
+    critical_threshold_days = 7
+    warning_threshold_days = 30
+    info_threshold_days = 90
+    exclude_auto_renewable = false
+  }
+}
+```
+
+### Configuration Parameters
+
+- **enabled** - Enable or disable certificate monitoring (default: `true`)
+- **cache_duration** - How long to cache API responses (default: `5m`)
+- **critical_threshold_days** - Days before expiration to trigger critical alerts (default: `7`)
+- **warning_threshold_days** - Days before expiration to trigger warnings (default: `30`)
+- **info_threshold_days** - Days before expiration for informational logging (default: `90`)
+- **exclude_auto_renewable** - Exclude auto-renewable certificates from monitoring (default: `false`)
+
+## Monitoring Methods
+
+### 1. Prometheus Metrics
+
+Consul emits Prometheus metrics for certificate expiration:
+
+```promql
+# Root CA expiry (seconds)
+consul_mesh_active_root_ca_expiry
+
+# Signing CA expiry (seconds)
+consul_mesh_active_signing_ca_expiry
+
+# Agent TLS certificate expiry (seconds, labeled by node)
+consul_agent_tls_cert_expiry{node="server-1"}
+
+# Leaf certificate expiry (seconds, labeled by service and kind)
+consul_leaf_certs_cert_expiry{service="web",kind="service"}
+
+# Certificate renewal failures
+consul_leaf_certs_cert_renewal_failure{service="web",kind="service",reason="rate_limited"}
+```
+
+#### Example Prometheus Alerts
+
+```yaml
+groups:
+  - name: consul_certificates
+    rules:
+      - alert: ConsulCertificateExpiringSoon
+        expr: consul_mesh_active_root_ca_expiry < (7 * 24 * 60 * 60)
+        labels:
+          severity: critical
+        annotations:
+          summary: "Consul root CA expires in less than 7 days"
+          description: "Root CA expires in {{ $value | humanizeDuration }}"
+
+      - alert: ConsulLeafCertRenewalFailure
+        expr: consul_leaf_certs_cert_renewal_failure > 0
+        labels:
+          severity: warning
+        annotations:
+          summary: "Leaf certificate renewal failing for {{ $labels.service }}"
+          description: "Service {{ $labels.service }} has renewal failures: {{ $labels.reason }}"
+```
+
+### 2. HTTP API
+
+Query certificate status via the HTTP API:
+
+```shell-session
+$ curl http://127.0.0.1:8500/v1/agent/metrics/certificates
+```
+
+The API returns detailed information about all monitored certificates, including:
+- Days and seconds until expiration
+- Severity classification (CRITICAL/WARNING/INFO)
+- Renewal failure information
+- Summary statistics
+
+Example response:
+
+```json
+{
+  "certificates": [
+    {
+      "id": "ca-root-primary",
+      "name": "Root CA",
+      "type": "ca",
+      "subtype": "root",
+      "days_remaining": 3650,
+      "severity": "INFO"
+    }
+  ],
+  "summary": {
+    "total": 1,
+    "by_severity": {
+      "critical": 0,
+      "warning": 0,
+      "info": 1
+    }
+  }
+}
+```
+
+### 3. Log Monitoring
+
+Consul logs certificate expiry warnings at different severity levels:
+
+```
+[CRITICAL] Certificate expiring soon: type=ca, name=Root CA, days_remaining=5
+[WARNING] Certificate expiring soon: type=leaf, service=web, days_remaining=25
+[INFO] Certificate status: type=ca, name=Root CA, days_remaining=3650
+```
+
+## Best Practices
+
+### 1. Set Appropriate Thresholds
+
+Configure thresholds based on your certificate rotation procedures:
+
+- **Critical threshold** - Should allow enough time for emergency rotation
+- **Warning threshold** - Should trigger proactive rotation planning
+- **Info threshold** - For general awareness and trending
+
+### 2. Monitor Renewal Failures
+
+Leaf certificates auto-renew, but failures can occur due to:
+- Rate limiting
+- CA unavailability
+- Network issues
+- ACL permission problems
+
+Monitor the `consul_leaf_certs_cert_renewal_failure` metric and investigate failures promptly.
+
+### 3. Automate Alerting
+
+Configure alerts in your monitoring system (Prometheus, Datadog, etc.) to notify operators when:
+- Certificates approach expiration
+- Renewal failures occur
+- Multiple certificates expire around the same time
+
+### 4. Regular Audits
+
+Periodically review certificate status using the API endpoint:
+
+```shell-session
+$ curl -s http://127.0.0.1:8500/v1/agent/metrics/certificates | jq '.summary'
+```
+
+### 5. Test Rotation Procedures
+
+Regularly test certificate rotation procedures in non-production environments to ensure smooth operations when rotation is needed.
+
+## Troubleshooting
+
+### Certificate Not Appearing in Metrics
+
+If a certificate doesn't appear in the metrics:
+
+1. Verify certificate telemetry is enabled
+2. Check that the certificate is being used by Consul
+3. Ensure Prometheus metrics are being collected
+4. Wait for the next metrics emission cycle (typically 1 hour for CA certificates)
+
+### Renewal Failures
+
+If leaf certificates show renewal failures:
+
+1. Check the `failure_reason` in the API response
+2. Verify CA availability and health
+3. Check for rate limiting (increase `CSRMaxPerSecond` if needed)
+4. Verify ACL permissions for certificate signing
+5. Review agent logs for detailed error messages
+
+### High Cache Hit Rate
+
+If the API always returns cached results:
+
+1. Reduce `cache_duration` for more frequent updates
+2. Note that caching reduces load on the metrics system
+3. Prometheus metrics are always up-to-date regardless of API caching
+
+## Related Resources
+
+- [Connect CA Configuration](/consul/docs/connect/ca)
+- [Agent Metrics Certificates API](/consul/api-docs/agent/metrics/certificates)
+- [Telemetry Configuration](/consul/docs/agent/config/config-files#telemetry)

--- a/content/consul/v2.0.x/content/docs/monitor/telemetry/certificate-expiration.mdx
+++ b/content/consul/v2.0.x/content/docs/monitor/telemetry/certificate-expiration.mdx
@@ -2,10 +2,10 @@
 layout: docs
 page_title: Monitor certificate expiration
 description: >-
-  Learn how to monitor certificate expiration in Consul service mesh to prevent service disruptions.
+  Learn how to monitor certificate expiration in Consul for both agent and service mesh operations. You can use the Consul HTTP API, monitor agent logs, or enable Prometheus alerts.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2026-04-01T22:15:12.000Z
-last_modified: 2026-04-01T22:15:12.000Z
+created_at: 2026-04-01T15:15:12-07:00
+last_modified: 2026-04-02T20:49:25.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -17,98 +17,41 @@ This topic describes how to monitor certificate expiration in Consul to prevent 
 
 Consul manages several types of certificates in a service mesh deployment:
 
-- **CA Root Certificates** - The primary root certificate authority
-- **Intermediate Certificates** - Signing certificates used to issue leaf certificates
-- **Leaf Certificates** - Service identity certificates for workloads
-- **Agent TLS Certificates** - Certificates for secure agent communication
+- **CA Root Certificates**: The primary root certificate authority
+- **Intermediate Certificates**: Signing certificates used to issue leaf certificates
+- **Leaf Certificates**: Service identity certificates for workloads
+- **Agent TLS Certificates**: Certificates for secure agent communication
 
-Certificate expiration can cause service disruptions if not monitored and renewed in time. Consul provides built-in certificate telemetry to help you track certificate expiration and take proactive action.
+Service disruptions may occur if you do renew certificates in time. Consul provides built-in certificate telemetry to help you track certificate expiration and act.
 
 ## Configuration
 
-Certificate telemetry is enabled by default. You can customize thresholds and behavior in your agent configuration:
+Certificate telemetry is enabled by default. You can [customize thresholds and behavior in your agent configuration](/consul/docs/reference/agent/configuration-file/telemetry#certificate-expiration).
 
-```hcl
-telemetry {
-  certificate {
-    enabled = true
-    cache_duration = "5m"
-    critical_threshold_days = 7
-    warning_threshold_days = 30
-    info_threshold_days = 90
-    exclude_auto_renewable = false
-  }
-}
-```
+@include 'examples/agent/telemetry/certificate.mdx'
 
-### Configuration Parameters
+## Monitoring workflows
 
-- **enabled** - Enable or disable certificate monitoring (default: `true`)
-- **cache_duration** - How long to cache API responses (default: `5m`)
-- **critical_threshold_days** - Days before expiration to trigger critical alerts (default: `7`)
-- **warning_threshold_days** - Days before expiration to trigger warnings (default: `30`)
-- **info_threshold_days** - Days before expiration for informational logging (default: `90`)
-- **exclude_auto_renewable** - Exclude auto-renewable certificates from monitoring (default: `false`)
+There are three methods for monitoring certificate expiration telemetry:
 
-## Monitoring Methods
+1. Query the [certificate telemetry API endpoint](/consul/api-docs/agent/metrics)
+1. Monitor agent logs
+1. Configure Prometheus alerts
 
-### 1. Prometheus Metrics
+### HTTP API
 
-Consul emits Prometheus metrics for certificate expiration:
+The [`/agent/metrics/certificates` endpoint](/consul/api-docs/agent/metrics) returns detailed information about certificate expiration status, including:
 
-```promql
-# Root CA expiry (seconds)
-consul_mesh_active_root_ca_expiry
+- Days and seconds until expiration
+- Severity classification
+- Renewal failure information
+- Summary statistics
 
-# Signing CA expiry (seconds)
-consul_mesh_active_signing_ca_expiry
-
-# Agent TLS certificate expiry (seconds, labeled by node)
-consul_agent_tls_cert_expiry{node="server-1"}
-
-# Leaf certificate expiry (seconds, labeled by service and kind)
-consul_leaf_certs_cert_expiry{service="web",kind="service"}
-
-# Certificate renewal failures
-consul_leaf_certs_cert_renewal_failure{service="web",kind="service",reason="rate_limited"}
-```
-
-#### Example Prometheus Alerts
-
-```yaml
-groups:
-  - name: consul_certificates
-    rules:
-      - alert: ConsulCertificateExpiringSoon
-        expr: consul_mesh_active_root_ca_expiry < (7 * 24 * 60 * 60)
-        labels:
-          severity: critical
-        annotations:
-          summary: "Consul root CA expires in less than 7 days"
-          description: "Root CA expires in {{ $value | humanizeDuration }}"
-
-      - alert: ConsulLeafCertRenewalFailure
-        expr: consul_leaf_certs_cert_renewal_failure > 0
-        labels:
-          severity: warning
-        annotations:
-          summary: "Leaf certificate renewal failing for {{ $labels.service }}"
-          description: "Service {{ $labels.service }} has renewal failures: {{ $labels.reason }}"
-```
-
-### 2. HTTP API
-
-Query certificate status via the HTTP API:
+Use the following command to request certificate expiration metrics from the Consul agent:
 
 ```shell-session
 $ curl http://127.0.0.1:8500/v1/agent/metrics/certificates
 ```
-
-The API returns detailed information about all monitored certificates, including:
-- Days and seconds until expiration
-- Severity classification (CRITICAL/WARNING/INFO)
-- Renewal failure information
-- Summary statistics
 
 Example response:
 
@@ -135,86 +78,77 @@ Example response:
 }
 ```
 
-### 3. Log Monitoring
+### Monitor agent logs
 
-Consul logs certificate expiry warnings at different severity levels:
+Consul logs certificate expiration warnings at different severity levels:
 
+- `CRITICAL`
+- `WARNING`
+- `INFO`
+
+Use the `consul monitor` CLI command to return an agent's logs. You can configure log behavior in [the Consul agent's configuration file](/consul/docs/reference/agent/configuration-file/log).
+
+### Prometheus Metrics
+
+Consul emits the following Prometheus metrics for certificate expiration:
+
+- `consul_mesh_active_root_ca_expiry`: Root CA expiration, in seconds
+- `consul_mesh_active_signing_ca_expiry`: Signing CA expiry (seconds)
+- `consul_agent_tls_cert_expiry{node="server-1"}`: Agent TLS certificate expiry (seconds, labeled by node)
+- `consul_leaf_certs_cert_expiry{service="web",kind="service"}`: Leaf certificate expiry (seconds, labeled by service and kind)
+- `consul_leaf_certs_cert_renewal_failure{service="web",kind="service",reason="rate_limited"}`: Certificate renewal failures
+
+You can configure certificate expiration alerts in Prometheus using these metrics. The following configuration example alerts you in the following scenarios:
+
+- there is a signing that CA expires in less than 7 days
+- leaf certificate renewal failed for a service
+
+```yaml
+groups:
+  - name: consul_certificates
+    rules:
+      - alert: ConsulCertificateExpiringSoon
+        expr: consul_mesh_active_root_ca_expiry < (7 * 24 * 60 * 60)
+        labels:
+          severity: critical
+        annotations:
+          summary: "Consul root CA expires in less than 7 days"
+          description: "Root CA expires in {{ $value | humanizeDuration }}"
+
+      - alert: ConsulLeafCertRenewalFailure
+        expr: consul_leaf_certs_cert_renewal_failure > 0
+        labels:
+          severity: warning
+        annotations:
+          summary: "Leaf certificate renewal failing for {{ $labels.service }}"
+          description: "Service {{ $labels.service }} has renewal failures: {{ $labels.reason }}"
 ```
-[CRITICAL] Certificate expiring soon: type=ca, name=Root CA, days_remaining=5
-[WARNING] Certificate expiring soon: type=leaf, service=web, days_remaining=25
-[INFO] Certificate status: type=ca, name=Root CA, days_remaining=3650
-```
-
-## Best Practices
-
-### 1. Set Appropriate Thresholds
-
-Configure thresholds based on your certificate rotation procedures:
-
-- **Critical threshold** - Should allow enough time for emergency rotation
-- **Warning threshold** - Should trigger proactive rotation planning
-- **Info threshold** - For general awareness and trending
-
-### 2. Monitor Renewal Failures
-
-Leaf certificates auto-renew, but failures can occur due to:
-- Rate limiting
-- CA unavailability
-- Network issues
-- ACL permission problems
-
-Monitor the `consul_leaf_certs_cert_renewal_failure` metric and investigate failures promptly.
-
-### 3. Automate Alerting
-
-Configure alerts in your monitoring system (Prometheus, Datadog, etc.) to notify operators when:
-- Certificates approach expiration
-- Renewal failures occur
-- Multiple certificates expire around the same time
-
-### 4. Regular Audits
-
-Periodically review certificate status using the API endpoint:
-
-```shell-session
-$ curl -s http://127.0.0.1:8500/v1/agent/metrics/certificates | jq '.summary'
-```
-
-### 5. Test Rotation Procedures
-
-Regularly test certificate rotation procedures in non-production environments to ensure smooth operations when rotation is needed.
 
 ## Troubleshooting
 
-### Certificate Not Appearing in Metrics
+If you experience one of these issues when using Consul's certificate expiration telemetry features, follow our troubleshooting suggestions.
 
-If a certificate doesn't appear in the metrics:
+### Certificate not listed
 
-1. Verify certificate telemetry is enabled
-2. Check that the certificate is being used by Consul
-3. Ensure Prometheus metrics are being collected
-4. Wait for the next metrics emission cycle (typically 1 hour for CA certificates)
+If a certificate does not appear in the metrics, take the following actions:
 
-### Renewal Failures
+- Verify that certificate telemetry is enabled.
+- Confirm that Consul uses the certificate.
+- Ensure Prometheus is collecting Consul metrics.
+- Wait for the next metrics emission cycl. For CA certificates, this occurs every hour.
+
+### Certificate renewal failures
 
 If leaf certificates show renewal failures:
 
-1. Check the `failure_reason` in the API response
-2. Verify CA availability and health
-3. Check for rate limiting (increase `CSRMaxPerSecond` if needed)
-4. Verify ACL permissions for certificate signing
-5. Review agent logs for detailed error messages
+- Check the `failure_reason` in the HTTP API response
+- Verify CA availability and health
+- Check for rate limiting and [increase `CSRMaxPerSecond` if needed](/consul/docs/secure-mesh/certificate/built-in#csrmaxpersecond)
+- Verify ACL permissions for certificate signing
+- Review agent logs for detailed error messages
 
-### High Cache Hit Rate
+### Frequent cached results
 
-If the API always returns cached results:
+If the API always returns the same cached results, reduce `cache_duration` to trigger more frequent updates.
 
-1. Reduce `cache_duration` for more frequent updates
-2. Note that caching reduces load on the metrics system
-3. Prometheus metrics are always up-to-date regardless of API caching
-
-## Related Resources
-
-- [Connect CA Configuration](/consul/docs/connect/ca)
-- [Agent Metrics Certificates API](/consul/api-docs/agent/metrics/certificates)
-- [Telemetry Configuration](/consul/docs/agent/config/config-files#telemetry)
+You may also consider using Promtetheus for monitoring. Caching reduces load on the agent's metrics system, but Prometheus metrics are always up-to-date regardless of the cache duration.

--- a/content/consul/v2.0.x/content/docs/reference/agent/configuration-file/telemetry.mdx
+++ b/content/consul/v2.0.x/content/docs/reference/agent/configuration-file/telemetry.mdx
@@ -4,8 +4,8 @@ page_title: Telemetry parameters for Consul agent configuration files
 description: >-
   Use agent configuration files to assign attributes to agents and configure multiple agents at once. Learn about agent configuration file parameters and formatting with this reference page and sample code.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2026-03-31T20:45:38.000Z
-last_modified: 2026-03-31T20:45:38.000Z
+created_at: 2026-03-31T13:43:36-07:00
+last_modified: 2026-04-02T18:16:45.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -165,6 +165,36 @@ The page provides reference information for telemetry parameters in a Consul age
     can be used to capture runtime information. This streams via TCP and can only
     be used with statsite.
 
+## Certificate telemetry
+
+Consul includes a [certificate telemetry API endpoint](/consul/api-docs/agent/metrics) for monitoring certificate expiration across your Consul infrastructure. You can monitor the following certificates:
+
+- **CA Root certificates**: Primary root CA certificates
+- **Agent TLS certificates**: Server and client TLS certificates for agent communication
+- **Intermediate/Signing CA certificates**: Active signing certificates used to issue leaf certificates
+- **Leaf certificates**: Service certificates, including:
+  - Service mesh certificates
+  - Mesh gateway certificates
+  - Ingress gateway certificates
+  - Terminating gateway certificates
+  - API gateway certificates
+
+Define monitoring behavior for an agent in the `telemetry` block of the agent configuration file.
+
+- `telemetry.certificate` - Configuration block for certificate expiration monitoring
+
+  - `enabled` `(bool: true)` - Enable certificate expiration monitoring and metrics.
+  
+  - `cache_duration` `(string: "5m")` - Duration to cache certificate metrics API responses. Valid time units are "ns", "us", "ms", "s", "m", "h".
+  
+  - `critical_threshold_days` `(int: 7)` - Number of days before expiration to mark certificates as `CRITICAL` severity. Certificates that expire within this threshold trigger critical-level logs and metrics.
+  
+  - `warning_threshold_days` `(int: 30)` - Number of days before expiration to mark certificates as `WARNING` severity. Certificates that expire within this threshold but not the critical threshold trigger warning-level logs and metrics.
+  
+  - `info_threshold_days` `(int: 90)` - Number of days before expiration to mark certificates as `INFO` severity. Certificates that expire beyond this threshold are considered healthy.
+  
+  - `exclude_auto_renewable` `(bool: false)` - Exclude auto-renewable certificates like leaf certificates from monitoring. When `true`, Consul limits monitoring to manually-rotated certificates such as CA roots and agent TLS.
+
 ## Examples
 
 The following examples demonstrate common agent telemetry configuration patterns.
@@ -195,7 +225,38 @@ telemetry {
 
 </CodeTabs>
 
+### Certificate expiration telemtry
 
+This example configures Consul certificate expiration modeling for all certificates. It caches API responses for 5 minutes, marks certificates `CRITICAL` when they expire within 7 days, marks them `WARNING` when they expire in 8-30 days, and considers certificates more than 90 days from expiration as healthy.
 
+<CodeTabs>
 
+```hcl
+telemetry {
+  certificate {
+    enabled = true
+    cache_duration = "5m"
+    critical_threshold_days = 7
+    warning_threshold_days = 30
+    info_threshold_days = 90
+    exclude_auto_renewable = false
+  }
+}
+```
 
+```json
+{
+  "telemetry": {
+    "certificate": {
+      "enabled": true,
+      "cache_duration": "5m",
+      "critical_threshold_days": 7,
+      "warning_threshold_days": 30,
+      "info_threshold_days": 90,
+      "exclude_auto_renewable": false
+    }
+  }
+}
+```
+
+</CodeTabs>

--- a/content/consul/v2.0.x/content/docs/reference/agent/configuration-file/telemetry.mdx
+++ b/content/consul/v2.0.x/content/docs/reference/agent/configuration-file/telemetry.mdx
@@ -5,7 +5,7 @@ description: >-
   Use agent configuration files to assign attributes to agents and configure multiple agents at once. Learn about agent configuration file parameters and formatting with this reference page and sample code.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2026-03-31T13:43:36-07:00
-last_modified: 2026-04-02T18:16:45.000Z
+last_modified: 2026-04-02T20:49:26.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -165,7 +165,7 @@ The page provides reference information for telemetry parameters in a Consul age
     can be used to capture runtime information. This streams via TCP and can only
     be used with statsite.
 
-## Certificate telemetry
+## Certificate expiration
 
 Consul includes a [certificate telemetry API endpoint](/consul/api-docs/agent/metrics) for monitoring certificate expiration across your Consul infrastructure. You can monitor the following certificates:
 
@@ -225,38 +225,6 @@ telemetry {
 
 </CodeTabs>
 
-### Certificate expiration telemtry
+### Certificate expiration telemetry
 
-This example configures Consul certificate expiration modeling for all certificates. It caches API responses for 5 minutes, marks certificates `CRITICAL` when they expire within 7 days, marks them `WARNING` when they expire in 8-30 days, and considers certificates more than 90 days from expiration as healthy.
-
-<CodeTabs>
-
-```hcl
-telemetry {
-  certificate {
-    enabled = true
-    cache_duration = "5m"
-    critical_threshold_days = 7
-    warning_threshold_days = 30
-    info_threshold_days = 90
-    exclude_auto_renewable = false
-  }
-}
-```
-
-```json
-{
-  "telemetry": {
-    "certificate": {
-      "enabled": true,
-      "cache_duration": "5m",
-      "critical_threshold_days": 7,
-      "warning_threshold_days": 30,
-      "info_threshold_days": 90,
-      "exclude_auto_renewable": false
-    }
-  }
-}
-```
-
-</CodeTabs>
+@include 'examples/agent/telemetry/certificate.mdx'

--- a/content/consul/v2.0.x/content/docs/reference/agent/telemetry.mdx
+++ b/content/consul/v2.0.x/content/docs/reference/agent/telemetry.mdx
@@ -5,7 +5,7 @@ description: >-
   Configure agent telemetry to collect operations metrics you can use to debug and observe Consul behavior and performance. Learn about configuration options, the metrics you can collect, and why they're important.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2026-03-31T13:43:36-07:00
-last_modified: 2026-04-01T22:05:36.000Z
+last_modified: 2026-04-02T18:16:46.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -104,71 +104,9 @@ Metrics relative to the Consul [catalog](/consul/docs/concept/catalog) and [KV s
 | `consul.discovery_chain.get`              | Measures the time it takes to retrieve a service discovery chain configuration.             | ms      | summary |
 | `consul.kvs.apply`                        | Measures the time it takes to complete an update to the KV store.                           | ms      | summary |
 
-## Certificate telemetry
+## Certificate expiration metrics
 
-Certificate telemetry monitors certificate expiration across your Consul infrastructure and emits metrics, logs, and provides an API endpoint for monitoring.
-
-- `certificate` - Certificate telemetry configuration block. Added in Consul 1.x.x.
-
-  - `enabled` `(bool: true)` - Enable certificate expiry monitoring and metrics.
-  
-  - `cache_duration` `(string: "5m")` - Duration to cache certificate metrics API responses. Valid time units are "ns", "us", "ms", "s", "m", "h".
-  
-  - `critical_threshold_days` `(int: 7)` - Number of days before expiration to mark certificates as CRITICAL severity. Certificates expiring within this threshold will trigger critical-level logs and metrics.
-  
-  - `warning_threshold_days` `(int: 30)` - Number of days before expiration to mark certificates as WARNING severity. Certificates expiring within this threshold (but not critical) will trigger warning-level logs and metrics.
-  
-  - `info_threshold_days` `(int: 90)` - Number of days before expiration to mark certificates as INFO severity. Certificates expiring beyond this threshold are considered healthy.
-  
-  - `exclude_auto_renewable` `(bool: false)` - Exclude auto-renewable certificates (like leaf certificates) from monitoring. When true, only manually-rotated certificates (CA roots, agent TLS) are monitored.
-
-### Example Configuration
-
-```hcl
-telemetry {
-  certificate {
-    enabled = true
-    cache_duration = "5m"
-    critical_threshold_days = 7
-    warning_threshold_days = 30
-    info_threshold_days = 90
-    exclude_auto_renewable = false
-  }
-}
-```
-
-```json
-{
-  "telemetry": {
-    "certificate": {
-      "enabled": true,
-      "cache_duration": "5m",
-      "critical_threshold_days": 7,
-      "warning_threshold_days": 30,
-      "info_threshold_days": 90,
-      "exclude_auto_renewable": false
-    }
-  }
-}
-```
-
-### Monitored Certificates
-
-The certificate telemetry system monitors:
-
-- **CA Root Certificates** - Primary root CA certificates
-- **Intermediate/Signing CA Certificates** - Active signing certificates used to issue leaf certificates
-- **Leaf Certificates** - Service certificates, including:
-  - Service mesh certificates
-  - Mesh gateway certificates
-  - Ingress gateway certificates
-  - Terminating gateway certificates
-  - API gateway certificates
-- **Agent TLS Certificates** - Server and client TLS certificates for agent communication
-
-### Metrics
-
-Certificate expiry metrics are emitted as Prometheus gauges:
+Certificate expiration metrics are emitted as Prometheus gauges:
 
 - `consul_mesh_active_root_ca_expiry` - Seconds until root CA expires
 - `consul_mesh_active_signing_ca_expiry` - Seconds until signing CA expires
@@ -176,25 +114,7 @@ Certificate expiry metrics are emitted as Prometheus gauges:
 - `consul_leaf_certs_cert_expiry` - Seconds until leaf certificate expires (labeled by service and kind)
 - `consul_leaf_certs_cert_renewal_failure` - Indicates certificate renewal failures (labeled by service, kind, and reason)
 
-### Logging
-
-Certificate expiry warnings are logged at different severity levels based on configured thresholds:
-
-- **CRITICAL** - Certificates expiring within `critical_threshold_days`
-- **WARNING** - Certificates expiring within `warning_threshold_days`
-- **INFO** - Certificates expiring beyond `warning_threshold_days`
-
-Logs include certificate details, days remaining, and renewal failure information when applicable.
-
-### API Endpoint
-
-Query certificate status via the HTTP API:
-
-```shell-session
-$ curl http://127.0.0.1:8500/v1/agent/metrics/certificates
-```
-
-See [Agent Metrics Certificates API](/consul/api-docs/agent/metrics-certificates) for details.
+For more information, refer to [monitor certificate expiration](/consul/docs/monitor/telemetry/certificate-expiration).
 
 ## Client agent metrics
 

--- a/content/consul/v2.0.x/content/docs/reference/agent/telemetry.mdx
+++ b/content/consul/v2.0.x/content/docs/reference/agent/telemetry.mdx
@@ -4,8 +4,8 @@ page_title: Consul agent telemetry metrics reference
 description: >-
   Configure agent telemetry to collect operations metrics you can use to debug and observe Consul behavior and performance. Learn about configuration options, the metrics you can collect, and why they're important.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2026-03-31T20:45:39.000Z
-last_modified: 2026-03-31T20:45:39.000Z
+created_at: 2026-03-31T13:43:36-07:00
+last_modified: 2026-04-01T22:05:36.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -57,7 +57,7 @@ To distinguish the different endpoints, it includes labels for `path` and `metho
 | `consul.api.http` | This samples how long it takes to service the given HTTP request for the given verb and path.  | ms      | timer   |
 
 
-# Autopilot metrics
+## Autopilot metrics
 
 Metrics relative to the [autopilot](/consul/docs/manage/scale/autopilot) subsystem that can be used to retrieve the general health of the Consul datacenter.
 
@@ -104,6 +104,97 @@ Metrics relative to the Consul [catalog](/consul/docs/concept/catalog) and [KV s
 | `consul.discovery_chain.get`              | Measures the time it takes to retrieve a service discovery chain configuration.             | ms      | summary |
 | `consul.kvs.apply`                        | Measures the time it takes to complete an update to the KV store.                           | ms      | summary |
 
+## Certificate telemetry
+
+Certificate telemetry monitors certificate expiration across your Consul infrastructure and emits metrics, logs, and provides an API endpoint for monitoring.
+
+- `certificate` - Certificate telemetry configuration block. Added in Consul 1.x.x.
+
+  - `enabled` `(bool: true)` - Enable certificate expiry monitoring and metrics.
+  
+  - `cache_duration` `(string: "5m")` - Duration to cache certificate metrics API responses. Valid time units are "ns", "us", "ms", "s", "m", "h".
+  
+  - `critical_threshold_days` `(int: 7)` - Number of days before expiration to mark certificates as CRITICAL severity. Certificates expiring within this threshold will trigger critical-level logs and metrics.
+  
+  - `warning_threshold_days` `(int: 30)` - Number of days before expiration to mark certificates as WARNING severity. Certificates expiring within this threshold (but not critical) will trigger warning-level logs and metrics.
+  
+  - `info_threshold_days` `(int: 90)` - Number of days before expiration to mark certificates as INFO severity. Certificates expiring beyond this threshold are considered healthy.
+  
+  - `exclude_auto_renewable` `(bool: false)` - Exclude auto-renewable certificates (like leaf certificates) from monitoring. When true, only manually-rotated certificates (CA roots, agent TLS) are monitored.
+
+### Example Configuration
+
+```hcl
+telemetry {
+  certificate {
+    enabled = true
+    cache_duration = "5m"
+    critical_threshold_days = 7
+    warning_threshold_days = 30
+    info_threshold_days = 90
+    exclude_auto_renewable = false
+  }
+}
+```
+
+```json
+{
+  "telemetry": {
+    "certificate": {
+      "enabled": true,
+      "cache_duration": "5m",
+      "critical_threshold_days": 7,
+      "warning_threshold_days": 30,
+      "info_threshold_days": 90,
+      "exclude_auto_renewable": false
+    }
+  }
+}
+```
+
+### Monitored Certificates
+
+The certificate telemetry system monitors:
+
+- **CA Root Certificates** - Primary root CA certificates
+- **Intermediate/Signing CA Certificates** - Active signing certificates used to issue leaf certificates
+- **Leaf Certificates** - Service certificates, including:
+  - Service mesh certificates
+  - Mesh gateway certificates
+  - Ingress gateway certificates
+  - Terminating gateway certificates
+  - API gateway certificates
+- **Agent TLS Certificates** - Server and client TLS certificates for agent communication
+
+### Metrics
+
+Certificate expiry metrics are emitted as Prometheus gauges:
+
+- `consul_mesh_active_root_ca_expiry` - Seconds until root CA expires
+- `consul_mesh_active_signing_ca_expiry` - Seconds until signing CA expires
+- `consul_agent_tls_cert_expiry` - Seconds until agent TLS certificate expires (labeled by node)
+- `consul_leaf_certs_cert_expiry` - Seconds until leaf certificate expires (labeled by service and kind)
+- `consul_leaf_certs_cert_renewal_failure` - Indicates certificate renewal failures (labeled by service, kind, and reason)
+
+### Logging
+
+Certificate expiry warnings are logged at different severity levels based on configured thresholds:
+
+- **CRITICAL** - Certificates expiring within `critical_threshold_days`
+- **WARNING** - Certificates expiring within `warning_threshold_days`
+- **INFO** - Certificates expiring beyond `warning_threshold_days`
+
+Logs include certificate details, days remaining, and renewal failure information when applicable.
+
+### API Endpoint
+
+Query certificate status via the HTTP API:
+
+```shell-session
+$ curl http://127.0.0.1:8500/v1/agent/metrics/certificates
+```
+
+See [Agent Metrics Certificates API](/consul/api-docs/agent/metrics-certificates) for details.
 
 ## Client agent metrics
 

--- a/content/consul/v2.0.x/content/partials/examples/agent/telemetry/certificate.mdx
+++ b/content/consul/v2.0.x/content/partials/examples/agent/telemetry/certificate.mdx
@@ -1,4 +1,4 @@
-This example configures Consul certificate expiration modeling for all certificates. It caches API responses for 5 minutes, marks certificates `CRITICAL` when they expire within 7 days, marks them `WARNING` when they expire in 8-30 days, and considers certificates more than 90 days from expiration as healthy.
+This example configures Consul certificate expiration modeling for all certificates. It caches API responses for five minutes, marks certificates `CRITICAL` when they expire within seven days, marks them `WARNING` when they expire in 8-30 days, and considers certificates more than 90 days from expiration as healthy.
 
 <CodeTabs>
 

--- a/content/consul/v2.0.x/content/partials/examples/agent/telemetry/certificate.mdx
+++ b/content/consul/v2.0.x/content/partials/examples/agent/telemetry/certificate.mdx
@@ -1,0 +1,33 @@
+This example configures Consul certificate expiration modeling for all certificates. It caches API responses for 5 minutes, marks certificates `CRITICAL` when they expire within 7 days, marks them `WARNING` when they expire in 8-30 days, and considers certificates more than 90 days from expiration as healthy.
+
+<CodeTabs>
+
+```hcl
+telemetry {
+  certificate {
+    enabled = true
+    cache_duration = "5m"
+    critical_threshold_days = 7
+    warning_threshold_days = 30
+    info_threshold_days = 90
+    exclude_auto_renewable = false
+  }
+}
+```
+
+```json
+{
+  "telemetry": {
+    "certificate": {
+      "enabled": true,
+      "cache_duration": "5m",
+      "critical_threshold_days": 7,
+      "warning_threshold_days": 30,
+      "info_threshold_days": 90,
+      "exclude_auto_renewable": false
+    }
+  }
+}
+```
+
+</CodeTabs>

--- a/content/consul/v2.0.x/data/api-docs-nav-data.json
+++ b/content/consul/v2.0.x/data/api-docs-nav-data.json
@@ -90,7 +90,7 @@
       },
       {
         "title": "Metrics",
-        "path": "agent/metrics/certificates"
+        "path": "agent/metrics"
       }
         ]
       }

--- a/content/consul/v2.0.x/data/api-docs-nav-data.json
+++ b/content/consul/v2.0.x/data/api-docs-nav-data.json
@@ -90,11 +90,8 @@
       },
       {
         "title": "Metrics",
-        "routes": [
-          {
-            "title": "Certificates",
-            "path": "agent/metrics/certificates"
-          }
+        "path": "agent/metrics/certificates"
+      }
         ]
       }
     ]

--- a/content/consul/v2.0.x/data/api-docs-nav-data.json
+++ b/content/consul/v2.0.x/data/api-docs-nav-data.json
@@ -87,6 +87,15 @@
       {
         "title": "Connect",
         "path": "agent/connect"
+      },
+      {
+        "title": "Metrics",
+        "routes": [
+          {
+            "title": "Certificates",
+            "path": "agent/metrics/certificates"
+          }
+        ]
       }
     ]
   },

--- a/content/consul/v2.0.x/data/api-docs-nav-data.json
+++ b/content/consul/v2.0.x/data/api-docs-nav-data.json
@@ -92,8 +92,6 @@
         "title": "Metrics",
         "path": "agent/metrics"
       }
-        ]
-      }
     ]
   },
   {

--- a/content/consul/v2.0.x/data/docs-nav-data.json
+++ b/content/consul/v2.0.x/data/docs-nav-data.json
@@ -1000,6 +1000,10 @@
             "path": "monitor/telemetry/agent"
           },
           {
+            "title": "Certificate telemetry",
+            "path": "monitor/telemetry/certificate-expiration"
+          },
+          {
             "title": "Dataplane telemetry",
             "path": "monitor/telemetry/dataplane"
           },


### PR DESCRIPTION
<!--
**Merge branch**

Make sure you create your PR against the correct **base** branch. For instructions, refer to
GitHub's **Change the branch range and destination repository guide** (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request).

If your content is an update to:

- Currently published content

  Choose **base: main** when you are updating published documentation, and you
  want your changes published when the PR is merged. We publish Consul content
  from the `main` branch.

- Upcoming Consul release

  Choose the branch for the Consul release that your content is for. Consul
  release branches use the `consul/<exact-release-number>` format. If you are not
  able to find the upcoming Consul release branch that you are looking for,
  contact the tech writer that works with the Consul team.

**Backports**

This repo stores previous version docs in folders instead of branches. There are
no backport labels.  If you backported your code PR to previous branches, update
the docs content in the corresponding folders. For example, if the current
release is 1.22.x and you backported your code to 1.21.x and 1.20.x, update the docs content
in the v1.22.x, v1.21.x, and v1.20.x folders.
-->

## Description

<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of. 

Include the target release as well as prior versions if applicable.
-->

This PR updates the Consul v2.0.0 documentation to support new certificate expiration monitoring capabilities. This changes include a new HTTP API endpoint, a new configuration block in the `telemetry` stanza of a Consul agent configuration file, and output that is ingestible by Prometheus for additional monitoring support.

## Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.



The bot does publish a root-level link to the deploy preview. The link changes with each build.
-->

Jira: [CSL-13398] 

Preview links:

- [API endpoint reference page](https://unified-docs-frontend-preview-rcdxvu9r0-hashicorp.vercel.app/consul/api-docs/agent/metrics)
- [Agent telemetry reference](https://unified-docs-frontend-preview-rcdxvu9r0-hashicorp.vercel.app/consul/docs/reference/agent/telemetry#certificate-expiration-metrics)
- [Agent configuration file reference](https://unified-docs-frontend-preview-rcdxvu9r0-hashicorp.vercel.app/consul/docs/reference/agent/configuration-file/telemetry#certificate-expiration)
- [Monitor certificate expiration](https://unified-docs-frontend-preview-rcdxvu9r0-hashicorp.vercel.app/consul/docs/monitor/telemetry/certificate-expiration)

## Contributor checklists

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [ ] 1 week: Default expectation
- [x] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [x] Verify that all status checks passed
- [x] Verify that the preview environment deployed successfully
- [x] Add additional reviewers if they are not part of assigned groups

Content:

- [ ] I added redirects for any moved or removed pages
- [x] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [x] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [ ] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.


[CSL-13398]: https://hashicorp.atlassian.net/browse/CSL-13398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ