### PR TITLE
docs(jobs): clarify allocation order and note lack of custom ordering…

### DIFF
--- a/content/nomad/v1.11.x/content/api-docs/jobs.mdx
+++ b/content/nomad/v1.11.x/content/api-docs/jobs.mdx
@@ -1246,6 +1246,9 @@ The table below shows this endpoint's support for
 enabled, this value must match a namespace that the token is allowed to
 access. This is specified as a query string parameter.
 
+~> Allocations are typically returned in lexicographical order by their identifier (UUID).
+Unlike `/v1/allocations`, this endpoint does not currently support custom ordering parameters such as `reverse`.
+
 ### Sample Request
 
 ```shell-session


### PR DESCRIPTION
### Description

Clarifies the ordering behaviour of allocations returned by the `/v1/job/:job_id/allocations` endpoint.

### Motivation

The current documentation does not specify how allocations are ordered. Based on observed behaviour and general API conventions, allocations are typically returned in lexicographical order by their identifier (UUID).

Also clarifies that this endpoint does not support the `reverse` parameter, unlike `/v1/allocations`.

### Changes

- Added note about typical lexicographical ordering of allocation IDs
- Documented lack of support for `reverse` query parameter