### PR TITLE
HCP Docs: remove Public Beta note from Azure hub-and-spoke options

### DIFF
--- a/content/hcp-docs/content/docs/hcp/network/hvn-azure/hub-spoke-options.mdx
+++ b/content/hcp-docs/content/docs/hcp/network/hvn-azure/hub-spoke-options.mdx
@@ -10,10 +10,6 @@ last_modified: 2025-09-05T13:57:53-05:00
 
 # Hub and spoke options
 
-<Note title="Public Beta">
-Hub and Spoke Support for Azure HVNs is currently in Public Beta
-</Note>
-
 This documentation focuses on Azure peering and the additional configurations
 for advanced network topologies, commonly referred to as
 [hub-and-spoke](https://learn.microsoft.com/en-us/azure/architecture/networking/architecture/hub-spoke).


### PR DESCRIPTION
## Description

:ticket: N/A

Removes the Public Beta note from the Azure HVN hub-and-spoke options page in HCP documentation.

This change only deletes the beta callout and does not otherwise change the Azure peering or topology guidance on the page.

### Requested review scope:

- [x] Content touched by the PR _only_ (typos, clarifications, tips)
- [ ] Code test (command and code block changes)
- [ ] Flow and language near changes (new/rearranged steps)
- [ ] Review everything (rewrites, major changes)

### Review urgency:

- [ ] ASAP (bug fixes, broken content, imminent releases)
- [x] 3 days (small changes, easy reviews)
- [ ] 1 week (default)
- [ ] Best effort (very non-urgent)

## All updates:

I have:

- [ ] Verified that all status checks have passed
- [ ] Verified that preview environment has successfully deployed
- [ ] Verified appropriate `label` applied (`hcp` + `product name`)
- [ ] Added all required reviewers (code owners and external)

## Content checklist (optional)

Please do these things before requesting a review. I have:

- [ ] Made any associated code repositories public
- [ ] Added the `hashicorp-education/teamName` to any additional code or example repos as repo admin
- [ ] Added redirects for any moved or removed pages
- [ ] Spell checked the tutorial(s)
- [x] Followed the [unified style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [ ] Linted code snippets (Details per language [here](https://github.com/hashicorp/engineering-docs/blob/master/writing/markdown.md#code-blocks))
- [ ] Checked the steps for completeness (no steps are implied or hidden)
- [ ] Looked at the local or vercel build and checked each new or changed page for:
  - display on the product curriculum page
  - callout box formatting
  - code block highlighting
  - right-hand navigation
  - next and back buttons
  - URL path