### PR TITLE
Clarify that to use the derived key endpoints, KEK must be convergent.

### DIFF
--- a/content/vault/v2.x (rc)/content/docs/secrets/transit/envelope-encryption.mdx
+++ b/content/vault/v2.x (rc)/content/docs/secrets/transit/envelope-encryption.mdx
@@ -31,7 +31,7 @@ keys.  To use Envelope Encryption,
 The data key set endpoints apply to Transit symmetric encryption keys.  To use
 envelope encryption, [create](/vault/api-docs/secret/transit#create-key) a
 symmetric encryption key, ideally `aes256-gcm96` or `chacha20-poly1305`.  If
-you want to use the derived keys endpoint, the transit key must be created
+you want to use the derived keys endpoint, you must create the transit key
 as both convergent and derived.
 
 Assuming a transit mount called `transit_mount` and a symmetric key named

--- a/content/vault/v2.x (rc)/content/docs/secrets/transit/envelope-encryption.mdx
+++ b/content/vault/v2.x (rc)/content/docs/secrets/transit/envelope-encryption.mdx
@@ -30,7 +30,9 @@ keys.  To use Envelope Encryption,
 [create](/vault/api-docs/secret/transit#create-key) a symmetric encryption
 The data key set endpoints apply to Transit symmetric encryption keys.  To use
 envelope encryption, [create](/vault/api-docs/secret/transit#create-key) a
-symmetric encryption key, ideally `aes256-gcm96` or `chacha20-poly1305`.
+symmetric encryption key, ideally `aes256-gcm96` or `chacha20-poly1305`.  If
+you want to use the derived keys endpoint, the transit key must be created
+as both convergent and derived.
 
 Assuming a transit mount called `transit_mount` and a symmetric key named
 `encryption_key`, you need to create an ACL policy for callers that perform


### PR DESCRIPTION
Otherwise the SDK cannot operate in a disconnected mode as every EDK would be unique.


Please go to the `Preview` tab and select the appropriate template:

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)