### PR TITLE
Small updates to managed key API docs

### DIFF
--- a/content/vault/v1.19.x/content/api-docs/system/managed-keys.mdx
+++ b/content/vault/v1.19.x/content/api-docs/system/managed-keys.mdx
@@ -24,8 +24,11 @@ This endpoint lists all the Managed Keys of a certain type within the namespace.
 | `LIST` | `/sys/managed-keys/:type` |
 
 ### Parameters
-- `type` `(string: <required>)` – The backend type of keys to be listed.
-Supported options are `pkcs11`, `awskms` and `azurekeyvault`.
+- `type` `(string: <required>)` – The backend type of keys to be listed. Supported options are
+  - pkcs11
+  - awskms
+  - azurekeyvault
+  - gcpckms
 
 ### Sample request
 
@@ -83,8 +86,11 @@ $ curl \
 - `name` `(string: <required>)` - A unique lowercase name that serves as identifying the key. Must be
   unique throughout all types in the namespace.
 
-- `type` `(string: <required>)` – The backend type that will be leveraged for the managed key.
-  Supported options are `pkcs11`, `awskms` and `azurekeyvault`.
+- `type` `(string: <required>)` – The backend type that will be leveraged for the managed key. Supported options are
+    - pkcs11
+    - awskms
+    - azurekeyvault
+    - gcpckms
 
 - `allow_generate_key` `(string: "false")` - If no existing key can be found in the referenced backend, instructs
   Vault to generate a key within the backend.
@@ -174,7 +180,7 @@ $ curl \
 #### AWS KMS parameters
 - `type` `(string: "awskms")` - To select an AWS KMS backend, the type parameter must be set to `awskms`.
 
-- `access_key` `(string: <required>)`: The AWS access key to use. This may also be provided in
+- `access_key` `(string: "")`: The AWS access key to use. This may also be provided in
   the `AWS_ACCESS_KEY_ID` environment variable or as part of the AWS profile from the AWS CLI or
   instance profile.
 
@@ -205,7 +211,7 @@ $ curl \
   This may also be provided in the `AWS_REGION` or `AWS_DEFAULT_REGION` environment variables,
   from your `~/.aws/config` file, or from instance metadata.
 
-- `secret_key` `(string: <required>)`: The AWS secret key ID to use. This may also be provided in
+- `secret_key` `(string: "")`: The AWS secret key ID to use. This may also be provided in
   the `AWS_SECRET_ACCESS_KEY` environment variable or as part of the AWS profile from the AWS CLI
   or instance profile.
 
@@ -237,8 +243,10 @@ $ curl \
 #### GCP Cloud KMS parameters
 - `type` `(string: "gcpckms")` - To select an GCP Cloud KMS backend, the type parameter must be set to `gcpckms`.
 
-- `credentials` `(string: <required>)`: The path of the credential file to use for authenticating to GCP.
+- `credentials` `(string: <required or WIF>)`: The path of the credential file to use for authenticating to GCP.
   This can also be provided in the `GOOGLE_CREDENTIALS` or `GOOGLE_APPLICATION_CREDENTIALS` environment variable.
+  If a value is not provided and the environment variables are not set, GCP's Workload Identity Federation (WIF)
+  is used.
 
 - `crypto_key` `(string: <required>)`: The name of the GCP Cloud KMS key. If there is no existing key
   and `allow_generate_key` is `true`, Vault will generate a key with this name.
@@ -280,7 +288,11 @@ This endpoint returns the managed key configuration at the given path.
 ### Parameters
 - `name` `(string: <required>)` - The lowercase name identifying the key.
 
-- `type` `(string: <required>)` – The backend type for the managed key. Supported options are `pkcs11`, `awskms` and `azurekeyvault`.
+- `type` `(string: <required>)` – The backend type for the managed key. Supported options are
+  - pkcs11
+  - awskms
+  - azurekeyvault
+  - gcpckms
 
 ### Sample request
 
@@ -328,7 +340,11 @@ status code, the configuration can be considered valid.
 ### Parameters
 - `name` `(string: <required>)` - The lowercase name identifying the key.
 
-- `type` `(string: <required>)` – The backend type for the managed key. Supported options are `pkcs11`, `awskms`, `azurekeyvault`, or `gcpckms`.
+- `type` `(string: <required>)` – The backend type for the managed key. Supported options are
+  - pkcs11
+  - awskms
+  - azurekeyvault
+  - gcpckms
 
 - `use_pss` `(bool: false)` - Use RSA PSS signatures within the signing/verification api calls.
 
@@ -366,7 +382,11 @@ listed within any mount point's `allowed_managed_keys`.
 ### Parameters
 - `name` `(string: <required>)` - The lowercase name identifying the key.
 
-- `type` `(string: <required>)` – The backend type for the managed key. Supported options are `pkcs11`, `awskms` and `azurekeyvault`.
+- `type` `(string: <required>)` – The backend type for the managed key. Supported options are
+  - pkcs11
+  - awskms
+  - azurekeyvault
+  - gcpckms
 
 ### Sample request
 

--- a/content/vault/v1.19.x/content/api-docs/system/managed-keys.mdx
+++ b/content/vault/v1.19.x/content/api-docs/system/managed-keys.mdx
@@ -24,7 +24,7 @@ This endpoint lists all the Managed Keys of a certain type within the namespace.
 | `LIST` | `/sys/managed-keys/:type` |
 
 ### Parameters
-- `type` `(string: <required>)` – The backend type of keys to be listed. Supported options are
+- `type` `(string: <required>)` – The backend type of keys to list. Supported options:
   - pkcs11
   - awskms
   - azurekeyvault
@@ -86,7 +86,7 @@ $ curl \
 - `name` `(string: <required>)` - A unique lowercase name that serves as identifying the key. Must be
   unique throughout all types in the namespace.
 
-- `type` `(string: <required>)` – The backend type that will be leveraged for the managed key. Supported options are
+- `type` `(string: <required>)` – The backend type Vault should leverage for the managed key. Supported options:
     - pkcs11
     - awskms
     - azurekeyvault
@@ -180,7 +180,7 @@ $ curl \
 #### AWS KMS parameters
 - `type` `(string: "awskms")` - To select an AWS KMS backend, the type parameter must be set to `awskms`.
 
-- `access_key` `(string: "")`: The AWS access key to use. This may also be provided in
+- `access_key` `(string: "")`: The AWS access key to use. You can also provide the access key in
   the `AWS_ACCESS_KEY_ID` environment variable or as part of the AWS profile from the AWS CLI or
   instance profile.
 
@@ -211,7 +211,7 @@ $ curl \
   This may also be provided in the `AWS_REGION` or `AWS_DEFAULT_REGION` environment variables,
   from your `~/.aws/config` file, or from instance metadata.
 
-- `secret_key` `(string: "")`: The AWS secret key ID to use. This may also be provided in
+- `secret_key` `(string: "")`: The AWS secret key ID to use. You can also provide the secret key in
   the `AWS_SECRET_ACCESS_KEY` environment variable or as part of the AWS profile from the AWS CLI
   or instance profile.
 
@@ -245,8 +245,7 @@ $ curl \
 
 - `credentials` `(string: <required or WIF>)`: The path of the credential file to use for authenticating to GCP.
   This can also be provided in the `GOOGLE_CREDENTIALS` or `GOOGLE_APPLICATION_CREDENTIALS` environment variable.
-  If a value is not provided and the environment variables are not set, GCP's Workload Identity Federation (WIF)
-  is used.
+  Vault uses Workload Identity Federation (WIF) if you leave `credentials` and the associated environment variables unset.
 
 - `crypto_key` `(string: <required>)`: The name of the GCP Cloud KMS key. If there is no existing key
   and `allow_generate_key` is `true`, Vault will generate a key with this name.
@@ -288,7 +287,7 @@ This endpoint returns the managed key configuration at the given path.
 ### Parameters
 - `name` `(string: <required>)` - The lowercase name identifying the key.
 
-- `type` `(string: <required>)` – The backend type for the managed key. Supported options are
+- `type` `(string: <required>)` – The backend type for the managed key. Supported options:
   - pkcs11
   - awskms
   - azurekeyvault
@@ -340,7 +339,7 @@ status code, the configuration can be considered valid.
 ### Parameters
 - `name` `(string: <required>)` - The lowercase name identifying the key.
 
-- `type` `(string: <required>)` – The backend type for the managed key. Supported options are
+- `type` `(string: <required>)` – The backend type for the managed key. Supported options:
   - pkcs11
   - awskms
   - azurekeyvault
@@ -382,7 +381,7 @@ listed within any mount point's `allowed_managed_keys`.
 ### Parameters
 - `name` `(string: <required>)` - The lowercase name identifying the key.
 
-- `type` `(string: <required>)` – The backend type for the managed key. Supported options are
+- `type` `(string: <required>)` – The backend type for the managed key. Supported options:
   - pkcs11
   - awskms
   - azurekeyvault

--- a/content/vault/v1.20.x/content/api-docs/system/managed-keys.mdx
+++ b/content/vault/v1.20.x/content/api-docs/system/managed-keys.mdx
@@ -24,8 +24,11 @@ This endpoint lists all the Managed Keys of a certain type within the namespace.
 | `LIST` | `/sys/managed-keys/:type` |
 
 ### Parameters
-- `type` `(string: <required>)` – The backend type of keys to be listed.
-Supported options are `pkcs11`, `awskms` and `azurekeyvault`.
+- `type` `(string: <required>)` – The backend type of keys to be listed. Supported options are
+  - pkcs11
+  - awskms
+  - azurekeyvault
+  - gcpckms
 
 ### Sample request
 
@@ -83,8 +86,11 @@ $ curl \
 - `name` `(string: <required>)` - A unique lowercase name that serves as identifying the key. Must be
   unique throughout all types in the namespace.
 
-- `type` `(string: <required>)` – The backend type that will be leveraged for the managed key.
-  Supported options are `pkcs11`, `awskms` and `azurekeyvault`.
+- `type` `(string: <required>)` – The backend type that will be leveraged for the managed key. Supported options are
+    - pkcs11
+    - awskms
+    - azurekeyvault
+    - gcpckms
 
 - `allow_generate_key` `(string: "false")` - If no existing key can be found in the referenced backend, instructs
   Vault to generate a key within the backend.
@@ -174,7 +180,7 @@ $ curl \
 #### AWS KMS parameters
 - `type` `(string: "awskms")` - To select an AWS KMS backend, the type parameter must be set to `awskms`.
 
-- `access_key` `(string: <required>)`: The AWS access key to use. This may also be provided in
+- `access_key` `(string: "")`: The AWS access key to use. This may also be provided in
   the `AWS_ACCESS_KEY_ID` environment variable or as part of the AWS profile from the AWS CLI or
   instance profile.
 
@@ -205,7 +211,7 @@ $ curl \
   This may also be provided in the `AWS_REGION` or `AWS_DEFAULT_REGION` environment variables,
   from your `~/.aws/config` file, or from instance metadata.
 
-- `secret_key` `(string: <required>)`: The AWS secret key ID to use. This may also be provided in
+- `secret_key` `(string: "")`: The AWS secret key ID to use. This may also be provided in
   the `AWS_SECRET_ACCESS_KEY` environment variable or as part of the AWS profile from the AWS CLI
   or instance profile.
 
@@ -237,8 +243,10 @@ $ curl \
 #### GCP Cloud KMS parameters
 - `type` `(string: "gcpckms")` - To select an GCP Cloud KMS backend, the type parameter must be set to `gcpckms`.
 
-- `credentials` `(string: <required>)`: The path of the credential file to use for authenticating to GCP.
+- `credentials` `(string: <required or WIF>)`: The path of the credential file to use for authenticating to GCP.
   This can also be provided in the `GOOGLE_CREDENTIALS` or `GOOGLE_APPLICATION_CREDENTIALS` environment variable.
+  If a value is not provided and the environment variables are not set, GCP's Workload Identity Federation (WIF)
+  is used.
 
 - `crypto_key` `(string: <required>)`: The name of the GCP Cloud KMS key. If there is no existing key
   and `allow_generate_key` is `true`, Vault will generate a key with this name.
@@ -280,7 +288,11 @@ This endpoint returns the managed key configuration at the given path.
 ### Parameters
 - `name` `(string: <required>)` - The lowercase name identifying the key.
 
-- `type` `(string: <required>)` – The backend type for the managed key. Supported options are `pkcs11`, `awskms` and `azurekeyvault`.
+- `type` `(string: <required>)` – The backend type for the managed key. Supported options are
+  - pkcs11
+  - awskms
+  - azurekeyvault
+  - gcpckms
 
 ### Sample request
 
@@ -328,7 +340,11 @@ status code, the configuration can be considered valid.
 ### Parameters
 - `name` `(string: <required>)` - The lowercase name identifying the key.
 
-- `type` `(string: <required>)` – The backend type for the managed key. Supported options are `pkcs11`, `awskms`, `azurekeyvault`, or `gcpckms`.
+- `type` `(string: <required>)` – The backend type for the managed key. Supported options are
+  - pkcs11
+  - awskms
+  - azurekeyvault
+  - gcpckms
 
 - `use_pss` `(bool: false)` - Use RSA PSS signatures within the signing/verification api calls.
 
@@ -366,7 +382,11 @@ listed within any mount point's `allowed_managed_keys`.
 ### Parameters
 - `name` `(string: <required>)` - The lowercase name identifying the key.
 
-- `type` `(string: <required>)` – The backend type for the managed key. Supported options are `pkcs11`, `awskms` and `azurekeyvault`.
+- `type` `(string: <required>)` – The backend type for the managed key. Supported options are
+  - pkcs11
+  - awskms
+  - azurekeyvault
+  - gcpckms
 
 ### Sample request
 

--- a/content/vault/v1.20.x/content/api-docs/system/managed-keys.mdx
+++ b/content/vault/v1.20.x/content/api-docs/system/managed-keys.mdx
@@ -24,7 +24,7 @@ This endpoint lists all the Managed Keys of a certain type within the namespace.
 | `LIST` | `/sys/managed-keys/:type` |
 
 ### Parameters
-- `type` `(string: <required>)` – The backend type of keys to be listed. Supported options are
+- `type` `(string: <required>)` – The backend type of keys to list. Supported options:
   - pkcs11
   - awskms
   - azurekeyvault
@@ -86,7 +86,7 @@ $ curl \
 - `name` `(string: <required>)` - A unique lowercase name that serves as identifying the key. Must be
   unique throughout all types in the namespace.
 
-- `type` `(string: <required>)` – The backend type that will be leveraged for the managed key. Supported options are
+- `type` `(string: <required>)` – The backend type Vault should leverage for the managed key. Supported options:
     - pkcs11
     - awskms
     - azurekeyvault
@@ -180,7 +180,7 @@ $ curl \
 #### AWS KMS parameters
 - `type` `(string: "awskms")` - To select an AWS KMS backend, the type parameter must be set to `awskms`.
 
-- `access_key` `(string: "")`: The AWS access key to use. This may also be provided in
+- `access_key` `(string: "")`: The AWS access key to use.  You can also provide the access key in
   the `AWS_ACCESS_KEY_ID` environment variable or as part of the AWS profile from the AWS CLI or
   instance profile.
 
@@ -211,7 +211,7 @@ $ curl \
   This may also be provided in the `AWS_REGION` or `AWS_DEFAULT_REGION` environment variables,
   from your `~/.aws/config` file, or from instance metadata.
 
-- `secret_key` `(string: "")`: The AWS secret key ID to use. This may also be provided in
+- `secret_key` `(string: "")`: The AWS secret key ID to use.  You can also provide the key in
   the `AWS_SECRET_ACCESS_KEY` environment variable or as part of the AWS profile from the AWS CLI
   or instance profile.
 
@@ -245,8 +245,7 @@ $ curl \
 
 - `credentials` `(string: <required or WIF>)`: The path of the credential file to use for authenticating to GCP.
   This can also be provided in the `GOOGLE_CREDENTIALS` or `GOOGLE_APPLICATION_CREDENTIALS` environment variable.
-  If a value is not provided and the environment variables are not set, GCP's Workload Identity Federation (WIF)
-  is used.
+  Vault uses Workload Identity Federation (WIF) if you leave `credentials` and the associated environment variables unset.
 
 - `crypto_key` `(string: <required>)`: The name of the GCP Cloud KMS key. If there is no existing key
   and `allow_generate_key` is `true`, Vault will generate a key with this name.
@@ -288,7 +287,7 @@ This endpoint returns the managed key configuration at the given path.
 ### Parameters
 - `name` `(string: <required>)` - The lowercase name identifying the key.
 
-- `type` `(string: <required>)` – The backend type for the managed key. Supported options are
+- `type` `(string: <required>)` – The backend type for the managed key. Supported options:
   - pkcs11
   - awskms
   - azurekeyvault
@@ -340,7 +339,7 @@ status code, the configuration can be considered valid.
 ### Parameters
 - `name` `(string: <required>)` - The lowercase name identifying the key.
 
-- `type` `(string: <required>)` – The backend type for the managed key. Supported options are
+- `type` `(string: <required>)` – The backend type for the managed key. Supported options:
   - pkcs11
   - awskms
   - azurekeyvault
@@ -382,7 +381,7 @@ listed within any mount point's `allowed_managed_keys`.
 ### Parameters
 - `name` `(string: <required>)` - The lowercase name identifying the key.
 
-- `type` `(string: <required>)` – The backend type for the managed key. Supported options are
+- `type` `(string: <required>)` – The backend type for the managed key. Supported options:
   - pkcs11
   - awskms
   - azurekeyvault

--- a/content/vault/v1.21.x/content/api-docs/system/managed-keys.mdx
+++ b/content/vault/v1.21.x/content/api-docs/system/managed-keys.mdx
@@ -24,7 +24,7 @@ This endpoint lists all the Managed Keys of a certain type within the namespace.
 | `LIST` | `/sys/managed-keys/:type` |
 
 ### Parameters
-- `type` `(string: <required>)` – The backend type of keys to be listed. Supported options are
+- `type` `(string: <required>)` – The backend type of keys to list. Supported options:
   - pkcs11
   - awskms
   - azurekeyvault
@@ -86,7 +86,7 @@ $ curl \
 - `name` `(string: <required>)` - A unique lowercase name that serves as identifying the key. Must be
   unique throughout all types in the namespace.
 
-- `type` `(string: <required>)` – The backend type that will be leveraged for the managed key. Supported options are
+- `type` `(string: <required>)` – The backend type Vault should leverage for the managed key. Supported options:
     - pkcs11
     - awskms
     - azurekeyvault
@@ -180,7 +180,7 @@ $ curl \
 #### AWS KMS parameters
 - `type` `(string: "awskms")` - To select an AWS KMS backend, the type parameter must be set to `awskms`.
 
-- `access_key` `(string: "")`: The AWS access key to use. This may also be provided in
+- `access_key` `(string: "")`: The AWS access key to use. You can also provide the access key in
   the `AWS_ACCESS_KEY_ID` environment variable or as part of the AWS profile from the AWS CLI or
   instance profile.
 
@@ -211,7 +211,7 @@ $ curl \
   This may also be provided in the `AWS_REGION` or `AWS_DEFAULT_REGION` environment variables,
   from your `~/.aws/config` file, or from instance metadata.
 
-- `secret_key` `(string: "")`: The AWS secret key ID to use. This may also be provided in
+- `secret_key` `(string: "")`: The AWS secret key ID to use. You can also provide the secret key in
   the `AWS_SECRET_ACCESS_KEY` environment variable or as part of the AWS profile from the AWS CLI
   or instance profile.
 
@@ -245,8 +245,7 @@ $ curl \
 
 - `credentials` `(string: <required or WIF>)`: The path of the credential file to use for authenticating to GCP.
   This can also be provided in the `GOOGLE_CREDENTIALS` or `GOOGLE_APPLICATION_CREDENTIALS` environment variable.
-  If a value is not provided and the environment variables are not set, GCP's Workload Identity Federation (WIF)
-  is used.
+  Vault uses Workload Identity Federation (WIF) if you leave `credentials` and the associated environment variables unset.
 
 - `crypto_key` `(string: <required>)`: The name of the GCP Cloud KMS key. If there is no existing key
   and `allow_generate_key` is `true`, Vault will generate a key with this name.
@@ -288,7 +287,7 @@ This endpoint returns the managed key configuration at the given path.
 ### Parameters
 - `name` `(string: <required>)` - The lowercase name identifying the key.
 
-- `type` `(string: <required>)` – The backend type for the managed key. Supported options are
+- `type` `(string: <required>)` – The backend type for the managed key. Supported options:
   - pkcs11
   - awskms
   - azurekeyvault
@@ -344,7 +343,7 @@ status code, the configuration can be considered valid.
 ### Parameters
 - `name` `(string: <required>)` - The lowercase name identifying the key.
 
-- `type` `(string: <required>)` – The backend type for the managed key. Supported options are
+- `type` `(string: <required>)` – The backend type for the managed key. Supported options:
   - pkcs11
   - awskms
   - azurekeyvault
@@ -386,7 +385,7 @@ listed within any mount point's `allowed_managed_keys`.
 ### Parameters
 - `name` `(string: <required>)` - The lowercase name identifying the key.
 
-- `type` `(string: <required>)` – The backend type for the managed key. Supported options are
+- `type` `(string: <required>)` – The backend type for the managed key. Supported options:
   - pkcs11
   - awskms
   - azurekeyvault

--- a/content/vault/v1.21.x/content/api-docs/system/managed-keys.mdx
+++ b/content/vault/v1.21.x/content/api-docs/system/managed-keys.mdx
@@ -24,8 +24,11 @@ This endpoint lists all the Managed Keys of a certain type within the namespace.
 | `LIST` | `/sys/managed-keys/:type` |
 
 ### Parameters
-- `type` `(string: <required>)` – The backend type of keys to be listed.
-Supported options are `pkcs11`, `awskms` and `azurekeyvault`.
+- `type` `(string: <required>)` – The backend type of keys to be listed. Supported options are
+  - pkcs11
+  - awskms
+  - azurekeyvault
+  - gcpckms
 
 ### Sample request
 
@@ -83,8 +86,11 @@ $ curl \
 - `name` `(string: <required>)` - A unique lowercase name that serves as identifying the key. Must be
   unique throughout all types in the namespace.
 
-- `type` `(string: <required>)` – The backend type that will be leveraged for the managed key.
-  Supported options are `pkcs11`, `awskms` and `azurekeyvault`.
+- `type` `(string: <required>)` – The backend type that will be leveraged for the managed key. Supported options are
+    - pkcs11
+    - awskms
+    - azurekeyvault
+    - gcpckms
 
 - `allow_generate_key` `(string: "false")` - If no existing key can be found in the referenced backend, instructs
   Vault to generate a key within the backend.
@@ -174,7 +180,7 @@ $ curl \
 #### AWS KMS parameters
 - `type` `(string: "awskms")` - To select an AWS KMS backend, the type parameter must be set to `awskms`.
 
-- `access_key` `(string: <required>)`: The AWS access key to use. This may also be provided in
+- `access_key` `(string: "")`: The AWS access key to use. This may also be provided in
   the `AWS_ACCESS_KEY_ID` environment variable or as part of the AWS profile from the AWS CLI or
   instance profile.
 
@@ -205,7 +211,7 @@ $ curl \
   This may also be provided in the `AWS_REGION` or `AWS_DEFAULT_REGION` environment variables,
   from your `~/.aws/config` file, or from instance metadata.
 
-- `secret_key` `(string: <required>)`: The AWS secret key ID to use. This may also be provided in
+- `secret_key` `(string: "")`: The AWS secret key ID to use. This may also be provided in
   the `AWS_SECRET_ACCESS_KEY` environment variable or as part of the AWS profile from the AWS CLI
   or instance profile.
 
@@ -237,8 +243,10 @@ $ curl \
 #### GCP Cloud KMS parameters
 - `type` `(string: "gcpckms")` - To select an GCP Cloud KMS backend, the type parameter must be set to `gcpckms`.
 
-- `credentials` `(string: <required>)`: The path of the credential file to use for authenticating to GCP.
+- `credentials` `(string: <required or WIF>)`: The path of the credential file to use for authenticating to GCP.
   This can also be provided in the `GOOGLE_CREDENTIALS` or `GOOGLE_APPLICATION_CREDENTIALS` environment variable.
+  If a value is not provided and the environment variables are not set, GCP's Workload Identity Federation (WIF)
+  is used.
 
 - `crypto_key` `(string: <required>)`: The name of the GCP Cloud KMS key. If there is no existing key
   and `allow_generate_key` is `true`, Vault will generate a key with this name.
@@ -280,7 +288,11 @@ This endpoint returns the managed key configuration at the given path.
 ### Parameters
 - `name` `(string: <required>)` - The lowercase name identifying the key.
 
-- `type` `(string: <required>)` – The backend type for the managed key. Supported options are `pkcs11`, `awskms` and `azurekeyvault`.
+- `type` `(string: <required>)` – The backend type for the managed key. Supported options are
+  - pkcs11
+  - awskms
+  - azurekeyvault
+  - gcpckms
 
 ### Sample request
 
@@ -332,7 +344,11 @@ status code, the configuration can be considered valid.
 ### Parameters
 - `name` `(string: <required>)` - The lowercase name identifying the key.
 
-- `type` `(string: <required>)` – The backend type for the managed key. Supported options are `pkcs11`, `awskms`, `azurekeyvault`, or `gcpckms`.
+- `type` `(string: <required>)` – The backend type for the managed key. Supported options are
+  - pkcs11
+  - awskms
+  - azurekeyvault
+  - gcpckms
 
 - `use_pss` `(bool: false)` - Use RSA PSS signatures within the signing/verification api calls.
 
@@ -370,7 +386,11 @@ listed within any mount point's `allowed_managed_keys`.
 ### Parameters
 - `name` `(string: <required>)` - The lowercase name identifying the key.
 
-- `type` `(string: <required>)` – The backend type for the managed key. Supported options are `pkcs11`, `awskms` and `azurekeyvault`.
+- `type` `(string: <required>)` – The backend type for the managed key. Supported options are
+  - pkcs11
+  - awskms
+  - azurekeyvault
+  - gcpckms
 
 ### Sample request
 

--- a/content/vault/v2.x (rc)/content/api-docs/system/managed-keys.mdx
+++ b/content/vault/v2.x (rc)/content/api-docs/system/managed-keys.mdx
@@ -24,7 +24,7 @@ This endpoint lists all the Managed Keys of a certain type within the namespace.
 | `LIST` | `/sys/managed-keys/:type` |
 
 ### Parameters
-- `type` `(string: <required>)` – The backend type of keys to be listed. Supported options are
+- `type` `(string: <required>)` – The backend type of keys to list. Supported options:
   - pkcs11
   - awskms
   - azurekeyvault
@@ -86,7 +86,7 @@ $ curl \
 - `name` `(string: <required>)` - A unique lowercase name that serves as identifying the key. Must be
   unique throughout all types in the namespace.
 
-- `type` `(string: <required>)` – The backend type that will be leveraged for the managed key. Supported options are
+- `type` `(string: <required>)` – The backend type that Vault should leverage for the managed key. Supported options:
     - pkcs11
     - awskms
     - azurekeyvault
@@ -180,7 +180,7 @@ $ curl \
 #### AWS KMS parameters
 - `type` `(string: "awskms")` - To select an AWS KMS backend, the type parameter must be set to `awskms`.
 
-- `access_key` `(string: "")`: The AWS access key to use. This may also be provided in
+- `access_key` `(string: "")`: The AWS access key to use. You can also provide the access key in
   the `AWS_ACCESS_KEY_ID` environment variable or as part of the AWS profile from the AWS CLI or
   instance profile.
 
@@ -211,7 +211,7 @@ $ curl \
   This may also be provided in the `AWS_REGION` or `AWS_DEFAULT_REGION` environment variables,
   from your `~/.aws/config` file, or from instance metadata.
 
-- `secret_key` `(string: "")`: The AWS secret key ID to use. This may also be provided in
+- `secret_key` `(string: "")`: The AWS secret key ID to use. You can also provide the secret key in
   the `AWS_SECRET_ACCESS_KEY` environment variable or as part of the AWS profile from the AWS CLI
   or instance profile.
 
@@ -245,8 +245,7 @@ $ curl \
 
 - `credentials` `(string: <required or WIF>)`: The path of the credential file to use for authenticating to GCP.
   This can also be provided in the `GOOGLE_CREDENTIALS` or `GOOGLE_APPLICATION_CREDENTIALS` environment variable.
-  If a value is not provided and the environment variables are not set, GCP's Workload Identity Federation (WIF)
-  is used.
+  Vault uses Workload Identity Federation (WIF) if you leave `credentials` and the associated environment variables unset.
 
 - `crypto_key` `(string: <required>)`: The name of the GCP Cloud KMS key. If there is no existing key
   and `allow_generate_key` is `true`, Vault will generate a key with this name.
@@ -288,7 +287,7 @@ This endpoint returns the managed key configuration at the given path.
 ### Parameters
 - `name` `(string: <required>)` - The lowercase name identifying the key.
 
-- `type` `(string: <required>)` – The backend type for the managed key. Supported options are
+- `type` `(string: <required>)` – The backend type for the managed key. Supported options:
   - pkcs11
   - awskms
   - azurekeyvault
@@ -344,7 +343,7 @@ status code, the configuration can be considered valid.
 ### Parameters
 - `name` `(string: <required>)` - The lowercase name identifying the key.
 
-- `type` `(string: <required>)` – The backend type for the managed key. Supported options are
+- `type` `(string: <required>)` – The backend type for the managed key. Supported options:
   - pkcs11
   - awskms
   - azurekeyvault
@@ -386,7 +385,7 @@ listed within any mount point's `allowed_managed_keys`.
 ### Parameters
 - `name` `(string: <required>)` - The lowercase name identifying the key.
 
-- `type` `(string: <required>)` – The backend type for the managed key. Supported options are
+- `type` `(string: <required>)` – The backend type for the managed key. Supported options:
   - pkcs11
   - awskms
   - azurekeyvault

--- a/content/vault/v2.x (rc)/content/api-docs/system/managed-keys.mdx
+++ b/content/vault/v2.x (rc)/content/api-docs/system/managed-keys.mdx
@@ -24,8 +24,11 @@ This endpoint lists all the Managed Keys of a certain type within the namespace.
 | `LIST` | `/sys/managed-keys/:type` |
 
 ### Parameters
-- `type` `(string: <required>)` – The backend type of keys to be listed.
-Supported options are `pkcs11`, `awskms` and `azurekeyvault`.
+- `type` `(string: <required>)` – The backend type of keys to be listed. Supported options are
+  - pkcs11
+  - awskms
+  - azurekeyvault
+  - gcpckms
 
 ### Sample request
 
@@ -83,8 +86,11 @@ $ curl \
 - `name` `(string: <required>)` - A unique lowercase name that serves as identifying the key. Must be
   unique throughout all types in the namespace.
 
-- `type` `(string: <required>)` – The backend type that will be leveraged for the managed key.
-  Supported options are `pkcs11`, `awskms` and `azurekeyvault`.
+- `type` `(string: <required>)` – The backend type that will be leveraged for the managed key. Supported options are
+    - pkcs11
+    - awskms
+    - azurekeyvault
+    - gcpckms
 
 - `allow_generate_key` `(string: "false")` - If no existing key can be found in the referenced backend, instructs
   Vault to generate a key within the backend.
@@ -174,7 +180,7 @@ $ curl \
 #### AWS KMS parameters
 - `type` `(string: "awskms")` - To select an AWS KMS backend, the type parameter must be set to `awskms`.
 
-- `access_key` `(string: <required>)`: The AWS access key to use. This may also be provided in
+- `access_key` `(string: "")`: The AWS access key to use. This may also be provided in
   the `AWS_ACCESS_KEY_ID` environment variable or as part of the AWS profile from the AWS CLI or
   instance profile.
 
@@ -205,7 +211,7 @@ $ curl \
   This may also be provided in the `AWS_REGION` or `AWS_DEFAULT_REGION` environment variables,
   from your `~/.aws/config` file, or from instance metadata.
 
-- `secret_key` `(string: <required>)`: The AWS secret key ID to use. This may also be provided in
+- `secret_key` `(string: "")`: The AWS secret key ID to use. This may also be provided in
   the `AWS_SECRET_ACCESS_KEY` environment variable or as part of the AWS profile from the AWS CLI
   or instance profile.
 
@@ -237,8 +243,10 @@ $ curl \
 #### GCP Cloud KMS parameters
 - `type` `(string: "gcpckms")` - To select an GCP Cloud KMS backend, the type parameter must be set to `gcpckms`.
 
-- `credentials` `(string: <required>)`: The path of the credential file to use for authenticating to GCP.
+- `credentials` `(string: <required or WIF>)`: The path of the credential file to use for authenticating to GCP.
   This can also be provided in the `GOOGLE_CREDENTIALS` or `GOOGLE_APPLICATION_CREDENTIALS` environment variable.
+  If a value is not provided and the environment variables are not set, GCP's Workload Identity Federation (WIF)
+  is used.
 
 - `crypto_key` `(string: <required>)`: The name of the GCP Cloud KMS key. If there is no existing key
   and `allow_generate_key` is `true`, Vault will generate a key with this name.
@@ -280,7 +288,11 @@ This endpoint returns the managed key configuration at the given path.
 ### Parameters
 - `name` `(string: <required>)` - The lowercase name identifying the key.
 
-- `type` `(string: <required>)` – The backend type for the managed key. Supported options are `pkcs11`, `awskms` and `azurekeyvault`.
+- `type` `(string: <required>)` – The backend type for the managed key. Supported options are
+  - pkcs11
+  - awskms
+  - azurekeyvault
+  - gcpckms
 
 ### Sample request
 
@@ -332,7 +344,11 @@ status code, the configuration can be considered valid.
 ### Parameters
 - `name` `(string: <required>)` - The lowercase name identifying the key.
 
-- `type` `(string: <required>)` – The backend type for the managed key. Supported options are `pkcs11`, `awskms`, `azurekeyvault`, or `gcpckms`.
+- `type` `(string: <required>)` – The backend type for the managed key. Supported options are
+  - pkcs11
+  - awskms
+  - azurekeyvault
+  - gcpckms
 
 - `use_pss` `(bool: false)` - Use RSA PSS signatures within the signing/verification api calls.
 
@@ -370,7 +386,11 @@ listed within any mount point's `allowed_managed_keys`.
 ### Parameters
 - `name` `(string: <required>)` - The lowercase name identifying the key.
 
-- `type` `(string: <required>)` – The backend type for the managed key. Supported options are `pkcs11`, `awskms` and `azurekeyvault`.
+- `type` `(string: <required>)` – The backend type for the managed key. Supported options are
+  - pkcs11
+  - awskms
+  - azurekeyvault
+  - gcpckms
 
 ### Sample request
 


### PR DESCRIPTION
Small tweaks to the managed keys api page, document that GCP will now leverage Workload Identity Federation (WIF) and add missing gcpckms to various endpoints.
