### PR TITLE
VAULT-43968 document SCIM known issue and limitations

### DIFF
--- a/content/vault/global/partials/important-changes/summary-tables/2xx.mdx
+++ b/content/vault/global/partials/important-changes/summary-tables/2xx.mdx
@@ -15,4 +15,6 @@ Introduced | Recommendations | Edition    | Change
 
 ### Known issues
 
-None.
+Introduced | Recommendations | Edition    | Change
+---------- | --------------- | ---------- | ------
+2.0.0      | **Yes**         | Enterprise | [Okta SCIM group membership removal does not revoke Vault group access](/vault/docs/v2.x/updates/important-changes#scim)

--- a/content/vault/v2.x (rc)/content/docs/updates/important-changes.mdx
+++ b/content/vault/v2.x (rc)/content/docs/updates/important-changes.mdx
@@ -72,7 +72,7 @@ information.
 
 ## Known issues
 
-### Okta SCIM group membership removal does not revoke Vault group access <EnterpriseAlert inline="true" />
+### Okta SCIM group membership removal does not revoke Vault group access ((#scim)) <EnterpriseAlert inline="true" />
 
 | Change      | Affected version | Fixed version |
 | ----------- | ---------------- | ------------- |
@@ -83,6 +83,8 @@ Okta Group Push with Vault SCIM, removing a user from an Okta group does not
 remove that user from the corresponding Vault group. Okta sends a SCIM `PATCH`
 request for member removal that Vault 2.0.0 does not support. As a result, the
 user remains in the Vault group and retains any policies that the group grants.
+
+#### Recommendation
 
 As a workaround, unlink and relink the Okta push group to recreate the
 corresponding Vault group with the intended membership.

--- a/content/vault/v2.x (rc)/content/docs/updates/important-changes.mdx
+++ b/content/vault/v2.x (rc)/content/docs/updates/important-changes.mdx
@@ -12,7 +12,7 @@ last_modified: 2026-04-03T00:44:16.000Z
 
 # Important changes
 
-**Last updated**: 2026-04-02
+**Last updated**: 2026-04-10
 
 Always review important or breaking changes and remediation recommendations
 before upgrading Vault.
@@ -72,4 +72,17 @@ information.
 
 ## Known issues
 
-None.
+### Okta SCIM group membership removal does not revoke Vault group access <EnterpriseAlert inline="true" />
+
+| Change      | Affected version | Fixed version |
+| ----------- | ---------------- | ------------- |
+| Known issue | 2.0.0            | None          |
+
+Vault Enterprise exposes SCIM as a beta feature in Vault 2.0.0. When you use
+Okta Group Push with Vault SCIM, removing a user from an Okta group does not
+remove that user from the corresponding Vault group. Okta sends a SCIM `PATCH`
+request for member removal that Vault 2.0.0 does not support. As a result, the
+user remains in the Vault group and retains any policies that the group grants.
+
+As a workaround, unlink and relink the Okta push group to recreate the
+corresponding Vault group with the intended membership.


### PR DESCRIPTION
This PR documents the Vault 2.0.0 SCIM beta limitation where Okta group membership removals do not revoke the corresponding Vault group membership.

Jira: [VAULT-43968](https://hashicorp.atlassian.net/browse/VAULT-43968)

[VAULT-43968]: https://hashicorp.atlassian.net/browse/VAULT-43968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ