### PR TITLE
[VAULT] Fix typo in version syntax and ent support doc

### DIFF
--- a/content/vault/v2.x (rc)/content/partials/version-syntax.mdx
+++ b/content/vault/v2.x (rc)/content/partials/version-syntax.mdx
@@ -10,7 +10,7 @@ Vault uses `V.M.F` syntax for versioning:
 
 - **F** indicates a "fix" release. Fix releases include security patches and bug
   fixes. You must update to the latest fix release within a major release to
-  receive the updated. We do not backport fixes across minor releases within a
+  receive the update. We do not backport fixes across minor releases within a
   major release.
 
 We strongly recommend upgrading to the latest fix release for supported major


### PR DESCRIPTION
Corrected typos in the version-syntax documentation regarding fix releases.