### PR TITLE
Update max_request_headers_kb description in envoy.mdx

### DIFF
--- a/content/consul/v1.22.x/content/docs/reference/proxy/envoy.mdx
+++ b/content/consul/v1.22.x/content/docs/reference/proxy/envoy.mdx
@@ -436,9 +436,10 @@ defaults that are inherited by all services.
   - `exact_balance` - Inbound connections to the service use the
   [Envoy Exact Balance Strategy.](https://cloudnative.to/envoy/api-v3/config/listener/v3/listener.proto.html#config-listener-v3-listener-connectionbalanceconfig-exactbalance)
 
-- `max_request_headers_kb` - The maximum size in kilobytes for request headers 
-  sent from downstream clients to upstream services. Applies to HTTP-based protocols only (HTTP, HTTP/2, gRPC). 
-  If not specified, uses Envoy's default limit(60KB). 
+- `max_request_headers_kb` - The maximum size in kilobytes for request headers
+  sent from downstream clients to upstream services. Applies to HTTP-based protocols only (HTTP, HTTP/2, gRPC).
+  If not specified, uses Envoy's default limit (60 KiB).
+  The maximum supported value is 96 KiB (Envoy-enforced). The values above this are rejected/clamped by Envoy.
   **Note**: This setting only takes effect when the service protocol is configured as `http`, `http2`, or `grpc`.
 
 - `xds_fetch_timeout_ms` - In milliseconds, the amount of time for Envoy to wait for EDS and RDS configuration before timing out. If not specified, this field uses Envoy's default value of `15000`, or 15 seconds. When an Envoy instance is configured with a large number of upstreams that take a significant amount of time to populate with data, setting this field to a higher value may prevent temporary disruption caused by unexpected timeouts.


### PR DESCRIPTION
Clarified the maximum request headers size limit and added information about the maximum supported value.

Please go to the `Preview` tab and select the appropriate template:

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
