### PR TITLE
fix: parameters for ListResourceConfigSchema

### DIFF
--- a/content/terraform-plugin-framework/v1.18.x/docs/plugin/framework/list-resources/list.mdx
+++ b/content/terraform-plugin-framework/v1.18.x/docs/plugin/framework/list-resources/list.mdx
@@ -37,7 +37,7 @@ type ThingListResourceModel struct {
 	ResourceGroupName types.String `tfsdk:"resource_group_name"`
 }
 
-func (r *ThingListResource) ListResourceConfigSchema(_ context.Context, _ list.ListResourceConfigSchemaRequest, resp *list.ListResourceConfigSchemaResponse) {
+func (r *ThingListResource) ListResourceConfigSchema(_ context.Context, _ list.ListResourceSchemaRequest, resp *list.ListResourceSchemaResponse) {
 	resp.Schema = listschema.Schema{
 		Attributes: map[string]listschema.Attribute{
 			"resource_group_name": listschema.StringAttribute{


### PR DESCRIPTION
This changes the parameter types for the `ListResourceConfigSchema` example method to match the ones documented on the [ListResource interface](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/list#ListResource)