### PR TITLE
[TOOLS ]Streamline github action

### DIFF
--- a/.github/workflows/create-ga-pr.yml
+++ b/.github/workflows/create-ga-pr.yml
@@ -25,11 +25,17 @@ env:
   prBranch: "${{ github.event.inputs.product }}/${{ github.event.inputs.targetVersion }}-to-ga"
   oldFolder: "v${{ github.event.inputs.targetVersion }} (${{ github.event.inputs.folderTag }})"
   newFolder: "v${{ github.event.inputs.targetVersion }}"
+  prTitle:     "[PUBLISH GA] Convert ${{ github.event.inputs.targetVersion }} to GA"
+  prBody: |
+    🚧 \`${{ github.repository }}\` publication PR
 
+    **Triggered by**: @${{ github.actor }} with a Github action
+    **Preview folder**: \`${{ github.event.inputs.product }}/v${{ github.event.inputs.targetVersion }} (${{ github.event.inputs.folderTag }})\`
+    **New folder**:   \`${{ github.event.inputs.product }}/v${{ github.event.inputs.targetVersion }}\`
 
 jobs:
 
-  update-folder:
+  move-to-ga:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN:   ${{ secrets.GITHUB_TOKEN }}
@@ -51,24 +57,6 @@ jobs:
           git add .
           git commit -m "Rename ${{ env.oldFolder }}"
           git push --force -u origin "${{ env.prBranch }}"
-
-  create-pr:
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN:   ${{ secrets.GITHUB_TOKEN }}
-      prTitle:     "[PUBLISH GA] Convert ${{ github.event.inputs.targetVersion }} to GA"
-      prBody: |
-        🚧 \`${{ github.repository }}\` publication PR
-
-        **Triggered by**: @${{ github.actor }} with a Github action
-        **Preview folder**: \`${{ github.event.inputs.product }}/v${{ github.event.inputs.targetVersion }} (${{ github.event.inputs.folderTag }})\`
-        **New folder**:   \`${{ github.event.inputs.product }}/v${{ github.event.inputs.targetVersion }}\`
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          ref: ${{ env.prBranch }}
-          fetch-depth: 0
       - name: Create pull request
         run: |
           gh pr create                    \


### PR DESCRIPTION
Simplifies the action to remove preview tags (e.g., " (rc)" and " (beta") from a folder name to make the preview docs the current version.

Addresses a previous error where the PR creation job couldn't access the branch created in the first step.

Having a github action lets a single person handle the preview -> GA transition since those PRs tend to be huge (e.g., the Vault PR will have almost 2k file "changes" just because the folder name changes.