### PR TITLE
Add use_psc and use_private_ip parameters for the relevant DB engines

### DIFF
--- a/content/vault/v1.21.x/content/api-docs/secret/databases/mysql-maria.mdx
+++ b/content/vault/v1.21.x/content/api-docs/secret/databases/mysql-maria.mdx
@@ -57,6 +57,12 @@ has a number of parameters to further configure a connection.
 - `service_account_json` `(string: "")` - JSON encoded credentials for a GCP Service Account to use
   for IAM authentication. Requires `auth_type` to be `gcp_iam`.
 
+- `use_private_ip` `(boolean: false)` - Enables the option to connect to CloudSQL Instances with Private IP.
+   Requires `auth_type` to be `gcp_iam`.
+
+- `use_psc` `(boolean: false)` - Enables the option to connect to CloudSQL Instances with Private Service Connect.
+   Requires `auth_type` to be `gcp_iam`.
+
 - `tls_certificate_key` `(string: "")` - x509 certificate for connecting to the database.
   This must be a PEM encoded version of the private key and the certificate combined.
 

--- a/content/vault/v1.21.x/content/api-docs/secret/databases/postgresql.mdx
+++ b/content/vault/v1.21.x/content/api-docs/secret/databases/postgresql.mdx
@@ -78,6 +78,9 @@ has a number of parameters to further configure a connection.
 - `use_private_ip` `(boolean: false)` - Enables the option to connect to CloudSQL Instances with Private IP.
    Requires `auth_type` to be `gcp_iam`.
 
+- `use_psc` `(boolean: false)` - Enables the option to connect to CloudSQL Instances with Private Service Connect.
+   Requires `auth_type` to be `gcp_iam`.
+
 - `username_template` `(string)` - [Template](/vault/docs/concepts/username-templating) describing how
   dynamic usernames are generated.
 

--- a/content/vault/v1.21.x/content/docs/secrets/databases/mysql-maria.mdx
+++ b/content/vault/v1.21.x/content/docs/secrets/databases/mysql-maria.mdx
@@ -206,7 +206,9 @@ GRANT SELECT, CREATE, CREATE USER ON <database>.<object> TO "test-user"@"%" WITH
         plugin_name="mysql-database-plugin" \
         allowed_roles="my-role" \
         connection_url="user@cloudsql-mysql(project:region:instance)/mysql" \
-        auth_type="gcp_iam"
+        auth_type="gcp_iam" \
+        use_private_ip="false" \
+        use_psc="false"
     ```
 
     You can also configure the connection and authenticate by directly passing in the service account credentials
@@ -218,6 +220,8 @@ GRANT SELECT, CREATE, CREATE USER ON <database>.<object> TO "test-user"@"%" WITH
         allowed_roles="my-role" \
         connection_url="user@cloudsql-mysql(project:region:instance)/mysql" \
         auth_type="gcp_iam" \
+        use_private_ip="false" \
+        use_psc="false" \
         service_account_json="@my_credentials.json"
     ```
 

--- a/content/vault/v1.21.x/content/docs/secrets/databases/postgresql.mdx
+++ b/content/vault/v1.21.x/content/docs/secrets/databases/postgresql.mdx
@@ -241,8 +241,9 @@ ALTER USER "<YOUR DB USERNAME>" WITH CREATEROLE;
         plugin_name="postgresql-database-plugin" \
         allowed_roles="my-role" \
         connection_url="host=project:us-west1:mydb user=test-user@project.iam dbname=postgres sslmode=disable" \
+        auth_type="gcp_iam" \
         use_private_ip="false" \
-        auth_type="gcp_iam"
+        use_psc="false"
     ```
 
     You can also configure the connection and authenticate by directly passing in the service account credentials
@@ -253,8 +254,9 @@ ALTER USER "<YOUR DB USERNAME>" WITH CREATEROLE;
         plugin_name="postgresql-database-plugin" \
         allowed_roles="my-role" \
         connection_url="host=project:region:instance user=test-user@project.iam dbname=postgres sslmode=disable" \
-        use_private_ip="false" \
         auth_type="gcp_iam" \
+        use_private_ip="false" \
+        use_psc="false" \
         service_account_json="@my_credentials.json"
     ```
 

--- a/content/vault/v2.x (rc)/content/api-docs/secret/databases/mysql-maria.mdx
+++ b/content/vault/v2.x (rc)/content/api-docs/secret/databases/mysql-maria.mdx
@@ -57,6 +57,12 @@ has a number of parameters to further configure a connection.
 - `service_account_json` `(string: "")` - JSON encoded credentials for a GCP Service Account to use
   for IAM authentication. Requires `auth_type` to be `gcp_iam`.
 
+- `use_private_ip` `(boolean: false)` - Enables the option to connect to CloudSQL Instances with Private IP.
+   Requires `auth_type` to be `gcp_iam`.
+
+- `use_psc` `(boolean: false)` - Enables the option to connect to CloudSQL Instances with Private Service Connect.
+   Requires `auth_type` to be `gcp_iam`.
+
 - `tls_certificate_key` `(string: "")` - x509 certificate for connecting to the database.
   This must be a PEM encoded version of the private key and the certificate combined.
 

--- a/content/vault/v2.x (rc)/content/api-docs/secret/databases/postgresql.mdx
+++ b/content/vault/v2.x (rc)/content/api-docs/secret/databases/postgresql.mdx
@@ -78,6 +78,9 @@ has a number of parameters to further configure a connection.
 - `use_private_ip` `(boolean: false)` - Enables the option to connect to CloudSQL Instances with Private IP.
    Requires `auth_type` to be `gcp_iam`.
 
+- `use_psc` `(boolean: false)` - Enables the option to connect to CloudSQL Instances with Private Service Connect.
+   Requires `auth_type` to be `gcp_iam`.
+
 - `username_template` `(string)` - [Template](/vault/docs/concepts/username-templating) describing how
   dynamic usernames are generated.
 

--- a/content/vault/v2.x (rc)/content/docs/secrets/databases/mysql-maria.mdx
+++ b/content/vault/v2.x (rc)/content/docs/secrets/databases/mysql-maria.mdx
@@ -206,7 +206,9 @@ GRANT SELECT, CREATE, CREATE USER ON <database>.<object> TO "test-user"@"%" WITH
         plugin_name="mysql-database-plugin" \
         allowed_roles="my-role" \
         connection_url="user@cloudsql-mysql(project:region:instance)/mysql" \
-        auth_type="gcp_iam"
+        auth_type="gcp_iam" \
+        use_private_ip="false" \
+        use_psc="false"
     ```
 
     You can also configure the connection and authenticate by directly passing in the service account credentials
@@ -218,6 +220,8 @@ GRANT SELECT, CREATE, CREATE USER ON <database>.<object> TO "test-user"@"%" WITH
         allowed_roles="my-role" \
         connection_url="user@cloudsql-mysql(project:region:instance)/mysql" \
         auth_type="gcp_iam" \
+        use_private_ip="false" \
+        use_psc="false" \
         service_account_json="@my_credentials.json"
     ```
 

--- a/content/vault/v2.x (rc)/content/docs/secrets/databases/postgresql.mdx
+++ b/content/vault/v2.x (rc)/content/docs/secrets/databases/postgresql.mdx
@@ -241,8 +241,9 @@ ALTER USER "<YOUR DB USERNAME>" WITH CREATEROLE;
         plugin_name="postgresql-database-plugin" \
         allowed_roles="my-role" \
         connection_url="host=project:us-west1:mydb user=test-user@project.iam dbname=postgres sslmode=disable" \
+        auth_type="gcp_iam" \
         use_private_ip="false" \
-        auth_type="gcp_iam"
+        use_psc="false" \
     ```
 
     You can also configure the connection and authenticate by directly passing in the service account credentials
@@ -253,8 +254,9 @@ ALTER USER "<YOUR DB USERNAME>" WITH CREATEROLE;
         plugin_name="postgresql-database-plugin" \
         allowed_roles="my-role" \
         connection_url="host=project:region:instance user=test-user@project.iam dbname=postgres sslmode=disable" \
-        use_private_ip="false" \
         auth_type="gcp_iam" \
+        use_private_ip="false" \
+        use_psc="false" \
         service_account_json="@my_credentials.json"
     ```
 


### PR DESCRIPTION
Please go to the `Preview` tab and select the appropriate template:

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
