### PR TITLE
[VAULT] Small fixes

### DIFF
--- a/content/vault/v1.21.x/redirects.jsonc
+++ b/content/vault/v1.21.x/redirects.jsonc
@@ -686,6 +686,13 @@
     "permanent": true
   },
 
+    // GUI page: Billing -> Metrics
+  {
+    "source": "/vault/gui/billing-metrics",
+    "destination": "/vault/docs/concepts/client-count",
+    "permanent": true
+  },
+
   /*****************************************************************************
     Temporary bandaids
    *****************************************************************************/

--- a/content/vault/v2.x (rc)/content/docs/commands/transit/envelope_header.mdx
+++ b/content/vault/v2.x (rc)/content/docs/commands/transit/envelope_header.mdx
@@ -5,6 +5,10 @@ description: |-
   The "transit envelope header" extracts the header from  files and streams that were
   encrypted using envelope encryption including the "transit envelope encrypt"
   command.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-04-03T05:27:03-07:00
+last_modified: 2026-04-14T15:54:02.000Z
+# END AUTO GENERATED METADATA
 ---
 
 # transit envelope header
@@ -12,18 +16,14 @@ description: |-
 The `transit envelope header` command retrieves the header on files or
 streams encrypted with envelope encryption 
 
-## Usage
-
 ```shell-session
-$ vault transit envelope header [flags] <file_path_1> [<file_path_2> .. <file_path_N>]```
+$ vault transit envelope header [flags] <file_path_1> [<file_path_2> .. <file_path_N>]
 ```
 
-### Command arguments
+## Command arguments
 
-- `file_path (string : "")` The path to a file to encrypt, or `-` to encrypt
-  input from stdin.  If encrypting from stdin, there must be only one
-  `file_path` input.  Encrypted files will be output to the input filename
-  with the suffix appended.
+- `file_path` (`string : ""`) The path to an encrypted file or `-` for stdin.
+You cannot use a second file path when reading from `stdin`.
 
 ## Example
 


### PR DESCRIPTION
Adds missing redirect to current docs (already exists in 2.x)
Fixes formatting for new command doc