### PR TITLE
Add minimum NPM package release age

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7d

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-min-release-age=7d
+min-release-age=7


### PR DESCRIPTION
This is a redo of this PR: https://github.com/hashicorp/web-unified-docs/pull/2116.

Which got committed, by me, but then broke the build and so got reverted.

This puts that work back in, just with a fix to the .npmrc file.