### PR TITLE
HCP Terraform Docs

### DIFF
--- a/content/terraform-docs-common/docs/cloud-docs/workspaces/policy-enforcement/index.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/workspaces/policy-enforcement/index.mdx
@@ -28,21 +28,18 @@ You can also use policies to enforce standards for your organization’s workflo
 
 The following workflow describes how to create and manage policies manually. 
 
-### Define policies 
+### Create a policy set
 
-You can manually write custom policies in Sentinel or OPA framework format or implement pre-written Sentinel policies created and maintained by HashiCorp. Pre-written Sentinal policies enforce common standards, such as PCI DSS. Refer to [Pre-written policy library](/terraform/cloud-docs/workspaces/policy-enforcement/prewritten-library) for information about publicly available pre-written policies.
+Add a policy configuration file to a repository in your version control system (VCS), add policies, then connect them to your organization. The policy configuration file format depends on your policy framework. Refer to the following topics for more information:
 
-Although the UI allows you author and store policies in the application, we recommend storing your policies in version control (VCS). Using VCS helps establish a policy-as-code workflow to ensure standardization, security, and auditibility.   
+- [Configure a Sentinel policy set with a VCS repository](/terraform/cloud-docs/workspaces/policy-enforcement/manage-policy-sets/sentinel-vcs)
+- [Configure an OPA policy set with a VCS repository](/terraform/cloud-docs/workspaces/policy-enforcement/manage-policy-sets/opa-vcs)
 
-### Create and apply policy sets
+You can manually write custom policies in Sentinel or OPA framework format or implement pre-written Sentinel policies created and maintained by HashiCorp. Pre-written Sentinal policies enforce common standards, such as PCI DSS. Refer to [Pre-written policy library](/terraform/cloud-docs/workspaces/policy-enforcement/prewritten-library) for information about publicly available pre-written policies. For information about writing custom Sentinel policies, refer to the [Sentinel documentation](/sentinel).
 
-Group policies into sets that you can apply globally or to specific [projects](/terraform/cloud-docs/projects/manage) and workspaces in your organization. For each run in the selected workspaces, HCP Terraform checks the Terraform plan against the policy set.
+You can apply policies globally or apply them to specific [projects](/terraform/cloud-docs/projects/manage) and workspaces. For each run in the selected workspaces, HCP Terraform checks the Terraform plan against the policy set. A policy set can only contain policies written in a single policy framework, but you can add Sentinel or OPA policy sets to the same workspace. 
 
-You can also exclude specific workspaces from global or project-scoped policy sets. HCP Terraform won't enforce a policy set's policies on any runs in an excluded workspace. For example, if you attach a policy set to a project and then exclude one of the project's workspaces from that policy set, HCP Terraform will not enforce the policy set on the excluded workspace.
-
-We recommend storing policy set files in your VCS and connecting to them from HCP Terraform. You can also create policy sets from the [user interface](/terraform/cloud-docs/policy-enforcement/manage-policy-sets#create-policy-sets) or prommatically using the API. A policy set can only contain policies written in a single policy framework, but you can add Sentinel or OPA policy sets to the same workspace.
-
-Refer to [Managing Policy Sets](/terraform/cloud-docs/policy-enforcement/manage-policy-sets) for details.
+Although the UI allows you author and store policies in the application, we recommend storing policies in VCS to implement a policy-as-code workflow, which ensure standardization, security, and auditibility. You can also create policy sets programmatically using the API. Refer to [Managing Policy Sets](/terraform/cloud-docs/policy-enforcement/manage-policy-sets) for details.
 
 ### Review policy results
 

--- a/content/terraform-docs-common/docs/cloud-docs/workspaces/policy-enforcement/index.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/workspaces/policy-enforcement/index.mdx
@@ -35,11 +35,11 @@ Add a policy configuration file to a repository in your version control system (
 - [Configure a Sentinel policy set with a VCS repository](/terraform/cloud-docs/workspaces/policy-enforcement/manage-policy-sets/sentinel-vcs)
 - [Configure an OPA policy set with a VCS repository](/terraform/cloud-docs/workspaces/policy-enforcement/manage-policy-sets/opa-vcs)
 
-You can manually write custom policies in Sentinel or OPA framework format or implement pre-written Sentinel policies created and maintained by HashiCorp. Pre-written Sentinal policies enforce common standards, such as PCI DSS. Refer to [Pre-written policy library](/terraform/cloud-docs/workspaces/policy-enforcement/prewritten-library) for information about publicly available pre-written policies. For information about writing custom Sentinel policies, refer to the [Sentinel documentation](/sentinel).
+You can manually write custom policies in Sentinel or OPA framework format, or implement pre-written Sentinel policies created and maintained by HashiCorp. Pre-written Sentinal policies enforce common standards, such as PCI DSS. Refer to [Pre-written policy library](/terraform/cloud-docs/workspaces/policy-enforcement/prewritten-library) for information about publicly available pre-written policies. For information about writing custom Sentinel policies, refer to the [Sentinel documentation](/sentinel).
 
-You can apply policies globally or apply them to specific [projects](/terraform/cloud-docs/projects/manage) and workspaces. For each run in the selected workspaces, HCP Terraform checks the Terraform plan against the policy set. A policy set can only contain policies written in a single policy framework, but you can add Sentinel or OPA policy sets to the same workspace. 
+You can apply policies globally or apply them to specific [projects](/terraform/cloud-docs/projects/manage) and workspaces. For each run in the selected workspaces, HCP Terraform checks the Terraform plan against the policy set. A policy set can only contain policies written in a single policy framework, but you can add Sentinel or OPA policy sets to the same workspace.
 
-Although the UI allows you author and store policies in the application, we recommend storing policies in VCS to implement a policy-as-code workflow, which ensure standardization, security, and auditibility. You can also create policy sets programmatically using the API. Refer to [Managing Policy Sets](/terraform/cloud-docs/policy-enforcement/manage-policy-sets) for details.
+Although the UI allows you author and store policies in the application, we recommend storing policies in a VCS to implement a policy-as-code workflow, which ensures standardization, security, and auditability. You can also create policy sets programmatically using the API. Refer to [Managing Policy Sets](/terraform/cloud-docs/policy-enforcement/manage-policy-sets) for details.
 
 ### Review policy results
 

--- a/content/terraform-docs-common/docs/cloud-docs/workspaces/policy-enforcement/index.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/workspaces/policy-enforcement/index.mdx
@@ -28,17 +28,19 @@ You can also use policies to enforce standards for your organization’s workflo
 
 The following workflow describes how to create and manage policies manually. 
 
-### Define policy 
+### Define policies 
 
-You can use either the Sentinel or OPA framework to create custom policies. You can also copy pre-written Sentinel policies created and maintained by HashiCorp.
+You can manually write custom policies in Sentinel or OPA framework format or implement pre-written Sentinel policies created and maintained by HashiCorp. Pre-written Sentinal policies enforce common standards, such as PCI DSS. Refer to [Pre-written policy library](/terraform/cloud-docs/workspaces/policy-enforcement/prewritten-library) for information about publicly available pre-written policies.
+
+Although the UI allows you author and store policies in the application, we recommend storing your policies in version control (VCS). Using VCS helps establish a policy-as-code workflow to ensure standardization, security, and auditibility.   
 
 ### Create and apply policy sets
 
-Policy sets are collections of policies you can apply globally or to specific [projects](/terraform/cloud-docs/projects/manage) and workspaces in your organization. For each run in the selected workspaces, HCP Terraform checks the Terraform plan against the policy set.
+Group policies into sets that you can apply globally or to specific [projects](/terraform/cloud-docs/projects/manage) and workspaces in your organization. For each run in the selected workspaces, HCP Terraform checks the Terraform plan against the policy set.
 
 You can also exclude specific workspaces from global or project-scoped policy sets. HCP Terraform won't enforce a policy set's policies on any runs in an excluded workspace. For example, if you attach a policy set to a project and then exclude one of the project's workspaces from that policy set, HCP Terraform will not enforce the policy set on the excluded workspace.
 
-You can create policy sets from the [user interface](/terraform/cloud-docs/policy-enforcement/manage-policy-sets#create-policy-sets), the API, or by connecting HCP Terraform to your version control system. A policy set can only contain policies written in a single policy framework, but you can add Sentinel or OPA policy sets to the same workspace.
+We recommend storing policy set files in your VCS and connecting to them from HCP Terraform. You can also create policy sets from the [user interface](/terraform/cloud-docs/policy-enforcement/manage-policy-sets#create-policy-sets) or prommatically using the API. A policy set can only contain policies written in a single policy framework, but you can add Sentinel or OPA policy sets to the same workspace.
 
 Refer to [Managing Policy Sets](/terraform/cloud-docs/policy-enforcement/manage-policy-sets) for details.
 
@@ -47,4 +49,3 @@ Refer to [Managing Policy Sets](/terraform/cloud-docs/policy-enforcement/manage-
 The HCP Terraform UI displays policy results for each policy set you apply to the workspace. Depending on their [enforcement level](/terraform/cloud-docs/policy-enforcement/manage-policy-sets#policy-enforcement-levels), failed policies can stop the run. You can override failed policies with the right permissions.
 
 Refer to [Policy Results](/terraform/cloud-docs/policy-enforcement/view-results) for details.
-


### PR DESCRIPTION
### What
This PR updates the description of the policy creation workflow to be more prescriptive about using a policy-as-code workflow, as opposed to adding polices ad hoc in the UI. 

### Why
Connecting to policies managed in VCS is more secure and auditable than adding policies from the UI.

