### PR TITLE
fix ruby comments from using "//" to "#" and use correct "delete" method for the erase call

### DIFF
--- a/content/vault/v2.x/content/docs/commands/token-helper.mdx
+++ b/content/vault/v2.x/content/docs/commands/token-helper.mdx
@@ -320,7 +320,7 @@ when 'store'
   tokens[ENV['VAULT_ADDR']] = STDIN.read
 when 'erase'
   # Delete the token entry if it exists
-  tokens.delete!(ENV['VAULT_ADDR'])
+  tokens.delete(ENV['VAULT_ADDR'])
 end
 
 

--- a/content/vault/v2.x/content/docs/commands/token-helper.mdx
+++ b/content/vault/v2.x/content/docs/commands/token-helper.mdx
@@ -294,14 +294,14 @@ exit 0
 
 require 'json'
 
-// We index the token according to the Vault server address
-// so the VAULT_ADDR variable is required 
+# We index the token according to the Vault server address
+# so the VAULT_ADDR variable is required 
 unless ENV['VAULT_ADDR']
   STDERR.puts "No VAULT_ADDR environment variable set. Set it and run me again!"
   exit 100
 end
 
-// If the token file does not exist, create and initialize the hashmap
+# If the token file does not exist, create and initialize the hashmap
 begin
   tokens = JSON.parse(File.read("#{ENV['HOME']}/.vault_tokens"))
 rescue Errno::ENOENT => e
@@ -309,22 +309,22 @@ rescue Errno::ENOENT => e
   tokens = {}
 end
 
-// Get the first command line argument
+# Get the first command line argument
 case ARGV.first
 when 'get'
-  // Write the token to stdout if it exists
+  # Write the token to stdout if it exists
   print tokens[ENV['VAULT_ADDR']] if tokens[ENV['VAULT_ADDR']]
   exit 0
 when 'store'
-  // Read the token from stdin
+  # Read the token from stdin
   tokens[ENV['VAULT_ADDR']] = STDIN.read
 when 'erase'
-  // Delete the token entry if it exists
+  # Delete the token entry if it exists
   tokens.delete!(ENV['VAULT_ADDR'])
 end
 
 
-// Update the token file
+# Update the token file
 File.open("#{ENV['HOME']}/.vault_tokens", 'w') { |file| file.write(tokens.to_json) }
 ```
 </CodeTabs>


### PR DESCRIPTION
This token-helper ruby script works well, but ruby comments are `#` not `//`. This change simply replaces the comment marker with the correct one for ruby.

Additionally, this pull request replaces the nonexistent `delete!` method for hashes with the correct `delete`