### PR TITLE
Fix link to SPIFFE secrets engine documentation

### DIFF
--- a/content/vault/v2.x/content/docs/secrets/spiffe.mdx
+++ b/content/vault/v2.x/content/docs/secrets/spiffe.mdx
@@ -42,4 +42,4 @@ validate the JWTs it mints:
 ## SPIFFE secrets engine API
 
 The SPIFFE secrets engine has a full HTTP API. Refer to the
-[SPIFFE secrets engine documentation](/vault/api-docs/spiffe) for more details.
+[SPIFFE secrets engine documentation](/vault/api-docs/secret/spiffe) for more details.


### PR DESCRIPTION
broken link to api docs updated, 
no option for VAULt in templates on preview tab?

Please go to the `Preview` tab and select the appropriate template:

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
