### PR TITLE
add known issue for ent license on `openldap` alias

### DIFF
--- a/content/vault/global/partials/important-changes/known-issue/openldap-license-check.mdx
+++ b/content/vault/global/partials/important-changes/known-issue/openldap-license-check.mdx
@@ -1,4 +1,4 @@
-### LDAP secrets self-managed static roles feature is not enabled on the `openldap` built-in alias
+### LDAP secrets self-managed static roles feature is not enabled on the `openldap` built-in type alias
 
 <!-- BEGIN: Vault:=v2.x -->
 
@@ -10,8 +10,8 @@
 
 #### Issue
 
-Self-managed static roles feature is not enabled on the `openldap` built-in alias for the LDAP Secrets plugin.
-Trying to use the feature with the `openldap` plugin results in the following error:
+Self-managed static roles feature is not enabled when using the `openldap` built-in TYPE alias for the LDAP Secrets plugin.
+Trying to use the feature with the `openldap` type results in the following error:
 
 ```
 * 1 error occurred:
@@ -20,7 +20,7 @@ Trying to use the feature with the `openldap` plugin results in the following er
 
 #### Workaround
 
-Use the `ldap` plugin to enable the new self-managed mounts. Enterprise license checking enables the feature on `ldap`:
+Use the `ldap` plugin type to enable the new self-managed mounts. Enterprise license checking enables the feature on the mount:
 
 ```
 vault secrets enable -path=<PATH> ldap

--- a/content/vault/global/partials/important-changes/known-issue/openldap-license-check.mdx
+++ b/content/vault/global/partials/important-changes/known-issue/openldap-license-check.mdx
@@ -1,31 +1,32 @@
-### LDAP secrets self-managed static roles feature is not enabled on the `openldap` built-in type alias
+### LDAP secrets self-managed static roles feature does not work with the `openldap` built-in type alias ((#self-managed-openldap-fails)) <EnterpriseAlert inline="true" />
 
 <!-- BEGIN: Vault:=v2.x -->
 
 | Change      | Status   | Vault edition | Affected version | Fixed version
 | ----------- | -------- | ------------- | ---------------- | -------------
-| Known issue | Closed   | Enterprise    | 2.0.0            | 2.0.1
+| Known issue | Closed   | Enterprise    | 2.0.0            | No
 
 <!-- END: Vault:=v2.x -->
 
 #### Issue
 
-Self-managed static roles feature is not enabled when using the `openldap` built-in TYPE alias for the LDAP Secrets plugin.
-Trying to use the feature with the `openldap` type results in the following error:
+Self-managed static roles feature does not work when using the `openldap` built-in TYPE alias for the LDAP Secrets plugin.
+Using the `openldap` built-in TYPE alias for the LDAP Secrets plugin with self-managed static roles will return the following error:
 
-```
+```text
 * 1 error occurred:
         * self-managed static roles feature requires a valid Vault Enterprise license
 ```
 
 #### Workaround
 
-Use the `ldap` plugin type to enable the new self-managed mounts. Enterprise license checking enables the feature on the mount:
+Use the `ldap` plugin type to configure the new self-managed mounts:
 
 ```
-vault secrets enable -path=<PATH> ldap
+vault secrets enable -path=<mount_path> ldap
 
-vault write <PATH>/config \
-    ...
+vault write <mount_path>/config \
     self_managed=true
 ```
+
+Vault will verify your enterprise license and enable the feature for the mount.

--- a/content/vault/global/partials/important-changes/known-issue/openldap-license-check.mdx
+++ b/content/vault/global/partials/important-changes/known-issue/openldap-license-check.mdx
@@ -1,4 +1,4 @@
-### LDAP secrets self-managed static roles feature does not work with the `openldap` built-in type alias ((#self-managed-openldap-fails)) <EnterpriseAlert inline="true" />
+### LDAP plugins must use `ldap` type for self-managed static roles ((#self-managed-openldap-fails)) <EnterpriseAlert inline="true" />
 
 <!-- BEGIN: Vault:=v2.x -->
 
@@ -10,8 +10,8 @@
 
 #### Issue
 
-Self-managed static roles feature does not work when using the `openldap` built-in TYPE alias for the LDAP Secrets plugin.
-Using the `openldap` built-in TYPE alias for the LDAP Secrets plugin with self-managed static roles will return the following error:
+Self-managed static roles do not work when using the `openldap` built-in `TYPE` alias for the LDAP Secrets plugin.
+Enabling a new LDAP mount with the `openldap` built-in TYPE alias with self-managed static roles returns the following error:
 
 ```text
 * 1 error occurred:
@@ -20,13 +20,15 @@ Using the `openldap` built-in TYPE alias for the LDAP Secrets plugin with self-m
 
 #### Workaround
 
-Use the `ldap` plugin type to configure the new self-managed mounts:
+1. Enable a new LDAP plugin for self-managed static roles:
+  ```shell-session
+  $ vault secrets enable -path=<mount_path> ldap
+  ```
+1. Use the `ldap` plugin type to configure the new mount:
+  ```shell-session
+  $ vault write <mount_path>/config \
+      self_managed=true
+  ```
 
-```
-vault secrets enable -path=<mount_path> ldap
-
-vault write <mount_path>/config \
-    self_managed=true
-```
-
-Vault will verify your enterprise license and enable the feature for the mount.
+When you set `self_managed` to `true`, Vault verifies your enterprise license
+and enables the feature for the new mount.

--- a/content/vault/global/partials/important-changes/known-issue/openldap-license-check.mdx
+++ b/content/vault/global/partials/important-changes/known-issue/openldap-license-check.mdx
@@ -1,0 +1,31 @@
+### LDAP secrets self-managed static roles feature is not enabled on the `openldap` built-in alias
+
+<!-- BEGIN: Vault:=v2.x -->
+
+| Change      | Status   | Vault edition | Affected version | Fixed version
+| ----------- | -------- | ------------- | ---------------- | -------------
+| Known issue | Closed   | Enterprise    | 2.0.0            | 2.0.1
+
+<!-- END: Vault:=v2.x -->
+
+#### Issue
+
+Self-managed static roles feature is not enabled on the `openldap` built-in alias for the LDAP Secrets plugin.
+Trying to use the feature with the `openldap` plugin results in the following error:
+
+```
+* 1 error occurred:
+        * self-managed static roles feature requires a valid Vault Enterprise license
+```
+
+#### Workaround
+
+Use the `ldap` plugin to enable the new self-managed mounts. Enterprise license checking enables the feature on `ldap`:
+
+```
+vault secrets enable -path=<PATH> ldap
+
+vault write <PATH>/config \
+    ...
+    self_managed=true
+```

--- a/content/vault/global/partials/important-changes/summary-tables/2xx.mdx
+++ b/content/vault/global/partials/important-changes/summary-tables/2xx.mdx
@@ -23,3 +23,4 @@ Introduced | Recommendations | Edition    | Change
 2.0.0      | **Yes**         | Enterprise | [Root token KV access blocked by EGP policy](/vault/docs/v2.x/updates/important-changes#root-token-kv-access-blocked-by-egp-policy)
 2.0.0      | No              | All        | [Sidebar menu reloads on engine-scoped pages](/vault/docs/v2.x/updates/important-changes#sidebar-menu-reloads-on-engine-scoped-pages)
 2.0.0      | **Yes**         | All        | [Secrets Engines items-per-page change can hide results](/vault/docs/v2.x/updates/important-changes#secrets-engines-items-per-page-hides-results)
+2.0.0      | **Yes**         | Enterprise | [LDAP secrets self-managed static roles feature does not work with the `openldap` built-in type alias](/vault/docs/v2.x/updates/important-changes#self-managed-openldap-fails)

--- a/content/vault/v2.x/content/docs/updates/important-changes.mdx
+++ b/content/vault/v2.x/content/docs/updates/important-changes.mdx
@@ -134,3 +134,5 @@ corresponding Vault group with the intended membership.
 @include '../../../global/partials/important-changes/known-issue/sidebar-menu-reloads-on-engine-scoped-pages.mdx'
 
 @include '../../../global/partials/important-changes/known-issue/secrets-engines-items-per-page-hides-results.mdx'
+
+@include '../../../global/partials/important-changes/known-issue/openldap-license-check.mdx'


### PR DESCRIPTION
This PR adds a known issue where the new v2.x Enterprise feature — self-managed static roles for LDAP — is not enabled when using the `openldap` plugin alias due to enterprise license checking.

The workaround is described in the PR. Users can instead use the `ldap` plugin instead of the `openldap` alias. This is the same plugin under the hood and has the feature enabled