### PR TITLE
[VAULT] Post release cleanup (2)

### DIFF
--- a/content/vault/v2.x/content/docs/index.mdx
+++ b/content/vault/v2.x/content/docs/index.mdx
@@ -5,8 +5,8 @@ description: >-
   Vault product and reference documentation covering key concepts, guides for
   common tasks, and best practices.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2026-04-15T00:15:25.000Z
-last_modified: 2026-04-15T00:15:25.000Z
+created_at: 2026-04-14T17:13:42-07:00
+last_modified: 2026-04-15T19:12:20.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -14,6 +14,6 @@ last_modified: 2026-04-15T00:15:25.000Z
 
 <Note>
 
-You are currently viewing documentation for a preview version of Vault.
+You are currently viewing documentation for an older version of Vault.
 
 </Note>

--- a/content/vault/v2.x/content/docs/updates/release-notes.mdx
+++ b/content/vault/v2.x/content/docs/updates/release-notes.mdx
@@ -5,7 +5,7 @@ description: >-
   Key updates for Vault 2.x.x
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2026-04-14T17:13:42-07:00
-last_modified: 2026-04-15T17:14:05.000Z
+last_modified: 2026-04-15T17:48:15.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -70,9 +70,9 @@ create policies, and discover Vault capabilities.
 - **[LDAP static role rotation enhancements](/vault/docs/secrets/ldap)** -
   Manage LDAP static credentials with more flexibility by adding initial
   passwords, self-managed rotation, schedules, and retry controls.
-- **[Rotation policies](/vault/docs/enterprise/rotation-policies)** - Standardize
-  how Vault handles failed automated rotations by defining reusable retry
-  behavior for supported roles.
+- **[Rotation policies](/vault/docs/enterprise/automated-credential-rotation/rotation-policies)** -
+  Standardize how Vault handles failed automated rotations by defining reusable
+  retry behavior for supported roles.
 
 
 ### Bug fixes and security patches

--- a/content/vault/v2.x/content/docs/updates/release-notes.mdx
+++ b/content/vault/v2.x/content/docs/updates/release-notes.mdx
@@ -5,7 +5,7 @@ description: >-
   Key updates for Vault 2.x.x
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2026-04-14T17:13:42-07:00
-last_modified: 2026-04-15T17:48:15.000Z
+last_modified: 2026-04-15T20:20:04.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -105,9 +105,9 @@ create policies, and discover Vault capabilities.
   automation, and machine identity growth so billing better reflects
   platform usage.
 - [JWT auth](/vault/docs/auth/jwt) updates improve JWT-based authentication workflows.
-- [Rotation retries](/vault/docs/enterprise/rotation-policies) use exponential
-  backoff and orphan handling so Vault can retry failed root and static
-  credential rotations without overloading the system. Vault 2.0.0 supports
+- [Rotation retries](/vault/docs/enterprise/automated-credential-rotation/rotation-policie)
+  use exponential backoff and orphan handling so Vault can retry failed root and
+  static credential rotations without overloading the system. Vault 2.0.0 supports
   LDAP static roles in addition to the engines that already support root rotation.
 
 ### Feature deprecations and EOL

--- a/content/vault/v2.x/content/docs/upgrade/index.mdx
+++ b/content/vault/v2.x/content/docs/upgrade/index.mdx
@@ -4,8 +4,8 @@ page_title: Upgrade Vault
 description: >-
   General guidance for upgrading a single Vault instance.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2026-04-15T00:15:59.000Z
-last_modified: 2026-04-15T00:15:59.000Z
+created_at: 2026-04-14T17:13:42-07:00
+last_modified: 2026-04-15T17:55:19.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -25,6 +25,13 @@ unseal Vault after the upgrade.
 
 ## Before you start
 
+- **Review the change tracker**. The historic
+  [change tracker](/vault/docs/updates/change-tracker) provides a summary of
+  breaking changes, new behavior, and known issues for recent Vault versions.
+- **Review the release notes for your target version**.
+  [Release notes](/vault/docs/updates/release-notes) provide an executive summary
+  for major releases and lists of new features, bug fixes, and improvements in
+  each available version.
 - **You must have `sudo` permissions on the Vault server**. Make sure you have
   can install binaries on the Vault server.
 - **You must have admin permissions for Vault**. Make sure you can stop and


### PR DESCRIPTION
- Fix a broken link in the release notes
- Cross link change tracker and release notes as prerequisites for upgrading
- Update markdown landing page to say "older" instead of "preview"