### PR TITLE
Fix command in docs tutorial for pki-external-ca

### DIFF
--- a/content/vault/v2.x/content/docs/secrets/pki-external-ca/index.mdx
+++ b/content/vault/v2.x/content/docs/secrets/pki-external-ca/index.mdx
@@ -205,7 +205,7 @@ the private key with the certificate so you can retrieve the key later if needed
 1. Fetch the challenge token and auth key for each identifier from Vault:
 
    ```shell-session
-   $ vault read pki-external-ca/role/web-servers/order/01936d8e-7c3a-7890-b123-456789abcdef/challenges \
+   $ vault read pki-external-ca/role/web-servers/order/01936d8e-7c3a-7890-b123-456789abcdef/challenge \
        identifier="www.example.com" \
        challenge_type="http-01"
    ```
@@ -266,7 +266,7 @@ a signed certificate.
 1. Fetch the challenge token and auth key for each identifier from Vault:
 
    ```shell-session
-   $ vault read pki-external-ca/role/web-servers/order/01936d8e-7c3a-7890-b123-456789abcdef/challenges \
+   $ vault read pki-external-ca/role/web-servers/order/01936d8e-7c3a-7890-b123-456789abcdef/challenge \
        identifier="www.example.com" \
        challenge_type="http-01"
    ```

--- a/content/vault/v2.x/content/docs/secrets/pki-external-ca/index.mdx
+++ b/content/vault/v2.x/content/docs/secrets/pki-external-ca/index.mdx
@@ -34,9 +34,7 @@ You can use the PKI external CA plugin to:
 1. Enable the plugin:
 
     ```shell-session
-    $ vault secrets enable  \
-    -path=pki-external-ca \
-    vault-plugin-secrets-pki-external-ca
+    $ vault secrets enable pki-external-ca
     ```
 
 1. Configure an ACME account:


### PR DESCRIPTION
Fix the command specified within the docs page for pki-external-ca. The command should have used challenge not the plural form of it 