### PR TITLE
HCP Terraform Docs

### DIFF
--- a/content/terraform-docs-common/docs/cloud-docs/dynamic-provider-credentials/index.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/dynamic-provider-credentials/index.mdx
@@ -82,4 +82,4 @@ In order to verify signed JWTs, cloud platforms must have network access to the 
 
 ### External Vault Policy
 
-If you are using an external Vault instance, you must ensure that your Vault instance has the correct policies setup as detailed in the [External Vault Requirements for Terraform Enterprise](/terraform/enterprise/requirements/data-storage/vault) documentation.
+If you are using an external Vault instance, you must ensure that your Vault instance has the correct policies setup as detailed in the [External Vault Requirements for Terraform Enterprise](/terraform/enterprise/deploy/replicated/install/vault) documentation.


### PR DESCRIPTION
### What
Fix a broken link on dynamic provider credentials page.
[IPE-1485](https://hashicorp.atlassian.net/browse/IPE-1485)

[Preview](https://unified-docs-frontend-preview-5c18s1hhm-hashicorp.vercel.app/terraform/cloud-docs/dynamic-provider-credentials#external-vault-policy)

### Why
Link was broken when target page moved.

### Screenshots
N/A

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages.
- [x] API documentation and the API Changelog have been updated.
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] New pages have metadata (page name and description) at the top.
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.


[IPE-1485]: https://hashicorp.atlassian.net/browse/IPE-1485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ