### PR TITLE
Updated TFE GCP reference architecture PostgreSQL machine types

### DIFF
--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/architecture/reference-architecture/gcp.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/architecture/reference-architecture/gcp.mdx
@@ -75,8 +75,8 @@ or “Shared-core machine types” in GCP terms, such as f1-series and g1-series
 
 | Type    | CPU    | Memory    | Storage | GCP Machine Types            |
 | ------- | ------ | --------- | ------- | ---------------------------- |
-| Minimum | 4 core | 16 GB RAM | 50GB    | Custom PostgreSQL Production |
-| Scaled  | 8 core | 32 GB RAM | 50GB    | Custom PostgreSQL Production |
+| Minimum | 4 core | 16 GB RAM | 50GB    | db-perf-optimized-N-4        |
+| Scaled  | 8 core | 32 GB RAM | 50GB    | db-perf-optimized-N-8        |
 
 #### Hardware Sizing Considerations
 


### PR DESCRIPTION
Custom machine types are no longer supported for GCP PostgreSQL Enterprise offering v16+ per https://docs.cloud.google.com/sql/docs/postgres/editions-intro so switched reference architecture to two closest machine types.

Please go to the `Preview` tab and select the appropriate template:

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
