### PR TITLE
Update HCP Vault 1.21.3 changelog entry

### DIFF
--- a/content/hcp-docs/content/docs/changelog.mdx
+++ b/content/hcp-docs/content/docs/changelog.mdx
@@ -13,6 +13,9 @@ last_modified: 2026-02-03T16:20:10-06:00
 ### 2026-04-09
 **HCP Organizations:** A self-service organization deletion checklist is now available for organization owners. The checklist provides an automated pre-flight check to verify that all prerequisites—such as decommissioning active resources, resolving billing requirements, and clearing IAM configurations—are met before an organization can be deleted. This reduces the need for manual support tickets and provides a more seamless, transparent experience. For more information, refer to the [Organizations documentation](/hcp/docs/hcp/admin/orgs#delete-an-organization).
 
+### 2026-02-26
+**HCP Vault 1.21.3 on AWS and Azure:** Vault 1.21.3 has started rolling out to HCP Vault Dedicated clusters on AWS and Azure. Refer to [1.21.3 Enterprise release notes](https://github.com/hashicorp/vault/blob/main/CHANGELOG.md#1213) in GitHub to learn more about what's new in 1.21.3.
+
 ### 2026-01-27
 **HCP Vault 1.21.2 on AWS and Azure:** Vault 1.21.2 has started rolling out to HCP Vault Dedicated clusters on AWS and Azure. Refer to [1.21.2 Enterprise release notes](https://github.com/hashicorp/vault/blob/main/CHANGELOG.md#1212) in GitHub to learn more about what's new in 1.21.2.
 


### PR DESCRIPTION
## Summary
- add the 2026-02-26 HCP changelog entry for Vault 1.21.3 on AWS and Azure
- link to the Vault 1.21.3 Enterprise release notes in GitHub

## Why
- publish the rollout announcement in the HCP docs changelog