### PR TITLE
terraform: Update `workspace list` docs to describe -json flag and new output

### DIFF
--- a/content/terraform/v1.15.x (rc)/docs/cli/commands/workspace/list.mdx
+++ b/content/terraform/v1.15.x (rc)/docs/cli/commands/workspace/list.mdx
@@ -20,7 +20,9 @@ This command accepts the following options:
 * `-json` - Produce output in a machine-readable JSON format. Always disables
   color.
 
-### Example: human-readable output
+## Examples
+
+### Human-readable output
 
 The current workspace is indicated using an asterisk (`*`) marker.
 
@@ -31,7 +33,7 @@ $ terraform workspace list
   jsmith-test
 ```
 
-### Example: machine-readable, JSON output
+### Machine-readable, JSON output
 
 ```
 $ terraform workspace list -json

--- a/content/terraform/v1.15.x (rc)/docs/cli/commands/workspace/list.mdx
+++ b/content/terraform/v1.15.x (rc)/docs/cli/commands/workspace/list.mdx
@@ -13,12 +13,16 @@ The `terraform workspace list` command lists all existing workspaces.
 
 ## Usage
 
-Usage: `terraform workspace list`
+Usage: `terraform workspace list [options]`
 
-The command will list all existing workspaces. The current workspace is
-indicated using an asterisk (`*`) marker.
+This command accepts the following options:
 
-## Example
+* `-json` - Produce output in a machine-readable JSON format. Always disables
+  color.
+
+### Example: human-readable output
+
+The current workspace is indicated using an asterisk (`*`) marker.
 
 ```
 $ terraform workspace list
@@ -26,3 +30,190 @@ $ terraform workspace list
 * development
   jsmith-test
 ```
+
+### Example: machine-readable, JSON output
+
+```
+$ terraform workspace list -json
+{
+  "format_version": "1.0",
+  "workspaces": [
+    {
+      "name": "default"
+    },
+    {
+      "name": "development",
+      "is_current": true
+    },
+    {
+      "name": "jsmith-test"
+    }
+  ],
+  "diagnostics": []
+}
+```
+
+## JSON Output Format
+
+When you use the `-json` option, Terraform will produce workspace list results in JSON format.
+
+As with all JSON output options, it's possible that Terraform will encounter
+an error prior to beginning the list task that will thus not be subject
+to the JSON output setting. For that reason, external software consuming
+Terraform's output should be prepared to find data on stdout that _isn't_ valid
+JSON, which it should then treat as a generic error case.
+
+The output includes a `format_version` key, which as of Terraform 1.15.0 has
+value `"1.0"`. The semantics of this version are:
+
+* We will increment the minor version, e.g. `"1.1"`, for backward-compatible
+  changes or additions. Ignore any object properties with unrecognized names to
+  remain forward-compatible with future minor versions.
+* We will increment the major version, e.g. `"2.0"`, for changes that are not
+  backward-compatible. Reject any input which reports an unsupported major
+  version.
+
+We will introduce new major versions only within the bounds of
+[the Terraform 1.0 Compatibility Promises](/terraform/language/v1-compatibility-promises).
+
+In the normal case, Terraform will print a JSON object to the standard output
+stream. The top-level JSON object will have the following properties:
+
+- `workspaces` (array of objects): A JSON array of nested objects that each
+  describe a workspace.
+
+- `diagnostics` (array of objects): A JSON array of nested objects that each
+  describe an error or warning from Terraform.
+
+
+The nested objects in `workspaces` have the following properties:
+
+- `name` (string): The name of the workspace.
+
+- `is_current` (boolean): Indicates whether this workspace is the current workspace.
+  This will only be present in the current workspace JSON object.
+
+The nested objects in `diagnostics` have the following properties:
+
+- `severity` (string): A string keyword, either `"error"` or
+  `"warning"`, indicating the diagnostic severity.
+
+  The presence of errors causes Terraform to consider a configuration to be
+  invalid, while warnings are just advice or caveats to the user which do not
+  block working with the configuration. Later versions of Terraform may
+  introduce new severity keywords, so consumers should be prepared to accept
+  and ignore severity values they don't understand.
+
+- `summary` (string): A short description of the nature of the problem that
+  the diagnostic is reporting.
+
+  In Terraform's usual human-oriented diagnostic messages, the summary serves
+  as a sort of "heading" for the diagnostic, printed after the "Error:" or
+  "Warning:" indicator.
+
+  Summaries are typically short, single sentences, but can sometimes be longer
+  as a result of returning errors from subsystems that are not designed to
+  return full diagnostics, where the entire error message becomes the
+  summary. In those cases, the summary might include newline characters which
+  a renderer should honor when presenting the message visually to a user.
+
+- `detail` (string): An optional additional message giving more detail about
+  the problem.
+
+  In Terraform's usual human-oriented diagnostic messages, the detail provides
+  the paragraphs of text that appear after the heading and the source location
+  reference.
+
+  Detail messages are often multiple paragraphs and possibly interspersed with
+  non-paragraph lines, so tools that aim to present detailed messages to the
+  user should distinguish between lines without leading spaces, treating them
+  as paragraphs, and lines with leading spaces, treating them as preformatted
+  text. Renderers should then soft-wrap the paragraphs to fit the width of the
+  rendering container, but leave the preformatted lines unwrapped.
+
+  Some Terraform detail messages contain an approximation of bullet
+  lists using ASCII characters to mark the bullets. This is not a
+  contractual formatting convention, so renderers should avoid depending on
+  it and should instead treat those lines as either paragraphs or preformatted
+  text. 
+
+- `range` (object): An optional object referencing a portion of the configuration
+  source code that the diagnostic message relates to. For errors, this will
+  typically indicate the bounds of the specific block header, attribute, or
+  expression which was detected as invalid.
+
+  A source range is an object with a property `filename` that gives the
+  filename as a relative path from the current working directory, and then
+  two properties `start` and `end` which are both themselves objects
+  describing source positions, as described below.
+
+  Not all diagnostic messages are connected with specific portions of the
+  configuration, so `range` will be omitted or `null` for diagnostic messages
+  where it isn't relevant.
+
+- `snippet` (object): An optional object including an excerpt of the
+  configuration source code that the diagnostic message relates to.
+
+  The snippet information includes:
+
+  - `context` (string): An optional summary of the root context of the
+    diagnostic. For example, this might be the resource block containing the
+    expression that triggered the diagnostic. For some diagnostics, this
+    information is not available, and then this property will be `null`.
+
+  - `code` (string): A snippet of Terraform configuration including the
+    source of the diagnostic. This can be multiple lines and may include
+    additional configuration source code around the expression which
+    triggered the diagnostic.
+
+  - `start_line` (number): A one-based line count representing the position
+    in the source file at which the `code` excerpt begins. This is not
+    necessarily the same value as `range.start.line`, as it is possible for
+    `code` to include one or more lines of context before the source of the
+    diagnostic.
+
+  - `highlight_start_offset` (number): A zero-based character offset into the
+    `code` string, pointing at the start of the expression which triggered
+    the diagnostic.
+
+  - `highlight_end_offset` (number): A zero-based character offset into the
+    `code` string, pointing at the end of the expression which triggered the
+    diagnostic.
+
+  - `values` (array of objects): Contains zero or more expression values
+    which may be useful in understanding the source of a diagnostic in a
+    complex expression. These expression value objects are described below.
+
+### Source Position
+
+A source position object, as used in the `range` property of a diagnostic
+object, has the following properties:
+
+- `byte` (number): A zero-based byte offset into the indicated file.
+
+- `line` (number): A one-based line count for the line containing the relevant
+  position in the indicated file.
+
+- `column` (number): A one-based count of _Unicode characters_ from the start
+  of the line indicated in `line`.
+
+A `start` position is inclusive while an `end` position is exclusive. The
+exact positions used for particular error messages are intended for human
+interpretation only.
+
+### Expression Value
+
+An expression value object gives additional information about a value that is
+part of the expression which triggered the diagnostic. This is especially
+useful when using `for_each` or similar constructs, in order to identify
+exactly which values are responsible for an error. The object has two properties:
+
+- `traversal` (string): An HCL-like traversal string, such as
+  `var.instance_count`. Complex index key values may be elided, so this will
+  not always be valid, parseable HCL. The contents of this string are intended
+  to be human-readable.
+
+- `statement` (string): A short English-language fragment describing the value
+  of the expression when the diagnostic was triggered. The contents of this
+  string are intended to be human-readable and are subject to change in future
+  versions of Terraform.


### PR DESCRIPTION
### What

Updated the Terraform docs of `workspace list` to reflect addition of a -json flag and machine-readable output.

The change is specific to TF v1.16

I need to edit `content/terraform/v1.16.x (alpha)/docs/cli/commands/workspace/list.mdx` when that file is created

### Why

Helps users use the new feature added in https://github.com/hashicorp/terraform/pull/38397

### Screenshots

N/A

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] You added redirects to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages **across all affected versions**. Refer to [Redirects](https://github.com/hashicorp/web-unified-docs/blob/main/docs/content-guide/redirects.md#example-redirects) for examples and guidance. 
- [ ] Links to related content where appropriate (e.g., CLI, language, API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
