### PR TITLE
Add changelog entry for v0.2.2 for vault-pkcs11-provider

### DIFF
--- a/content/vault/v2.x/content/docs/enterprise/pkcs11-provider/index.mdx
+++ b/content/vault/v2.x/content/docs/enterprise/pkcs11-provider/index.mdx
@@ -436,6 +436,14 @@ Due to the nature of Vault, the KMIP Secrets Engine, and PKCS#11, there are some
 
 ## Changelog
 
+### v0.2.2
+
+ * Fix session pooling support for PKCS#11 clients.
+ * Fix a bug on C_GetAttributeValue for private RSA keys.
+ * Fix a bug that prevented the correct registration of private RSA keys.
+ * Fix a problem when building the provider on big-endian architectures.
+ * Go update to 1.25.4 and Go dependency updates
+
 ### v0.2.1
 
  * Go update to 1.22.7 and Go dependency updates


### PR DESCRIPTION

Add a missing changelog for the v0.2.2 version of the vault-pkcs11-provider to the docs page.