### PR TITLE
Document Managed key limitation within SCEP page

### DIFF
--- a/content/vault/v1.20.x/content/docs/secrets/pki/scep.mdx
+++ b/content/vault/v1.20.x/content/docs/secrets/pki/scep.mdx
@@ -228,7 +228,7 @@ The following Vault PKI features do not support SCEP integration:
 
  - Certificate Metadata - SCEP has no means of providing metadata.
  - Certificate Issuance External Policy Service [CIEPS](/vault/docs/secrets/pki/cieps)
-
+ - Managed Keys - SCEP requires encryption/decryption capabilities from the CA key which are not supported at this time.
 
 ## Resources
 

--- a/content/vault/v1.21.x/content/docs/secrets/pki/scep.mdx
+++ b/content/vault/v1.21.x/content/docs/secrets/pki/scep.mdx
@@ -228,6 +228,7 @@ The following Vault PKI features do not support SCEP integration:
 
  - Certificate Metadata - SCEP has no means of providing metadata.
  - Certificate Issuance External Policy Service [CIEPS](/vault/docs/secrets/pki/cieps)
+ - Managed Keys - SCEP requires encryption/decryption capabilities from the CA key which are not supported at this time.
 
 ## Resources
 

--- a/content/vault/v2.x/content/docs/secrets/pki/scep.mdx
+++ b/content/vault/v2.x/content/docs/secrets/pki/scep.mdx
@@ -228,6 +228,7 @@ The following Vault PKI features do not support SCEP integration:
 
  - Certificate Metadata - SCEP has no means of providing metadata.
  - Certificate Issuance External Policy Service [CIEPS](/vault/docs/secrets/pki/cieps)
+ - Managed Keys - SCEP requires encryption/decryption capabilities from the CA key which are not supported at this time.
 
 ## Resources
 


### PR DESCRIPTION
Document that Managed keys are not compatible SCEP at this time as we don't support encryption/decryption operations.