### PR TITLE
Removed tip that support can be contacted for emergency licenses

### DIFF
--- a/content/vault/v1.19.x/content/docs/license/index.mdx
+++ b/content/vault/v1.19.x/content/docs/license/index.mdx
@@ -32,14 +32,6 @@ Each license key has a start date and an expiration date:
 - You **can** start, restart, and unseal Vault versions **released before** the
   expiration date.
 
-<Tip>
-
-If you have an expired license key and need to perform an immediate update to
-apply critical security fixes, reach out to your Vault support contact for a
-temporary trial license key.
-
-</Tip>
-
 Some license keys also enforce a termination date. If your license key enforces
 a termination date, you cannot start, restart, or unseal any version of Vault
 after the termination date. Existing, unsealed nodes continue to operate

--- a/content/vault/v1.20.x/content/docs/license/index.mdx
+++ b/content/vault/v1.20.x/content/docs/license/index.mdx
@@ -32,14 +32,6 @@ Each license key has a start date and an expiration date:
 - You **can** start, restart, and unseal Vault versions **released before** the
   expiration date.
 
-<Tip>
-
-If you have an expired license key and need to perform an immediate update to
-apply critical security fixes, reach out to your Vault support contact for a
-temporary trial license key.
-
-</Tip>
-
 Some license keys also enforce a termination date. If your license key enforces
 a termination date, you cannot start, restart, or unseal any version of Vault
 after the termination date. Existing, unsealed nodes continue to operate

--- a/content/vault/v1.21.x/content/docs/license/index.mdx
+++ b/content/vault/v1.21.x/content/docs/license/index.mdx
@@ -32,14 +32,6 @@ Each license key has a start date and an expiration date:
 - You **can** start, restart, and unseal Vault versions **released before** the
   expiration date.
 
-<Tip>
-
-If you have an expired license key and need to perform an immediate update to
-apply critical security fixes, reach out to your Vault support contact for a
-temporary trial license key.
-
-</Tip>
-
 Some license keys also enforce a termination date. If your license key enforces
 a termination date, you cannot start, restart, or unseal any version of Vault
 after the termination date. Existing, unsealed nodes continue to operate

--- a/content/vault/v2.x/content/docs/license/index.mdx
+++ b/content/vault/v2.x/content/docs/license/index.mdx
@@ -32,14 +32,6 @@ Each license key has a start date and an expiration date:
 - You **can** start, restart, and unseal Vault versions **released before** the
   expiration date.
 
-<Tip>
-
-If you have an expired license key and need to perform an immediate update to
-apply critical security fixes, reach out to your Vault support contact for a
-temporary trial license key.
-
-</Tip>
-
 Some license keys also enforce a termination date. If your license key enforces
 a termination date, you cannot start, restart, or unseal any version of Vault
 after the termination date. Existing, unsealed nodes continue to operate


### PR DESCRIPTION
The support organization may no longer generated Vault licenses. The documentation was updated to reflect this.
