### PR TITLE
Upload the changed mdx files to artifacts to avoid arg limits

### DIFF
--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -370,7 +370,7 @@ jobs:
 
       - name: Run lychee link checker for internal links
         id: lychee-internal
-        uses: lycheeverse/lychee-action@f613c4a64e50d792e0b31ec34bbcbba12263c6a6 # v2.3.0
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
           output: ./internal.md
           args: >-
@@ -394,7 +394,7 @@ jobs:
 
       - name: Run lychee link checker for external links
         id: lychee-external
-        uses: lycheeverse/lychee-action@f613c4a64e50d792e0b31ec34bbcbba12263c6a6 # v2.3.0
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
           output: ./external.md
           args: >-

--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -24,7 +24,6 @@ jobs:
     name: Get Changed Files
     runs-on: ubuntu-latest
     outputs:
-      changed_markdown_content_files: ${{ steps.changed-files.outputs.changed_mdx_files }}
       changed_content_files_count: ${{ steps.changed-files.outputs.changed_mdx_files_count }}
     steps:
       - name: Get changed .mdx files in content/
@@ -45,20 +44,26 @@ jobs:
 
           if [ -z "$changed_mdx_files_lines" ]; then
             changed_mdx_files_count=0
-            changed_mdx_files=""
           else
             changed_mdx_files_count=$(printf '%s\n' "$changed_mdx_files_lines" | grep -c .)
-            changed_mdx_files=$(printf '%s\n' "$changed_mdx_files_lines" \
-            | sed 's/"/\\"/g; s/.*/"&"/' \
-            | paste -sd' ' -)
+            printf '%s\n' "$changed_mdx_files_lines" > /tmp/changed-mdx-files.txt
           fi
 
-          echo "changed_mdx_files=$changed_mdx_files" >> $GITHUB_OUTPUT
           echo "changed_mdx_files_count=$changed_mdx_files_count" >> $GITHUB_OUTPUT
 
           echo "Changed .mdx files count: $changed_mdx_files_count"
-          echo "Changed .mdx files:"
-          echo "$changed_mdx_files"
+          if [ -f /tmp/changed-mdx-files.txt ]; then
+            echo "Changed .mdx files:"
+            cat /tmp/changed-mdx-files.txt
+          fi
+
+      - name: Upload changed .mdx files artifact
+        if: steps.changed-files.outputs.changed_mdx_files_count > 0
+        uses: actions/upload-artifact@c6a366c94c3e0affe28c06c8df20a878f24da3cf # v3.2.2
+        with:
+          name: changed-mdx-files
+          path: /tmp/changed-mdx-files.txt
+          retention-days: 1
 
   security-check:
     name: Security Check
@@ -350,10 +355,16 @@ jobs:
           fetch-depth: 1
           sparse-checkout: content/
 
-      - name: Checking links in files
+      - name: Download changed .mdx files artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v5.0.0
+        with:
+          name: changed-mdx-files
+          path: /tmp
+
+      - name: Links to check
         run: |
-          echo "Checking links in files:"
-          echo ${{ needs.get-changed-files.outputs.changed_markdown_content_files }}
+          echo "Checking links:"
+          cat /tmp/changed-mdx-files.txt
 
       - name: Run lychee link checker for internal links
         id: lychee-internal
@@ -361,7 +372,7 @@ jobs:
         with:
           output: ./internal.md
           args: >-
-            ${{ needs.get-changed-files.outputs.changed_markdown_content_files }}
+            --files-from /tmp/changed-mdx-files.txt
             -b ${{ needs.deploy-dev-portal-preview.outputs.preview_url }}
             --exclude-all-private
             --exclude '\.(svg|gif|jpg|png)'
@@ -385,7 +396,7 @@ jobs:
         with:
           output: ./external.md
           args: >-
-            ${{ needs.get-changed-files.outputs.changed_markdown_content_files }}
+            --files-from /tmp/changed-mdx-files.txt
             -b ${{ needs.deploy-dev-portal-preview.outputs.preview_url }}
             --exclude-all-private
             --exclude '\.(svg|gif|jpg|png)'

--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -110,7 +110,7 @@ jobs:
   deploy-unified-docs-api-preview:
     name: Deploy Unified Docs API Preview
     runs-on: ubuntu-latest
-    needs: [security-check]
+    needs: [security-check, get-changed-files]
     outputs:
       preview_url: ${{ steps.unified_docs_preview_url.outputs.preview_url }}
       preview_url_to_fetch_deployment: ${{ steps.unified_docs_preview_url.outputs.preview_url_to_fetch_deployment }}

--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -46,24 +46,26 @@ jobs:
             changed_mdx_files_count=0
           else
             changed_mdx_files_count=$(printf '%s\n' "$changed_mdx_files_lines" | grep -c .)
-            printf '%s\n' "$changed_mdx_files_lines" > /tmp/changed-mdx-files.txt
+            mkdir -p "${{ github.workspace }}/tmp"
+            printf '%s\n' "$changed_mdx_files_lines" > "${{ github.workspace }}/tmp/changed-mdx-files.txt"
           fi
 
           echo "changed_mdx_files_count=$changed_mdx_files_count" >> $GITHUB_OUTPUT
 
           echo "Changed .mdx files count: $changed_mdx_files_count"
-          if [ -f /tmp/changed-mdx-files.txt ]; then
+          if [ -f "${{ github.workspace }}/tmp/changed-mdx-files.txt" ]; then
             echo "Changed .mdx files:"
-            cat /tmp/changed-mdx-files.txt
+            cat "${{ github.workspace }}/tmp/changed-mdx-files.txt"
           fi
 
       - name: Upload changed .mdx files artifact
         if: steps.changed-files.outputs.changed_mdx_files_count > 0
-        uses: actions/upload-artifact@c6a366c94c3e0affe28c06c8df20a878f24da3cf # v3.2.2
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
-          name: changed-mdx-files
-          path: /tmp/changed-mdx-files.txt
+          name: changed mdx files
+          path: ${{ github.workspace }}/tmp/changed-mdx-files.txt
           retention-days: 1
+          overwrite: true
 
   security-check:
     name: Security Check
@@ -356,15 +358,15 @@ jobs:
           sparse-checkout: content/
 
       - name: Download changed .mdx files artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v5.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: changed-mdx-files
-          path: /tmp
+          name: changed mdx files
+          path: ${{ github.workspace }}/tmp
 
       - name: Links to check
         run: |
           echo "Checking links:"
-          cat /tmp/changed-mdx-files.txt
+          cat ${{ github.workspace }}/tmp/changed-mdx-files.txt
 
       - name: Run lychee link checker for internal links
         id: lychee-internal
@@ -372,7 +374,7 @@ jobs:
         with:
           output: ./internal.md
           args: >-
-            --files-from /tmp/changed-mdx-files.txt
+            --files-from ${{ github.workspace }}/tmp/changed-mdx-files.txt
             -b ${{ needs.deploy-dev-portal-preview.outputs.preview_url }}
             --exclude-all-private
             --exclude '\.(svg|gif|jpg|png)'
@@ -396,7 +398,7 @@ jobs:
         with:
           output: ./external.md
           args: >-
-            --files-from /tmp/changed-mdx-files.txt
+            --files-from ${{ github.workspace }}/tmp/changed-mdx-files.txt
             -b ${{ needs.deploy-dev-portal-preview.outputs.preview_url }}
             --exclude-all-private
             --exclude '\.(svg|gif|jpg|png)'


### PR DESCRIPTION
## Description
Fixes the PR preview build link checker to support arbitrary long args. We do this by saving and uploading the changed MDX files as an artifact and then download and using that artifact file when running the link checker. Which means that the arg size will no longer be variable.

## Testing

This PR was tested in the PR: https://github.com/hashicorp/web-unified-docs/pull/2299.