### PR TITLE
vault: adding a note about wildcards in identity policy templates

### DIFF
--- a/content/vault/v1.19.x/content/docs/concepts/policies.mdx
+++ b/content/vault/v1.19.x/content/docs/concepts/policies.mdx
@@ -6,7 +6,7 @@ description: >-
   which parts of Vault a user can access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-07-01T14:39:24-05:00
-last_modified: 2025-11-19T22:54:28Z
+last_modified: 2026-04-23T04:57:44.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -273,6 +273,12 @@ credentials, the policy would grant `read` access on the appropriate path.
 The policy syntax allows for doing variable replacement in some policy strings
 with values available to the token. Currently `identity` information can be
 injected, and currently the `path` keys in policies allow injection.
+
+<Note>
+
+Wildcards (`+`) and globs (`*`) are not permitted in an identity template's rendered output.
+
+</Note>
 
 ### Parameters
 

--- a/content/vault/v1.21.x/content/docs/concepts/policies.mdx
+++ b/content/vault/v1.21.x/content/docs/concepts/policies.mdx
@@ -6,7 +6,7 @@ description: >-
   which parts of Vault a user can access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-07-22T12:58:23-07:00
-last_modified: 2025-10-22T13:53:42-07:00
+last_modified: 2026-04-23T04:57:46.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -275,6 +275,12 @@ credentials, the policy would grant `read` access on the appropriate path.
 The policy syntax allows for doing variable replacement in some policy strings
 with values available to the token. Currently `identity` information can be
 injected, and currently the `path` keys in policies allow injection.
+
+<Note>
+
+Wildcards (`+`) and globs (`*`) are not permitted in an identity template's rendered output.
+
+</Note>
 
 ### Parameters
 

--- a/content/vault/v2.x/content/docs/concepts/policies.mdx
+++ b/content/vault/v2.x/content/docs/concepts/policies.mdx
@@ -5,8 +5,8 @@ description: >-
   Policies are how authorization is done in Vault, allowing you to restrict
   which parts of Vault a user can access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2026-04-15T00:14:53.000Z
-last_modified: 2026-04-15T00:14:53.000Z
+created_at: 2026-04-14T17:13:42-07:00
+last_modified: 2026-04-23T04:57:46.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -275,6 +275,12 @@ credentials, the policy would grant `read` access on the appropriate path.
 The policy syntax allows for doing variable replacement in some policy strings
 with values available to the token. Currently `identity` information can be
 injected, and currently the `path` keys in policies allow injection.
+
+<Note>
+
+Wildcards (`+`) and globs (`*`) are not permitted in an identity template's rendered output.
+
+</Note>
 
 ### Parameters
 


### PR DESCRIPTION
Adding a note for this upcoming fix: https://github.com/hashicorp/vault-enterprise/pull/13864