### PR TITLE
Document SCEP requires RSA backed issuers

### DIFF
--- a/content/vault/v1.20.x/content/docs/secrets/pki/scep.mdx
+++ b/content/vault/v1.20.x/content/docs/secrets/pki/scep.mdx
@@ -229,6 +229,7 @@ The following Vault PKI features do not support SCEP integration:
  - Certificate Metadata - SCEP has no means of providing metadata.
  - Certificate Issuance External Policy Service [CIEPS](/vault/docs/secrets/pki/cieps)
  - Managed Keys - SCEP requires encryption/decryption capabilities from the CA key which are not supported at this time.
+ - SCEP is only compatible with RSA key backed issuers
 
 ## Resources
 

--- a/content/vault/v1.21.x/content/docs/secrets/pki/scep.mdx
+++ b/content/vault/v1.21.x/content/docs/secrets/pki/scep.mdx
@@ -229,6 +229,7 @@ The following Vault PKI features do not support SCEP integration:
  - Certificate Metadata - SCEP has no means of providing metadata.
  - Certificate Issuance External Policy Service [CIEPS](/vault/docs/secrets/pki/cieps)
  - Managed Keys - SCEP requires encryption/decryption capabilities from the CA key which are not supported at this time.
+ - SCEP is only compatible with RSA key backed issuers
 
 ## Resources
 

--- a/content/vault/v2.x/content/docs/secrets/pki/scep.mdx
+++ b/content/vault/v2.x/content/docs/secrets/pki/scep.mdx
@@ -229,6 +229,7 @@ The following Vault PKI features do not support SCEP integration:
  - Certificate Metadata - SCEP has no means of providing metadata.
  - Certificate Issuance External Policy Service [CIEPS](/vault/docs/secrets/pki/cieps)
  - Managed Keys - SCEP requires encryption/decryption capabilities from the CA key which are not supported at this time.
+ - SCEP is only compatible with RSA key backed issuers 
 
 ## Resources
 


### PR DESCRIPTION
Add another limitation to the SCEP set of limitations that the protocol is only compatible with RSA backed issuers as most SCEP clients won't be able to encrypt the payload with something other than an RSA key and our implementation only supports decrypting at this time with RSA keys.
