### PR TITLE
Default to inc-builds in PR Previews

### DIFF
--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -171,7 +171,8 @@ jobs:
           echo "PR labels:"
           echo "$labels" | tr ' ' '\n'
 
-          # full-build overrides everything else
+          # 1. full-build label overrides everything else
+          # 2. default to incremental build
           if echo "$labels" | grep -qw "full-build"; then
             echo "INCREMENTAL_BUILD=false" >> $GITHUB_ENV
             echo "Build type: Full (forced by 'full-build' label)" >> $GITHUB_STEP_SUMMARY
@@ -179,8 +180,8 @@ jobs:
             echo "INCREMENTAL_BUILD=true" >> $GITHUB_ENV
             echo "Build type: Incremental" >> $GITHUB_STEP_SUMMARY
           else
-            echo "INCREMENTAL_BUILD=false" >> $GITHUB_ENV
-            echo "Build type: Full" >> $GITHUB_STEP_SUMMARY
+            echo "INCREMENTAL_BUILD=true" >> $GITHUB_ENV
+            echo "Build type: Incremental" >> $GITHUB_STEP_SUMMARY
           fi
 
       - name: Build Project Artifacts


### PR DESCRIPTION
## Description

Set incremental build to be on by default for PR Preview Builds.

**Currently set to be deployed on May 1st.**