### PR TITLE
Fix lifecycle condition syntax in resource.mdx

### DIFF
--- a/content/terraform/v1.14.x/docs/language/block/resource.mdx
+++ b/content/terraform/v1.14.x/docs/language/block/resource.mdx
@@ -287,7 +287,7 @@ resource "<TYPE>" "<LABEL>" {
   lifecycle {
     action_trigger {
       events     = [ <EVENT> ]
-      conditions = < true || false >
+      condition = < true || false >
       actions    = [ action.<TYPE>.<LABEL> ]
     }
   }


### PR DESCRIPTION
Terraform expects 'condition' not 'conditions'. Reported by client

Please go to the `Preview` tab and select the appropriate template:

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
