### PR TITLE
Consul: drop bootstrap and ui_config from client multi-interface example

### DIFF
--- a/content/consul/global/partials/examples/agent/client/multi-interface.mdx
+++ b/content/consul/global/partials/examples/agent/client/multi-interface.mdx
@@ -11,12 +11,8 @@ information](/consul/docs/reference/agent/configuration-file/general#client_addr
 <CodeTabs>
 
 ```hcl
-node_name = "consul-client"
-server    = false
-bootstrap = true
-ui_config {
-  enabled = true
-}
+node_name  = "consul-client"
+server     = false
 datacenter = "dc1"
 data_dir   = "consul/data"
 log_level  = "INFO"
@@ -36,10 +32,6 @@ advertise_addr = "{{ GetInterfaceIP \"en0\" }}"
 {
   "node_name": "consul-client",
   "server": false,
-  "bootstrap": true,
-  "ui_config": {
-    "enabled": true
-  },
   "datacenter": "dc1",
   "data_dir": "consul/data",
   "log_level": "INFO",

--- a/content/consul/v1.20.x/content/docs/agent/index.mdx
+++ b/content/consul/v1.20.x/content/docs/agent/index.mdx
@@ -386,12 +386,8 @@ The `client_addr` configuration specifies IP addresses used for HTTP, HTTPS, DNS
 <CodeTabs>
 
 ```hcl
-node_name = "consul-client"
-server    = false
-bootstrap = true
-ui_config {
-  enabled = true
-}
+node_name  = "consul-client"
+server     = false
 datacenter = "dc1"
 data_dir   = "consul/data"
 log_level  = "INFO"
@@ -411,10 +407,6 @@ advertise_addr = "{{ GetInterfaceIP \"en0\" }}"
 {
   "node_name": "consul-client",
   "server": false,
-  "bootstrap": true,
-  "ui_config": {
-    "enabled": true
-  },
   "datacenter": "dc1",
   "data_dir": "consul/data",
   "log_level": "INFO",


### PR DESCRIPTION
## Summary

The Consul docs page `Agents → Configuration` includes an example titled "Client node with multiple interfaces or IP addresses" whose body sets `server = false` (correct, it's a client) but also sets `bootstrap = true` and `ui_config.enabled = true`.

`bootstrap` is server-only: it tells the single bootstrap server to elect itself leader, so it makes no sense on a client agent. The `ui_config` block is also unrelated to what the example is meant to demonstrate (the multi-interface `bind_addr`/`client_addr` setup) and looks like server-side config on a section that is supposed to be about clients. That mismatch is exactly the confusion reported in [hashicorp/consul#18523](https://github.com/hashicorp/consul/issues/18523).

This PR drops both `bootstrap` and `ui_config` from:

- the canonical `global/partials/examples/agent/client/multi-interface.mdx` partial used by current versions, and
- the inlined copy in `v1.20.x/content/docs/agent/index.mdx` that doesn't go through the partial.

No other inputs are changed; the example still demonstrates the same multi-interface configuration.