### PR TITLE
add iso 27001 entry to prewritten library

### DIFF
--- a/content/terraform-enterprise/2.0.x/docs/enterprise/workspaces/policy-enforcement/prewritten-library.mdx
+++ b/content/terraform-enterprise/2.0.x/docs/enterprise/workspaces/policy-enforcement/prewritten-library.mdx
@@ -38,6 +38,14 @@ The Foundational Security Best Practices (FSBP) standard enforces security best 
 
 Refer to the [AWS FSBP policy set repository](https://github.com/hashicorp/policy-library-FSBP-Policy-Set-for-AWS-Terraform/) for details about these policies.
 
+### ISO/IEC 27001:2013 Annex A
+
+[International Electrotechnical Commission (IEC)](https://iec.ch/homepage) and [International Organization for Standardization (ISO)](https://www.iso.org/home.html) are independent, non-governmental, not-for-profit organizations that develop and publish international software standards.
+
+The ISO/IEC 27001:2013 standard defines guidelines on how to establish, implement, maintain, and continually improve an information security management system. Annex A describes a set of information security controls, including cloud services governance, for mitigating risks identified in an information security management system. Refer to the [AWS ISO/IEC 27001:2013 Annex A user guide](https://docs.aws.amazon.com/audit-manager/latest/userguide/iso-27001-2013.html) for more information about the standard.
+
+Refer to the [27001:2013 Annex A policy set repository](https://github.com/hashicorp/policy-library-iso-iec-27001-2013-annex-a-policy-set-for-aws-terraform) for details about the policies HashiCorp publishes and maintains to support ISO/IEC 27001:2013 Annex A.
+
 ### PCI DSS
 
 The Payment Card Industry Data Security Standard (PCI DSS) is set of rules for protecting payment data throughout the data's lifecycle. Compliance with PCI DSS is mandatory for organizations that handle credit card information. Refer to the [PCI DSS website](https://www.pcisecuritystandards.org/standards/) for more information about the standard.


### PR DESCRIPTION
This PR adds an entry in the Terraform Enterprise docs about the prewritten ISO 27001 policies. We added the policies t HCP Terraform, but the changes didn't make it into TFE 2.0