### PR TITLE
Terraform: Document full AWS credential chain for S3 module sources

### DIFF
--- a/content/terraform/v1.1.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.1.x/docs/language/modules/sources.mdx
@@ -400,20 +400,24 @@ extensions as for [archives over standard HTTP](#fetching-archives-over-http).
 Terraform will extract the archive to obtain the module source tree.
 
 Terraform uses the [default AWS credential provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html#credentialProviderChain)
-from the AWS SDK to locate credentials. This includes, in order of precedence:
-environment variables (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, or
-`AWS_PROFILE` to select a named profile), the shared credentials file at
-`~/.aws/credentials`, the shared config file at `~/.aws/config` (including SSO
-and assume-role configuration), and container or EC2 instance profile
-credentials (IMDS) when running on AWS compute.
+from the AWS SDK to locate credentials. In order of precedence, this includes:
+
+1. Either `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, or `AWS_PROFILE`
+   environment variables. The `AWS_PROFILE` environment variable selects a
+   named profile.
+1. Shared credentials file at `~/.aws/credentials`.
+1. Shared configuration file at `~/.aws/config`, including SSO and assume-role
+   configuration.
+1. Container or EC2 instance profile credentials (IMDS) when running on AWS
+   compute.
 
 You can also supply credentials directly on the source URL using query
 parameters:
 
-- `aws_profile` — use a named profile from the shared config, for example
-  `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
-- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token` — pass
-  static credentials inline. Avoid committing these to version control.
+- `aws_profile`: Specifies a named profile from the shared configuration, for
+  example `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
+- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token`: Pass
+  static credentials inline. Do not commit these to version control.
 
 ## GCS Bucket
 

--- a/content/terraform/v1.1.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.1.x/docs/language/modules/sources.mdx
@@ -399,13 +399,21 @@ The resulting object must be an archive with one of the same file
 extensions as for [archives over standard HTTP](#fetching-archives-over-http).
 Terraform will extract the archive to obtain the module source tree.
 
-The module installer looks for AWS credentials in the following locations,
-preferring those earlier in the list when multiple are available:
+Terraform uses the [default AWS credential provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html#credentialProviderChain)
+from the AWS SDK to locate credentials. This includes, in order of precedence:
+environment variables (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, or
+`AWS_PROFILE` to select a named profile), the shared credentials file at
+`~/.aws/credentials`, the shared config file at `~/.aws/config` (including SSO
+and assume-role configuration), and container or EC2 instance profile
+credentials (IMDS) when running on AWS compute.
 
-- The `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
-- The default profile in the `.aws/credentials` file in your home directory.
-- If running on an EC2 instance, temporary credentials associated with the
-  instance's IAM Instance Profile.
+You can also supply credentials directly on the source URL using query
+parameters:
+
+- `aws_profile` — use a named profile from the shared config, for example
+  `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
+- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token` — pass
+  static credentials inline. Avoid committing these to version control.
 
 ## GCS Bucket
 

--- a/content/terraform/v1.10.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.10.x/docs/language/modules/sources.mdx
@@ -426,13 +426,21 @@ The resulting object must be an archive with one of the same file
 extensions as for [archives over standard HTTP](#fetching-archives-over-http).
 Terraform will extract the archive to obtain the module source tree.
 
-The module installer looks for AWS credentials in the following locations,
-preferring those earlier in the list when multiple are available:
+Terraform uses the [default AWS credential provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html#credentialProviderChain)
+from the AWS SDK to locate credentials. This includes, in order of precedence:
+environment variables (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, or
+`AWS_PROFILE` to select a named profile), the shared credentials file at
+`~/.aws/credentials`, the shared config file at `~/.aws/config` (including SSO
+and assume-role configuration), and container or EC2 instance profile
+credentials (IMDS) when running on AWS compute.
 
-- The `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
-- The default profile in the `.aws/credentials` file in your home directory.
-- If running on an EC2 instance, temporary credentials associated with the
-  instance's IAM Instance Profile.
+You can also supply credentials directly on the source URL using query
+parameters:
+
+- `aws_profile` — use a named profile from the shared config, for example
+  `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
+- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token` — pass
+  static credentials inline. Avoid committing these to version control.
 
 ## GCS Bucket
 

--- a/content/terraform/v1.10.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.10.x/docs/language/modules/sources.mdx
@@ -427,20 +427,24 @@ extensions as for [archives over standard HTTP](#fetching-archives-over-http).
 Terraform will extract the archive to obtain the module source tree.
 
 Terraform uses the [default AWS credential provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html#credentialProviderChain)
-from the AWS SDK to locate credentials. This includes, in order of precedence:
-environment variables (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, or
-`AWS_PROFILE` to select a named profile), the shared credentials file at
-`~/.aws/credentials`, the shared config file at `~/.aws/config` (including SSO
-and assume-role configuration), and container or EC2 instance profile
-credentials (IMDS) when running on AWS compute.
+from the AWS SDK to locate credentials. In order of precedence, this includes:
+
+1. Either `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, or `AWS_PROFILE`
+   environment variables. The `AWS_PROFILE` environment variable selects a
+   named profile.
+1. Shared credentials file at `~/.aws/credentials`.
+1. Shared configuration file at `~/.aws/config`, including SSO and assume-role
+   configuration.
+1. Container or EC2 instance profile credentials (IMDS) when running on AWS
+   compute.
 
 You can also supply credentials directly on the source URL using query
 parameters:
 
-- `aws_profile` — use a named profile from the shared config, for example
-  `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
-- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token` — pass
-  static credentials inline. Avoid committing these to version control.
+- `aws_profile`: Specifies a named profile from the shared configuration, for
+  example `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
+- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token`: Pass
+  static credentials inline. Do not commit these to version control.
 
 ## GCS Bucket
 

--- a/content/terraform/v1.11.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.11.x/docs/language/modules/sources.mdx
@@ -426,13 +426,21 @@ The resulting object must be an archive with one of the same file
 extensions as for [archives over standard HTTP](#fetching-archives-over-http).
 Terraform will extract the archive to obtain the module source tree.
 
-The module installer looks for AWS credentials in the following locations,
-preferring those earlier in the list when multiple are available:
+Terraform uses the [default AWS credential provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html#credentialProviderChain)
+from the AWS SDK to locate credentials. This includes, in order of precedence:
+environment variables (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, or
+`AWS_PROFILE` to select a named profile), the shared credentials file at
+`~/.aws/credentials`, the shared config file at `~/.aws/config` (including SSO
+and assume-role configuration), and container or EC2 instance profile
+credentials (IMDS) when running on AWS compute.
 
-- The `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
-- The default profile in the `.aws/credentials` file in your home directory.
-- If running on an EC2 instance, temporary credentials associated with the
-  instance's IAM Instance Profile.
+You can also supply credentials directly on the source URL using query
+parameters:
+
+- `aws_profile` — use a named profile from the shared config, for example
+  `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
+- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token` — pass
+  static credentials inline. Avoid committing these to version control.
 
 ## GCS Bucket
 

--- a/content/terraform/v1.11.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.11.x/docs/language/modules/sources.mdx
@@ -427,20 +427,24 @@ extensions as for [archives over standard HTTP](#fetching-archives-over-http).
 Terraform will extract the archive to obtain the module source tree.
 
 Terraform uses the [default AWS credential provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html#credentialProviderChain)
-from the AWS SDK to locate credentials. This includes, in order of precedence:
-environment variables (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, or
-`AWS_PROFILE` to select a named profile), the shared credentials file at
-`~/.aws/credentials`, the shared config file at `~/.aws/config` (including SSO
-and assume-role configuration), and container or EC2 instance profile
-credentials (IMDS) when running on AWS compute.
+from the AWS SDK to locate credentials. In order of precedence, this includes:
+
+1. Either `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, or `AWS_PROFILE`
+   environment variables. The `AWS_PROFILE` environment variable selects a
+   named profile.
+1. Shared credentials file at `~/.aws/credentials`.
+1. Shared configuration file at `~/.aws/config`, including SSO and assume-role
+   configuration.
+1. Container or EC2 instance profile credentials (IMDS) when running on AWS
+   compute.
 
 You can also supply credentials directly on the source URL using query
 parameters:
 
-- `aws_profile` — use a named profile from the shared config, for example
-  `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
-- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token` — pass
-  static credentials inline. Avoid committing these to version control.
+- `aws_profile`: Specifies a named profile from the shared configuration, for
+  example `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
+- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token`: Pass
+  static credentials inline. Do not commit these to version control.
 
 ## GCS Bucket
 

--- a/content/terraform/v1.12.x/docs/language/block/module.mdx
+++ b/content/terraform/v1.12.x/docs/language/block/module.mdx
@@ -332,11 +332,17 @@ Terraform extracts the archive to obtain the module source tree.
 
 Buckets in AWS's us-east-1 region must use the hostname `s3.amazonaws.com`, instead of `s3-us-east-1.amazonaws.com`.
 
-The module installer checks for AWS credentials in the following locations in order of precedence:
+The module installer uses the [default AWS credential provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html#credentialProviderChain) from the AWS SDK to locate credentials. In order of precedence, this includes:
 
-1. The `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
-1. The default profile in the `.aws/credentials` file in your home directory.
-1. If running on an EC2 instance, temporary credentials associated with the instance's IAM instance profile.
+1. Either `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, or `AWS_PROFILE` environment variables. The `AWS_PROFILE` environment variable selects a named profile.
+1. Shared credentials file at `~/.aws/credentials`.
+1. Shared configuration file at `~/.aws/config`, including SSO and assume-role configuration.
+1. Container or EC2 instance profile credentials (IMDS) when running on AWS compute.
+
+You can also supply credentials directly on the source URL using query parameters:
+
+- `aws_profile`: Specifies a named profile from the shared configuration, for example `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
+- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token`: Pass static credentials inline. Do not commit these to version control.
 
 Other AWS services may handle authentication in a manner similar to the S3 API. As a result, you may be able to use the `s3::` format for other services.
 

--- a/content/terraform/v1.12.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.12.x/docs/language/modules/sources.mdx
@@ -426,13 +426,21 @@ The resulting object must be an archive with one of the same file
 extensions as for [archives over standard HTTP](#fetching-archives-over-http).
 Terraform will extract the archive to obtain the module source tree.
 
-The module installer looks for AWS credentials in the following locations,
-preferring those earlier in the list when multiple are available:
+Terraform uses the [default AWS credential provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html#credentialProviderChain)
+from the AWS SDK to locate credentials. This includes, in order of precedence:
+environment variables (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, or
+`AWS_PROFILE` to select a named profile), the shared credentials file at
+`~/.aws/credentials`, the shared config file at `~/.aws/config` (including SSO
+and assume-role configuration), and container or EC2 instance profile
+credentials (IMDS) when running on AWS compute.
 
-- The `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
-- The default profile in the `.aws/credentials` file in your home directory.
-- If running on an EC2 instance, temporary credentials associated with the
-  instance's IAM Instance Profile.
+You can also supply credentials directly on the source URL using query
+parameters:
+
+- `aws_profile` — use a named profile from the shared config, for example
+  `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
+- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token` — pass
+  static credentials inline. Avoid committing these to version control.
 
 ## GCS Bucket
 

--- a/content/terraform/v1.12.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.12.x/docs/language/modules/sources.mdx
@@ -427,20 +427,24 @@ extensions as for [archives over standard HTTP](#fetching-archives-over-http).
 Terraform will extract the archive to obtain the module source tree.
 
 Terraform uses the [default AWS credential provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html#credentialProviderChain)
-from the AWS SDK to locate credentials. This includes, in order of precedence:
-environment variables (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, or
-`AWS_PROFILE` to select a named profile), the shared credentials file at
-`~/.aws/credentials`, the shared config file at `~/.aws/config` (including SSO
-and assume-role configuration), and container or EC2 instance profile
-credentials (IMDS) when running on AWS compute.
+from the AWS SDK to locate credentials. In order of precedence, this includes:
+
+1. Either `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, or `AWS_PROFILE`
+   environment variables. The `AWS_PROFILE` environment variable selects a
+   named profile.
+1. Shared credentials file at `~/.aws/credentials`.
+1. Shared configuration file at `~/.aws/config`, including SSO and assume-role
+   configuration.
+1. Container or EC2 instance profile credentials (IMDS) when running on AWS
+   compute.
 
 You can also supply credentials directly on the source URL using query
 parameters:
 
-- `aws_profile` — use a named profile from the shared config, for example
-  `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
-- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token` — pass
-  static credentials inline. Avoid committing these to version control.
+- `aws_profile`: Specifies a named profile from the shared configuration, for
+  example `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
+- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token`: Pass
+  static credentials inline. Do not commit these to version control.
 
 ## GCS Bucket
 

--- a/content/terraform/v1.13.x/docs/language/block/module.mdx
+++ b/content/terraform/v1.13.x/docs/language/block/module.mdx
@@ -332,11 +332,17 @@ Terraform extracts the archive to obtain the module source tree.
 
 Buckets in AWS's us-east-1 region must use the hostname `s3.amazonaws.com`, instead of `s3-us-east-1.amazonaws.com`.
 
-The module installer checks for AWS credentials in the following locations in order of precedence:
+The module installer uses the [default AWS credential provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html#credentialProviderChain) from the AWS SDK to locate credentials. In order of precedence, this includes:
 
-1. The `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
-1. The default profile in the `.aws/credentials` file in your home directory.
-1. If running on an EC2 instance, temporary credentials associated with the instance's IAM instance profile.
+1. Either `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, or `AWS_PROFILE` environment variables. The `AWS_PROFILE` environment variable selects a named profile.
+1. Shared credentials file at `~/.aws/credentials`.
+1. Shared configuration file at `~/.aws/config`, including SSO and assume-role configuration.
+1. Container or EC2 instance profile credentials (IMDS) when running on AWS compute.
+
+You can also supply credentials directly on the source URL using query parameters:
+
+- `aws_profile`: Specifies a named profile from the shared configuration, for example `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
+- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token`: Pass static credentials inline. Do not commit these to version control.
 
 Other AWS services may handle authentication in a manner similar to the S3 API. As a result, you may be able to use the `s3::` format for other services.
 

--- a/content/terraform/v1.13.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.13.x/docs/language/modules/sources.mdx
@@ -426,13 +426,21 @@ The resulting object must be an archive with one of the same file
 extensions as for [archives over standard HTTP](#fetching-archives-over-http).
 Terraform will extract the archive to obtain the module source tree.
 
-The module installer looks for AWS credentials in the following locations,
-preferring those earlier in the list when multiple are available:
+Terraform uses the [default AWS credential provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html#credentialProviderChain)
+from the AWS SDK to locate credentials. This includes, in order of precedence:
+environment variables (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, or
+`AWS_PROFILE` to select a named profile), the shared credentials file at
+`~/.aws/credentials`, the shared config file at `~/.aws/config` (including SSO
+and assume-role configuration), and container or EC2 instance profile
+credentials (IMDS) when running on AWS compute.
 
-- The `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
-- The default profile in the `.aws/credentials` file in your home directory.
-- If running on an EC2 instance, temporary credentials associated with the
-  instance's IAM Instance Profile.
+You can also supply credentials directly on the source URL using query
+parameters:
+
+- `aws_profile` — use a named profile from the shared config, for example
+  `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
+- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token` — pass
+  static credentials inline. Avoid committing these to version control.
 
 ## GCS Bucket
 

--- a/content/terraform/v1.13.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.13.x/docs/language/modules/sources.mdx
@@ -427,20 +427,24 @@ extensions as for [archives over standard HTTP](#fetching-archives-over-http).
 Terraform will extract the archive to obtain the module source tree.
 
 Terraform uses the [default AWS credential provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html#credentialProviderChain)
-from the AWS SDK to locate credentials. This includes, in order of precedence:
-environment variables (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, or
-`AWS_PROFILE` to select a named profile), the shared credentials file at
-`~/.aws/credentials`, the shared config file at `~/.aws/config` (including SSO
-and assume-role configuration), and container or EC2 instance profile
-credentials (IMDS) when running on AWS compute.
+from the AWS SDK to locate credentials. In order of precedence, this includes:
+
+1. Either `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, or `AWS_PROFILE`
+   environment variables. The `AWS_PROFILE` environment variable selects a
+   named profile.
+1. Shared credentials file at `~/.aws/credentials`.
+1. Shared configuration file at `~/.aws/config`, including SSO and assume-role
+   configuration.
+1. Container or EC2 instance profile credentials (IMDS) when running on AWS
+   compute.
 
 You can also supply credentials directly on the source URL using query
 parameters:
 
-- `aws_profile` — use a named profile from the shared config, for example
-  `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
-- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token` — pass
-  static credentials inline. Avoid committing these to version control.
+- `aws_profile`: Specifies a named profile from the shared configuration, for
+  example `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
+- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token`: Pass
+  static credentials inline. Do not commit these to version control.
 
 ## GCS Bucket
 

--- a/content/terraform/v1.14.x/docs/language/block/module.mdx
+++ b/content/terraform/v1.14.x/docs/language/block/module.mdx
@@ -328,11 +328,17 @@ Terraform extracts the archive to obtain the module source tree.
 
 Buckets in AWS's us-east-1 region must use the hostname `s3.amazonaws.com`, instead of `s3-us-east-1.amazonaws.com`.
 
-The module installer checks for AWS credentials in the following locations in order of precedence:
+The module installer uses the [default AWS credential provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html#credentialProviderChain) from the AWS SDK to locate credentials. In order of precedence, this includes:
 
-1. The `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
-1. The default profile in the `.aws/credentials` file in your home directory.
-1. If running on an EC2 instance, temporary credentials associated with the instance's IAM instance profile.
+1. Either `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, or `AWS_PROFILE` environment variables. The `AWS_PROFILE` environment variable selects a named profile.
+1. Shared credentials file at `~/.aws/credentials`.
+1. Shared configuration file at `~/.aws/config`, including SSO and assume-role configuration.
+1. Container or EC2 instance profile credentials (IMDS) when running on AWS compute.
+
+You can also supply credentials directly on the source URL using query parameters:
+
+- `aws_profile`: Specifies a named profile from the shared configuration, for example `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
+- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token`: Pass static credentials inline. Do not commit these to version control.
 
 Other AWS services may handle authentication in a manner similar to the S3 API. As a result, you may be able to use the `s3::` format for other services.
 

--- a/content/terraform/v1.14.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.14.x/docs/language/modules/sources.mdx
@@ -426,13 +426,21 @@ The resulting object must be an archive with one of the same file
 extensions as for [archives over standard HTTP](#fetching-archives-over-http).
 Terraform will extract the archive to obtain the module source tree.
 
-The module installer looks for AWS credentials in the following locations,
-preferring those earlier in the list when multiple are available:
+Terraform uses the [default AWS credential provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html#credentialProviderChain)
+from the AWS SDK to locate credentials. This includes, in order of precedence:
+environment variables (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, or
+`AWS_PROFILE` to select a named profile), the shared credentials file at
+`~/.aws/credentials`, the shared config file at `~/.aws/config` (including SSO
+and assume-role configuration), and container or EC2 instance profile
+credentials (IMDS) when running on AWS compute.
 
-- The `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
-- The default profile in the `.aws/credentials` file in your home directory.
-- If running on an EC2 instance, temporary credentials associated with the
-  instance's IAM Instance Profile.
+You can also supply credentials directly on the source URL using query
+parameters:
+
+- `aws_profile` — use a named profile from the shared config, for example
+  `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
+- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token` — pass
+  static credentials inline. Avoid committing these to version control.
 
 ## GCS Bucket
 

--- a/content/terraform/v1.14.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.14.x/docs/language/modules/sources.mdx
@@ -427,20 +427,24 @@ extensions as for [archives over standard HTTP](#fetching-archives-over-http).
 Terraform will extract the archive to obtain the module source tree.
 
 Terraform uses the [default AWS credential provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html#credentialProviderChain)
-from the AWS SDK to locate credentials. This includes, in order of precedence:
-environment variables (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, or
-`AWS_PROFILE` to select a named profile), the shared credentials file at
-`~/.aws/credentials`, the shared config file at `~/.aws/config` (including SSO
-and assume-role configuration), and container or EC2 instance profile
-credentials (IMDS) when running on AWS compute.
+from the AWS SDK to locate credentials. In order of precedence, this includes:
+
+1. Either `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, or `AWS_PROFILE`
+   environment variables. The `AWS_PROFILE` environment variable selects a
+   named profile.
+1. Shared credentials file at `~/.aws/credentials`.
+1. Shared configuration file at `~/.aws/config`, including SSO and assume-role
+   configuration.
+1. Container or EC2 instance profile credentials (IMDS) when running on AWS
+   compute.
 
 You can also supply credentials directly on the source URL using query
 parameters:
 
-- `aws_profile` — use a named profile from the shared config, for example
-  `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
-- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token` — pass
-  static credentials inline. Avoid committing these to version control.
+- `aws_profile`: Specifies a named profile from the shared configuration, for
+  example `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
+- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token`: Pass
+  static credentials inline. Do not commit these to version control.
 
 ## GCS Bucket
 

--- a/content/terraform/v1.15.x/docs/language/block/module.mdx
+++ b/content/terraform/v1.15.x/docs/language/block/module.mdx
@@ -336,11 +336,17 @@ Terraform extracts the archive to obtain the module source tree.
 
 Buckets in AWS's us-east-1 region must use the hostname `s3.amazonaws.com`, instead of `s3-us-east-1.amazonaws.com`.
 
-The module installer checks for AWS credentials in the following locations in order of precedence:
+The module installer uses the [default AWS credential provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html#credentialProviderChain) from the AWS SDK to locate credentials. In order of precedence, this includes:
 
-1. The `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
-1. The default profile in the `.aws/credentials` file in your home directory.
-1. If running on an EC2 instance, temporary credentials associated with the instance's IAM instance profile.
+1. Either `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, or `AWS_PROFILE` environment variables. The `AWS_PROFILE` environment variable selects a named profile.
+1. Shared credentials file at `~/.aws/credentials`.
+1. Shared configuration file at `~/.aws/config`, including SSO and assume-role configuration.
+1. Container or EC2 instance profile credentials (IMDS) when running on AWS compute.
+
+You can also supply credentials directly on the source URL using query parameters:
+
+- `aws_profile`: Specifies a named profile from the shared configuration, for example `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
+- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token`: Pass static credentials inline. Do not commit these to version control.
 
 Other AWS services may handle authentication in a manner similar to the S3 API. As a result, you may be able to use the `s3::` format for other services.
 

--- a/content/terraform/v1.15.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.15.x/docs/language/modules/sources.mdx
@@ -426,13 +426,21 @@ The resulting object must be an archive with one of the same file
 extensions as for [archives over standard HTTP](#fetching-archives-over-http).
 Terraform will extract the archive to obtain the module source tree.
 
-The module installer looks for AWS credentials in the following locations,
-preferring those earlier in the list when multiple are available:
+Terraform uses the [default AWS credential provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html#credentialProviderChain)
+from the AWS SDK to locate credentials. This includes, in order of precedence:
+environment variables (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, or
+`AWS_PROFILE` to select a named profile), the shared credentials file at
+`~/.aws/credentials`, the shared config file at `~/.aws/config` (including SSO
+and assume-role configuration), and container or EC2 instance profile
+credentials (IMDS) when running on AWS compute.
 
-- The `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
-- The default profile in the `.aws/credentials` file in your home directory.
-- If running on an EC2 instance, temporary credentials associated with the
-  instance's IAM Instance Profile.
+You can also supply credentials directly on the source URL using query
+parameters:
+
+- `aws_profile` — use a named profile from the shared config, for example
+  `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
+- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token` — pass
+  static credentials inline. Avoid committing these to version control.
 
 ## GCS Bucket
 

--- a/content/terraform/v1.15.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.15.x/docs/language/modules/sources.mdx
@@ -427,20 +427,24 @@ extensions as for [archives over standard HTTP](#fetching-archives-over-http).
 Terraform will extract the archive to obtain the module source tree.
 
 Terraform uses the [default AWS credential provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html#credentialProviderChain)
-from the AWS SDK to locate credentials. This includes, in order of precedence:
-environment variables (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, or
-`AWS_PROFILE` to select a named profile), the shared credentials file at
-`~/.aws/credentials`, the shared config file at `~/.aws/config` (including SSO
-and assume-role configuration), and container or EC2 instance profile
-credentials (IMDS) when running on AWS compute.
+from the AWS SDK to locate credentials. In order of precedence, this includes:
+
+1. Either `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, or `AWS_PROFILE`
+   environment variables. The `AWS_PROFILE` environment variable selects a
+   named profile.
+1. Shared credentials file at `~/.aws/credentials`.
+1. Shared configuration file at `~/.aws/config`, including SSO and assume-role
+   configuration.
+1. Container or EC2 instance profile credentials (IMDS) when running on AWS
+   compute.
 
 You can also supply credentials directly on the source URL using query
 parameters:
 
-- `aws_profile` — use a named profile from the shared config, for example
-  `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
-- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token` — pass
-  static credentials inline. Avoid committing these to version control.
+- `aws_profile`: Specifies a named profile from the shared configuration, for
+  example `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
+- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token`: Pass
+  static credentials inline. Do not commit these to version control.
 
 ## GCS Bucket
 

--- a/content/terraform/v1.2.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.2.x/docs/language/modules/sources.mdx
@@ -420,13 +420,21 @@ The resulting object must be an archive with one of the same file
 extensions as for [archives over standard HTTP](#fetching-archives-over-http).
 Terraform will extract the archive to obtain the module source tree.
 
-The module installer looks for AWS credentials in the following locations,
-preferring those earlier in the list when multiple are available:
+Terraform uses the [default AWS credential provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html#credentialProviderChain)
+from the AWS SDK to locate credentials. This includes, in order of precedence:
+environment variables (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, or
+`AWS_PROFILE` to select a named profile), the shared credentials file at
+`~/.aws/credentials`, the shared config file at `~/.aws/config` (including SSO
+and assume-role configuration), and container or EC2 instance profile
+credentials (IMDS) when running on AWS compute.
 
-- The `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
-- The default profile in the `.aws/credentials` file in your home directory.
-- If running on an EC2 instance, temporary credentials associated with the
-  instance's IAM Instance Profile.
+You can also supply credentials directly on the source URL using query
+parameters:
+
+- `aws_profile` — use a named profile from the shared config, for example
+  `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
+- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token` — pass
+  static credentials inline. Avoid committing these to version control.
 
 ## GCS Bucket
 

--- a/content/terraform/v1.2.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.2.x/docs/language/modules/sources.mdx
@@ -421,20 +421,24 @@ extensions as for [archives over standard HTTP](#fetching-archives-over-http).
 Terraform will extract the archive to obtain the module source tree.
 
 Terraform uses the [default AWS credential provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html#credentialProviderChain)
-from the AWS SDK to locate credentials. This includes, in order of precedence:
-environment variables (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, or
-`AWS_PROFILE` to select a named profile), the shared credentials file at
-`~/.aws/credentials`, the shared config file at `~/.aws/config` (including SSO
-and assume-role configuration), and container or EC2 instance profile
-credentials (IMDS) when running on AWS compute.
+from the AWS SDK to locate credentials. In order of precedence, this includes:
+
+1. Either `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, or `AWS_PROFILE`
+   environment variables. The `AWS_PROFILE` environment variable selects a
+   named profile.
+1. Shared credentials file at `~/.aws/credentials`.
+1. Shared configuration file at `~/.aws/config`, including SSO and assume-role
+   configuration.
+1. Container or EC2 instance profile credentials (IMDS) when running on AWS
+   compute.
 
 You can also supply credentials directly on the source URL using query
 parameters:
 
-- `aws_profile` — use a named profile from the shared config, for example
-  `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
-- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token` — pass
-  static credentials inline. Avoid committing these to version control.
+- `aws_profile`: Specifies a named profile from the shared configuration, for
+  example `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
+- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token`: Pass
+  static credentials inline. Do not commit these to version control.
 
 ## GCS Bucket
 

--- a/content/terraform/v1.3.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.3.x/docs/language/modules/sources.mdx
@@ -420,13 +420,21 @@ The resulting object must be an archive with one of the same file
 extensions as for [archives over standard HTTP](#fetching-archives-over-http).
 Terraform will extract the archive to obtain the module source tree.
 
-The module installer looks for AWS credentials in the following locations,
-preferring those earlier in the list when multiple are available:
+Terraform uses the [default AWS credential provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html#credentialProviderChain)
+from the AWS SDK to locate credentials. This includes, in order of precedence:
+environment variables (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, or
+`AWS_PROFILE` to select a named profile), the shared credentials file at
+`~/.aws/credentials`, the shared config file at `~/.aws/config` (including SSO
+and assume-role configuration), and container or EC2 instance profile
+credentials (IMDS) when running on AWS compute.
 
-- The `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
-- The default profile in the `.aws/credentials` file in your home directory.
-- If running on an EC2 instance, temporary credentials associated with the
-  instance's IAM Instance Profile.
+You can also supply credentials directly on the source URL using query
+parameters:
+
+- `aws_profile` — use a named profile from the shared config, for example
+  `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
+- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token` — pass
+  static credentials inline. Avoid committing these to version control.
 
 ## GCS Bucket
 

--- a/content/terraform/v1.3.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.3.x/docs/language/modules/sources.mdx
@@ -421,20 +421,24 @@ extensions as for [archives over standard HTTP](#fetching-archives-over-http).
 Terraform will extract the archive to obtain the module source tree.
 
 Terraform uses the [default AWS credential provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html#credentialProviderChain)
-from the AWS SDK to locate credentials. This includes, in order of precedence:
-environment variables (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, or
-`AWS_PROFILE` to select a named profile), the shared credentials file at
-`~/.aws/credentials`, the shared config file at `~/.aws/config` (including SSO
-and assume-role configuration), and container or EC2 instance profile
-credentials (IMDS) when running on AWS compute.
+from the AWS SDK to locate credentials. In order of precedence, this includes:
+
+1. Either `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, or `AWS_PROFILE`
+   environment variables. The `AWS_PROFILE` environment variable selects a
+   named profile.
+1. Shared credentials file at `~/.aws/credentials`.
+1. Shared configuration file at `~/.aws/config`, including SSO and assume-role
+   configuration.
+1. Container or EC2 instance profile credentials (IMDS) when running on AWS
+   compute.
 
 You can also supply credentials directly on the source URL using query
 parameters:
 
-- `aws_profile` — use a named profile from the shared config, for example
-  `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
-- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token` — pass
-  static credentials inline. Avoid committing these to version control.
+- `aws_profile`: Specifies a named profile from the shared configuration, for
+  example `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
+- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token`: Pass
+  static credentials inline. Do not commit these to version control.
 
 ## GCS Bucket
 

--- a/content/terraform/v1.4.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.4.x/docs/language/modules/sources.mdx
@@ -421,13 +421,21 @@ The resulting object must be an archive with one of the same file
 extensions as for [archives over standard HTTP](#fetching-archives-over-http).
 Terraform will extract the archive to obtain the module source tree.
 
-The module installer looks for AWS credentials in the following locations,
-preferring those earlier in the list when multiple are available:
+Terraform uses the [default AWS credential provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html#credentialProviderChain)
+from the AWS SDK to locate credentials. This includes, in order of precedence:
+environment variables (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, or
+`AWS_PROFILE` to select a named profile), the shared credentials file at
+`~/.aws/credentials`, the shared config file at `~/.aws/config` (including SSO
+and assume-role configuration), and container or EC2 instance profile
+credentials (IMDS) when running on AWS compute.
 
-- The `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
-- The default profile in the `.aws/credentials` file in your home directory.
-- If running on an EC2 instance, temporary credentials associated with the
-  instance's IAM Instance Profile.
+You can also supply credentials directly on the source URL using query
+parameters:
+
+- `aws_profile` — use a named profile from the shared config, for example
+  `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
+- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token` — pass
+  static credentials inline. Avoid committing these to version control.
 
 ## GCS Bucket
 

--- a/content/terraform/v1.4.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.4.x/docs/language/modules/sources.mdx
@@ -422,20 +422,24 @@ extensions as for [archives over standard HTTP](#fetching-archives-over-http).
 Terraform will extract the archive to obtain the module source tree.
 
 Terraform uses the [default AWS credential provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html#credentialProviderChain)
-from the AWS SDK to locate credentials. This includes, in order of precedence:
-environment variables (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, or
-`AWS_PROFILE` to select a named profile), the shared credentials file at
-`~/.aws/credentials`, the shared config file at `~/.aws/config` (including SSO
-and assume-role configuration), and container or EC2 instance profile
-credentials (IMDS) when running on AWS compute.
+from the AWS SDK to locate credentials. In order of precedence, this includes:
+
+1. Either `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, or `AWS_PROFILE`
+   environment variables. The `AWS_PROFILE` environment variable selects a
+   named profile.
+1. Shared credentials file at `~/.aws/credentials`.
+1. Shared configuration file at `~/.aws/config`, including SSO and assume-role
+   configuration.
+1. Container or EC2 instance profile credentials (IMDS) when running on AWS
+   compute.
 
 You can also supply credentials directly on the source URL using query
 parameters:
 
-- `aws_profile` — use a named profile from the shared config, for example
-  `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
-- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token` — pass
-  static credentials inline. Avoid committing these to version control.
+- `aws_profile`: Specifies a named profile from the shared configuration, for
+  example `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
+- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token`: Pass
+  static credentials inline. Do not commit these to version control.
 
 ## GCS Bucket
 

--- a/content/terraform/v1.5.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.5.x/docs/language/modules/sources.mdx
@@ -421,13 +421,21 @@ The resulting object must be an archive with one of the same file
 extensions as for [archives over standard HTTP](#fetching-archives-over-http).
 Terraform will extract the archive to obtain the module source tree.
 
-The module installer looks for AWS credentials in the following locations,
-preferring those earlier in the list when multiple are available:
+Terraform uses the [default AWS credential provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html#credentialProviderChain)
+from the AWS SDK to locate credentials. This includes, in order of precedence:
+environment variables (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, or
+`AWS_PROFILE` to select a named profile), the shared credentials file at
+`~/.aws/credentials`, the shared config file at `~/.aws/config` (including SSO
+and assume-role configuration), and container or EC2 instance profile
+credentials (IMDS) when running on AWS compute.
 
-- The `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
-- The default profile in the `.aws/credentials` file in your home directory.
-- If running on an EC2 instance, temporary credentials associated with the
-  instance's IAM Instance Profile.
+You can also supply credentials directly on the source URL using query
+parameters:
+
+- `aws_profile` — use a named profile from the shared config, for example
+  `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
+- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token` — pass
+  static credentials inline. Avoid committing these to version control.
 
 ## GCS Bucket
 

--- a/content/terraform/v1.5.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.5.x/docs/language/modules/sources.mdx
@@ -422,20 +422,24 @@ extensions as for [archives over standard HTTP](#fetching-archives-over-http).
 Terraform will extract the archive to obtain the module source tree.
 
 Terraform uses the [default AWS credential provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html#credentialProviderChain)
-from the AWS SDK to locate credentials. This includes, in order of precedence:
-environment variables (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, or
-`AWS_PROFILE` to select a named profile), the shared credentials file at
-`~/.aws/credentials`, the shared config file at `~/.aws/config` (including SSO
-and assume-role configuration), and container or EC2 instance profile
-credentials (IMDS) when running on AWS compute.
+from the AWS SDK to locate credentials. In order of precedence, this includes:
+
+1. Either `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, or `AWS_PROFILE`
+   environment variables. The `AWS_PROFILE` environment variable selects a
+   named profile.
+1. Shared credentials file at `~/.aws/credentials`.
+1. Shared configuration file at `~/.aws/config`, including SSO and assume-role
+   configuration.
+1. Container or EC2 instance profile credentials (IMDS) when running on AWS
+   compute.
 
 You can also supply credentials directly on the source URL using query
 parameters:
 
-- `aws_profile` — use a named profile from the shared config, for example
-  `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
-- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token` — pass
-  static credentials inline. Avoid committing these to version control.
+- `aws_profile`: Specifies a named profile from the shared configuration, for
+  example `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
+- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token`: Pass
+  static credentials inline. Do not commit these to version control.
 
 ## GCS Bucket
 

--- a/content/terraform/v1.6.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.6.x/docs/language/modules/sources.mdx
@@ -423,13 +423,21 @@ The resulting object must be an archive with one of the same file
 extensions as for [archives over standard HTTP](#fetching-archives-over-http).
 Terraform will extract the archive to obtain the module source tree.
 
-The module installer looks for AWS credentials in the following locations,
-preferring those earlier in the list when multiple are available:
+Terraform uses the [default AWS credential provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html#credentialProviderChain)
+from the AWS SDK to locate credentials. This includes, in order of precedence:
+environment variables (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, or
+`AWS_PROFILE` to select a named profile), the shared credentials file at
+`~/.aws/credentials`, the shared config file at `~/.aws/config` (including SSO
+and assume-role configuration), and container or EC2 instance profile
+credentials (IMDS) when running on AWS compute.
 
-- The `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
-- The default profile in the `.aws/credentials` file in your home directory.
-- If running on an EC2 instance, temporary credentials associated with the
-  instance's IAM Instance Profile.
+You can also supply credentials directly on the source URL using query
+parameters:
+
+- `aws_profile` — use a named profile from the shared config, for example
+  `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
+- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token` — pass
+  static credentials inline. Avoid committing these to version control.
 
 ## GCS Bucket
 

--- a/content/terraform/v1.6.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.6.x/docs/language/modules/sources.mdx
@@ -424,20 +424,24 @@ extensions as for [archives over standard HTTP](#fetching-archives-over-http).
 Terraform will extract the archive to obtain the module source tree.
 
 Terraform uses the [default AWS credential provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html#credentialProviderChain)
-from the AWS SDK to locate credentials. This includes, in order of precedence:
-environment variables (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, or
-`AWS_PROFILE` to select a named profile), the shared credentials file at
-`~/.aws/credentials`, the shared config file at `~/.aws/config` (including SSO
-and assume-role configuration), and container or EC2 instance profile
-credentials (IMDS) when running on AWS compute.
+from the AWS SDK to locate credentials. In order of precedence, this includes:
+
+1. Either `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, or `AWS_PROFILE`
+   environment variables. The `AWS_PROFILE` environment variable selects a
+   named profile.
+1. Shared credentials file at `~/.aws/credentials`.
+1. Shared configuration file at `~/.aws/config`, including SSO and assume-role
+   configuration.
+1. Container or EC2 instance profile credentials (IMDS) when running on AWS
+   compute.
 
 You can also supply credentials directly on the source URL using query
 parameters:
 
-- `aws_profile` — use a named profile from the shared config, for example
-  `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
-- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token` — pass
-  static credentials inline. Avoid committing these to version control.
+- `aws_profile`: Specifies a named profile from the shared configuration, for
+  example `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
+- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token`: Pass
+  static credentials inline. Do not commit these to version control.
 
 ## GCS Bucket
 

--- a/content/terraform/v1.7.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.7.x/docs/language/modules/sources.mdx
@@ -425,13 +425,21 @@ The resulting object must be an archive with one of the same file
 extensions as for [archives over standard HTTP](#fetching-archives-over-http).
 Terraform will extract the archive to obtain the module source tree.
 
-The module installer looks for AWS credentials in the following locations,
-preferring those earlier in the list when multiple are available:
+Terraform uses the [default AWS credential provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html#credentialProviderChain)
+from the AWS SDK to locate credentials. This includes, in order of precedence:
+environment variables (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, or
+`AWS_PROFILE` to select a named profile), the shared credentials file at
+`~/.aws/credentials`, the shared config file at `~/.aws/config` (including SSO
+and assume-role configuration), and container or EC2 instance profile
+credentials (IMDS) when running on AWS compute.
 
-- The `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
-- The default profile in the `.aws/credentials` file in your home directory.
-- If running on an EC2 instance, temporary credentials associated with the
-  instance's IAM Instance Profile.
+You can also supply credentials directly on the source URL using query
+parameters:
+
+- `aws_profile` — use a named profile from the shared config, for example
+  `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
+- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token` — pass
+  static credentials inline. Avoid committing these to version control.
 
 ## GCS Bucket
 

--- a/content/terraform/v1.7.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.7.x/docs/language/modules/sources.mdx
@@ -426,20 +426,24 @@ extensions as for [archives over standard HTTP](#fetching-archives-over-http).
 Terraform will extract the archive to obtain the module source tree.
 
 Terraform uses the [default AWS credential provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html#credentialProviderChain)
-from the AWS SDK to locate credentials. This includes, in order of precedence:
-environment variables (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, or
-`AWS_PROFILE` to select a named profile), the shared credentials file at
-`~/.aws/credentials`, the shared config file at `~/.aws/config` (including SSO
-and assume-role configuration), and container or EC2 instance profile
-credentials (IMDS) when running on AWS compute.
+from the AWS SDK to locate credentials. In order of precedence, this includes:
+
+1. Either `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, or `AWS_PROFILE`
+   environment variables. The `AWS_PROFILE` environment variable selects a
+   named profile.
+1. Shared credentials file at `~/.aws/credentials`.
+1. Shared configuration file at `~/.aws/config`, including SSO and assume-role
+   configuration.
+1. Container or EC2 instance profile credentials (IMDS) when running on AWS
+   compute.
 
 You can also supply credentials directly on the source URL using query
 parameters:
 
-- `aws_profile` — use a named profile from the shared config, for example
-  `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
-- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token` — pass
-  static credentials inline. Avoid committing these to version control.
+- `aws_profile`: Specifies a named profile from the shared configuration, for
+  example `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
+- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token`: Pass
+  static credentials inline. Do not commit these to version control.
 
 ## GCS Bucket
 

--- a/content/terraform/v1.8.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.8.x/docs/language/modules/sources.mdx
@@ -425,13 +425,21 @@ The resulting object must be an archive with one of the same file
 extensions as for [archives over standard HTTP](#fetching-archives-over-http).
 Terraform will extract the archive to obtain the module source tree.
 
-The module installer looks for AWS credentials in the following locations,
-preferring those earlier in the list when multiple are available:
+Terraform uses the [default AWS credential provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html#credentialProviderChain)
+from the AWS SDK to locate credentials. This includes, in order of precedence:
+environment variables (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, or
+`AWS_PROFILE` to select a named profile), the shared credentials file at
+`~/.aws/credentials`, the shared config file at `~/.aws/config` (including SSO
+and assume-role configuration), and container or EC2 instance profile
+credentials (IMDS) when running on AWS compute.
 
-- The `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
-- The default profile in the `.aws/credentials` file in your home directory.
-- If running on an EC2 instance, temporary credentials associated with the
-  instance's IAM Instance Profile.
+You can also supply credentials directly on the source URL using query
+parameters:
+
+- `aws_profile` — use a named profile from the shared config, for example
+  `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
+- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token` — pass
+  static credentials inline. Avoid committing these to version control.
 
 ## GCS Bucket
 

--- a/content/terraform/v1.8.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.8.x/docs/language/modules/sources.mdx
@@ -426,20 +426,24 @@ extensions as for [archives over standard HTTP](#fetching-archives-over-http).
 Terraform will extract the archive to obtain the module source tree.
 
 Terraform uses the [default AWS credential provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html#credentialProviderChain)
-from the AWS SDK to locate credentials. This includes, in order of precedence:
-environment variables (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, or
-`AWS_PROFILE` to select a named profile), the shared credentials file at
-`~/.aws/credentials`, the shared config file at `~/.aws/config` (including SSO
-and assume-role configuration), and container or EC2 instance profile
-credentials (IMDS) when running on AWS compute.
+from the AWS SDK to locate credentials. In order of precedence, this includes:
+
+1. Either `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, or `AWS_PROFILE`
+   environment variables. The `AWS_PROFILE` environment variable selects a
+   named profile.
+1. Shared credentials file at `~/.aws/credentials`.
+1. Shared configuration file at `~/.aws/config`, including SSO and assume-role
+   configuration.
+1. Container or EC2 instance profile credentials (IMDS) when running on AWS
+   compute.
 
 You can also supply credentials directly on the source URL using query
 parameters:
 
-- `aws_profile` — use a named profile from the shared config, for example
-  `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
-- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token` — pass
-  static credentials inline. Avoid committing these to version control.
+- `aws_profile`: Specifies a named profile from the shared configuration, for
+  example `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
+- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token`: Pass
+  static credentials inline. Do not commit these to version control.
 
 ## GCS Bucket
 

--- a/content/terraform/v1.9.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.9.x/docs/language/modules/sources.mdx
@@ -426,13 +426,21 @@ The resulting object must be an archive with one of the same file
 extensions as for [archives over standard HTTP](#fetching-archives-over-http).
 Terraform will extract the archive to obtain the module source tree.
 
-The module installer looks for AWS credentials in the following locations,
-preferring those earlier in the list when multiple are available:
+Terraform uses the [default AWS credential provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html#credentialProviderChain)
+from the AWS SDK to locate credentials. This includes, in order of precedence:
+environment variables (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, or
+`AWS_PROFILE` to select a named profile), the shared credentials file at
+`~/.aws/credentials`, the shared config file at `~/.aws/config` (including SSO
+and assume-role configuration), and container or EC2 instance profile
+credentials (IMDS) when running on AWS compute.
 
-- The `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
-- The default profile in the `.aws/credentials` file in your home directory.
-- If running on an EC2 instance, temporary credentials associated with the
-  instance's IAM Instance Profile.
+You can also supply credentials directly on the source URL using query
+parameters:
+
+- `aws_profile` — use a named profile from the shared config, for example
+  `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
+- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token` — pass
+  static credentials inline. Avoid committing these to version control.
 
 ## GCS Bucket
 

--- a/content/terraform/v1.9.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.9.x/docs/language/modules/sources.mdx
@@ -427,20 +427,24 @@ extensions as for [archives over standard HTTP](#fetching-archives-over-http).
 Terraform will extract the archive to obtain the module source tree.
 
 Terraform uses the [default AWS credential provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html#credentialProviderChain)
-from the AWS SDK to locate credentials. This includes, in order of precedence:
-environment variables (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, or
-`AWS_PROFILE` to select a named profile), the shared credentials file at
-`~/.aws/credentials`, the shared config file at `~/.aws/config` (including SSO
-and assume-role configuration), and container or EC2 instance profile
-credentials (IMDS) when running on AWS compute.
+from the AWS SDK to locate credentials. In order of precedence, this includes:
+
+1. Either `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, or `AWS_PROFILE`
+   environment variables. The `AWS_PROFILE` environment variable selects a
+   named profile.
+1. Shared credentials file at `~/.aws/credentials`.
+1. Shared configuration file at `~/.aws/config`, including SSO and assume-role
+   configuration.
+1. Container or EC2 instance profile credentials (IMDS) when running on AWS
+   compute.
 
 You can also supply credentials directly on the source URL using query
 parameters:
 
-- `aws_profile` — use a named profile from the shared config, for example
-  `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
-- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token` — pass
-  static credentials inline. Avoid committing these to version control.
+- `aws_profile`: Specifies a named profile from the shared configuration, for
+  example `s3::https://bucket.s3.amazonaws.com/module.zip?aws_profile=dev`.
+- `aws_access_key_id`, `aws_access_key_secret`, and `aws_access_token`: Pass
+  static credentials inline. Do not commit these to version control.
 
 ## GCS Bucket
 


### PR DESCRIPTION
The module sources page listed only AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY, the default shared-credentials profile, and EC2 instance profiles. go-getter has used the AWS SDK default credential chain since v1.5.0 (2020), which Terraform has shipped since v1.0.0. That chain also honors AWS_PROFILE, shared config (SSO, assume-role, web-identity), and container credentials.

Replace the list with a pointer to the AWS SDK default credential provider chain and document the aws_profile and static-credential URL query parameters supported by go-getter. Applied to every versioned copy (v1.1.x-v1.15.x rc).

Please go to the `Preview` tab and select the appropriate template:

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
