### PR TITLE
CE-1132:  remove maxInstances 

### DIFF
--- a/content/consul/v2.0.x/content/docs/reference/k8s/api-gateway/gatewayclassconfig.mdx
+++ b/content/consul/v2.0.x/content/docs/reference/k8s/api-gateway/gatewayclassconfig.mdx
@@ -123,18 +123,6 @@ This field is deprecated. Use the `consul.hashicorp.com/default-replicas` annota
 * Required: optional
 * Default: `1`
 
-### deployment.maxInstances
-Specifies the maximum allowed number of gateway instances per gateway configuration.
-
-<Note>
-
-This field is deprecated. Use the `consul.hashicorp.com/hpa-enabled`, `consul.hashicorp.com/hpa-minimum-replicas`, and `consul.hashicorp.com/hpa-maximum-replicas` annotations on the [`Gateway`](/consul/docs/reference/k8s/api-gateway/gateway) resource instead. Refer to [Scale API gateways on Kubernetes](/consul/docs/north-south/api-gateway/k8s/scale) for the supported scaling workflow.
-
-</Note>
-* Type: Integer
-* Required: optional
-* Default: `8`
-
 ### deployment.minInstances
 Specifies the minimum allowed number of gateway instances per gateway configuration.
 


### PR DESCRIPTION
## Description

The Consul 2.0.0 release removes the k8s API Gateway scaling limit, this PR is making the documentation reflect that.

## Links

Jira: [CE-1129]

## Contributor checklists

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [x] 3 days: Small changes, easy reviews
- [ ] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [ ] Verify that the PR is set to merge into the correct base branch
- [ ] Verify that all status checks passed
- [ ] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [ ] I added redirects for any moved or removed pages
- [ ] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [ ] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [ ] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.


[CE-1129]: https://hashicorp.atlassian.net/browse/CE-1129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ