### PR TITLE
Update /sys/billing/overview docs

### DIFF
--- a/content/vault/v2.x/content/api-docs/system/billing/overview.mdx
+++ b/content/vault/v2.x/content/api-docs/system/billing/overview.mdx
@@ -15,7 +15,7 @@ last_modified: 2026-04-15T00:13:58.000Z
 
 The `/sys/billing/overview` endpoint returns a monthly overview of usage data relevant to usage-based licensing. 
 
-The retention period for historical usage data is 37 months, up to the current month. If no `start_month` or `end_month` parameters are specified, data from the full retention period is returned.
+Vault retains usage data for 37 months, including the current month.
 
 Vault updates current-month metrics every 10 minutes. Refer to the `updated_at` field in monthly response data to determine when Vault last updated the billing metrics for each month.
 
@@ -29,11 +29,13 @@ Vault updates current-month metrics every 10 minutes. Refer to the `updated_at` 
 - `start_month` `(string: optional)` - When set using the `YYYY-MM` format, the response includes months starting from the specified month. Leave `start_month` unset to use the start of the retention period.
 - `end_month` `(string: optional)` - When set using the `YYYY-MM` format, the response includes months up to the specified month. Leave `end_month` unset to use the current month.
 
+When both `start_month` and `end_month` parameters are unset, the endpoint returns data from the full retention period.
+
 ### Sample request
 
 ```shell-session
 $ curl --header "X-Vault-Token: ${VAULT_TOKEN}" \
-    "${VAULT_ADDR}/v1/sys/billing/overview?start_month="2025-12"&end_month="2026-01"&refresh_data=false"
+    "${VAULT_ADDR}/v1/sys/billing/overview?start_month=2025-12&end_month=2026-01&refresh_data=false"
 ```
 
 ### Sample response

--- a/content/vault/v2.x/content/api-docs/system/billing/overview.mdx
+++ b/content/vault/v2.x/content/api-docs/system/billing/overview.mdx
@@ -13,7 +13,9 @@ last_modified: 2026-04-15T00:13:58.000Z
 
 @include 'alerts/restricted-root.mdx'
 
-The `/sys/billing/overview` endpoint returns a monthly overview of usage data relevant to usage-based licensing for the current and previous months.
+The `/sys/billing/overview` endpoint returns a monthly overview of usage data relevant to usage-based licensing. 
+
+The retention period for historical usage data is 37 months, up to the current month. If no `start_month` or `end_month` parameters are specified, data from the full retention period is returned.
 
 Vault updates current-month metrics every 10 minutes. Refer to the `updated_at` field in monthly response data to determine when Vault last updated the billing metrics for each month.
 
@@ -24,12 +26,14 @@ Vault updates current-month metrics every 10 minutes. Refer to the `updated_at` 
 ### Request parameters
 
 - `refresh_data` `(boolean: false)` - When set to `true`, Vault recalculates all billing metrics and stores the new metrics. Leave `refresh_data` unset, or set to `false`, to return data as of when it was last calculated. Recalculating metrics consumes server resources and may cause performance issues if done too frequently.
+- `start_month` `(string: optional)` - When set using the `YYYY-MM` format, the response includes months starting from the specified month. Leave `start_month` unset to use the start of the retention period.
+- `end_month` `(string: optional)` - When set using the `YYYY-MM` format, the response includes months up to the specified month. Leave `end_month` unset to use the current month.
 
 ### Sample request
 
 ```shell-session
 $ curl --header "X-Vault-Token: ${VAULT_TOKEN}" \
-    "${VAULT_ADDR}/v1/sys/billing/overview?refresh_data=false"
+    "${VAULT_ADDR}/v1/sys/billing/overview?start_month="2025-12"&end_month="2026-01"&refresh_data=false"
 ```
 
 ### Sample response

--- a/content/vault/v2.x/content/docs/updates/release-notes.mdx
+++ b/content/vault/v2.x/content/docs/updates/release-notes.mdx
@@ -44,8 +44,7 @@ create policies, and discover Vault capabilities.
 
 ### Improvements
 
-- [/sys/billing/overview](/vault/api-docs/system/billing/overview) includes 37 months
-of usage data by default and adds `start_month` and `end_month` parameters.
+- [/sys/billing/overview](/vault/api-docs/system/billing/overview) now retains 37 months of usage data and adds `start_month` and `end_month` query parameters.
 
 
 ## Vault 2.0.0

--- a/content/vault/v2.x/content/docs/updates/release-notes.mdx
+++ b/content/vault/v2.x/content/docs/updates/release-notes.mdx
@@ -44,7 +44,8 @@ create policies, and discover Vault capabilities.
 
 ### Improvements
 
-- TBD
+- [/sys/billing/overview](/vault/api-docs/system/billing/overview) includes 37 months
+of usage data by default and adds `start_month` and `end_month` parameters.
 
 
 ## Vault 2.0.0


### PR DESCRIPTION
Updates the docs for `/sys/billing/overview` for 2.0.1 to reflect the following changes:
* the historical data retention period has been changed to 37 months
* new `start_month` and `end_month` parameters

Jira: https://hashicorp.atlassian.net/browse/VAULT-44291

Please go to the `Preview` tab and select the appropriate template:

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
