### PR TITLE
docs: Add dependency updates to release notes

### DIFF
--- a/content/boundary/v0.19.x/content/docs/release-notes/v0_19_0.mdx
+++ b/content/boundary/v0.19.x/content/docs/release-notes/v0_19_0.mdx
@@ -526,7 +526,7 @@ last_modified: 2025-10-29T10:56:20-04:00
     SQL injection via placeholder confusion
     </td>
     <td style={{verticalAlign: 'middle'}}>
-    A vulnerability in the jackc/pgx/v5 dependency could allow SQL injection using a placeholder outside of a string literal. jackc/pgx was updated to v5.9.2 in HCP Boundary and Boundary Enteprise version 0.19.5. This issue is now resolved.
+    A vulnerability in the jackc/pgx/v5 dependency could allow SQL injection using a placeholder outside of a string literal. jackc/pgx was updated to v5.9.2 in HCP Boundary and Boundary Enterprise version 0.19.5. This issue is now resolved.
     <br /><br />
     Learn more: <a href="https://github.com/advisories/GHSA-j88v-2chj-qfwx">GHSA-j88v-2chj-qfwx</a> advisory
     <br /><br />

--- a/content/boundary/v0.19.x/content/docs/release-notes/v0_19_0.mdx
+++ b/content/boundary/v0.19.x/content/docs/release-notes/v0_19_0.mdx
@@ -498,6 +498,42 @@ last_modified: 2025-10-29T10:56:20-04:00
     </td>
   </tr>
 
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+    0.19.x
+    <br /><br />
+    (Fixed in HCP Boundary and Boundary Enterprise version 0.19.5)
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    NTLM challenge can panic on malformed payload
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    A vulnerability in the Azure/go-ntlmssp dependency could cause an out-of-bounds panic that would crash any Go process that used <code>ntlmssp.Negotiator</code> as an HTTP transport. Azure/go-ntlmssp was updated to v0.1.1 in HCP Boundary and Boundary Enterprise version 0.19.5. This issue is now resolved.
+    <br /><br />
+    Learn more: <a href="https://github.com/Azure/go-ntlmssp/security/advisories/GHSA-pjcq-xvwq-hhpj">GHSA-pjcq-xvwq-hhpj</a> advisory
+    <br /><br />
+    <a href="/boundary/tutorials/self-managed-deployment/upgrade-version">Upgrade to the latest version of Boundary</a>
+    </td>
+  </tr>
+
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+    0.19.x
+    <br /><br />
+    (Fixed in HCP Boundary and Boundary Enterprise version 0.19.5)
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    SQL injection via placeholder confusion
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    A vulnerability in the jackc/pgx/v5 dependency could allow SQL injection using a placeholder outside of a string literal. jackc/pgx was updated to v5.9.2 in HCP Boundary and Boundary Enteprise version 0.19.5. This issue is now resolved.
+    <br /><br />
+    Learn more: <a href="https://github.com/advisories/GHSA-j88v-2chj-qfwx">GHSA-j88v-2chj-qfwx</a> advisory
+    <br /><br />
+    <a href="/boundary/tutorials/self-managed-deployment/upgrade-version">Upgrade to the latest version of Boundary</a>
+    </td>
+  </tr>
+
 
   </tbody>
 </table>

--- a/content/boundary/v0.20.x/content/docs/release-notes/v0_19_0.mdx
+++ b/content/boundary/v0.20.x/content/docs/release-notes/v0_19_0.mdx
@@ -526,7 +526,7 @@ last_modified: 2025-10-29T10:56:20-04:00
     SQL injection via placeholder confusion
     </td>
     <td style={{verticalAlign: 'middle'}}>
-    A vulnerability in the jackc/pgx/v5 dependency could allow SQL injection using a placeholder outside of a string literal. jackc/pgx was updated to v5.9.2 in HCP Boundary and Boundary Enteprise version 0.19.5. This issue is now resolved.
+    A vulnerability in the jackc/pgx/v5 dependency could allow SQL injection using a placeholder outside of a string literal. jackc/pgx was updated to v5.9.2 in HCP Boundary and Boundary Enterprise version 0.19.5. This issue is now resolved.
     <br /><br />
     Learn more: <a href="https://github.com/advisories/GHSA-j88v-2chj-qfwx">GHSA-j88v-2chj-qfwx</a> advisory
     <br /><br />

--- a/content/boundary/v0.20.x/content/docs/release-notes/v0_19_0.mdx
+++ b/content/boundary/v0.20.x/content/docs/release-notes/v0_19_0.mdx
@@ -498,5 +498,41 @@ last_modified: 2025-10-29T10:56:20-04:00
     </td>
   </tr>
 
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+    0.19.x
+    <br /><br />
+    (Fixed in HCP Boundary and Boundary Enterprise version 0.19.5)
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    NTLM challenge can panic on malformed payload
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    A vulnerability in the Azure/go-ntlmssp dependency could cause an out-of-bounds panic that would crash any Go process that used <code>ntlmssp.Negotiator</code> as an HTTP transport. Azure/go-ntlmssp was updated to v0.1.1 in HCP Boundary and Boundary Enterprise version 0.19.5. This issue is now resolved.
+    <br /><br />
+    Learn more: <a href="https://github.com/Azure/go-ntlmssp/security/advisories/GHSA-pjcq-xvwq-hhpj">GHSA-pjcq-xvwq-hhpj</a> advisory
+    <br /><br />
+    <a href="/boundary/tutorials/self-managed-deployment/upgrade-version">Upgrade to the latest version of Boundary</a>
+    </td>
+  </tr>
+
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+    0.19.x
+    <br /><br />
+    (Fixed in HCP Boundary and Boundary Enterprise version 0.19.5)
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    SQL injection via placeholder confusion
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    A vulnerability in the jackc/pgx/v5 dependency could allow SQL injection using a placeholder outside of a string literal. jackc/pgx was updated to v5.9.2 in HCP Boundary and Boundary Enteprise version 0.19.5. This issue is now resolved.
+    <br /><br />
+    Learn more: <a href="https://github.com/advisories/GHSA-j88v-2chj-qfwx">GHSA-j88v-2chj-qfwx</a> advisory
+    <br /><br />
+    <a href="/boundary/tutorials/self-managed-deployment/upgrade-version">Upgrade to the latest version of Boundary</a>
+    </td>
+  </tr>
+
   </tbody>
 </table>

--- a/content/boundary/v0.20.x/content/docs/release-notes/v0_20_0.mdx
+++ b/content/boundary/v0.20.x/content/docs/release-notes/v0_20_0.mdx
@@ -305,6 +305,41 @@ last_modified: 2025-12-03T13:54:54-05:00
     </td>
   </tr>
 
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+    0.19.x - 0.20.x
+    <br /><br />
+    (Fixed in HCP Boundary and Boundary Enterprise version 0.20.3)
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    NTLM challenge can panic on malformed payload
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    A vulnerability in the Azure/go-ntlmssp dependency could cause an out-of-bounds panic that would crash any Go process that used <code>ntlmssp.Negotiator</code> as an HTTP transport. Azure/go-ntlmssp was updated to v0.1.1 in HCP Boundary and Boundary Enterprise version 0.20.3. This issue is now resolved.
+    <br /><br />
+    Learn more: <a href="https://github.com/Azure/go-ntlmssp/security/advisories/GHSA-pjcq-xvwq-hhpj">GHSA-pjcq-xvwq-hhpj</a> advisory
+    <br /><br />
+    <a href="/boundary/tutorials/self-managed-deployment/upgrade-version">Upgrade to the latest version of Boundary</a>
+    </td>
+  </tr>
+
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+    0.19.x - 0.20.x
+    <br /><br />
+    (Fixed in HCP Boundary and Boundary Enterprise version 0.20.3)
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    SQL injection via placeholder confusion
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    A vulnerability in the jackc/pgx/v5 dependency could allow SQL injection using a placeholder outside of a string literal. jackc/pgx was updated to v5.9.2 in HCP Boundary and Boundary Enterprise version 0.20.3. This issue is now resolved.
+    <br /><br />
+    Learn more: <a href="https://github.com/advisories/GHSA-j88v-2chj-qfwx">GHSA-j88v-2chj-qfwx</a> advisory
+    <br /><br />
+    <a href="/boundary/tutorials/self-managed-deployment/upgrade-version">Upgrade to the latest version of Boundary</a>
+    </td>
+  </tr>
 
   </tbody>
 </table>

--- a/content/boundary/v0.21.x/content/docs/release-notes/v0_19_0.mdx
+++ b/content/boundary/v0.21.x/content/docs/release-notes/v0_19_0.mdx
@@ -498,5 +498,41 @@ last_modified: 2025-11-18T17:04:41-05:00
     </td>
   </tr>
 
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+    0.19.x
+    <br /><br />
+    (Fixed in HCP Boundary and Boundary Enterprise version 0.19.5)
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    NTLM challenge can panic on malformed payload
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    A vulnerability in the Azure/go-ntlmssp dependency could cause an out-of-bounds panic that would crash any Go process that used <code>ntlmssp.Negotiator</code> as an HTTP transport. Azure/go-ntlmssp was updated to v0.1.1 in HCP Boundary and Boundary Enterprise version 0.19.5. This issue is now resolved.
+    <br /><br />
+    Learn more: <a href="https://github.com/Azure/go-ntlmssp/security/advisories/GHSA-pjcq-xvwq-hhpj">GHSA-pjcq-xvwq-hhpj</a> advisory
+    <br /><br />
+    <a href="/boundary/tutorials/self-managed-deployment/upgrade-version">Upgrade to the latest version of Boundary</a>
+    </td>
+  </tr>
+
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+    0.19.x
+    <br /><br />
+    (Fixed in HCP Boundary and Boundary Enterprise version 0.19.5)
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    SQL injection via placeholder confusion
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    A vulnerability in the jackc/pgx/v5 dependency could allow SQL injection using a placeholder outside of a string literal. jackc/pgx was updated to v5.9.2 in HCP Boundary and Boundary Enteprise version 0.19.5. This issue is now resolved.
+    <br /><br />
+    Learn more: <a href="https://github.com/advisories/GHSA-j88v-2chj-qfwx">GHSA-j88v-2chj-qfwx</a> advisory
+    <br /><br />
+    <a href="/boundary/tutorials/self-managed-deployment/upgrade-version">Upgrade to the latest version of Boundary</a>
+    </td>
+  </tr>
+
   </tbody>
 </table>

--- a/content/boundary/v0.21.x/content/docs/release-notes/v0_19_0.mdx
+++ b/content/boundary/v0.21.x/content/docs/release-notes/v0_19_0.mdx
@@ -526,7 +526,7 @@ last_modified: 2025-11-18T17:04:41-05:00
     SQL injection via placeholder confusion
     </td>
     <td style={{verticalAlign: 'middle'}}>
-    A vulnerability in the jackc/pgx/v5 dependency could allow SQL injection using a placeholder outside of a string literal. jackc/pgx was updated to v5.9.2 in HCP Boundary and Boundary Enteprise version 0.19.5. This issue is now resolved.
+    A vulnerability in the jackc/pgx/v5 dependency could allow SQL injection using a placeholder outside of a string literal. jackc/pgx was updated to v5.9.2 in HCP Boundary and Boundary Enterprise version 0.19.5. This issue is now resolved.
     <br /><br />
     Learn more: <a href="https://github.com/advisories/GHSA-j88v-2chj-qfwx">GHSA-j88v-2chj-qfwx</a> advisory
     <br /><br />

--- a/content/boundary/v0.21.x/content/docs/release-notes/v0_20_0.mdx
+++ b/content/boundary/v0.21.x/content/docs/release-notes/v0_20_0.mdx
@@ -306,5 +306,41 @@ last_modified: 2025-12-09T16:47:36-05:00
     </td>
   </tr>
 
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+    0.19.x - 0.20.x
+    <br /><br />
+    (Fixed in HCP Boundary and Boundary Enterprise version 0.20.3)
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    NTLM challenge can panic on malformed payload
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    A vulnerability in the Azure/go-ntlmssp dependency could cause an out-of-bounds panic that would crash any Go process that used <code>ntlmssp.Negotiator</code> as an HTTP transport. Azure/go-ntlmssp was updated to v0.1.1 in HCP Boundary and Boundary Enterprise version 0.20.3. This issue is now resolved.
+    <br /><br />
+    Learn more: <a href="https://github.com/Azure/go-ntlmssp/security/advisories/GHSA-pjcq-xvwq-hhpj">GHSA-pjcq-xvwq-hhpj</a> advisory
+    <br /><br />
+    <a href="/boundary/tutorials/self-managed-deployment/upgrade-version">Upgrade to the latest version of Boundary</a>
+    </td>
+  </tr>
+
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+    0.19.x - 0.20.x
+    <br /><br />
+    (Fixed in HCP Boundary and Boundary Enterprise version 0.20.3)
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    SQL injection via placeholder confusion
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    A vulnerability in the jackc/pgx/v5 dependency could allow SQL injection using a placeholder outside of a string literal. jackc/pgx was updated to v5.9.2 in HCP Boundary and Boundary Enterprise version 0.20.3. This issue is now resolved.
+    <br /><br />
+    Learn more: <a href="https://github.com/advisories/GHSA-j88v-2chj-qfwx">GHSA-j88v-2chj-qfwx</a> advisory
+    <br /><br />
+    <a href="/boundary/tutorials/self-managed-deployment/upgrade-version">Upgrade to the latest version of Boundary</a>
+    </td>
+  </tr>
+
   </tbody>
 </table>

--- a/content/boundary/v0.21.x/content/docs/release-notes/v0_21_0.mdx
+++ b/content/boundary/v0.21.x/content/docs/release-notes/v0_21_0.mdx
@@ -386,5 +386,41 @@ last_modified: 2025-12-10T11:48:49-05:00
     </td>
   </tr>
 
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+    0.19.x - 0.21.x
+    <br /><br />
+    (Fixed in version 0.21.3)
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    NTLM challenge can panic on malformed payload
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    A vulnerability in the Azure/go-ntlmssp dependency could cause an out-of-bounds panic that would crash any Go process that used <code>ntlmssp.Negotiator</code> as an HTTP transport. Azure/go-ntlmssp was updated to v0.1.1 in Boundary version 0.21.3. This issue is now resolved.
+    <br /><br />
+    Learn more: <a href="https://github.com/Azure/go-ntlmssp/security/advisories/GHSA-pjcq-xvwq-hhpj">GHSA-pjcq-xvwq-hhpj</a> advisory
+    <br /><br />
+    <a href="/boundary/tutorials/self-managed-deployment/upgrade-version">Upgrade to the latest version of Boundary</a>
+    </td>
+  </tr>
+
+  <tr>
+    <td style={{verticalAlign: 'middle'}}>
+    0.19.x - 0.21.x
+    <br /><br />
+    (Fixed in version 0.21.3)
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    SQL injection via placeholder confusion
+    </td>
+    <td style={{verticalAlign: 'middle'}}>
+    A vulnerability in the jackc/pgx/v5 dependency could allow SQL injection using a placeholder outside of a string literal. jackc/pgx was updated to v5.9.2 in Boundary version 0.21.3. This issue is now resolved.
+    <br /><br />
+    Learn more: <a href="https://github.com/advisories/GHSA-j88v-2chj-qfwx">GHSA-j88v-2chj-qfwx</a> advisory
+    <br /><br />
+    <a href="/boundary/tutorials/self-managed-deployment/upgrade-version">Upgrade to the latest version of Boundary</a>
+    </td>
+  </tr>
+
   </tbody>
 </table>


### PR DESCRIPTION
<!--
**Merge branch**

Make sure your PR uses the correct **base** branch for the merge destination.

For more information, refer to **Change the branch range and destination repository** (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request).

To update:

- Existing content

  Choose **base: main** to update existing documentation.
  Your content will be published when the PR is merged.

- Content for an upcoming Boundary release

  Choose the branch for the relevant upcoming Boundary release.
  Boundary release branches use the `boundary/<exact-release-number>` format.
  Your content will be published when the upcoming release goes live.

If you are not sure which base branch to use, or you cannot find the release branch you are looking for:

  - Choose the `main` branch.
  - Add the "do not merge" label.
  - Convert the PR to a DRAFT.
  - Explain the update in the **Description**.

**Back porting to older versions**

This repo stores versioned documentation in folders instead of branches.
There are no backport labels.
If your update applies to multiple versions, you must update the content in each of the corresponding version folders.

For example, you make an update to the Boundary code in the current release, 0.21.0, and back port it to versions 0.20.x and 0.19.x.
To document the update for each of the relevant versions, you would update the documentation in the v0.21.x, v0.20.x, and v0.19.x folders.
-->

## Description

Adds third party dependency updates to the release notes for an upcoming release. This PR updates the 0.21.x, 0.20.x, and 0.19.x release notes on each of those respective branches.

View the updates in the preview deployment:

Version 0.21.x docs:
- [Version 0.21.x release notes](https://unified-docs-frontend-preview-b01j8904i-hashicorp.vercel.app/boundary/docs/release-notes/v0_21_0#known-issues-and-breaking-changes)
- [Version 0.20.x release notes](https://unified-docs-frontend-preview-b01j8904i-hashicorp.vercel.app/boundary/docs/release-notes/v0_20_0#known-issues-and-breaking-changes)
- [Version 0.19.x release notes](https://unified-docs-frontend-preview-b01j8904i-hashicorp.vercel.app/boundary/docs/release-notes/v0_19_0#known-issues-and-breaking-changes)

Version 0.20.x docs:
- [Version 0.20.x release notes](https://unified-docs-frontend-preview-b01j8904i-hashicorp.vercel.app/boundary/docs/v0.20.x/release-notes/v0_20_0#known-issues-and-breaking-changes)
- [Version 0.19.x release notes](https://unified-docs-frontend-preview-b01j8904i-hashicorp.vercel.app/boundary/docs/v0.20.x/release-notes/v0_19_0#known-issues-and-breaking-changes)

Version 0.19.x docs:
- [Version 0.19.x release notes](https://unified-docs-frontend-preview-b01j8904i-hashicorp.vercel.app/boundary/docs/v0.19.x/release-notes/v0_19_0#known-issues-and-breaking-changes)

## Links
<!--
Include links to any associated pull requests, GitHub issues, or documentation that is relevant to this update.

// GH-Jira integration generates the link and updates the Jira ticket.
Jira: [<jira-ticket-number>]  // for example, Jira: [ICU-1234]

GitHub Issue: <issue-link>
-->

Code PR:
Jira:
GitHub issue:
RFC/PRD:

## Contributor checklists

<!--
Help your reviewer understand the type of review you need by selecting the scope and urgency.
-->

Review urgency:

- [x] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [ ] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [x] Verify that all status checks passed
- [x] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [ ] I added redirects for any moved or removed pages
- [x] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [x] I looked at the local or Vercel build to make sure the content rendered correctly


[ICU-1234]: https://hashicorp.atlassian.net/browse/ICU-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ