### PR TITLE
reapply 1.14 nav and post-apply changes

### DIFF
--- a/content/terraform/v1.15.x/data/language-nav-data.json
+++ b/content/terraform/v1.15.x/data/language-nav-data.json
@@ -1,73 +1,12 @@
 [
   {
-    "heading": "Terraform Language"
+    "title": "Get started",
+    "href": "https://developer.hashicorp.com/terraform/tutorials"
   },
   {
-    "title": "Overview",
-    "path": ""
-  },
-  {
-    "title": "Attributes as Blocks - Configuration Language",
-    "path": "attr-as-blocks",
-    "hidden": true
-  },
-  {
-    "title": "Style guide",
-    "path": "style"
-  },
-  {
-    "title": "Syntax",
+    "title": "Configure providers",
     "routes": [
-      {
-        "title": "Overview",
-        "path": "syntax"
-      },
-      {
-        "title": "Configuration syntax",
-        "path": "syntax/configuration"
-      },
-      {
-        "title": "JSON configuration syntax",
-        "path": "syntax/json"
-      }
-    ]
-  },
-  {
-    "title": "Files and configuration structure",
-    "routes": [
-      {
-        "title": "Overview",
-        "path": "files"
-      },
-      {
-        "title": "Override files",
-        "path": "files/override"
-      },
-      {
-        "title": "Dependency lock file",
-        "path": "files/dependency-lock"
-      },
-      {
-        "title": "Test files",
-        "path": "files/tests"
-      },
-      {
-        "title": "Query files",
-        "path": "files/tfquery"
-      },
-      {
-        "title": "Stack files",
-        "path": "files/stack"
-      }
-    ]
-  },
-  {
-    "title": "Install providers",
-    "routes": [
-      {
-        "title": "Overview",
-        "path": "providers"
-      },
+      { "title": "Overview", "path": "providers" },
       {
         "title": "Provider requirements",
         "path": "providers/requirements"
@@ -75,89 +14,87 @@
       {
         "title": "Dependency lock file",
         "href": "/language/files/dependency-lock"
+      },
+      {
+        "title": "provider block reference",
+        "path": "block/provider"
+      },
+      {
+        "title": "terraform block reference",
+        "path": "block/terraform"
       }
     ]
   },
   {
-    "title": "Create and manage resources",
+    "title": "Resources",
     "routes": [
-      {
-        "title": "Overview",
-        "path": "resources"
-      },
-      {
-        "title": "Configure a resource",
-        "path": "resources/configure"
-      },
-      {
-        "title": "Destroy a resource",
-        "path": "resources/destroy"
-      }
+      { "title": "Overview", "path": "resources" },
+      { "title": "Configure a resource", "path": "resources/configure" },
+      { "title": "Destroy a resource", "path": "resources/destroy" },
+      { "title": "resource block reference", "path": "block/resource" }
     ]
   },
   {
-    "title": "Manage values in modules",
-    "alias": "variables, outputs, locals",
+    "title": "Data sources",
     "routes": [
-      {
-        "title": "Overview",
-        "path": "values"
+      { 
+        "title": "Query infrastructure data", 
+        "path": "data-sources" 
       },
       {
-        "title": "Use variables",
-        "path": "values/variables"
-      },
+        "title": "data block reference",
+        "path": "block/data"
+      }
+    ]
+  }, 
+  {
+      "title": "Variables",
+      "routes": [
+        {
+          "title": "Use variables",
+          "path": "values/variables"
+        },
+        {
+          "title": "variable block reference",
+          "path": "block/variable"
+        }
+      ]
+  },
+  {
+    "title": "Locals",
+    "routes": [
       {
         "title": "Use locals",
         "path": "values/locals"
       },
       {
+        "title":"locals block reference",
+        "path": "block/locals"
+      }
+    ]
+  },
+  {
+    "title": "Outputs",
+    "routes": [
+      {
         "title": "Use outputs",
         "path": "values/outputs"
+      },
+      {
+        "title": "output block reference",
+        "path": "block/output"
       }
     ]
   },
-  {
-    "title": "Manage sensitive data",
+    {
+    "title": "Modules",
     "routes": [
-      {
-        "title": "Overview",
-        "path": "manage-sensitive-data"
-      },
-      {
-        "title": "Ephemeral values in resources",
-        "path": "manage-sensitive-data/ephemeral"
-      },
-      {
-        "title": "Use temporary write-only arguments",
-        "path": "manage-sensitive-data/write-only",
-        "alias": "write only"
-      }
-    ]
-  },
-  {
-    "title": "Query infrastructure data",
-    "path": "data-sources",
-    "alias": "data sources"
-  },
-  {
-    "title": "Build and use modules",
-    "routes": [
-      {
-        "title": "Overview",
-        "path": "modules"
-      },
-      {
-        "title": "Use modules",
-        "path": "modules/configuration"
-      },
+      { "title": "Overview", "path": "modules" },
+      { "title":"Use modules", "path": "modules/configuration" },
       {
         "title": "Develop modules",
         "routes": [
-          {
-            "title": "Overview",
-            "path": "modules/develop"
-          },
+          { "title": "Overview", "path": "modules/develop" },
           {
             "title": "Standard module structure",
             "path": "modules/develop/structure"
@@ -179,51 +116,45 @@
             "path": "modules/develop/refactoring"
           }
         ]
+      },
+      {
+        "title": "module block reference",
+        "path": "block/module"
+      }
+    ]
+  },
+  { 
+    "title": "Meta-arguments",         
+    "alias": "depends_on, count, for_each, lifecycle, providers, provider meta-argument",
+    "path": "meta-arguments" 
+  }, 
+  {
+    "title": "Sensitive data",
+    "routes": [
+      {
+        "title": "Manage sensitive data",
+        "path": "manage-sensitive-data"
+      },
+      {
+        "title": "Use temporary write-only arguments",
+        "path": "manage-sensitive-data/write-only",
+        "alias": "write only"
+      },
+      {
+        "title": "Ephemeral values in resources",
+        "path": "manage-sensitive-data/ephemeral"
+      },
+      {
+        "title": "ephemeral block reference",
+        "path": "block/ephemeral"
       }
     ]
   },
   {
-    "title": "Manage state",
+    "title": "Backends",
     "routes": [
       {
-        "title": "Overview",
-        "path": "state"
-      },
-      {
-        "title": "Purpose",
-        "path": "state/purpose"
-      },
-      {
-        "title": "Manage state in remote backends",
-        "path": "state/backends"
-      },
-      {
-        "title": "Refactor state",
-        "path": "state/refactor"
-      },
-      {
-        "title": "Remove a resource from state",
-        "path": "state/remove"
-      },
-      {
-        "title": "Locking",
-        "path": "state/locking"
-      },
-      {
-        "title": "Workspaces",
-        "path": "state/workspaces"
-      },
-      {
-        "title": "Remote state",
-        "path": "state/remote"
-      }
-    ]
-  },
-  {
-    "title": "Store state remotely",
-    "routes": [
-      {
-        "title": "Overview",
+        "title": "Configure a backend",
         "path": "backend"
       },
       {
@@ -277,35 +208,76 @@
     ]
   },
   {
-    "title": "Import existing resources",
+    "title": "Search and import",
     "routes": [
-      {
-        "title": "Overview",
-        "path": "import"
-      },
+      { "title": "Overview", "path": "import"},
       {
         "title": "Import resources in bulk",
-        "path": "import/bulk",
-        "alias": "search, terraform search, query, list"
+        "alias": "search, terraform search, query, list",
+        "path": "import/bulk"
       },
-      {
-        "title": "Import a single resource",
-        "path": "import/single-resource"
-      },
+      { "title": "Import a single resource", "path": "import/single-resource" },
       {
         "title": "Generate configuration for single imports",
         "path": "import/generating-configuration"
+      },
+      {
+        "title": "import block reference",
+        "path": "block/import"
+      },
+      {
+        "title": "list block reference",
+        "alias": "search, terraform search, query, list",
+        "path": "block/tfquery/list"
       }
     ]
   },
   {
-    "title": "Test and validate configuration",
+    "title": "State",
     "routes": [
+      { "title": "Overview", "path": "state" },
+      { "title": "Purpose", "path": "state/purpose" },
+      { "title": "Manage state in remote backends", "path": "state/backends" },
+      { "title": "Refactor state", "path": "state/refactor" },
+      { "title": "Remove a resource from state", "path": "state/remove" },
+      { "title": "Locking", "path": "state/locking" },
+      { "title": "Workspaces", "path": "state/workspaces" },
+      { "title": "Remote state", "path": "state/remote" },
+      { "title": "removed block reference", "path": "block/removed" },
+      { "title": "moved block reference", "path": "block/moved" }
+    ]
+  },
+  {
+    "title": "Stacks",
+    "routes": [
+      { "title": "Overview", "path": "stacks",  "alias": "stacks"},
+      { "title": "Update from beta to general availability", "path": "stacks/update-GA" },
+      { "title": "Use cases", "path": "stacks/use-cases" },
+      { "title": "Design a Stack", "path": "stacks/design" },
       {
-        "title": "Validate your configuration",
-        "path": "validate"
+        "title": "Create a Stack",
+        "routes": [
+          { "title": "Define configuration", "path": "stacks/component/config" },
+          { "title": "Declare providers", "path": "stacks/component/declare-providers" },
+          { "title": "Manage components", "path": "stacks/component/manage" }
+        ]
       },
       {
+        "title": "Define deployments",
+        "routes": [
+          { "title": "Define configuration", "path": "stacks/deploy/config" },
+          { "title": "Set conditions for deployment runs", "path": "stacks/deploy/conditions" },
+          { "title": "Authenticate a Stack", "path": "stacks/deploy/authenticate" },
+          { "title": "Pass data from one Stack to another", "path": "stacks/deploy/pass-data" }
+        ]
+      }
+    ]
+  },
+  {
+    "title": "Test and validate",
+    "routes": [
+     { "title": "Validate your configuration", "path": "validate" },
+       {
         "title": "Test your configuration",
         "routes": [
           {
@@ -317,91 +289,78 @@
             "path": "tests/mocking"
           }
         ]
+      },
+      {
+        "title": "check block reference",
+        "path": "block/check"
       }
     ]
   },
   {
-    "title": "Manage infrastructure at scale with Stacks",
+    "title": "Extend CRUD operations",
+    "alias": "actions, terraform actions",
     "routes": [
       {
-        "title": "Overview",
-        "path": "stacks",
-        "alias": "stacks"
+        "title": "Invoke actions",
+        "path": "invoke-actions"
       },
       {
-        "title": "Update from beta to general availability",
-        "path": "stacks/update-GA"
+        "title": "Post-apply operations",
+        "path": "post-apply-operations"
       },
       {
-        "title": "Use cases",
-        "path": "stacks/use-cases"
+        "title": "Provisioners",
+        "path": "provisioners"
       },
       {
-        "title": "Design a Stack",
-        "path": "stacks/design"
-      },
-      {
-        "title": "Create a Stack",
-        "routes": [
-          {
-            "title": "Define configuration",
-            "path": "stacks/component/config"
-          },
-          {
-            "title": "Declare providers",
-            "path": "stacks/component/declare-providers"
-          },
-          {
-            "title": "Manage components",
-            "path": "stacks/component/manage"
-          }
-        ]
-      },
-      {
-        "title": "Define deployments",
-        "routes": [
-          {
-            "title": "Define configuration",
-            "path": "stacks/deploy/config"
-          },
-          {
-            "title": "Set conditions for deployment runs",
-            "path": "stacks/deploy/conditions"
-          },
-          {
-            "title": "Authenticate a Stack",
-            "path": "stacks/deploy/authenticate"
-          },
-          {
-            "title": "Pass data from one Stack to another",
-            "path": "stacks/deploy/pass-data"
-          }
-        ]
+        "title": "action block reference",
+        "path": "block/action"
       }
     ]
   },
+  { "divider": true },
+  { "heading": "UPGRADE"},
+  { "title": "Upgrade to v1.14", "path": "upgrade-guides" },
   {
-    "title": "Invoke actions",
-    "path": "invoke-actions"
-  },
-  {
-    "title": "Use provisioners for post-apply operations",
-    "path": "provisioners",
-    "alias": "provisioners"
-  },
-  {
-    "title": "Upgrading to Terraform v1.15",
-    "path": "upgrade-guides"
-  },
-  {
-    "title": "v1.x Compatibility promises",
+    "title": "v1.x compatibility promises",
     "path": "v1-compatibility-promises"
   },
   {
-    "divider": true
+    "divider": true },    
+  { "heading": "REFERENCE" },
+  {
+    "title": "Style guide",
+    "path": "style"
   },
   {
-    "heading": "REFERENCE"
+    "title": "Syntax",
+    "routes": [
+      { "title": "Overview", "path": "syntax" },
+      {
+        "title": "Configuration syntax",
+        "path": "syntax/configuration"
+      },
+      {
+        "title": "JSON configuration syntax",
+        "path": "syntax/json"
+      },
+      {
+        "title": "Attributes as blocks",
+        "path": "attr-as-blocks",
+        "hidden": false
+      }
+    ]
+  },
+  {
+    "title": "Files and configuration structure",
+    "routes": [
+      { "title": "Overview", "path": "files" },
+      { "title": "Override files", "path": "files/override" },
+      { "title": "Dependency lock file", "path": "files/dependency-lock" },
+      { "title": "Test files", "path": "files/tests" },
+      { "title": "Query files", "path": "files/tfquery" },
+      { "title": "Stack files", "path": "files/stack" }
+    ]
   },
   {
     "title": "Configuration blocks",
@@ -464,90 +423,38 @@
       }
     ]
   },
-  {
+{
     "title": "Stack blocks",
     "routes": [
-      {
-        "title": "Component configuration",
-        "routes": [
-          {
-            "title": "Overview",
-            "path": "block/stack/tfcomponent"
-          },
-          {
-            "title": "component",
-            "path": "block/stack/tfcomponent/component"
-          },
-          { "title": "stack", "path": "block/stack/tfcomponent/stack" },
-          {
-            "title": "required_providers",
-            "path": "block/stack/tfcomponent/required_providers"
-          },
-          {
-            "title": "provider",
-            "path": "block/stack/tfcomponent/provider"
-          },
-          {
-            "title": "variable",
-            "path": "block/stack/tfcomponent/variable"
-          },
-          {
-            "title": "output",
-            "path": "block/stack/tfcomponent/output"
-          },
-          {
-            "title": "removed",
-            "path": "block/stack/tfcomponent/removed"
-          },
-          {
-            "title": "locals",
-            "href": "block/locals"
-          }
-        ]
+      { "title": "Component configuration", "routes": [
+        { "title": "Overview", "path": "block/stack/tfcomponent" },
+        { "title": "component", "path": "block/stack/tfcomponent/component" },
+        { "title": "stack", "path": "block/stack/tfcomponent/stack" },
+        { "title": "required_providers", "path": "block/stack/tfcomponent/required_providers" },
+        { "title": "provider", "path": "block/stack/tfcomponent/provider" },
+        { "title": "variable", "path": "block/stack/tfcomponent/variable" },
+        { "title": "output", "path": "block/stack/tfcomponent/output" },
+        { "title": "removed", "path": "block/stack/tfcomponent/removed" },
+        { "title": "locals", "href": "block/locals" }
+      ]
       },
-      {
-        "title": "Deployment configuration",
-        "routes": [
-          {
-            "title": "Overview",
-            "path": "block/stack/tfdeploy"
-          },
-          {
-            "title": "deployment",
-            "path": "block/stack/tfdeploy/deployment"
-          },
-          {
-            "title": "deployment_group",
-            "path": "block/stack/tfdeploy/deployment_group"
-          },
-          {
-            "title": "deployment_auto_approve",
-            "path": "block/stack/tfdeploy/deployment_auto_approve"
-          },
-          {
-            "title": "identity_token",
-            "path": "block/stack/tfdeploy/identity_token"
-          },
-          {
-            "title": "store",
-            "path": "block/stack/tfdeploy/store"
-          },
-          {
-            "title": "publish_output",
-            "path": "block/stack/tfdeploy/publish_output"
-          },
-          {
-            "title": "upstream_input",
-            "path": "block/stack/tfdeploy/upstream_input"
-          },
-          {
-            "title": "locals",
-            "href": "block/locals"
-          }
-        ]
+      { "title": "Deployment configuration", "routes": [
+        { "title": "Overview", "path": "block/stack/tfdeploy" },
+        { "title": "deployment", "path": "block/stack/tfdeploy/deployment" },
+        { "title": "deployment_group", "path": "block/stack/tfdeploy/deployment_group" },
+        { "title": "deployment_auto_approve", "path": "block/stack/tfdeploy/deployment_auto_approve" },
+        { "title": "identity_token", "path": "block/stack/tfdeploy/identity_token" },
+        { "title": "store", "path": "block/stack/tfdeploy/store" },
+        { "title": "publish_output", "path": "block/stack/tfdeploy/publish_output" },
+        { "title": "upstream_input", "path": "block/stack/tfdeploy/upstream_input" },
+        {
+          "title": "locals",
+          "href": "block/locals"
+        }
+      ]
       }
     ]
-  },
+    },
   {
     "title": "Query blocks",
     "routes": [
@@ -610,6 +517,7 @@
       {
         "title": "<code>terraform_data</code> resource reference",
         "path": "resources/terraform-data"
+
       },
       {
         "title": "The <code>terraform_remote_state</code> data source",
@@ -617,17 +525,11 @@
       }
     ]
   },
-  {
+   {
     "title": "Expressions",
     "routes": [
-      {
-        "title": "Overview",
-        "path": "expressions"
-      },
-      {
-        "title": "Types and values",
-        "path": "expressions/types"
-      },
+      { "title": "Overview", "path": "expressions" },
+      { "title": "Types and values", "path": "expressions/types" },
       {
         "title": "Strings and templates",
         "path": "expressions/strings"
@@ -636,10 +538,7 @@
         "title": "References to values",
         "path": "expressions/references"
       },
-      {
-        "title": "Operators",
-        "path": "expressions/operators"
-      },
+      { "title": "Operators", "path": "expressions/operators" },
       {
         "title": "Function calls",
         "path": "expressions/function-calls"
@@ -648,14 +547,12 @@
         "title": "Conditional expressions",
         "path": "expressions/conditionals"
       },
-      {
-        "title": "For expressions",
-        "path": "expressions/for"
-      },
+      { "title": "For expressions", "path": "expressions/for" },
       {
         "title": "Splat expressions",
         "path": "expressions/splat"
       },
+
       {
         "title": "Dynamic blocks",
         "path": "expressions/dynamic-blocks"
@@ -673,45 +570,24 @@
   {
     "title": "Functions",
     "routes": [
-      {
-        "title": "Overview",
-        "path": "functions"
-      },
+      { "title": "Overview", "path": "functions" },
       {
         "title": "Numeric functions",
         "routes": [
-          {
-            "title": "<code>abs</code>",
-            "href": "/language/functions/abs"
-          },
-          {
-            "title": "<code>ceil</code>",
-            "href": "/language/functions/ceil"
-          },
+          { "title": "<code>abs</code>", "href": "/language/functions/abs" },
+          { "title": "<code>ceil</code>", "href": "/language/functions/ceil" },
           {
             "title": "<code>floor</code>",
             "href": "/language/functions/floor"
           },
-          {
-            "title": "<code>log</code>",
-            "href": "/language/functions/log"
-          },
-          {
-            "title": "<code>max</code>",
-            "href": "/language/functions/max"
-          },
-          {
-            "title": "<code>min</code>",
-            "href": "/language/functions/min"
-          },
+          { "title": "<code>log</code>", "href": "/language/functions/log" },
+          { "title": "<code>max</code>", "href": "/language/functions/max" },
+          { "title": "<code>min</code>", "href": "/language/functions/min" },
           {
             "title": "<code>parseint</code>",
             "href": "/language/functions/parseint"
           },
-          {
-            "title": "<code>pow</code>",
-            "href": "/language/functions/pow"
-          },
+          { "title": "<code>pow</code>", "href": "/language/functions/pow" },
           {
             "title": "<code>signum</code>",
             "href": "/language/functions/signum"
@@ -741,10 +617,7 @@
             "title": "<code>indent</code>",
             "href": "/language/functions/indent"
           },
-          {
-            "title": "<code>join</code>",
-            "href": "/language/functions/join"
-          },
+          { "title": "<code>join</code>", "href": "/language/functions/join" },
           {
             "title": "<code>lower</code>",
             "href": "/language/functions/lower"
@@ -789,10 +662,7 @@
             "title": "<code>title</code>",
             "href": "/language/functions/title"
           },
-          {
-            "title": "<code>trim</code>",
-            "href": "/language/functions/trim"
-          },
+          { "title": "<code>trim</code>", "href": "/language/functions/trim" },
           {
             "title": "<code>trimprefix</code>",
             "href": "/language/functions/trimprefix"
@@ -805,10 +675,7 @@
             "title": "<code>trimspace</code>",
             "href": "/language/functions/trimspace"
           },
-          {
-            "title": "<code>upper</code>",
-            "href": "/language/functions/upper"
-          }
+          { "title": "<code>upper</code>", "href": "/language/functions/upper" }
         ]
       },
       {
@@ -862,26 +729,17 @@
             "title": "<code>index</code>",
             "href": "/language/functions/index_function"
           },
-          {
-            "title": "<code>keys</code>",
-            "href": "/language/functions/keys"
-          },
+          { "title": "<code>keys</code>", "href": "/language/functions/keys" },
           {
             "title": "<code>length</code>",
             "href": "/language/functions/length"
           },
-          {
-            "title": "<code>list</code>",
-            "href": "/language/functions/list"
-          },
+          { "title": "<code>list</code>", "href": "/language/functions/list" },
           {
             "title": "<code>lookup</code>",
             "href": "/language/functions/lookup"
           },
-          {
-            "title": "<code>map</code>",
-            "href": "/language/functions/map"
-          },
+          { "title": "<code>map</code>", "href": "/language/functions/map" },
           {
             "title": "<code>matchkeys</code>",
             "href": "/language/functions/matchkeys"
@@ -890,10 +748,7 @@
             "title": "<code>merge</code>",
             "href": "/language/functions/merge"
           },
-          {
-            "title": "<code>one</code>",
-            "href": "/language/functions/one"
-          },
+          { "title": "<code>one</code>", "href": "/language/functions/one" },
           {
             "title": "<code>range</code>",
             "href": "/language/functions/range"
@@ -922,14 +777,8 @@
             "title": "<code>slice</code>",
             "href": "/language/functions/slice"
           },
-          {
-            "title": "<code>sort</code>",
-            "href": "/language/functions/sort"
-          },
-          {
-            "title": "<code>sum</code>",
-            "href": "/language/functions/sum"
-          },
+          { "title": "<code>sort</code>", "href": "/language/functions/sort" },
+          { "title": "<code>sum</code>", "href": "/language/functions/sum" },
           {
             "title": "<code>transpose</code>",
             "href": "/language/functions/transpose"
@@ -1012,10 +861,7 @@
             "title": "<code>basename</code>",
             "href": "/language/functions/basename"
           },
-          {
-            "title": "<code>file</code>",
-            "href": "/language/functions/file"
-          },
+          { "title": "<code>file</code>", "href": "/language/functions/file" },
           {
             "title": "<code>fileexists</code>",
             "href": "/language/functions/fileexists"
@@ -1098,18 +944,12 @@
             "title": "<code>filesha512</code>",
             "href": "/language/functions/filesha512"
           },
-          {
-            "title": "<code>md5</code>",
-            "href": "/language/functions/md5"
-          },
+          { "title": "<code>md5</code>", "href": "/language/functions/md5" },
           {
             "title": "<code>rsadecrypt</code>",
             "href": "/language/functions/rsadecrypt"
           },
-          {
-            "title": "<code>sha1</code>",
-            "href": "/language/functions/sha1"
-          },
+          { "title": "<code>sha1</code>", "href": "/language/functions/sha1" },
           {
             "title": "<code>sha256</code>",
             "href": "/language/functions/sha256"
@@ -1118,10 +958,7 @@
             "title": "<code>sha512</code>",
             "href": "/language/functions/sha512"
           },
-          {
-            "title": "<code>uuid</code>",
-            "href": "/language/functions/uuid"
-          },
+          { "title": "<code>uuid</code>", "href": "/language/functions/uuid" },
           {
             "title": "<code>uuidv5</code>",
             "href": "/language/functions/uuidv5"
@@ -1152,14 +989,8 @@
       {
         "title": "Type conversion functions",
         "routes": [
-          {
-            "title": "<code>can</code>",
-            "href": "/language/functions/can"
-          },
-          {
-            "title": "<code>ephemeralasnull</code>",
-            "href": "/language/functions/ephemeralasnull"
-          },
+          { "title": "<code>can</code>", "href": "/language/functions/can" },
+          { "title": "<code>ephemeralasnull</code>", "href": "/language/functions/ephemeralasnull" },
           {
             "title": "<code>issensitive</code>",
             "href": "/language/functions/issensitive"
@@ -1196,57 +1027,23 @@
             "title": "<code>tostring</code>",
             "href": "/language/functions/tostring"
           },
-          {
-            "title": "<code>try</code>",
-            "href": "/language/functions/try"
-          },
-          {
-            "title": "<code>type</code>",
-            "href": "/language/functions/type"
-          }
+          { "title": "<code>try</code>", "href": "/language/functions/try" },
+          { "title": "<code>type</code>", "href": "/language/functions/type" }
         ]
       },
       {
         "title": "Terraform-specific functions",
         "routes": [
-          {
-            "title": "<code>provider::terraform::encode_tfvars</code>",
-            "href": "/language/functions/terraform-encode_tfvars"
-          },
-          {
-            "title": "<code>provider::terraform::decode_tfvars</code>",
-            "href": "/language/functions/terraform-decode_tfvars"
-          },
-          {
-            "title": "<code>provider::terraform::encode_expr</code>",
-            "href": "/language/functions/terraform-encode_expr"
-          },
-          {
-            "title": "<code>terraform.applying</code>",
-            "href": "/language/functions/terraform-applying"
-          }
+          { "title": "<code>provider::terraform::encode_tfvars</code>", "href": "/language/functions/terraform-encode_tfvars" },
+          { "title": "<code>provider::terraform::decode_tfvars</code>", "href": "/language/functions/terraform-decode_tfvars" },
+          { "title": "<code>provider::terraform::encode_expr</code>", "href": "/language/functions/terraform-encode_expr" },
+          { "title": "<code>terraform.applying</code>", "href": "/language/functions/terraform-applying" }
         ]
       },
-      {
-        "title": "abs",
-        "path": "functions/abs",
-        "hidden": true
-      },
-      {
-        "title": "abspath",
-        "path": "functions/abspath",
-        "hidden": true
-      },
-      {
-        "title": "alltrue",
-        "path": "functions/alltrue",
-        "hidden": true
-      },
-      {
-        "title": "anytrue",
-        "path": "functions/anytrue",
-        "hidden": true
-      },
+      { "title": "abs", "path": "functions/abs", "hidden": true },
+      { "title": "abspath", "path": "functions/abspath", "hidden": true },
+      { "title": "alltrue", "path": "functions/alltrue", "hidden": true },
+      { "title": "anytrue", "path": "functions/anytrue", "hidden": true },
       {
         "title": "base64decode",
         "path": "functions/base64decode",
@@ -1257,11 +1054,7 @@
         "path": "functions/base64encode",
         "hidden": true
       },
-      {
-        "title": "base64gzip",
-        "path": "functions/base64gzip",
-        "hidden": true
-      },
+      { "title": "base64gzip", "path": "functions/base64gzip", "hidden": true },
       {
         "title": "base64sha256",
         "path": "functions/base64sha256",
@@ -1272,121 +1065,41 @@
         "path": "functions/base64sha512",
         "hidden": true
       },
-      {
-        "title": "basename",
-        "path": "functions/basename",
-        "hidden": true
-      },
-      {
-        "title": "bcrypt",
-        "path": "functions/bcrypt",
-        "hidden": true
-      },
-      {
-        "title": "can",
-        "path": "functions/can",
-        "hidden": true
-      },
-      {
-        "title": "ceil",
-        "path": "functions/ceil",
-        "hidden": true
-      },
-      {
-        "title": "chomp",
-        "path": "functions/chomp",
-        "hidden": true
-      },
-      {
-        "title": "chunklist",
-        "path": "functions/chunklist",
-        "hidden": true
-      },
-      {
-        "title": "cidrhost",
-        "path": "functions/cidrhost",
-        "hidden": true
-      },
+      { "title": "basename", "path": "functions/basename", "hidden": true },
+      { "title": "bcrypt", "path": "functions/bcrypt", "hidden": true },
+      { "title": "can", "path": "functions/can", "hidden": true },
+      { "title": "ceil", "path": "functions/ceil", "hidden": true },
+      { "title": "chomp", "path": "functions/chomp", "hidden": true },
+      { "title": "chunklist", "path": "functions/chunklist", "hidden": true },
+      { "title": "cidrhost", "path": "functions/cidrhost", "hidden": true },
       {
         "title": "cidrnetmask",
         "path": "functions/cidrnetmask",
         "hidden": true
       },
-      {
-        "title": "cidrsubnet",
-        "path": "functions/cidrsubnet",
-        "hidden": true
-      },
+      { "title": "cidrsubnet", "path": "functions/cidrsubnet", "hidden": true },
       {
         "title": "cidrsubnets",
         "path": "functions/cidrsubnets",
         "hidden": true
       },
-      {
-        "title": "coalesce",
-        "path": "functions/coalesce",
-        "hidden": true
-      },
+      { "title": "coalesce", "path": "functions/coalesce", "hidden": true },
       {
         "title": "coalescelist",
         "path": "functions/coalescelist",
         "hidden": true
       },
-      {
-        "title": "compact",
-        "path": "functions/compact",
-        "hidden": true
-      },
-      {
-        "title": "concat",
-        "path": "functions/concat",
-        "hidden": true
-      },
-      {
-        "title": "contains",
-        "path": "functions/contains",
-        "hidden": true
-      },
-      {
-        "title": "csvdecode",
-        "path": "functions/csvdecode",
-        "hidden": true
-      },
-      {
-        "title": "dirname",
-        "path": "functions/dirname",
-        "hidden": true
-      },
-      {
-        "title": "distinct",
-        "path": "functions/distinct",
-        "hidden": true
-      },
-      {
-        "title": "element",
-        "path": "functions/element",
-        "hidden": true
-      },
-      {
-        "title": "endswith",
-        "path": "functions/endswith",
-        "hidden": true
-      },
-      {
-        "title": "ephemeralasnull",
-        "path": "functions/ephemeralasnull",
-        "hidden": true
-      },
-      {
-        "title": "file",
-        "path": "functions/file",
-        "hidden": true
-      },
-      {
-        "title": "filebase64",
-        "path": "functions/filebase64",
-        "hidden": true
-      },
+      { "title": "compact", "path": "functions/compact", "hidden": true },
+      { "title": "concat", "path": "functions/concat", "hidden": true },
+      { "title": "contains", "path": "functions/contains", "hidden": true },
+      { "title": "csvdecode", "path": "functions/csvdecode", "hidden": true },
+      { "title": "dirname", "path": "functions/dirname", "hidden": true },
+      { "title": "distinct", "path": "functions/distinct", "hidden": true },
+      { "title": "element", "path": "functions/element", "hidden": true },
+      { "title": "endswith", "path": "functions/endswith", "hidden": true },
+      { "title": "ephemeralasnull", "path": "functions/ephemeralasnull", "hidden": true },
+      { "title": "file", "path": "functions/file", "hidden": true },
+      { "title": "filebase64", "path": "functions/filebase64", "hidden": true },
       {
         "title": "filebase64sha256",
         "path": "functions/filebase64sha256",
@@ -1397,296 +1110,80 @@
         "path": "functions/filebase64sha512",
         "hidden": true
       },
-      {
-        "title": "fileexists",
-        "path": "functions/fileexists",
-        "hidden": true
-      },
-      {
-        "title": "filemd5",
-        "path": "functions/filemd5",
-        "hidden": true
-      },
-      {
-        "title": "fileset",
-        "path": "functions/fileset",
-        "hidden": true
-      },
-      {
-        "title": "filesha1",
-        "path": "functions/filesha1",
-        "hidden": true
-      },
-      {
-        "title": "filesha256",
-        "path": "functions/filesha256",
-        "hidden": true
-      },
-      {
-        "title": "filesha512",
-        "path": "functions/filesha512",
-        "hidden": true
-      },
-      {
-        "title": "flatten",
-        "path": "functions/flatten",
-        "hidden": true
-      },
-      {
-        "title": "floor",
-        "path": "functions/floor",
-        "hidden": true
-      },
-      {
-        "title": "format",
-        "path": "functions/format",
-        "hidden": true
-      },
-      {
-        "title": "formatdate",
-        "path": "functions/formatdate",
-        "hidden": true
-      },
-      {
-        "title": "formatlist",
-        "path": "functions/formatlist",
-        "hidden": true
-      },
-      {
-        "title": "indent",
-        "path": "functions/indent",
-        "hidden": true
-      },
-      {
-        "title": "index",
-        "path": "functions/index_function",
-        "hidden": true
-      },
+      { "title": "fileexists", "path": "functions/fileexists", "hidden": true },
+      { "title": "filemd5", "path": "functions/filemd5", "hidden": true },
+      { "title": "fileset", "path": "functions/fileset", "hidden": true },
+      { "title": "filesha1", "path": "functions/filesha1", "hidden": true },
+      { "title": "filesha256", "path": "functions/filesha256", "hidden": true },
+      { "title": "filesha512", "path": "functions/filesha512", "hidden": true },
+      { "title": "flatten", "path": "functions/flatten", "hidden": true },
+      { "title": "floor", "path": "functions/floor", "hidden": true },
+      { "title": "format", "path": "functions/format", "hidden": true },
+      { "title": "formatdate", "path": "functions/formatdate", "hidden": true },
+      { "title": "formatlist", "path": "functions/formatlist", "hidden": true },
+      { "title": "indent", "path": "functions/indent", "hidden": true },
+      { "title": "index", "path": "functions/index_function", "hidden": true },
       {
         "title": "issensitive",
         "path": "functions/issensitive",
         "hidden": true
       },
-      {
-        "title": "join",
-        "path": "functions/join",
-        "hidden": true
-      },
-      {
-        "title": "jsondecode",
-        "path": "functions/jsondecode",
-        "hidden": true
-      },
-      {
-        "title": "jsonencode",
-        "path": "functions/jsonencode",
-        "hidden": true
-      },
-      {
-        "title": "keys",
-        "path": "functions/keys",
-        "hidden": true
-      },
-      {
-        "title": "length",
-        "path": "functions/length",
-        "hidden": true
-      },
-      {
-        "title": "list",
-        "path": "functions/list",
-        "hidden": true
-      },
-      {
-        "title": "log",
-        "path": "functions/log",
-        "hidden": true
-      },
-      {
-        "title": "lookup",
-        "path": "functions/lookup",
-        "hidden": true
-      },
-      {
-        "title": "lower",
-        "path": "functions/lower",
-        "hidden": true
-      },
-      {
-        "title": "map",
-        "path": "functions/map",
-        "hidden": true
-      },
-      {
-        "title": "matchkeys",
-        "path": "functions/matchkeys",
-        "hidden": true
-      },
-      {
-        "title": "max",
-        "path": "functions/max",
-        "hidden": true
-      },
-      {
-        "title": "md5",
-        "path": "functions/md5",
-        "hidden": true
-      },
-      {
-        "title": "merge",
-        "path": "functions/merge",
-        "hidden": true
-      },
-      {
-        "title": "min",
-        "path": "functions/min",
-        "hidden": true
-      },
+      { "title": "join", "path": "functions/join", "hidden": true },
+      { "title": "jsondecode", "path": "functions/jsondecode", "hidden": true },
+      { "title": "jsonencode", "path": "functions/jsonencode", "hidden": true },
+      { "title": "keys", "path": "functions/keys", "hidden": true },
+      { "title": "length", "path": "functions/length", "hidden": true },
+      { "title": "list", "path": "functions/list", "hidden": true },
+      { "title": "log", "path": "functions/log", "hidden": true },
+      { "title": "lookup", "path": "functions/lookup", "hidden": true },
+      { "title": "lower", "path": "functions/lower", "hidden": true },
+      { "title": "map", "path": "functions/map", "hidden": true },
+      { "title": "matchkeys", "path": "functions/matchkeys", "hidden": true },
+      { "title": "max", "path": "functions/max", "hidden": true },
+      { "title": "md5", "path": "functions/md5", "hidden": true },
+      { "title": "merge", "path": "functions/merge", "hidden": true },
+      { "title": "min", "path": "functions/min", "hidden": true },
       {
         "title": "nonsensitive",
         "path": "functions/nonsensitive",
         "hidden": true
       },
-      {
-        "title": "one",
-        "path": "functions/one",
-        "hidden": true
-      },
-      {
-        "title": "parseint",
-        "path": "functions/parseint",
-        "hidden": true
-      },
-      {
-        "title": "pathexpand",
-        "path": "functions/pathexpand",
-        "hidden": true
-      },
-      {
-        "title": "plantimestamp",
-        "path": "functions/plantimestamp",
-        "hidden": true
-      },
-      {
-        "title": "pow",
-        "path": "functions/pow",
-        "hidden": true
-      },
-      {
-        "title": "range",
-        "path": "functions/range",
-        "hidden": true
-      },
-      {
-        "title": "regex",
-        "path": "functions/regex",
-        "hidden": true
-      },
-      {
-        "title": "regexall",
-        "path": "functions/regexall",
-        "hidden": true
-      },
-      {
-        "title": "replace",
-        "path": "functions/replace",
-        "hidden": true
-      },
-      {
-        "title": "reverse",
-        "path": "functions/reverse",
-        "hidden": true
-      },
-      {
-        "title": "rsadecrypt",
-        "path": "functions/rsadecrypt",
-        "hidden": true
-      },
-      {
-        "title": "sensitive",
-        "path": "functions/sensitive",
-        "hidden": true
-      },
+      { "title": "one", "path": "functions/one", "hidden": true },
+      { "title": "parseint", "path": "functions/parseint", "hidden": true },
+      { "title": "pathexpand", "path": "functions/pathexpand", "hidden": true },
+      { "title": "plantimestamp", "path": "functions/plantimestamp", "hidden": true },
+      { "title": "pow", "path": "functions/pow", "hidden": true },
+      { "title": "range", "path": "functions/range", "hidden": true },
+      { "title": "regex", "path": "functions/regex", "hidden": true },
+      { "title": "regexall", "path": "functions/regexall", "hidden": true },
+      { "title": "replace", "path": "functions/replace", "hidden": true },
+      { "title": "reverse", "path": "functions/reverse", "hidden": true },
+      { "title": "rsadecrypt", "path": "functions/rsadecrypt", "hidden": true },
+      { "title": "sensitive", "path": "functions/sensitive", "hidden": true },
       {
         "title": "setintersection",
         "path": "functions/setintersection",
         "hidden": true
       },
-      {
-        "title": "setproduct",
-        "path": "functions/setproduct",
-        "hidden": true
-      },
+      { "title": "setproduct", "path": "functions/setproduct", "hidden": true },
       {
         "title": "setsubtract",
         "path": "functions/setsubtract",
         "hidden": true
       },
-      {
-        "title": "setunion",
-        "path": "functions/setunion",
-        "hidden": true
-      },
-      {
-        "title": "sha1",
-        "path": "functions/sha1",
-        "hidden": true
-      },
-      {
-        "title": "sha256",
-        "path": "functions/sha256",
-        "hidden": true
-      },
-      {
-        "title": "sha512",
-        "path": "functions/sha512",
-        "hidden": true
-      },
-      {
-        "title": "signum",
-        "path": "functions/signum",
-        "hidden": true
-      },
-      {
-        "title": "slice",
-        "path": "functions/slice",
-        "hidden": true
-      },
-      {
-        "title": "sort",
-        "path": "functions/sort",
-        "hidden": true
-      },
-      {
-        "title": "split",
-        "path": "functions/split",
-        "hidden": true
-      },
-      {
-        "title": "startswith",
-        "path": "functions/startswith",
-        "hidden": true
-      },
-      {
-        "title": "strcontains",
-        "path": "functions/strcontains",
-        "hidden": true
-      },
-      {
-        "title": "strrev",
-        "path": "functions/strrev",
-        "hidden": true
-      },
-      {
-        "title": "substr",
-        "path": "functions/substr",
-        "hidden": true
-      },
-      {
-        "title": "sum",
-        "path": "functions/sum",
-        "hidden": true
-      },
+      { "title": "setunion", "path": "functions/setunion", "hidden": true },
+      { "title": "sha1", "path": "functions/sha1", "hidden": true },
+      { "title": "sha256", "path": "functions/sha256", "hidden": true },
+      { "title": "sha512", "path": "functions/sha512", "hidden": true },
+      { "title": "signum", "path": "functions/signum", "hidden": true },
+      { "title": "slice", "path": "functions/slice", "hidden": true },
+      { "title": "sort", "path": "functions/sort", "hidden": true },
+      { "title": "split", "path": "functions/split", "hidden": true },
+      { "title": "startswith", "path": "functions/startswith", "hidden": true },
+      { "title": "strcontains", "path": "functions/strcontains", "hidden": true},
+      { "title": "strrev", "path": "functions/strrev", "hidden": true },
+      { "title": "substr", "path": "functions/substr", "hidden": true },
+      { "title": "sum", "path": "functions/sum", "hidden": true },
       {
         "title": "templatefile",
         "path": "functions/templatefile",
@@ -1702,21 +1199,9 @@
         "path": "functions/terraform-applying",
         "hidden": true
       },
-      {
-        "title": "terraform-encode_tfvars",
-        "path": "functions/terraform-encode_tfvars",
-        "hidden": true
-      },
-      {
-        "title": "terraform-decode_tfvars",
-        "path": "functions/terraform-decode_tfvars",
-        "hidden": true
-      },
-      {
-        "title": "terraform-encode_expr",
-        "path": "functions/terraform-encode_expr",
-        "hidden": true
-      },
+      { "title": "terraform-encode_tfvars", "path": "functions/terraform-encode_tfvars", "hidden": true },
+      { "title": "terraform-decode_tfvars", "path": "functions/terraform-decode_tfvars", "hidden": true },
+      { "title": "terraform-encode_expr", "path": "functions/terraform-encode_expr", "hidden": true },
       {
         "title": "textdecodebase64",
         "path": "functions/textdecodebase64",
@@ -1727,135 +1212,32 @@
         "path": "functions/textencodebase64",
         "hidden": true
       },
-      {
-        "title": "timeadd",
-        "path": "functions/timeadd",
-        "hidden": true
-      },
-      {
-        "title": "timecmp",
-        "path": "functions/timecmp",
-        "hidden": true
-      },
-      {
-        "title": "timestamp",
-        "path": "functions/timestamp",
-        "hidden": true
-      },
-      {
-        "title": "title",
-        "path": "functions/title",
-        "hidden": true
-      },
-      {
-        "title": "tobool",
-        "path": "functions/tobool",
-        "hidden": true
-      },
-      {
-        "title": "tolist",
-        "path": "functions/tolist",
-        "hidden": true
-      },
-      {
-        "title": "tomap",
-        "path": "functions/tomap",
-        "hidden": true
-      },
-      {
-        "title": "tonumber",
-        "path": "functions/tonumber",
-        "hidden": true
-      },
-      {
-        "title": "toset",
-        "path": "functions/toset",
-        "hidden": true
-      },
-      {
-        "title": "tostring",
-        "path": "functions/tostring",
-        "hidden": true
-      },
-      {
-        "title": "transpose",
-        "path": "functions/transpose",
-        "hidden": true
-      },
-      {
-        "title": "trim",
-        "path": "functions/trim",
-        "hidden": true
-      },
-      {
-        "title": "trimprefix",
-        "path": "functions/trimprefix",
-        "hidden": true
-      },
-      {
-        "title": "trimspace",
-        "path": "functions/trimspace",
-        "hidden": true
-      },
-      {
-        "title": "trimsuffix",
-        "path": "functions/trimsuffix",
-        "hidden": true
-      },
-      {
-        "title": "try",
-        "path": "functions/try",
-        "hidden": true
-      },
-      {
-        "title": "type",
-        "path": "functions/type",
-        "hidden": true
-      },
-      {
-        "title": "upper",
-        "path": "functions/upper",
-        "hidden": true
-      },
-      {
-        "title": "urlencode",
-        "path": "functions/urlencode",
-        "hidden": true
-      },
-      {
-        "title": "uuid",
-        "path": "functions/uuid",
-        "hidden": true
-      },
-      {
-        "title": "uuidv5",
-        "path": "functions/uuidv5",
-        "hidden": true
-      },
-      {
-        "title": "values",
-        "path": "functions/values",
-        "hidden": true
-      },
-      {
-        "title": "yamldecode",
-        "path": "functions/yamldecode",
-        "hidden": true
-      },
-      {
-        "title": "yamlencode",
-        "path": "functions/yamlencode",
-        "hidden": true
-      },
-      {
-        "title": "zipmap",
-        "path": "functions/zipmap",
-        "hidden": true
-      }
+      { "title": "timeadd", "path": "functions/timeadd", "hidden": true },
+      { "title": "timecmp", "path": "functions/timecmp", "hidden": true },
+      { "title": "timestamp", "path": "functions/timestamp", "hidden": true },
+      { "title": "title", "path": "functions/title", "hidden": true },
+      { "title": "tobool", "path": "functions/tobool", "hidden": true },
+      { "title": "tolist", "path": "functions/tolist", "hidden": true },
+      { "title": "tomap", "path": "functions/tomap", "hidden": true },
+      { "title": "tonumber", "path": "functions/tonumber", "hidden": true },
+      { "title": "toset", "path": "functions/toset", "hidden": true },
+      { "title": "tostring", "path": "functions/tostring", "hidden": true },
+      { "title": "transpose", "path": "functions/transpose", "hidden": true },
+      { "title": "trim", "path": "functions/trim", "hidden": true },
+      { "title": "trimprefix", "path": "functions/trimprefix", "hidden": true },
+      { "title": "trimspace", "path": "functions/trimspace", "hidden": true },
+      { "title": "trimsuffix", "path": "functions/trimsuffix", "hidden": true },
+      { "title": "try", "path": "functions/try", "hidden": true },
+      { "title": "type", "path": "functions/type", "hidden": true },
+      { "title": "upper", "path": "functions/upper", "hidden": true },
+      { "title": "urlencode", "path": "functions/urlencode", "hidden": true },
+      { "title": "uuid", "path": "functions/uuid", "hidden": true },
+      { "title": "uuidv5", "path": "functions/uuidv5", "hidden": true },
+      { "title": "values", "path": "functions/values", "hidden": true },
+      { "title": "yamldecode", "path": "functions/yamldecode", "hidden": true },
+      { "title": "yamlencode", "path": "functions/yamlencode", "hidden": true },
+      { "title": "zipmap", "path": "functions/zipmap", "hidden": true }
     ]
   },
-  {
-    "title": "Terraform internals",
-    "href": "/internals"
-  }
+  { "title": "Internals", "href": "/internals" }
 ]

--- a/content/terraform/v1.15.x/data/language-nav-data.json
+++ b/content/terraform/v1.15.x/data/language-nav-data.json
@@ -258,8 +258,7 @@
         "title": "Create a Stack",
         "routes": [
           { "title": "Define configuration", "path": "stacks/component/config" },
-          { "title": "Declare providers", "path": "stacks/component/declare-providers" },
-          { "title": "Manage components", "path": "stacks/component/manage" }
+          { "title": "Declare providers", "path": "stacks/component/declare-providers" }
         ]
       },
       {
@@ -270,7 +269,8 @@
           { "title": "Authenticate a Stack", "path": "stacks/deploy/authenticate" },
           { "title": "Pass data from one Stack to another", "path": "stacks/deploy/pass-data" }
         ]
-      }
+      },
+      { "title": "Manage components", "path": "stacks/component/manage" }
     ]
   },
   {

--- a/content/terraform/v1.15.x/docs/language/post-apply-operations.mdx
+++ b/content/terraform/v1.15.x/docs/language/post-apply-operations.mdx
@@ -1,0 +1,118 @@
+---
+page_title: Perform post-apply operations using provisioners
+description: Learn how to run commands and scripts and upload files to prepare resources for service after applying the configuration with provisioners, config-init, and configuration management software.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2025-12-04T10:14:56-08:00
+last_modified: 2025-12-04T10:14:56-08:00
+# END AUTO GENERATED METADATA
+---
+
+# Perform post-apply operations
+
+You may need to upload files, run commands and scripts, and perform other operations to prepare resources you create and manage with Terraform for service. Terraform is primarily designed for immutable infrastructure operations, so we strongly recommend using purpose-built solutions to perform post-apply operations. 
+
+> **Hands-on:** Try the [Provision Infrastructure with Cloud-Init](/terraform/tutorials/provision/cloud-init) tutorial.
+
+## Overview
+
+You can use the following methods to prepare a resource for service after applying the configuration:
+
+- Pass data to the resource using the provider's `cloud-init` implementation.
+- Use the `cloudinit-config` data source.
+- Provision machine images with the necessary tools and packages.
+- Use configuration management tools.
+
+The provider may support post-apply operations, such as runing CLI commands and scripts on the resource. Refer to the resource provider documentation for instructions. If the provider does not include a mechanism for interacting with the resource, we recommend opening a feature request ticket with the provider. When you are unable to use a purpose-built solution, you can use functionality built into Terraform called [provisioners](/terraform/language/provisioners).
+
+## Requirements
+
+If you are using third-party software to set resources up for service, such as configuration management or automation software, refer to your vendor's documentation for specific requirements.
+
+## Pass data into compute resources
+
+When deploying virtual machines or other similar compute resources, you can pass data to the resource. Most cloud computing platforms provide mechanisms to pass data to instances at the time of their creation. This makes the data immediately available on system boot.
+
+### Cloud-init
+
+Many Linux distribution disk images include [cloud-init](https://cloudinit.readthedocs.io/en/latest/), which lets you run scripts and configure systems on system boot up. Some providers let you configure cloud-init on the virtual machine's guest operating system. For providers that support cloud-init, the `user_data` and `custom_data` arguments are common methods for passing data. Refer to the provider documentation for details.
+
+In the following example, the `custom_data` argument in the `azurerm_linux_virtual_machine` resource specifies a file containing the data to pass to the resource on startup:
+
+```hcl
+resource "azurerm_linux_virtual_machine" "example" {
+  # . . .
+  custom_data = base64encode(file("custom-data.sh"))
+}
+```
+
+If you build custom machine images, you may be able to access the data passed to the resource using `user_data` or `metadata` at runtime. Refer to your vendor's documentation for more information.
+
+This approach is required when you use your cloud provider to automatically launch and destroy servers in a group because individual servers will launch unattended when Terraform is not available to provision them.
+
+Even if you're deploying individual servers directly with Terraform, using `user_data` or `metadata` to pass data allows for faster boot times. It also simplifies deployment by avoiding the need for direct network access from Terraform to the new server and for remote access credentials to be provided.
+
+### Input arguments
+
+Refer to the following provider resources for instructions on how to pass data to respective compute resources. Note that you can also specify cloud-config files as values. You can use the `cloudinit_config` data source to render cloud-config files. Refer to the [cloudinit_config documentation](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) for more information.
+
+| Cloud service | Argument | Resource type |
+| --- | --- | --- |
+| Alibaba Cloud | `user_data` | [`alicloud_instance`](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/instance), [`alicloud_launch_template`](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/launch_template) |
+| Amazon EC2 | `user_data`, `user_data_base64` | [`aws_instance`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance), [`aws_launch_template`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template), [`aws_launch_configuration`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_configuration) |
+| Amazon Lightsail | `user_data` | [`aws_lightsail_instance`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lightsail_instance) |
+| Microsoft Azure | `custom_data` | [`azurerm_virtual_machine`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_machine), [`azurerm_virtual_machine_scale_set`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_machine_scale_set) |
+| Google Cloud Platform | `metadata` | [`google_compute_instance`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance), [`google_compute_instance_group`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance_group) |
+| Oracle Cloud Infrastructure | `metadata`, `extended_metadata` |  [`oci_core_instance`](https://registry.terraform.io/providers/oracle/oci/), [`oci_core_instance_configuration`](https://registry.terraform.io/providers/oracle/oci/) |
+| VMware vSphere | `cdrom` block | Attach a virtual CDROM to [`vsphere_virtual_machine`](https://registry.terraform.io/providers/hashicorp/vsphere/latest/docs/resources/virtual_machine) using the `cdrom` block and specify a file called `user-data.txt` |
+
+## Use the `cloud-config` data source to pass data
+
+You can add the [`cloudinit_config`](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs) data source to your Terraform configuration and specify the files you want to provision as `text/cloud-config` content. The `cloudinit_config` data source renders multi-part MIME configurations for use with [cloud-init](https://cloudinit.readthedocs.io/en/latest/). Pass the files in the `content` field as YAML-encoded configurations using the `write_files` block.
+
+In the following example, the `my_cloud_config` data source specifies a `text/cloud-config` MIME part named `cloud.conf`. The `part.content` field is set to [`yamlencode`](/terraform/language/functions/yamlencode), which encodes the `write_files` JSON object as YAML so that the system can provision the referenced files.
+
+```hcl
+data "cloudinit_config" "my_cloud_config" {
+  gzip          = false
+  base64_encode = false
+
+  part {
+    content_type = "text/cloud-config"
+    filename     = "cloud.conf"
+    content = yamlencode(
+      {
+        "write_files" : [
+          {
+            "path" : "/etc/foo.conf",
+            "content" : "foo contents",
+          },
+          {
+            "path" : "/etc/bar.conf",
+            "content" : file("bar.conf"),
+          },
+          {
+            "path" : "/etc/baz.conf",
+            "content" : templatefile("baz.tpl.conf", { SOME_VAR = "qux" }),
+          },
+        ],
+      }
+    )
+  }
+}
+```
+
+## Build configuration into machine images
+
+You can use [HashiCorp Packer](/packer) or similar systems to build system configuration steps into custom images. Packer uses configuration management provisioners that can run installation steps during the build process before creating a system disk image that you can reuse.
+
+Configuration management software that uses a centralized server component may require you to register the software as part of the configuration process. You must delay the registration step until the final system is booted from your custom image. You can [pass the necessary information to the resource](#pass-data-into-compute-resources) to delay registration so that the configuration management software can register itself with the centralized server immediately on boot without requiring the resource to accept commands from Terraform over SSH or WinRM.
+
+> **Hands-on:** Try the [Provision Infrastructure with Packer](/terraform/tutorials/provision/packer) tutorial.
+
+## Run CLI commands
+
+The provider may support executing CLI commands on the resource. Refer to the resource provider documentation for instructions on how to invoke the CLI on your target system. If the provider does not include a mechanism for interacting with the resource CLI, we recommend opening a feature request ticket with the provider.
+
+## Execute remote scripts
+
+If the provider does not include a mechanism for executing scripts, we recommend opening a feature request ticket with the provider.

--- a/content/terraform/v1.15.x/docs/language/provisioners.mdx
+++ b/content/terraform/v1.15.x/docs/language/provisioners.mdx
@@ -7,203 +7,36 @@ last_modified: 2025-11-19T19:11:19Z
 # END AUTO GENERATED METADATA
 ---
 
-# Perform post-apply operations
+# Use provisioners to perform post-apply operations
 
-You may need to upload files, run commands and scripts, and perform other operations to prepare resources you create and manage with Terraform for service. Terraform is primarily designed for immutable infrastructure operations, so we strongly recommend using purpose-built solutions to perform post-apply operations. When you are unable to use a purpose-built solution, you can use functionality built into Terraform called provisioners.
+You may need to upload files, run commands and scripts, and perform other operations to prepare resources you create and manage with Terraform for service. 
 
-> **Hands-on:** Try the [Provision Infrastructure Deployed with Terraform](/terraform/tutorials/provision?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorials to learn how to use provisioners.
+<Warning>
+
+Terraform is primarily designed for immutable infrastructure operations, so we strongly recommend using purpose-built solutions to [perform post-apply operations](/terraform/language/post-apply-operations). When you are unable to use a purpose-built solution, you can use functionality built into Terraform called provisioners.
+
+</Warning>
 
 ## Overview
 
-You can use the following methods to prepare a resource for service after applying the configuration:
+Before using a provisioner, you should check with your provider for instructions on how to perform post-apply operations, such as executing CLI commands and scripts on your target system. If the provider does not include a mechanism for interacting with the resource CLI, we recommend opening a feature request ticket with the provider. Refer to [Perform post-apply operations](/terraform/language/post-apply-operations) for more information. 
 
-- Pass data to the resource using the provider's `cloud-init` implementation.
-- Use the `cloudinit-config` data source.
-- Provision machine images with the necessary tools and packages.
-- Use configuration management tools.
-- Use provisioners built into Terraform.
-
-You should exercise extreme caution when using provisioners. Terraform cannot predictably model provisioner behaviors represented in the configuration. Additionally, most provisioners require direct network access to your servers and credentials to install and configure external software, which introduces complexity and potential security issues.
+Terraform includes several built-in provisioners for helping you prepare resources for service when you cannot use machine images or configuration management. You should exhaust all alternatives before using provisioners in your configurations. This is because Terraform cannot predictably model provisioner behaviors represented in the configuration. Additionally, most provisioners require direct network access to your servers and credentials to install and configure external software, which introduces complexity and potential security issues.
 
 ## Requirements
-
-If you are using third-party software to set resources up for service, such as configuration management or automation software, refer to your vendor's documentation for specific requirements.
-
-### Provisioner requirements
 
 - Terraform v0.9 is required to use provisioners.
 - Terraform v1.10 and later is required to use ephemeral values in `provisioner` and  `connection` blocks.
 - Many provisioners require access to the remote resource. Refer to [Connect to remote resources](#connect-to-remote-resources) for instructions on configuring connection settings.
 - To use provisioners that upload files over SSH, the `scp` service program must be installed on the remote system.
 
-## Pass data into compute resources
-
-When deploying virtual machines or other similar compute resources, you can pass data to the resource. Most cloud computing platforms provide mechanisms to pass data to instances at the time of their creation. This makes the data immediately available on system boot.
-
-### Cloud-init
-
-Many Linux distribution disk images include [cloud-init](https://cloudinit.readthedocs.io/en/latest/), which lets you run scripts and configure systems on system boot up. Some providers let you configure cloud-init on the virtual machine's guest operating system. For providers that support cloud-init, the `user_data` and `custom_data` arguments are common methods for passing data. Refer to the provider documentation for details.
-
-In the following example, the `custom_data` argument in the `azurerm_linux_virtual_machine` resource specifies a file containing the data to pass to the resource on startup:
-
-```hcl
-resource "azurerm_linux_virtual_machine" "example" {
-  # . . .
-  custom_data = base64encode(file("custom-data.sh"))
-}
-```
-
-If you build custom machine images, you may be able to access the data passed to the resource using `user_data` or `metadata` at runtime. Refer to your vendor's documentation for more information.
-
-This approach is required when you use your cloud provider to automatically launch and destroy servers in a group because individual servers will launch unattended when Terraform is not available to provision them.
-
-Even if you're deploying individual servers directly with Terraform, using `user_data` or `metadata` to pass data allows for faster boot times. It also simplifies deployment by avoiding the need for direct network access from Terraform to the new server and for remote access credentials to be provided.
-
-### Input arguments
-
-Refer to the following provider resources for instructions on how to pass data to respective compute resources. Note that you can also specify cloud-config files as values. You can use the `cloudinit_config` data source to render cloud-config files. Refer to the [cloudinit_config documentation](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) for more information.
-
-| Cloud service | Argument | Resource type |
-| --- | --- | --- |
-| Alibaba Cloud | `user_data` | [`alicloud_instance`](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/instance), [`alicloud_launch_template`](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/launch_template) |
-| Amazon EC2 | `user_data`, `user_data_base64` | [`aws_instance`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance), [`aws_launch_template`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template), [`aws_launch_configuration`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_configuration) |
-| Amazon Lightsail | `user_data` | [`aws_lightsail_instance`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lightsail_instance) |
-| Microsoft Azure | `custom_data` | [`azurerm_virtual_machine`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_machine), [`azurerm_virtual_machine_scale_set`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_machine_scale_set) |
-| Google Cloud Platform | `metadata` | [`google_compute_instance`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance), [`google_compute_instance_group`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance_group) |
-| Oracle Cloud Infrastructure | `metadata`, `extended_metadata` |  [`oci_core_instance`](https://registry.terraform.io/providers/oracle/oci/), [`oci_core_instance_configuration`](https://registry.terraform.io/providers/oracle/oci/) |
-| VMware vSphere | `cdrom` block | Attach a virtual CDROM to [`vsphere_virtual_machine`](https://registry.terraform.io/providers/hashicorp/vsphere/latest/docs/resources/virtual_machine) using the `cdrom` block and specify a file called `user-data.txt` |
-
-> **Hands-on:** Try the [Provision Infrastructure with Cloud-Init](/terraform/tutorials/provision/cloud-init) tutorial.
-
-## Use the `cloud-config` data source to pass data
-
-You can add the [`cloudinit_config`](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs) data source to your Terraform configuration and specify the files you want to provision as `text/cloud-config` content. The `cloudinit_config` data source renders multi-part MIME configurations for use with [cloud-init](https://cloudinit.readthedocs.io/en/latest/). Pass the files in the `content` field as YAML-encoded configurations using the `write_files` block.
-
-In the following example, the `my_cloud_config` data source specifies a `text/cloud-config` MIME part named `cloud.conf`. The `part.content` field is set to [`yamlencode`](/terraform/language/functions/yamlencode), which encodes the `write_files` JSON object as YAML so that the system can provision the referenced files.
-
-```hcl
-data "cloudinit_config" "my_cloud_config" {
-  gzip          = false
-  base64_encode = false
-
-  part {
-    content_type = "text/cloud-config"
-    filename     = "cloud.conf"
-    content = yamlencode(
-      {
-        "write_files" : [
-          {
-            "path" : "/etc/foo.conf",
-            "content" : "foo contents",
-          },
-          {
-            "path" : "/etc/bar.conf",
-            "content" : file("bar.conf"),
-          },
-          {
-            "path" : "/etc/baz.conf",
-            "content" : templatefile("baz.tpl.conf", { SOME_VAR = "qux" }),
-          },
-        ],
-      }
-    )
-  }
-}
-```
-
-## Build configuration into machine images
-
-You can use [HashiCorp Packer](/packer) or similar systems to build system configuration steps into custom images. Packer uses configuration management provisioners that can run installation steps during the build process before creating a system disk image that you can reuse.
-
-Configuration management software that uses a centralized server component may require you to register the software as part of the configuration process. You must delay the registration step until the final system is booted from your custom image. You can [pass the necessary information to the resource](#pass-data-into-compute-resources) to delay registration so that the configuration management software can register itself with the centralized server immediately on boot without requiring the resource to accept commands from Terraform over SSH or WinRM.
-
-> **Hands-on:** Try the [Provision Infrastructure with Packer](/terraform/tutorials/provision/packer) tutorial.
-
-## Run CLI commands
-
-The provider may support executing CLI commands on the resource. Refer to the resource provider documentation for instructions on how to invoke the CLI on your target system. If the provider does not include a mechanism for interacting with the resource CLI, we recommend opening a feature request ticket with the provider.
-
-As a workaround, you can use a Terraform provisioner to run commands on the machine where Terraform or on a remote resource. Refer to [Use a provisioner](#use-a-provisioner) for instructions on adding provisioners to the resource configuration.
-
-### Commands on the local machine
-
-To run commands on the machine where Terraform is installed, add the `provisioner "local-exec"` block to your `resource` block and specify commands to run in the `command` argument. The following example configures an `aws_instance` resource named `web` to run a local command that prints its IP address:
-
-```hcl
-resource "aws_instance" "web" {
-  # ...
-
-  provisioner "local-exec" {
-    command = "echo The server's IP address is ${self.private_ip}"
-  }
-}
-```
-
-Refer to the [`provisioner` block reference](/terraform/language/block/resource#provisioner) for details about the available arguments.
-
-### Commands on a remote resource
-
-To run commands on a remote resource, add the `remote-exec` provisioner type. This provisioner lets you run the CLI for your target system in order to create, update, or otherwise interact with remote objects in that system. You must include [a `connection` block](/terraform/language/block/resource#connection) for Terraform to connect to the server.
-
-## Execute remote scripts
-
- If the provider does not include a mechanism for executing scripts, we recommend opening a feature request ticket with the provider.
-
-As a workaround, you can use a Terraform provisioner to execute scripts. Refer to [Use a provisioner](#use-a-provisioner) for instructions on adding provisioners to the resource configuration.
-
-When provisioners execute scripts on a remote system over SSH, they usually upload the script file to the remote system then use the default shell to execute it. Provisioners use this strategy because it allows you to use all of the typical scripting techniques supported by that shell, including preserving environment variable values and other context between script statements.
-
-### Remote system paths
-
-Terraform requires a suitable location in the remote filesystem where the provisioner can create the script file. By default, Terraform chooses a path containing a random number using the following patterns depending on how `target_platform` is set:
-
-- `"unix"`: `/tmp/terraform_%RAND%.sh`
-- `"windows"`: `C:/windows/temp/terraform_%RAND%.cmd`
-
-In both cases, the provisioner replaces the sequence `%RAND%` with randomly-chosen decimal digits.
-
-Provisioners cannot react directly to remote environment variables, such as `TMPDIR`, or use functions such as `mktemp` because they run on the system where Terraform is running, not on the remote system. As a result, you can configure the `script_path` argument in your `connection` block to override the path when your remote system doesn't use the filesystem layout expected by these default paths.
-
-```hcl
-connection {
-  # ...
-  script_path = "H:/terraform-temp/script_%RAND%.sh"
-}
-```
-
-Provisioners replace the `%RAND%` sequence with randomly-selected decimal digits to reduce the likelihood of collisions between multiple provisioners running concurrently.
-
-For Windows systems, we recommend using forward slashes instead of backslashes, despite the typical convention on Windows, because the Terraform language uses backslash as the quoted string escape character.
-
-### Execute scripts using SCP over SSH
-
-<Warning>
-
-When using Terraform v1.0 and earlier, avoid using untrusted external values as part of the `script_path` argument.
-
-</Warning>
-
-Provisioners pass the specified script path, after `%RAND%` expansion, directly to the remote `scp` process, which interprets the path. With the default configuration of `scp` as distributed with OpenSSH, you can place temporary scripts in the home directory of the remote user by specifying a relative path:
-
-```hcl
-connection {
-  type = "ssh"
-  # ...
-  script_path = "terraform_provisioner_%RAND%.sh"
-}
-```
-
-## Use a provisioner
-
-Terraform includes several built-in provisioners for helping you prepare resources for service when you cannot use machine images or configuration management. You should exhaust all alternatives before using provisioners in your configurations.
-
-### Add a provisioner to your resource
+## Add a provisioner to your resource
 
 Add one or more `provisioner "<TYPE>"` blocks to the `resource` block you want to perform operations on. You can specify the following types:
 
-  - `file`: Copies files or directories from the machine where Terraform is running to the new resource.
-  - `local-exec`: Invokes an executable on the local machine after Terraform creates the resource.
-  - `remote-exec`: Invokes an executable on the remote resource after Terraform creates the resource.
+- `file`: Copies files or directories from the machine where Terraform is running to the new resource. 
+- `local-exec`: Invokes an executable on the local machine after Terraform creates the resource. Refer to [Run commands on the local machine](#run-commands-on-the-local-machine) for more information.
+- `remote-exec`: Invokes an executable on the remote resource after Terraform creates the resource. Refer to [Run commands on a remote resource](#run-commands-on-a-remote-resource) for more information.
 
 For details about each provisioner type and its arguments, refer to the [`provisioner` block reference](/terraform/language/block/resource#provisioner).
 
@@ -292,11 +125,75 @@ Expressions in `provisioner` blocks and `connection` blocks cannot refer to thei
 You must use the `self` object to reference the resource because using references in the configuration creates dependencies, and referring to a resource by name within its own
 block would create a dependency cycle.
 
+## Run commands on the local machine
+
+To run commands on the machine where Terraform is installed, add the `provisioner "local-exec"` block to your `resource` block and specify commands to run in the `command` argument. The following example configures an `aws_instance` resource named `web` to run a local command that prints its IP address:
+
+```hcl
+resource "aws_instance" "web" {
+  # ...
+
+  provisioner "local-exec" {
+    command = "echo The server's IP address is ${self.private_ip}"
+  }
+}
+```
+
+Refer to the [`provisioner` block reference](/terraform/language/block/resource#provisioner) for details about the available arguments.
+
+## Run commands on a remote resource
+
+To run commands on a remote resource, add the `remote-exec` provisioner type. This provisioner lets you run the CLI for your target system in order to create, update, or otherwise interact with remote objects in that system. You must include [a `connection` block](/terraform/language/block/resource#connection) for Terraform to connect to the server.
+
+## Execute remote scripts
+
+When provisioners execute scripts on a remote system over SSH, they usually upload the script file to the remote system then use the default shell to execute it. Provisioners use this strategy because it allows you to use all of the typical scripting techniques supported by that shell, including preserving environment variable values and other context between script statements.
+
+### Remote system paths
+
+Terraform requires a suitable location in the remote filesystem where the provisioner can create the script file. By default, Terraform chooses a path containing a random number using the following patterns depending on how `target_platform` is set:
+
+- `"unix"`: `/tmp/terraform_%RAND%.sh`
+- `"windows"`: `C:/windows/temp/terraform_%RAND%.cmd`
+
+In both cases, the provisioner replaces the sequence `%RAND%` with randomly-chosen decimal digits.
+
+Provisioners cannot react directly to remote environment variables, such as `TMPDIR`, or use functions such as `mktemp` because they run on the system where Terraform is running, not on the remote system. As a result, you can configure the `script_path` argument in your `connection` block to override the path when your remote system doesn't use the filesystem layout expected by these default paths.
+
+```hcl
+connection {
+  # ...
+  script_path = "H:/terraform-temp/script_%RAND%.sh"
+}
+```
+
+Provisioners replace the `%RAND%` sequence with randomly-selected decimal digits to reduce the likelihood of collisions between multiple provisioners running concurrently.
+
+For Windows systems, we recommend using forward slashes instead of backslashes, despite the typical convention on Windows, because the Terraform language uses backslash as the quoted string escape character.
+
+### Execute scripts using SCP over SSH
+
+<Warning>
+
+When using Terraform v1.0 and earlier, avoid using untrusted external values as part of the `script_path` argument.
+
+</Warning>
+
+Provisioners pass the specified script path, after `%RAND%` expansion, directly to the remote `scp` process, which interprets the path. With the default configuration of `scp` as distributed with OpenSSH, you can place temporary scripts in the home directory of the remote user by specifying a relative path:
+
+```hcl
+connection {
+  type = "ssh"
+  # ...
+  script_path = "terraform_provisioner_%RAND%.sh"
+}
+```
+
 ## Sensitive values
 
 You can use sensitive values in `provisioner` blocks. Terraform suppresses sensitive values in all log output. Refer to [Manage sensitive data](/terraform/language/manage-sensitive-data) for more information about using sensitive values in your configurations.
 
-### Ephemeral values
+## Ephemeral values
 
 You can use ephemeral values in `provisioner` blocks and `connection` blocks that enable provisioners to connect to remote resources. Terraform does not store ephemeral values in your plan or state or output them in logs. Refer to the following topics for more information about using ephemeral values in your configurations:
 
@@ -304,7 +201,7 @@ You can use ephemeral values in `provisioner` blocks and `connection` blocks tha
 - [`ephemeral` variables](/terraform/language/block/variable#ephemeral)
 - [`ephemeral` output values](/terraform/language/block/output#ephemeral)
 
-### Determine when provisioners perform tasks
+## Determine when provisioners perform tasks
 
 By default, Terraform runs provisioners immediately after it finishes creating the resource, but you can set the `when` argument a Terraform stage control when provisioners perform their configured actions.
 
@@ -334,7 +231,7 @@ Destroy provisioners run before the resource is destroyed. If the provisioner fa
 
 Enabling the [`create_before_destroy` argument](/terraform/language/block/resource#create_before_destroy) on the resource prevents destroy-time provisioners from running.
 
-#### Remove a `resource` block containing a destroy-time provisioner
+### Remove a `resource` block containing a destroy-time provisioner
 
 Destroy-time provisioners can only run if they remain in the configuration at the time a resource is destroyed. If a `resource` block with a destroy-time provisioner is removed entirely from the configuration, its provisioner configurations are removed along with it. The destroy provisioner won't run as a result. To work around this, configure a multi-step process to safely remove a resource with a destroy-time provisioner:
 
@@ -345,11 +242,11 @@ Destroy-time provisioners can only run if they remain in the configuration at th
 
 Because of this limitation, you should use destroy-time provisioners sparingly and with care.
 
-#### Tainted resources
+### Tainted resources
 
 A destroy-time provisioner within a resource that is tainted will not run. This includes resources that are marked tainted from a failed creation-time provisioner or tainted manually using `terraform taint`.
 
-### Configure multiple provisioners
+## Configure multiple provisioners
 
 You can specify multiple provisioners within a `resource` block. Terraform executes provisioners in the order they are defined in the configuration file.
 
@@ -371,7 +268,7 @@ resource "aws_instance" "web" {
 }
 ```
 
-### Configure provisioner failure behavior
+## Configure provisioner failure behavior
 
 By default, provisioners that fail also cause the `terraform apply` command to fail. To configure Terraform to continue its operation, set the `on_failure` argument to `continue`. Terraform ignores the error and continues the operation. Refer to the [`on_failure` argument reference](/terraform/language/block/resource#define-provisioner-failure-behaviors) for more information.
 
@@ -388,7 +285,7 @@ resource "aws_instance" "web" {
 }
 ```
 
-### Install third-party provisioners
+## Install third-party provisioners
 
 We recommend using only provisioners built into Terraform, but you can use third-party provisioners as plugins when no other alternative is available. Place third-party provisioners into the `%APPDATA%\terraform.d\plugins` directory, `~/.terraform.d/plugins` directory, or in the directory where the Terraform binary is installed.
 


### PR DESCRIPTION
This PR reapplies the nav changes from v1.14.x that were apparently made after the v1.15.x folder was copied.
It also re-adds the "Perform post-apply operations" topic, which had been mixed into the topic on using provisioners but was spun off in the v1.14.x version of the docs. 
