### PR TITLE
TF-37105: Broken API link on 1.2.x diagnostics documentation page

### DIFF
--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/troubleshoot/perform-diagnostics.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/troubleshoot/perform-diagnostics.mdx
@@ -31,7 +31,7 @@ curl \
   "https://tfe.example.com:8443/api/v1/diagnostics"
 ```
 
-You can customize the timeout and filter specific checks using query parameters. Refer to the [Diagnostics API reference](/terraform/enterprise/1.2.x/docs/enterprise/api-docs/diagnostics) for detailed information on parameters, responses, and examples.
+You can customize the timeout and filter specific checks using query parameters. Refer to the [Diagnostics API reference](/terraform/enterprise/api-docs/diagnostics) for detailed information on parameters, responses, and examples.
 
 ### Diagnostic Registry Checks
 


### PR DESCRIPTION
This PR is to update the broken link to the diagnostics API page for Terraform Enterprise

https://hashicorp.atlassian.net/browse/TF-37105

https://unified-docs-frontend-preview-23ghqtzyu-hashicorp.vercel.app/terraform/enterprise/1.2.x/api-docs/diagnostics
