### PR TITLE
Consul Docs: Remove Terminating Gateway deprecation sentence

### DIFF
--- a/content/consul/v1.22.x/content/partials/text/descriptions/terminating-gateway.mdx
+++ b/content/consul/v1.22.x/content/partials/text/descriptions/terminating-gateway.mdx
@@ -1,5 +1,9 @@
-Terminating gateways handle requests from services in the network for external services running on external nodes. They act as service mesh proxies that can services in the Consul catalog. These gateways terminate service mesh mTLS connections, enforce service intentions, and forward requests to the appropriate destination.
+Terminating gateways handle requests from services in the network for external
+services running on external nodes. They act as service mesh proxies that can
+services in the Consul catalog. These gateways terminate service mesh mTLS
+connections, enforce service intentions, and forward requests to the appropriate
+destination.
 
-Terminating gateways are deprecated. Use [Consul API gateways](/north-south/api-gateway) instead.
-
-Refer to [Terminating gateways](/consul/docs/north-south/terminating-gateway) for more information about how to deploy terminating gateways to your Consul service mesh.
+Refer to [Terminating gateways](/consul/docs/north-south/terminating-gateway)
+for more information about how to deploy terminating gateways to your Consul
+service mesh.


### PR DESCRIPTION
## Description

Remove `Terminating gateways are deprecated. Use Consul API gateways instead.`.

## Links

Jira: [CE-1206]

## Contributor checklists

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [ ] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [ ] Verify that the PR is set to merge into the correct base branch
- [ ] Verify that all status checks passed
- [ ] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [ ] I added redirects for any moved or removed pages
- [ ] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [ ] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [ ] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.


[CE-1206]: https://hashicorp.atlassian.net/browse/CE-1206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ