### PR TITLE
fix typo in data sources documentation

### DIFF
--- a/content/terraform/v1.15.x/docs/language/data-sources/index.mdx
+++ b/content/terraform/v1.15.x/docs/language/data-sources/index.mdx
@@ -17,7 +17,7 @@ You can instruct Terraform to fetch data from a range of data sources, including
 
 Many providers make data sources available when you install the provider. Data sources fetch data from the provider, but do not create or modify resources. To access data from a data source, configure the `data` block and specify its arguments. Refer to your provider's documentation for details about the arguments available for the data source. 
 
-The provider queries the data source according to the configuration. You can reference the your infrastructure's data using the data source's attributes in other parts of your configuration. 
+The provider queries the data source according to the configuration. You can reference the infrastructure's data using the data source's attributes in other parts of your configuration. 
 
 The `data` block supports expressions and other dynamic Terraform language features. You can also use many of the arguments built into Terraform that control how Terraform creates the data object. Refer to the following topics for details:
 


### PR DESCRIPTION
fix typo in data source section.

Please go to the `Preview` tab and select the appropriate template:

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
