### PR TITLE
TF-37167: removes tfectl db commands

### DIFF
--- a/content/terraform-enterprise/2.0.x/docs/enterprise/deploy/reference/cli.mdx
+++ b/content/terraform-enterprise/2.0.x/docs/enterprise/deploy/reference/cli.mdx
@@ -365,18 +365,6 @@ Terraform Enterprise runs validations to ensure proper application configuration
 $ tfectl app startup-check
 ```
 
-## View ongoing database migrations
-
-<Note title="Deprecation Notice">
-The `tfectl db last-applied-migration` command is marked for deprecation as of 1.2.0, and will be removed in the upcoming major release.
-</Note>
-
-This command retrieves the current version of the ongoing database migrations:
-
-```shell-session
-$ tfectl db last-applied-migration
-```
-
 ## View Terraform Enterprise application version
 
 This command retrieves the currently running version of Terraform Enterprise:
@@ -393,57 +381,3 @@ $ tfectl app version
 
 When using `TFE_OPERATIONAL_MODE: disk`, Terraform Enterprise runs its Postgres instance managed through the container.
 Admin CLI provides commands for common operations.
-
-### Create a database backup
-
-<Note title="Deprecation Notice">
-The `tfectl db backup` command is marked for deprecation as of 1.2.0, and will be removed in the upcoming major release.
-</Note>
-
-To create backups of the internal database instance, use the following command:
-
-```shell-session
-$ tfectl db backup
-```
-
-This command will generate the backup in the directory passed via the environment variable `TFE_DISK_PATH`, default `/var/lib/terraform-enterprise`.
-The backup filename will be created in the format `TIMESTAMP_hashicorp.db`. `
-
-You can specify the backup's destination via the `--out` flag, e.g.
-
-```shell-session
-$ tfectl db backup --out /path/to/backup.db
-```
-
-### Recreate database indices
-
-<Note title="Deprecation Notice">
-The `tfectl db reindex` command is marked for deprecation as of 1.2.0, and will be removed in the upcoming major release.
-</Note>
-
-Rebuild Postgres database indices using:
-
-```shell-session
-$ tfectl db reindex
-```
-
-### Restore database from a backup
-
-<Note title="Deprecation Notice">
-The `tfectl db restore` command is marked for deprecation as of 1.2.0, and will be removed in the upcoming major release.
-</Note>
-
-* The execution of this command will **momentarily shut down your Terraform Enterprise instance**. Please make sure that no work
-is being executed, and no one is using the instance before running this command. After the restore takes place, Atlas
-will come back online.
-
-* This operation is **irreversible**, once a database backup has been loaded, all data created between the time of the
-backup and the date of restoration **will be lost**.
-
-To restore a database from a backup file, run:
-
-```shell-session
-$ tfectl db restore --file /path/to/backup.db
-```
-
-Confirmation is needed, with only `yes` as a valid response.


### PR DESCRIPTION
[Jira](https://hashicorp.atlassian.net/browse/TF-37167)

## Description
The `tfectl db` commands were deprecated in 1.2.x and can now be removed.