### PR TITLE
CE-1183: OpenShift support changes for API gateway

### DIFF
--- a/content/consul/v2.0.x/content/docs/north-south/api-gateway/k8s/enable.mdx
+++ b/content/consul/v2.0.x/content/docs/north-south/api-gateway/k8s/enable.mdx
@@ -34,7 +34,7 @@ The Consul API gateway ships with Consul and is automatically installed when you
 
     <Tab heading="OpenShift">
 
-    If you are installing Consul on an OpenShift Kubernetes cluster, you must include the `global.openShift.enabled` parameter and set it to `true`. Refer to [OpenShift requirements](/consul/docs/connect/gateways/api-gateway/tech-specs#openshift-requirements) for additional information. Furthermore, if your OpenShift cluster is version 4.19 or later, you may choose to use new Kubernetes resource types in the `consul.hashicorp.com` API resource group that provide additional support for Consul on OpenShift Container Platform (OCP). For guidance, refer to the related [resource types upgrade procedure](/consul/docs/north-south/api-gateway/k8s/resource-upgrade).
+    If you are installing Consul on an OpenShift Kubernetes cluster, you must include the `global.openShift.enabled` parameter and set it to `true`. Refer to [OpenShift requirements](/consul/docs/connect/gateways/api-gateway/tech-specs#openshift-requirements) for additional information. Furthermore, if your OpenShift cluster is version 4.19 or later, you may choose to use new Kubernetes resource types in the `consul.hashicorp.com` API resource group. These types provide additional support for Consul on OpenShift Container Platform (OCP). For guidance, refer to the related [resource types upgrade procedure](/consul/docs/north-south/api-gateway/k8s/resource-upgrade).
 
     <CodeBlockConfig filename="values.yaml">
 

--- a/content/consul/v2.0.x/content/docs/north-south/api-gateway/k8s/enable.mdx
+++ b/content/consul/v2.0.x/content/docs/north-south/api-gateway/k8s/enable.mdx
@@ -34,7 +34,7 @@ The Consul API gateway ships with Consul and is automatically installed when you
 
     <Tab heading="OpenShift">
 
-    If you are installing Consul on an OpenShift Kubernetes cluster, you must include the `global.openShift.enabled` parameter and set it to `true`. Refer to [OpenShift requirements](/consul/docs/connect/gateways/api-gateway/tech-specs#openshift-requirements) for additional information.
+    If you are installing Consul on an OpenShift Kubernetes cluster, you must include the `global.openShift.enabled` parameter and set it to `true`. Refer to [OpenShift requirements](/consul/docs/connect/gateways/api-gateway/tech-specs#openshift-requirements) for additional information. Furthermore, if your OpenShift cluster is version 4.19 or later, you may choose to use new Kubernetes resource types in the `consul.hashicorp.com` API resource group that provide additional support for Consul on OpenShift Container Platform (OCP). For guidance, refer to the related [resource types upgrade procedure](/consul/docs/north-south/api-gateway/k8s/resource-upgrade).
 
     <CodeBlockConfig filename="values.yaml">
 

--- a/content/consul/v2.0.x/content/docs/north-south/api-gateway/k8s/resource-upgrade.mdx
+++ b/content/consul/v2.0.x/content/docs/north-south/api-gateway/k8s/resource-upgrade.mdx
@@ -2,7 +2,7 @@
 layout: docs
 page_title: Resource upgrade
 description: >-
-    Learn how to upgrade Kubernetes resource types for Consul.
+    Learn how to upgrade Kubernetes resource types for Consul v2.0+.
 ---
 
 # Resource upgrade
@@ -11,34 +11,44 @@ This topic describes what steps you need to take to complete the Kubernetes reso
 
 ## Overview
 
-Kubernetes resources for Consul provide a way to configure and manage Consul on Kubernetes clusters. With the release of Consul 2.0.0, there are new resource types available that offer enhanced functionality and improved compatibility with OpenShift Container Platform (OCP) versions 4.19 and above. These new resource types are part of the `consul.hashicorp.com` API group and are designed to replace the older resource types that were used in previous versions of Consul.
+Kubernetes resources for Consul provide a way to configure and manage Consul on
+Kubernetes clusters. Consul 2.0.0 provides new resource
+types that offer enhanced functionality and improved compatibility
+with OpenShift Container Platform (OCP) versions 4.19 and above. These new
+resource types are part of the `consul.hashicorp.com` API group and are designed
+to replace the older resource types that previous versions of Consul used.
 
 ## Requirements
 
 - OpenShift Container Platform (OCP) 4.19 or later
 - Consul 2.0.0 or later
 
-As of Consul 2.0.0, the API gateway resources can be updated from the current API resource group `gateway.networking.k8s.io`, to the new `consul.hashicorp.com`. This change is necessary to take advantage of the new features and improvements in the API gateway functionality on specific K8s environments, like OpenShift.
+Update the API gateway resources from the current API resource group `gateway.networking.k8s.io` to the new `consul.hashicorp.com`. This change is necessary to take advantage of the new features and improvements in the API gateway functionality on specific Kubernetes environments, like OpenShift.
 
 ## Upgrade scenarios
 
-Kubernetes clusters not using the `TCPRoute` resource can, but do not need to upgrade their API gateway resources to the new API group. This leaves two cases:
+Kubernetes clusters not using the `TCPRoute` resource can, but do not need to, upgrade their API gateway resources to the new API group. This leaves two cases:
 
 - OpenShift Container Platform (OCP) Kubernetes clusters that use TCPRoutes and want to upgrade their cluster from 4.18 to 4.19+.
 
     Moving to the new `consul.hashicorp.com` custom API resource group is required to ensure compatibility with OpenShift 4.19+.
 
-- Any Kubernetes cluster that uses TCPRoutes and wants to use the new custom API resource group
+- Any Kubernetes cluster that uses TCPRoutes and wants to use the new custom API resource group.
 
-    Moving to the new `consul.hashicorp.com` custom API resource group is not required, but is recommended.
+    Moving to the new `consul.hashicorp.com` custom API resource group is not
+    required, but we do recommend it.
 
 ## Upgrade steps
 
 To upgrade your Kubernetes resources for Consul, follow these steps:
 
-1. Update your Consul Helm chart values. Add the following configuration to your `values.yaml` file:
+1. Update your Consul Helm chart values. 
 
-    This Helm upgrade generates manifests and applies the stable `v1` API version by replacing the `v1alpha` API version of the `gateway.networking.k8s.io` resources and then applies the manifests. 
+    This Helm upgrade generates manifests and applies the stable `v1` API
+    version by replacing the `v1alpha` API version of the
+    `gateway.networking.k8s.io` resources and then applies the manifests. 
+    
+    Add this configuration to your `values.yaml` file.
 
     ```yaml
     openshift:
@@ -50,12 +60,14 @@ To upgrade your Kubernetes resources for Consul, follow these steps:
                 enabled: true
     ```
 
-    If `openshift.crds.enableTcpRoute` is true, then we install the TCPRoute CRD under the `gateway.networking.k8s.io`.
-    If `openshift.crds.consulapi.enabled` is true, then we install all the CRDs under the API group `consul.hashicorp.com`.
+    If `openshift.crds.enableTcpRoute` is true, then install the TCPRoute CRD under the `gateway.networking.k8s.io`.
+    If `openshift.crds.consulapi.enabled` is true, then install all the CRDs under the API group `consul.hashicorp.com`.
 
-2. Make backups of all the manifests after the Consul upgrade before proceeding to the OCP upgrade.
+1. Make backups of all the manifests after the Consul upgrade before proceeding to the OCP upgrade.
 
-3. Delete the old CRDs and resources. Run the following command to delete the old CRDs:
+1. Delete the old CRDs and resources. 
+
+   Run the following command to delete the old CRDs:
 
     ```bash
     for i in gateways gatewayclasses httproutes grpcroutes tcproutes referencegrants; \

--- a/content/consul/v2.0.x/content/docs/north-south/api-gateway/k8s/resource-upgrade.mdx
+++ b/content/consul/v2.0.x/content/docs/north-south/api-gateway/k8s/resource-upgrade.mdx
@@ -1,0 +1,66 @@
+---
+layout: docs
+page_title: Resource upgrade
+description: >-
+    Learn how to upgrade Kubernetes resource types for Consul.
+---
+
+# Resource upgrade
+
+This topic describes what steps you need to take to complete the Kubernetes resource types upgrade, when a new version of Consul requires it.
+
+## Overview
+
+Kubernetes resources for Consul provide a way to configure and manage Consul on Kubernetes clusters. With the release of Consul 2.0.0, there are new resource types available that offer enhanced functionality and improved compatibility with OpenShift Container Platform (OCP) versions 4.19 and above. These new resource types are part of the `consul.hashicorp.com` API group and are designed to replace the older resource types that were used in previous versions of Consul.
+
+## Requirements
+
+- OpenShift Container Platform (OCP) 4.19 or later
+- Consul 2.0.0 or later
+
+As of Consul 2.0.0, the API gateway resources can be updated from the current API resource group `gateway.networking.k8s.io`, to the new `consul.hashicorp.com`. This change is necessary to take advantage of the new features and improvements in the API gateway functionality on specific K8s environments, like OpenShift.
+
+## Upgrade scenarios
+
+Kubernetes clusters not using the `TCPRoute` resource can, but do not need to upgrade their API gateway resources to the new API group. This leaves two cases:
+
+- OpenShift Container Platform (OCP) Kubernetes clusters that use TCPRoutes and want to upgrade their cluster from 4.18 to 4.19+.
+
+    Moving to the new `consul.hashicorp.com` custom API resource group is required to ensure compatibility with OpenShift 4.19+.
+
+- Any Kubernetes cluster that uses TCPRoutes and wants to use the new custom API resource group
+
+    Moving to the new `consul.hashicorp.com` custom API resource group is not required, but is recommended.
+
+## Upgrade steps
+
+To upgrade your Kubernetes resources for Consul, follow these steps:
+
+1. Update your Consul Helm chart values. Add the following configuration to your `values.yaml` file:
+
+    This Helm upgrade generates manifests and applies the stable `v1` API version by replacing the `v1alpha` API version of the `gateway.networking.k8s.io` resources and then applies the manifests. 
+
+    ```yaml
+    openshift:
+        enabled: true
+        upgradeTo419From418: true
+        crds:
+            enableTcpRoute: false
+            consulapi:
+                enabled: true
+    ```
+
+    If `openshift.crds.enableTcpRoute` is true, then we install the TCPRoute CRD under the `gateway.networking.k8s.io`.
+    If `openshift.crds.consulapi.enabled` is true, then we install all the CRDs under the API group `consul.hashicorp.com`.
+
+2. Make backups of all the manifests after the Consul upgrade before proceeding to the OCP upgrade.
+
+3. Delete the old CRDs and resources. Run the following command to delete the old CRDs:
+
+    ```bash
+    for i in gateways gatewayclasses httproutes grpcroutes tcproutes referencegrants; \
+    do oc delete crd $i.gateway.networking.k8s.io; \
+    done
+    ```
+
+4. Upgrade your OpenShift cluster to version 4.19 or later.

--- a/content/consul/v2.0.x/content/docs/north-south/api-gateway/k8s/tech-specs.mdx
+++ b/content/consul/v2.0.x/content/docs/north-south/api-gateway/k8s/tech-specs.mdx
@@ -36,6 +36,8 @@ You can deploy API gateways to Kubernetes clusters managed by Red Hat OpenShift,
     enabled: true
  ```
 
+If your OpenShift cluster is version 4.19 or later, you may choose to use new Kubernetes resource types in the `consul.hashicorp.com` API resource group that provide additional support for Consul on OpenShift Container Platform (OCP). For guidance, refer to the related [resource types upgrade procedure](/consul/docs/north-south/api-gateway/k8s/resource-upgrade).
+
 Refer to the following topics for additional information:
 
 - [Install Consul on OpenShift clusters with Helm](/consul/docs/k8s/installation/install#install-consul-on-openshift-clusters)

--- a/content/consul/v2.0.x/content/docs/north-south/api-gateway/k8s/tech-specs.mdx
+++ b/content/consul/v2.0.x/content/docs/north-south/api-gateway/k8s/tech-specs.mdx
@@ -36,7 +36,7 @@ You can deploy API gateways to Kubernetes clusters managed by Red Hat OpenShift,
     enabled: true
  ```
 
-If your OpenShift cluster is version 4.19 or later, you may choose to use new Kubernetes resource types in the `consul.hashicorp.com` API resource group that provide additional support for Consul on OpenShift Container Platform (OCP). For guidance, refer to the related [resource types upgrade procedure](/consul/docs/north-south/api-gateway/k8s/resource-upgrade).
+If your OpenShift cluster is version 4.19 or later, you may choose to use new Kubernetes resource types in the `consul.hashicorp.com` API resource group. These types provide additional support for Consul on OpenShift Container Platform (OCP). For guidance, refer to the related [resource types upgrade procedure](/consul/docs/north-south/api-gateway/k8s/resource-upgrade).
 
 Refer to the following topics for additional information:
 

--- a/content/consul/v2.0.x/content/docs/reference/k8s/helm.mdx
+++ b/content/consul/v2.0.x/content/docs/reference/k8s/helm.mdx
@@ -690,8 +690,8 @@ Use these links to navigate to a particular top-level stanza.
     - `enabled` ((#v-global-openshift-enabled)) (`boolean: false`) - If true, the Helm chart will create necessary configuration for running
       its components on OpenShift.
 
-    - `upgradeTo419From418` ((#v-global-openshift-upgradeto419from418)) (`boolean: false`) - If true, the Helm chart will upgrade existing resources to be compatible with OpenShift v4.19+.
-      This should only be set to true if you are currently running on OpenShift v4.18 and plan to upgrade to v4.19 imminently.
+    - `upgradeTo419From418` ((#v-global-openshift-upgradeto419from418)) (`boolean: false`) - If true, the Helm chart upgrades existing resources to be compatible with OpenShift v4.19+.
+      Only set to true if you are currently running on OpenShift v4.18 and plan to upgrade to v4.19 imminently.
 
   - `consulAPITimeout` ((#v-global-consulapitimeout)) (`string: 5s`) - The time in seconds that the consul API client will wait for a response from
     the API before cancelling the request.

--- a/content/consul/v2.0.x/content/docs/reference/k8s/helm.mdx
+++ b/content/consul/v2.0.x/content/docs/reference/k8s/helm.mdx
@@ -690,6 +690,9 @@ Use these links to navigate to a particular top-level stanza.
     - `enabled` ((#v-global-openshift-enabled)) (`boolean: false`) - If true, the Helm chart will create necessary configuration for running
       its components on OpenShift.
 
+    - `upgradeTo419From418` ((#v-global-openshift-upgradeto419from418)) (`boolean: false`) - If true, the Helm chart will upgrade existing resources to be compatible with OpenShift v4.19+.
+      This should only be set to true if you are currently running on OpenShift v4.18 and plan to upgrade to v4.19 imminently.
+
   - `consulAPITimeout` ((#v-global-consulapitimeout)) (`string: 5s`) - The time in seconds that the consul API client will wait for a response from
     the API before cancelling the request.
 

--- a/content/consul/v2.0.x/data/docs-nav-data.json
+++ b/content/consul/v2.0.x/data/docs-nav-data.json
@@ -1785,6 +1785,9 @@
                 "path": "north-south/api-gateway/k8s/listener"
               },
               {
+                "title": "Resource upgrade",
+                "path": "north-south/api-gateway/k8s/resource-upgrade"
+              },              {
                 "title": "Define route",
                 "path": "north-south/api-gateway/k8s/route"
               },

--- a/content/consul/v2.0.x/data/docs-nav-data.json
+++ b/content/consul/v2.0.x/data/docs-nav-data.json
@@ -1787,7 +1787,8 @@
               {
                 "title": "Resource upgrade",
                 "path": "north-south/api-gateway/k8s/resource-upgrade"
-              },              {
+              },
+              {
                 "title": "Define route",
                 "path": "north-south/api-gateway/k8s/route"
               },


### PR DESCRIPTION
## Description

When upgrading Consul 2.0.0 on Openshift Container Platform >= 4.1.19, the customer needs to delete `gateway.networking.k8s.io` K8s resources, since Consul gateway is deployed via the new `consul.hashicorp.com/v1beta1` resource definitions generated automatically by Helm.

## Links

Jira: [CE-1183]
[[RFC] [CSL-2006]: Dual Gateway Controller Architecture for Supporting Stable and Experimental Gateway APIs](https://ibm.sharepoint.com/:w:/r/sites/hermes/_layouts/15/Doc.aspx?sourcedoc=%7Bf7a34963-b63c-4efd-bbd5-89aa999a00ec%7D&action=edit&wdPid=5d027f3)
[Consul-K8s Changes for OCP Support 4.19 and upgrade flow](https://hashicorp.atlassian.net/wiki/spaces/CSL/pages/4699357259/Consul-K8s+Changes+for+OCP+Support+4.19+and+upgrade+flow#Upgrade-flow-for-OCP)

## Contributor checklists

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [x] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [ ] Verify that the PR is set to merge into the correct base branch
- [ ] Verify that all status checks passed
- [ ] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [ ] I added redirects for any moved or removed pages
- [ ] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [ ] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [ ] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.


[CE-1183]: https://hashicorp.atlassian.net/browse/CE-1183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CSL-2006]: https://hashicorp.atlassian.net/browse/CSL-2006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ