### PR TITLE
Make elements copyable on Discovering Vagrant Boxes page

### DIFF
--- a/content/vagrant/v2.4.9/content/vagrant-cloud/boxes/catalog.mdx
+++ b/content/vagrant/v2.4.9/content/vagrant-cloud/boxes/catalog.mdx
@@ -20,7 +20,7 @@ You don't need a Vagrant Cloud account to use public boxes.
 
 1. Once you find a box, click its name to learn more about it.
 
-1. When you're ready to use it, copy the name, such as "hashicorp/bionic64"
+1. When you're ready to use it, copy the name, such as `hashicorp/bionic64`
    and initialize your Vagrant project using the `vagrant init` command.  For example:
 
     ```bash

--- a/content/vagrant/v2.4.9/content/vagrant-cloud/boxes/catalog.mdx
+++ b/content/vagrant/v2.4.9/content/vagrant-cloud/boxes/catalog.mdx
@@ -21,7 +21,7 @@ You don't need a Vagrant Cloud account to use public boxes.
 1. Once you find a box, click its name to learn more about it.
 
 1. When you're ready to use it, copy the name, such as "hashicorp/bionic64"
-   and initialize your Vagrant project with `vagrant init`.  For example:
+   and initialize your Vagrant project using the `vagrant init` command.  For example:
 
     ```bash
     vagrant init hashicorp/bionic64

--- a/content/vagrant/v2.4.9/content/vagrant-cloud/boxes/catalog.mdx
+++ b/content/vagrant/v2.4.9/content/vagrant-cloud/boxes/catalog.mdx
@@ -21,9 +21,18 @@ You don't need a Vagrant Cloud account to use public boxes.
 1. Once you find a box, click its name to learn more about it.
 
 1. When you're ready to use it, copy the name, such as "hashicorp/bionic64"
-   and initialize your Vagrant project with `vagrant init hashicorp/bionic64`.
+   and initialize your Vagrant project with `vagrant init`.  For example:
+
+    ```bash
+    vagrant init hashicorp/bionic64
+    ```
+
    Or, if you already have a Vagrant project created, modify the Vagrantfile
-   to use the box: `config.vm.box = "hashicorp/bionic64"`.
+   to use the box:
+
+    ```ruby
+    config.vm.box = "hashicorp/bionic64"
+    ```
 
 ## Provider Support
 


### PR DESCRIPTION
Updated the Vagrant Boxes page to make commands easily copyable by users.

[Preview](https://unified-docs-frontend-preview-knobtukfv-hashicorp.vercel.app/vagrant/vagrant-cloud/boxes/catalog)