### PR TITLE
Remove role precedence section from groups documentation

### DIFF
--- a/content/hcp-docs/content/docs/hcp/iam/groups.mdx
+++ b/content/hcp-docs/content/docs/hcp/iam/groups.mdx
@@ -86,14 +86,3 @@ All members with more permissive [organization roles](/hcp/docs/hcp/iam/users#us
 1.  Search for and then select the groups you want to assign projects and roles to.
 1.  Select a service and role to set the group's permissions for the project.
 1.  Click **Save**.
-
-## Role precedence
-
-When a user is a member of a group that has permission conflicts with the user's permissions in the organization, HCP enforces the most elevated role assigned to the user.
-
-For example, a user assigned the admin role for an organization is an admin for all projects, regardless of the project roles assigned to the groups they are members of.
-
-When a user is in multiple groups with different roles for a project, then HCP enforces the highest role.
-
-When a user is not a member of any group, then HCP enforces their organization role for the
-project.


### PR DESCRIPTION
Removed the section on role precedence from the IAM groups documentation.

This section is incorrect.  Permissions and role mgmt is explained further in the access control page. 