### PR TITLE
TF-35079: update query api to include `generate-config-out` attribute

### DIFF
--- a/content/terraform-docs-common/docs/cloud-docs/api-docs/queries/index.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/api-docs/queries/index.mdx
@@ -3,7 +3,7 @@ page_title: /queries API reference for HCP Terraform
 description: Call the HCP Terraform API's `/queries` endpoint to create and manage query runs.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-10-22T16:27:16-07:00
-last_modified: 2026-01-27T15:29:13-08:00
+last_modified: 2026-05-04T21:30:08.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -67,6 +67,7 @@ Properties without a default value are required.
 |---------------------------------------------------|---------|------------------|-------------------------------------------------------------------------------------------------------------|
 | `data.type`                                       | string  |                  | Must be `"queries"`.                                                                                        |
 | `data.attributes.source`                          | string  |                  | The source of the query such as query content or reference.                                                |
+| `data.attributes.generate-config-out`             | boolean | `true`           | Specifies whether the Terraform CLI execution passes the `-generate-config-out` flag during the query run. |
 | `data.attributes.variables`                       | array[{key, value}] | (empty array) | Specifies an optional list of run-specific variable values. Refer to run-specific variables for details.   |
 | `data.relationships.workspace.data.type`          | string  |                  | Must be `"workspaces"`.                                                                                     |
 | `data.relationships.workspace.data.id`            | string  |                  | The ID of the workspace to run the query against.                                                          |
@@ -81,6 +82,7 @@ Properties without a default value are required.
     "type": "queries",
     "attributes": {
       "source": "example-query-content",
+      "generate-config-out": true,
       "variables": [
         { "key": "replicas", "value": "2" }
       ]
@@ -130,6 +132,7 @@ $ curl\
       "updated-at": "2025-01-15T10:30:00.000Z",
       "created-at": "2025-01-15T10:30:00.000Z",
       "source": "example-query-content",
+      "generate-config-out": true,
       "variables": [
         { "key": "replicas", "value": "2" }
       ],
@@ -219,7 +222,8 @@ $ curl\
         "canceled-at": null,
         "updated-at": "2025-01-15T10:35:00.000Z",
         "created-at": "2025-01-15T10:30:00.000Z",
-        "source": "example-query-content", 
+        "source": "example-query-content",
+        "generate-config-out": true,
         "variables": [
           { "key": "replicas", "value": "2" }
         ],
@@ -322,6 +326,7 @@ $ curl\
       "updated-at": "2025-01-15T10:30:15.000Z",
       "created-at": "2025-01-15T10:30:00.000Z",
       "source": "example-query-content",
+      "generate-config-out": true,
       "variables": [
         { "key": "replicas", "value": "2" }
       ],
@@ -419,6 +424,10 @@ The `status-timestamps` object contains timestamps for when the query run entere
 ### Log read URL
 
 The `log-read-url` attribute contains a URL to retrieve the logs for the query run.
+
+### Generate config out
+
+The `generate-config-out` attribute indicates whether the Terraform CLI execution passes the `-generate-config-out` flag during the query run. Defaults to `true` if omitted.
 
 ## Available Related Resources
 

--- a/content/terraform-docs-common/docs/cloud-docs/api-docs/queries/index.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/api-docs/queries/index.mdx
@@ -425,10 +425,6 @@ The `status-timestamps` object contains timestamps for when the query run entere
 
 The `log-read-url` attribute contains a URL to retrieve the logs for the query run.
 
-### Generate config out
-
-The `generate-config-out` attribute indicates whether the Terraform CLI execution passes the `-generate-config-out` flag during the query run. Defaults to `true` if omitted.
-
 ## Available Related Resources
 
 The GET endpoints above can optionally return related resources, if requested with the [`include`](/terraform/cloud-docs/api-docs#inclusion-of-related-resources) query parameter. The following resource types are available:


### PR DESCRIPTION
### What
Added the `generate-config-out` attribute to the Query API reference documentation.

Changed page: `cloud-docs/api-docs/queries`

- Added `data.attributes.generate-config-out` to the request body attribute table
- Added `generate-config-out` to the sample payload and all sample response JSON blocks (create, list, show)
- Added a `### Generate config out` subsection to the Query run attributes reference

### Why
Documents the new `generate-config-out` field on QueryRun. This field controls whether the Terraform CLI passes the `-generate-config-out` flag during a query run execution. It defaults to `true` if omitted. Without this documentation, users would have no visibility into this configuration option when working with the Queries API.

### Screenshots
N/A

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages. (N/A)
- [ ] API documentation and the API Changelog have been updated.
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.). (N/A)
- [x] Pages with related content are updated and link to this content when appropriate. (N/A)
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages. (N/A)
- [x] New pages have metadata (page name and description) at the top. (N/A)
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility. (N/A)
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded. (N/A)
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.