### PR TITLE
Vault 43670 update mssql doc for lease revocation

### DIFF
--- a/content/vault/v1.19.x/content/docs/secrets/databases/mssql.mdx
+++ b/content/vault/v1.19.x/content/docs/secrets/databases/mssql.mdx
@@ -34,6 +34,9 @@ CREATE user vault_user for login vault_login;
 GRANT ALTER ANY LOGIN TO "vault_user";
 GRANT ALTER ANY USER TO "vault_user";
 GRANT ALTER ANY CONNECTION TO "vault_login";
+GRANT VIEW ANY DEFINITION TO "vault_login";
+GRANT VIEW SERVER STATE TO "vault_login";
+GRANT VIEW DEFINITION TO "vault_user";
 GRANT CONTROL ON SCHEMA::<schema_name> TO "vault_user";
 EXEC sp_addrolemember "db_accessadmin", "vault_user";
 ```
@@ -95,6 +98,9 @@ EXEC sp_addrolemember "db_accessadmin", "vault_user";
 
 ~> **Be aware!** If no `revocation_statement` is supplied,
 vault will execute the default revocation procedure.
+The revocation procedure uses a metadata query scoped to the database defined in
+`connection_url`. If your statements create users in a different database, Vault
+cannot detect or remove those users automatically.
 In larger databases, this might cause connection timeouts.
 Please specify a revocation statement in such a scenario.
 

--- a/content/vault/v1.19.x/content/docs/secrets/databases/mssql.mdx
+++ b/content/vault/v1.19.x/content/docs/secrets/databases/mssql.mdx
@@ -181,10 +181,12 @@ When we no longer need the backend, we can unmount it with `vault unmount azures
 
 ## Amazon RDS
 
-The MSSQL plugin supports databases running on [Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_SQLServer.html),
-but there are differences that need to be accommodated. A key limitation is that Amazon RDS doesn't support
-the "sysadmin" role, which is used by default during Vault's revocation process for MSSQL. The workaround
-is to add custom revocation statements to roles, for example:
+The MSSQL plugin supports databases running on [Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_SQLServer.html).
+
+As of Vault 1.19.17, the default revocation process works with Amazon RDS without requiring custom statements.
+The plugin uses standard permissions (`VIEW ANY DEFINITION`, `VIEW SERVER STATE` and `VIEW DEFINITION`) instead of the sysadmin role that RDS doesn't support.
+
+If you need to customize the revocation behavior, you can still provide custom revocation statements:
 
 ```shell
 vault write database/roles/my-role revocation_statements="\

--- a/content/vault/v1.19.x/content/docs/secrets/databases/mssql.mdx
+++ b/content/vault/v1.19.x/content/docs/secrets/databases/mssql.mdx
@@ -186,7 +186,7 @@ The MSSQL plugin supports databases running on [Amazon RDS](https://docs.aws.ama
 As of Vault 1.19.17, the default revocation process works with Amazon RDS without requiring custom statements.
 The plugin uses standard permissions (`VIEW ANY DEFINITION`, `VIEW SERVER STATE` and `VIEW DEFINITION`) instead of the sysadmin role that RDS doesn't support.
 
-If you need to customize the revocation behavior, you can still provide custom revocation statements:
+To customize the revocation behavior, provide custom revocation statements:
 
 ```shell
 vault write database/roles/my-role revocation_statements="\

--- a/content/vault/v1.20.x/content/docs/secrets/databases/mssql.mdx
+++ b/content/vault/v1.20.x/content/docs/secrets/databases/mssql.mdx
@@ -34,6 +34,9 @@ CREATE user vault_user for login vault_login;
 GRANT ALTER ANY LOGIN TO "vault_user";
 GRANT ALTER ANY USER TO "vault_user";
 GRANT ALTER ANY CONNECTION TO "vault_login";
+GRANT VIEW ANY DEFINITION TO "vault_login";
+GRANT VIEW SERVER STATE TO "vault_login";
+GRANT VIEW DEFINITION TO "vault_user";
 GRANT CONTROL ON SCHEMA::<schema_name> TO "vault_user";
 EXEC sp_addrolemember "db_accessadmin", "vault_user";
 ```
@@ -95,6 +98,9 @@ EXEC sp_addrolemember "db_accessadmin", "vault_user";
 
 ~> **Be aware!** If no `revocation_statement` is supplied,
 vault will execute the default revocation procedure.
+The revocation procedure uses a metadata query scoped to the database defined in
+`connection_url`. If your statements create users in a different database, Vault
+cannot detect or remove those users automatically.
 In larger databases, this might cause connection timeouts.
 Please specify a revocation statement in such a scenario.
 

--- a/content/vault/v1.20.x/content/docs/secrets/databases/mssql.mdx
+++ b/content/vault/v1.20.x/content/docs/secrets/databases/mssql.mdx
@@ -186,7 +186,7 @@ The MSSQL plugin supports databases running on [Amazon RDS](https://docs.aws.ama
 As of Vault 1.20.11, the default revocation process works with Amazon RDS without requiring custom statements.
 The plugin uses standard permissions (`VIEW ANY DEFINITION`, `VIEW SERVER STATE` and `VIEW DEFINITION`) instead of the sysadmin role that RDS doesn't support.
 
-If you need to customize the revocation behavior, you can still provide custom revocation statements:
+To customize the revocation behavior, provide custom revocation statements:
 
 ```shell
 vault write database/roles/my-role revocation_statements="\

--- a/content/vault/v1.20.x/content/docs/secrets/databases/mssql.mdx
+++ b/content/vault/v1.20.x/content/docs/secrets/databases/mssql.mdx
@@ -181,10 +181,12 @@ When we no longer need the backend, we can unmount it with `vault unmount azures
 
 ## Amazon RDS
 
-The MSSQL plugin supports databases running on [Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_SQLServer.html),
-but there are differences that need to be accommodated. A key limitation is that Amazon RDS doesn't support
-the "sysadmin" role, which is used by default during Vault's revocation process for MSSQL. The workaround
-is to add custom revocation statements to roles, for example:
+The MSSQL plugin supports databases running on [Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_SQLServer.html).
+
+As of Vault 1.20.11, the default revocation process works with Amazon RDS without requiring custom statements.
+The plugin uses standard permissions (`VIEW ANY DEFINITION`, `VIEW SERVER STATE` and `VIEW DEFINITION`) instead of the sysadmin role that RDS doesn't support.
+
+If you need to customize the revocation behavior, you can still provide custom revocation statements:
 
 ```shell
 vault write database/roles/my-role revocation_statements="\

--- a/content/vault/v1.21.x/content/docs/secrets/databases/mssql.mdx
+++ b/content/vault/v1.21.x/content/docs/secrets/databases/mssql.mdx
@@ -34,6 +34,9 @@ CREATE user vault_user for login vault_login;
 GRANT ALTER ANY LOGIN TO "vault_user";
 GRANT ALTER ANY USER TO "vault_user";
 GRANT ALTER ANY CONNECTION TO "vault_login";
+GRANT VIEW ANY DEFINITION TO "vault_login";
+GRANT VIEW SERVER STATE TO "vault_login";
+GRANT VIEW DEFINITION TO "vault_user";
 GRANT CONTROL ON SCHEMA::<schema_name> TO "vault_user";
 EXEC sp_addrolemember "db_accessadmin", "vault_user";
 ```
@@ -95,6 +98,9 @@ EXEC sp_addrolemember "db_accessadmin", "vault_user";
 
 ~> **Be aware!** If no `revocation_statement` is supplied,
 vault will execute the default revocation procedure.
+The revocation procedure uses a metadata query scoped to the database defined in
+`connection_url`. If your statements create users in a different database, Vault
+cannot detect or remove those users automatically.
 In larger databases, this might cause connection timeouts.
 Please specify a revocation statement in such a scenario.
 

--- a/content/vault/v1.21.x/content/docs/secrets/databases/mssql.mdx
+++ b/content/vault/v1.21.x/content/docs/secrets/databases/mssql.mdx
@@ -198,7 +198,7 @@ The MSSQL plugin supports databases running on [Amazon RDS](https://docs.aws.ama
 As of Vault 1.21.6, the default revocation process works with Amazon RDS without requiring custom statements.
 The plugin uses standard permissions (`VIEW ANY DEFINITION`, `VIEW SERVER STATE` and `VIEW DEFINITION`) instead of the sysadmin role that RDS doesn't support.
 
-If you need to customize the revocation behavior, you can still provide custom revocation statements:
+To customize the revocation behavior, provide custom revocation statements:
 
 ```shell
 vault write database/roles/my-role revocation_statements="\

--- a/content/vault/v1.21.x/content/docs/secrets/databases/mssql.mdx
+++ b/content/vault/v1.21.x/content/docs/secrets/databases/mssql.mdx
@@ -193,10 +193,12 @@ When we no longer need the backend, we can unmount it with `vault unmount azures
 
 ## Amazon RDS
 
-The MSSQL plugin supports databases running on [Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_SQLServer.html),
-but there are differences that need to be accommodated. A key limitation is that Amazon RDS doesn't support
-the "sysadmin" role, which is used by default during Vault's revocation process for MSSQL. The workaround
-is to add custom revocation statements to roles, for example:
+The MSSQL plugin supports databases running on [Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_SQLServer.html).
+
+As of Vault 1.21.6, the default revocation process works with Amazon RDS without requiring custom statements.
+The plugin uses standard permissions (`VIEW ANY DEFINITION`, `VIEW SERVER STATE` and `VIEW DEFINITION`) instead of the sysadmin role that RDS doesn't support.
+
+If you need to customize the revocation behavior, you can still provide custom revocation statements:
 
 ```shell
 vault write database/roles/my-role revocation_statements="\

--- a/content/vault/v2.x/content/docs/secrets/databases/mssql.mdx
+++ b/content/vault/v2.x/content/docs/secrets/databases/mssql.mdx
@@ -34,6 +34,9 @@ CREATE user vault_user for login vault_login;
 GRANT ALTER ANY LOGIN TO "vault_user";
 GRANT ALTER ANY USER TO "vault_user";
 GRANT ALTER ANY CONNECTION TO "vault_login";
+GRANT VIEW ANY DEFINITION TO "vault_login";
+GRANT VIEW SERVER STATE TO "vault_login";
+GRANT VIEW DEFINITION TO "vault_user";
 GRANT CONTROL ON SCHEMA::<schema_name> TO "vault_user";
 EXEC sp_addrolemember "db_accessadmin", "vault_user";
 ```
@@ -95,6 +98,9 @@ EXEC sp_addrolemember "db_accessadmin", "vault_user";
 
 ~> **Be aware!** If no `revocation_statement` is supplied,
 vault will execute the default revocation procedure.
+The revocation procedure uses a metadata query scoped to the database defined in
+`connection_url`. If your statements create users in a different database, Vault
+cannot detect or remove those users automatically.
 In larger databases, this might cause connection timeouts.
 Please specify a revocation statement in such a scenario.
 

--- a/content/vault/v2.x/content/docs/secrets/databases/mssql.mdx
+++ b/content/vault/v2.x/content/docs/secrets/databases/mssql.mdx
@@ -193,10 +193,12 @@ When we no longer need the backend, we can unmount it with `vault unmount azures
 
 ## Amazon RDS
 
-The MSSQL plugin supports databases running on [Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_SQLServer.html),
-but there are differences that need to be accommodated. A key limitation is that Amazon RDS doesn't support
-the "sysadmin" role, which is used by default during Vault's revocation process for MSSQL. The workaround
-is to add custom revocation statements to roles, for example:
+The MSSQL plugin supports databases running on [Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_SQLServer.html).
+
+As of Vault 2.0.1, the default revocation process works with Amazon RDS without requiring custom statements.
+The plugin uses standard permissions (`VIEW ANY DEFINITION`, `VIEW SERVER STATE` and `VIEW DEFINITION`) instead of the sysadmin role that RDS doesn't support.
+
+If you need to customize the revocation behavior, you can still provide custom revocation statements:
 
 ```shell
 vault write database/roles/my-role revocation_statements="\

--- a/content/vault/v2.x/content/docs/secrets/databases/mssql.mdx
+++ b/content/vault/v2.x/content/docs/secrets/databases/mssql.mdx
@@ -198,7 +198,7 @@ The MSSQL plugin supports databases running on [Amazon RDS](https://docs.aws.ama
 As of Vault 2.0.1, the default revocation process works with Amazon RDS without requiring custom statements.
 The plugin uses standard permissions (`VIEW ANY DEFINITION`, `VIEW SERVER STATE` and `VIEW DEFINITION`) instead of the sysadmin role that RDS doesn't support.
 
-If you need to customize the revocation behavior, you can still provide custom revocation statements:
+To customize the revocation behavior, provide custom revocation statements:
 
 ```shell
 vault write database/roles/my-role revocation_statements="\

--- a/content/vault/v2.x/content/docs/updates/release-notes.mdx
+++ b/content/vault/v2.x/content/docs/updates/release-notes.mdx
@@ -40,7 +40,10 @@ create policies, and discover Vault capabilities.
 
 ### Bug fixes and security patches
 
-- TBD
+- MSSQL database secrets engine: Fixed lease revocation to work without 
+sysadmin privileges by replacing the undocumented `sp_msloginmappings` procedure
+with a metadata query. The plugin now functions with `VIEW ANY DEFINITION` and
+`VIEW SERVER STATE` permissions instead of requiring full sysadmin access.
 
 ### Improvements
 


### PR DESCRIPTION
## PR Description

### Summary
Updates the permissions for the MSSQL docs for this bug fix 

```
MSSql Server database plugin throws "Logins other than the current user can only be seen by members of the sysadmin role." when using the default revocation statement.
```


Please go to the `Preview` tab and select the appropriate template:

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
