### PR TITLE
Document SCEP managed key support

### DIFF
--- a/content/vault/v1.20.x/content/docs/secrets/pki/scep.mdx
+++ b/content/vault/v1.20.x/content/docs/secrets/pki/scep.mdx
@@ -220,15 +220,27 @@ certificate.
 
 </Tabs>
 
+## Managed Key Support
+
+Managed key support for SCEP was added to Vault versions 2.0.1, 1.21.6 and 1.20.11.
+
+SCEP requires decryption and signing capabilities from the same key backing the issuer.
+Due to this requirement, we only support PKCS#11 RSA managed keys.
+
+When creating the managed key, the following usages are the minimum required to be set.
+ - sign
+ - verify
+ - decrypt
+
+A further limitation of the PKCS#11 managed key integration is only PKCS1v15 encryption
+is supported. Clients attempting to use RSA-OEAP encryption will fail.
 
 ## Limitations
-
 
 The following Vault PKI features do not support SCEP integration:
 
  - Certificate Metadata - SCEP has no means of providing metadata.
  - Certificate Issuance External Policy Service [CIEPS](/vault/docs/secrets/pki/cieps)
- - Managed Keys - SCEP requires encryption/decryption capabilities from the CA key which are not supported at this time.
  - SCEP is only compatible with RSA key backed issuers
 
 ## Resources

--- a/content/vault/v1.21.x/content/docs/secrets/pki/scep.mdx
+++ b/content/vault/v1.21.x/content/docs/secrets/pki/scep.mdx
@@ -220,15 +220,27 @@ certificate.
 
 </Tabs>
 
+## Managed Key Support
+
+Managed key support for SCEP was added to Vault versions 2.0.1, 1.21.6 and 1.20.11.
+
+SCEP requires decryption and signing capabilities from the same key backing the issuer.
+Due to this requirement, we only support PKCS#11 RSA managed keys.
+
+When creating the managed key, the following usages are the minimum required to be set.
+ - sign
+ - verify
+ - decrypt
+
+A further limitation of the PKCS#11 managed key integration is only PKCS1v15 encryption
+is supported. Clients attempting to use RSA-OEAP encryption will fail.
 
 ## Limitations
-
 
 The following Vault PKI features do not support SCEP integration:
 
  - Certificate Metadata - SCEP has no means of providing metadata.
  - Certificate Issuance External Policy Service [CIEPS](/vault/docs/secrets/pki/cieps)
- - Managed Keys - SCEP requires encryption/decryption capabilities from the CA key which are not supported at this time.
  - SCEP is only compatible with RSA key backed issuers
 
 ## Resources

--- a/content/vault/v2.x/content/docs/secrets/pki/scep.mdx
+++ b/content/vault/v2.x/content/docs/secrets/pki/scep.mdx
@@ -220,16 +220,28 @@ certificate.
 
 </Tabs>
 
+## Managed Key Support
+
+Managed key support for SCEP was added to Vault versions 2.0.1, 1.21.6 and 1.20.11.
+
+SCEP requires decryption and signing capabilities from the same key backing the issuer.
+Due to this requirement, we only support PKCS#11 RSA managed keys.
+
+When creating the managed key, the following usages are the minimum required to be set.
+ - sign
+ - verify
+ - decrypt
+
+A further limitation of the PKCS#11 managed key integration is only PKCS1v15 encryption
+is supported. Clients attempting to use RSA-OEAP encryption will fail.
 
 ## Limitations
-
 
 The following Vault PKI features do not support SCEP integration:
 
  - Certificate Metadata - SCEP has no means of providing metadata.
  - Certificate Issuance External Policy Service [CIEPS](/vault/docs/secrets/pki/cieps)
- - Managed Keys - SCEP requires encryption/decryption capabilities from the CA key which are not supported at this time.
- - SCEP is only compatible with RSA key backed issuers 
+ - SCEP is only compatible with RSA key backed issuers
 
 ## Resources
 


### PR DESCRIPTION
Add a new section on documenting the Managed key support for the PKI SCEP protocol that we've added to the upcoming release versions of Vault.

<img width="831" height="673" alt="Screenshot 2026-05-05 at 11 07 39" src="https://github.com/user-attachments/assets/36f76f00-2157-46c9-952c-6018c7fd2199" />
