### PR TITLE
remove temp redirect

### DIFF
--- a/content/terraform-docs-common/redirects.jsonc
+++ b/content/terraform-docs-common/redirects.jsonc
@@ -730,12 +730,6 @@
     "destination": "/terraform/cloud-docs/workspaces/run/:slug*",
     "permanent": true
   },
-  // Temporary redirect for search and import using TF 1.14 beta. Remove when 1.14 becomes GA
-  {
-    "source": "/terraform/language/import/bulk",
-    "destination": "/terraform/language/v1.14.x/import/bulk",
-    "permanent": true
-  },
   {
     "source": "/terraform/intro/v:version/index.html",
     "destination": "/terraform/intro/",


### PR DESCRIPTION
This PR removes the temporary redirect we had set up for the import docs. Because the query docs were part of v.1.14 beta, we used a redirect to make sure that unversioned links routed to the correct information. We are actually late on fixing this because once 1.14 went GA, the redirect was no longer needed.