### PR TITLE
add import docs to tfe nav

### DIFF
--- a/content/terraform-enterprise/1.2.x/data/enterprise-nav-data.json
+++ b/content/terraform-enterprise/1.2.x/data/enterprise-nav-data.json
@@ -841,6 +841,10 @@
         ]
       },
       {
+        "title": "Import existing resources",
+        "path": "workspaces/import"
+      },
+      {
         "title": "Terraform Runs",
         "routes": [
           { "title": "Remote Operations", "path": "workspaces/run/remote-operations" },

--- a/content/terraform-enterprise/2.0.x/data/enterprise-nav-data.json
+++ b/content/terraform-enterprise/2.0.x/data/enterprise-nav-data.json
@@ -873,6 +873,10 @@
         ]
       },
       {
+        "title": "Import existing resources",
+        "path": "workspaces/import"
+      },
+      {
         "title": "Terraform Runs",
         "routes": [
           { "title": "Remote Operations", "path": "workspaces/run/remote-operations" },


### PR DESCRIPTION
This PR adds the "Import existing resources" topic to the Terraform Enterprise navigation for v1.2 and v2.0
