### PR TITLE
Vault-41312: os local account roles

### DIFF
--- a/content/vault/v2.x/content/api-docs/system/billing/overview.mdx
+++ b/content/vault/v2.x/content/api-docs/system/billing/overview.mdx
@@ -90,7 +90,8 @@ $ curl --header "X-Vault-Token: ${VAULT_TOKEN}" \
               { "type": "gcp_static", "count": 10 },
               { "type": "gcp_impersonated", "count": 10 },
               { "type": "ldap_static", "count": 10 },
-              { "type": "openldap_static", "count": 10 }
+              { "type": "openldap_static", "count": 10 },
+              { "type": "os_local_account_static", "count": 10 }
             ]
           }
         },

--- a/content/vault/v2.x/content/docs/license/product-usage-reporting.mdx
+++ b/content/vault/v2.x/content/docs/license/product-usage-reporting.mdx
@@ -226,6 +226,7 @@ IBM collects the following product usage metrics as numerical data. Vault does n
 | `secret.engine.openldap.count` | Number of secret engine mounts of type OpenLDAP across all namespaces. |
 | `secret.engine.openldap.dynamic.role.count` | Number of OpenLDAP secret engine dynamic roles across all namespaces. |
 | `secret.engine.openldap.static.role.count` | Number of OpenLDAP secret engine static roles across all namespaces. |
+| `secret.engine.os.local.account.static.role.count` | Number of local account static roles managed by mounts of OS secrets engine across all namespaces. |
 | `secret.engine.pki-external-ca.count` | Number of secret engine mounts of type PKI External CA across all namespaces. |
 | `secret.engine.pki.count` | Number of secret engine mounts of type PKI across all namespaces. |
 | `secret.engine.plugin.count` | Number of secret engines with unrecognized types (custom plugins) across all namespaces. |

--- a/content/vault/v2.x/content/docs/license/utilization/metrics.mdx
+++ b/content/vault/v2.x/content/docs/license/utilization/metrics.mdx
@@ -133,6 +133,8 @@ Each `snapshot_record` includes the following fields:
 | `mongodb_atlas_max_role_count.previous_month_complete` | High watermark count of MongoDB Atlas roles in the previous month. |
 | `nomad_max_role_count.current_month_estimate` | High watermark count of Nomad roles in the current month. |
 | `nomad_max_role_count.previous_month_complete` | High watermark count of Nomad roles in the previous month. |
+| `os_local_static_max_role_count.current_month_estimate` | High watermark count of OS Local Accounts static roles in the current month. |
+| `os_local_static_max_role_count.previous_month_complete` | High watermark count of OS Local Accounts static roles in the previous month. |
 | `normalized_certs_issued.current_month_estimate` | The duration-adjusted count of certificates issued by built-in PKI backends for the current month. |
 | `normalized_certs_issued.previous_month_complete` | The duration-adjusted count of certificates issued by built-in PKI backends for the previous month. |
 | `normalized_oidc_tokens_issued.current_month_estimate` | The duration-adjusted count of OIDC tokens issued for the current month. |
@@ -503,6 +505,16 @@ Each `snapshot_record` includes the following fields:
           },
           "openldap_static_max_role_count.previous_month_complete": {
             "key": "openldap_static_max_role_count.previous_month_complete",
+            "value": 0,
+            "mode": "write"
+          },
+          "os_local_static_max_role_count.current_month_estimate": {
+            "key": "os_local_static_max_role_count.current_month_estimate",
+            "value": 0,
+            "mode": "write"
+          },
+          "os_local_static_max_role_count.previous_month_complete": {
+            "key": "os_local_static_max_role_count.previous_month_complete",
             "value": 0,
             "mode": "write"
           },

--- a/content/vault/v2.x/content/docs/updates/release-notes.mdx
+++ b/content/vault/v2.x/content/docs/updates/release-notes.mdx
@@ -137,6 +137,9 @@ None                 | None
   - GCP KMS operation counts for data protection API calls (`gcp_kms_operation_count.current_month_estimate` and `gcp_kms_operation_count.previous_month_complete`)
   - OIDC token units for duration-adjusted OIDC token issuance (`normalized_oidc_tokens_issued.current_month_estimate` and `normalized_oidc_tokens_issued.previous_month_complete`)
   - SPIFFE JWT token units for duration-adjusted SPIFFE JWT token issuance (`normalized_spiffe_jwt_token_units.current_month_estimate` and `normalized_spiffe_jwt_token_units.previous_month_complete`)
+  - High watermark tracking of local account static roles managed by OS secrets engine (`os_local_static_max_role_count.current_month_estimate` and `os_local_static_max_role_count.previous_month_complete`)
 
+- **Product usage metrics**: Added new product usage metrics:
+  - Count of local account static roles managed by mounts of OS secrets engine across all namespaces (secret.engine.os.local.account.static.role.count)
 
 @include 'release-notes/deprecation-note.mdx'


### PR DESCRIPTION
This PR updates docs after the addition of a new billing and product usage metrics to track local account roles managed by OS secrets engine.

Jira: https://hashicorp.atlassian.net/browse/VAULT-41312
Vault PR: https://github.com/hashicorp/vault-enterprise/pull/14467/changes#top