### PR TITLE
Document enable_unauthenticated_access in 1.19

### DIFF
--- a/content/vault/global/partials/important-changes/summary-tables/1_19.mdx
+++ b/content/vault/global/partials/important-changes/summary-tables/1_19.mdx
@@ -12,6 +12,7 @@ Introduced | Recommendations | Edition    | Change
 1.19.0     | **Yes**         | All        | [Security improvement for LDAP user DN search with upndomain](/vault/docs/v1.19.x/updates/important-changes#ldap)
 1.19.6     | **Yes**         | All        | [Rekey cancellations use a nonce](/vault/docs/v1.19.x/updates/important-changes#rekey-cancel-nonce)
 1.19.7     | **Yes**         | All        | [CVE-2025-6000: File audit devices cannot use executable file permissions](/vault/docs/v1.19.x/updates/important-changes#cve-2025-6000)
+1.19.17    | **Yes**         | All        | [Previously unauthenticated endpoints require authentication](/vault/docs/v1.19.x/updates/important-changes#sys-endpoint-auth)
 
 ### New behavior
 
@@ -24,7 +25,7 @@ Introduced | Recommendations | Edition    | Change
 1.19.1     | **Yes**         | All        | [Strict validation for Azure auth login requests](/vault/docs/v1.19.x/updates/important-changes#strict-azure)
 1.19.9     | No              | All        | [JSON Payload Limits](/vault/docs/v1.19.x/updates/important-changes#json-limits)
 1.19.11    | **Yes**         | Enterprise | [Rotation manager schedule strings in UTC](/vault/docs/v1.19.x/updates/important-changes#rotation-manager-utc)
-
+1.19.17    | **Yes**         | Enterprise | [DR secondaries now accept root tokens from the primary](/vault/docs/v1.19.x/updates/important-changes#root-token-secondary)
 
 ### Known issues
 

--- a/content/vault/v1.19.x/content/api-docs/system/generate-root.mdx
+++ b/content/vault/v1.19.x/content/api-docs/system/generate-root.mdx
@@ -14,6 +14,12 @@ last_modified: 2025-07-02T11:30:26-05:00
 
 @include 'alerts/restricted-root.mdx'
 
+<Note title="Conditionally unauthenticated endpoint">
+
+ Clients can call these endpoints without authenticating to Vault if the HCL config [`enable_unauthenticated_access`](/vault/docs/configuration#enable_unauthenticated_access) includes "generate-root".
+
+</Note>
+
 The `/sys/generate-root` endpoint is used to create a new root key for Vault.
 
 ## Read root generation progress

--- a/content/vault/v1.19.x/content/api-docs/system/rekey-recovery-key.mdx
+++ b/content/vault/v1.19.x/content/api-docs/system/rekey-recovery-key.mdx
@@ -18,6 +18,12 @@ The `/sys/rekey-recovery-key` endpoints are used to rekey the recovery keys for
 Vault. Key recovery endpoints are only applicable to seals that support recovery
 keys.
 
+<Note title="Conditionally unauthenticated endpoint">
+
+ Clients can call these endpoints without authenticating to Vault if the HCL config [`enable_unauthenticated_access`](/vault/docs/configuration#enable_unauthenticated_access) includes "rekey".
+
+</Note>
+
 ## Read rekey progress
 
 This endpoint reads the configuration and progress of the current rekey attempt.
@@ -125,10 +131,6 @@ This endpoint cancels any in-progress rekey. This clears the rekey settings as
 well as any progress made. This must be called to change the parameters of the
 rekey. Note: verification is still a part of a rekey. If rekeying is canceled
 during the verification flow, the current unseal keys remain valid.
-
-<Note title="Unrestricted endpoint">
-  Clients can call the endpoint without authenticating to Vault.
-</Note>
 
 | Method   | Path                           |
 | :------- | :----------------------------- |

--- a/content/vault/v1.19.x/content/api-docs/system/rekey.mdx
+++ b/content/vault/v1.19.x/content/api-docs/system/rekey.mdx
@@ -14,6 +14,12 @@ last_modified: 2025-07-02T11:30:26-05:00
 
 The `/sys/rekey` endpoints are used to rekey the unseal keys for Vault.
 
+<Note title="Conditionally unauthenticated endpoint">
+
+ Clients can call these endpoints without authenticating to Vault if [`enable_unauthenticated_access`](/vault/docs/configuration#enable_unauthenticated_access) includes "rekey".
+
+</Note>
+
 On seals that support stored keys (e.g. HSM PKCS11), the recovery key share(s)
 can be provided to rekey the root key since no unseal keys are available. The
 secret shares, secret threshold, and stored shares parameters must be set to 1.
@@ -125,10 +131,6 @@ This endpoint cancels any in-progress rekey. This clears the rekey settings as
 well as any progress made. This must be called to change the parameters of the
 rekey. Note: verification is still a part of a rekey. If rekeying is canceled
 during the verification flow, the current unseal keys remain valid.
-
-<Note title="Unrestricted endpoint">
-  Clients can call the endpoint without authenticating to Vault.
-</Note>
 
 | Method   | Path              |
 | :------- | :---------------- |

--- a/content/vault/v1.19.x/content/api-docs/system/replication/replication-dr.mdx
+++ b/content/vault/v1.19.x/content/api-docs/system/replication/replication-dr.mdx
@@ -614,6 +614,8 @@ being generated when needed and deleted soon after.
 
 @include 'alerts/enterprise-only.mdx'
 
+@include 'alerts/generate-operation-token.mdx'
+
 This endpoint reads the configuration and process of the current generation
 attempt.
 
@@ -654,6 +656,8 @@ encode the final token, it will never be returned.
 @include 'alerts/enterprise-only.mdx'
 
 @include 'alerts/restricted-root.mdx'
+
+@include 'alerts/generate-operation-token.mdx'
 
 This endpoint initializes a new generation attempt. Only a single
 generation attempt can take place at a time.
@@ -697,6 +701,8 @@ $ curl \
 
 @include 'alerts/restricted-root.mdx'
 
+@include 'alerts/generate-operation-token.mdx'
+
 This endpoint cancels any in-progress generation attempt. This clears any
 progress made. This must be called to change the OTP or PGP key being used.
 
@@ -717,6 +723,8 @@ $ curl \
 @include 'alerts/enterprise-only.mdx'
 
 @include 'alerts/restricted-root.mdx'
+
+@include 'alerts/generate-operation-token.mdx'
 
 This endpoint is used to enter a single root key share to progress the
 generation attempt. If the threshold number of root key shares is reached,
@@ -774,6 +782,8 @@ status, and the encoded token, if the attempt is complete.
 @include 'alerts/enterprise-only.mdx'
 
 @include 'alerts/restricted-root.mdx'
+
+@include 'alerts/generate-operation-token.mdx'
 
 This endpoint revokes the DR Operation Token. This token does not have a TTL
 and therefore should be deleted when it is no longer needed.

--- a/content/vault/v1.19.x/content/docs/configuration/index.mdx
+++ b/content/vault/v1.19.x/content/docs/configuration/index.mdx
@@ -284,6 +284,14 @@ can have a negative effect on performance due to the tracking of each lock attem
 - `allow_audit_log_prefixing` `(bool: false)` - Enable to allow prefixes on audit log entries for
   [file sinks](/vault/docs/audit/file).
 
+- `enable_unauthenticated_access` `(string array: [])` - A list of authenticated
+  endpoint family names that you want Vault to treat as unauthenticated. The
+  `enable_unauthenticated_access` parameter provides backward compatability for
+  endpoints that were unauthenticated in older versions of Vault. You can use
+  a SIGHUP signal to update `enable_unauthenticated_access` on a running Vault
+  process. Supported endpoint families: "rekey", "generate-root",
+  "generate-operation-token".
+
 ### High availability parameters
 
 The following parameters are used on backends that support [high availability][high-availability].

--- a/content/vault/v1.19.x/content/docs/updates/important-changes.mdx
+++ b/content/vault/v1.19.x/content/docs/updates/important-changes.mdx
@@ -19,7 +19,7 @@ last_modified: 2026-03-16T22:36:15.000Z
 
 # Important changes
 
-**Last updated**: 2025-09-12
+**Last updated**: 2026-05-07
 
 Always review important or breaking changes and remediation recommendations
 before upgrading Vault.
@@ -174,6 +174,17 @@ Vault interprets `rotation_schedule` strings relative to UTC to match the
 behavior of static role rotations in the database plugin. Old rotations use
 their existing schedule until you manually update rotation with an API call.
 
+### DR secondaries now accept root tokens from the primary ((#root-token-secondary)) <EnterpriseAlert inline="true" />
+
+| Change       | Affected version | Vault edition
+| ------------ | ---------------- | -------------
+| New behavior | 2.0.0+           | Enterprise
+
+
+Vault now allows authentication against secondary DR nodes with a root token
+generated on the primary. Previous versions of Vault only allowed requests
+against secondary nodes to authenticate using a batch token or DR operation
+token created by `sys/replication/dr/secondary/generate-operation-token`.
 
 ## Breaking changes
 
@@ -217,6 +228,35 @@ Refer to [the Github PR](https://github.com/hashicorp/cap/pull/151) for more
 details.
 
 
+### Previously unauthenticated endpoints require authentication ((#sys-endpoint-auth)) <EnterpriseAlert inline="true" />
+
+| Change       | Affected version | Vault edition
+| ------------ | ---------------- | -------------
+| Breaking     | 2.0.0+           | All
+
+Vault now authenticates the following endpoint families to prevent attackers from
+sending key-update requests with bogus key fragments with the aim of preventing legitimate
+use of the endpoints:
+
+- `sys/rekey`
+- `sys/generate-root`
+- `sys/replication/dr/secondary/generate-operation-token`
+
+Previous versions only required authentication with a seal or recovery keys to
+be provided. Authenticating to the affected endpoints now requires seal/recovery
+key fragments and a valid Vault token.
+
+#### Recommendation
+
+Modify callers of these endpoints to provide a vault token if they weren't already,
+or populate `enable_unauthenticated_access`.  Note that the reason for this change is
+to prevent an attacker from taking advantage of these endpoints being unauthenticated,
+by sending key-update requests with bogus key fragments which prevent legitimate use.
+Modify callers of these endpoints to always provide a valid Vault token.
+
+If you must continue to use the endpoints unauthenticated, set the
+[`enable_unauthenticated_access`](/vault/docs/configuration#enable_unauthenticated_access),
+configuration parameter to provide backward compatability with existing clients.
 
 ## Bugs
 
@@ -525,43 +565,13 @@ Incorrect forwarding leads to two distinct failure modes:
 
 #### Recommendation
 
-Do not attempt to configure local auth mounts on performance replication
-secondaries.
+As a workaround, unlink and relink the Okta push group to recreate the
+corresponding Vault group with the intended membership.
 
-### Missed events with multiple event clients ((#missed-events)) <EnterpriseAlert inline="true" />
+@include '../../../global/partials/important-changes/known-issue/root-token-kv-access-blocked-by-egp-policy.mdx'
 
-| Change      | Affected version | Fixed version
-| ----------- | ---------------- | -------------
-| Known issue | 1.19.0+ent       | 1.19.16+ent
+@include '../../../global/partials/important-changes/known-issue/sidebar-menu-reloads-on-engine-scoped-pages.mdx'
 
-Users may miss events when multiple clients subscribe to the same performance
-standby node in a cluster with the same namespace and event type filters because
-one client disconnecting effectively unsubscribes the remaining clients who no
-longer receive events.
+@include '../../../global/partials/important-changes/known-issue/secrets-engines-items-per-page-hides-results.mdx'
 
-#### Recommendation
-
-If you have multiple event subscribers with the same namespace and event type
-filters you have two options:
-
-1. Spread them out among the nodes of the Vault cluster.
-1. Only subscribe to events on the active node of the cluster.
-
-@include '../../../global/partials/important-changes/known-issue/multi-seal-rewrap.mdx'
-
-### Rotation timing shifts across vault restarts ((#rotation-drift)) <EnterpriseAlert inline="true" />
-
-| Change      | Affected version | Fixed version
-| ----------- | ---------------- | -------------
-| Known issue | 1.19.0+ent | 1.19.11+ent
-
-When you set `rotation_schedule`, Vault interprets the schedule definition
-relative to the local time zone of the machine. After a restart or leadership
-change, Vault interprets the value of `rotation schedule` relative to UTC, which
-may result in shifted rotation times depending on the time zone offset of the
-Vault instance.
-may result in shifted rotation times depending on the time zone offset of the
-Vault instance.
-
-As of Vault Enterprise v1.19.11, Vault interprets `rotation_schedule` values
-relative to UTC in all cases.
+@include '../../../global/partials/important-changes/known-issue/openldap-license-check.mdx'

--- a/content/vault/v1.19.x/content/partials/alerts/generate-operation-token.mdx
+++ b/content/vault/v1.19.x/content/partials/alerts/generate-operation-token.mdx
@@ -1,0 +1,7 @@
+<Note title="Conditionally unauthenticated DR endpoint">
+
+ Clients can call this endpoint without authenticating to Vault if the HCL config [`enable_unauthenticated_access`](/vault/docs/configuration#enable_unauthenticated_access) includes "generate-operation-token".
+
+ Otherwise, requests must be authenticated by a DR-secondary supported token: a batch token, a DR operation token, or a root token generated on the primary.
+
+</Note>


### PR DESCRIPTION
Add equivalent changes to https://github.com/hashicorp/web-unified-docs/pull/2190 now that the code changes were backported to 1.19.

Please go to the `Preview` tab and select the appropriate template:

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
