### PR TITLE
State that KMIP imported CAs are only used for client verification.

### DIFF
--- a/content/vault/v2.x/content/api-docs/secret/kmip.mdx
+++ b/content/vault/v2.x/content/api-docs/secret/kmip.mdx
@@ -207,9 +207,9 @@ $ curl \
 | :----- | :------------------------- |
 | `POST` | `/kmip/ca/:name/import` |
 
-Import an external Certificate Authority. Imported CAs can only be used to verify
-client certificates, not to generate server certificates. You must specify how to
-extract scope and role information from client certificates.
+Import an external Certificate Authority. Imported CAs can **only** be used to
+verify client certificates, not to generate client or server certificates. You
+must specify how to extract scope and role information from client certificates.
 
 ### Parameters
 

--- a/content/vault/v2.x/content/api-docs/secret/kmip.mdx
+++ b/content/vault/v2.x/content/api-docs/secret/kmip.mdx
@@ -207,7 +207,7 @@ $ curl \
 | :----- | :------------------------- |
 | `POST` | `/kmip/ca/:name/import` |
 
-Import an external Certificate Authority. Imported CAs can **only** be used to
+Import an external Certificate Authority. Imported CAs can only be used to
 verify client certificates, not to generate client or server certificates. You
 must specify how to extract scope and role information from client certificates.
 

--- a/content/vault/v2.x/content/docs/secrets/kmip.mdx
+++ b/content/vault/v2.x/content/docs/secrets/kmip.mdx
@@ -115,7 +115,7 @@ used for:
 Named CAs can be either:
 
 1. **Generated CAs**: Created by Vault with specified key type and bits
-2. **Imported CAs**: Imported from external sources, can **only** be used for
+2. **Imported CAs**: Imported from external sources, can only be used for
    client certificate verification, not to generate client or server
    certificates
 

--- a/content/vault/v2.x/content/docs/secrets/kmip.mdx
+++ b/content/vault/v2.x/content/docs/secrets/kmip.mdx
@@ -100,7 +100,7 @@ Certificate Authorities (CAs).
 #### Legacy CA for Client Certificates
 
 When the KMIP Secrets Engine is initially configured, Vault generates a legacy
-KMIP Certificate Authority (CA). This CA is used by default to issue client
+KMIP Certificate Authority (CA). Vault uses this CA by default to issue client
 certificates as well as the server TLS certificate. This CA is automatically
 created and cannot be imported from external sources.
 

--- a/content/vault/v2.x/content/docs/secrets/kmip.mdx
+++ b/content/vault/v2.x/content/docs/secrets/kmip.mdx
@@ -94,15 +94,15 @@ requests.
 
 ### KMIP Certificate Authorities
 
-Starting with recent versions of the KMIP secrets engine, you can manage multiple
-Certificate Authorities (CAs) for different purposes:
+Starting with Vault 2.0, the KMIP secrets engine can manage multiple
+Certificate Authorities (CAs).
 
 #### Legacy CA for Client Certificates
 
-When the KMIP Secrets Engine is initially configured, Vault generates a legacy KMIP
-Certificate Authority (CA) whose only purpose is to authenticate KMIP client
-certificates. This CA is automatically created and cannot be imported from external
-sources.
+When the KMIP Secrets Engine is initially configured, Vault generates a legacy
+KMIP Certificate Authority (CA). This CA is used by default to issue client
+certificates as well as the server TLS certificate. This CA is automatically
+created and cannot be imported from external sources.
 
 #### Named CAs for Server and Client Certificates
 
@@ -115,7 +115,9 @@ used for:
 Named CAs can be either:
 
 1. **Generated CAs**: Created by Vault with specified key type and bits
-2. **Imported CAs**: Imported from external sources for client certificate verification
+2. **Imported CAs**: Imported from external sources, can **only** be used for
+   client certificate verification, not to generate client or server
+   certificates
 
 To create a generated CA:
 


### PR DESCRIPTION
State that KMIP imported CAs are only used for client verification.

