### PR TITLE
[VAULT] Clarify use of today-only flag

### DIFF
--- a/content/vault/v2.x/content/docs/license/utilization/manual-reporting.mdx
+++ b/content/vault/v2.x/content/docs/license/utilization/manual-reporting.mdx
@@ -89,21 +89,31 @@ path "sys/utilization" {
 }
 ```
 
-Both the CLI command and API endpoint support the following parameters:
+You may find the following flags and parameters useful for modifing your data report:
 
-- `today_only` - When set, the endpoint returns only snapshots from the last 24 hours.
-- `message` - Optional message to include in the server logs.
+Flag          | CLI | API | Description
+------------- | --- | --- | -----------
+`-output`     | Yes | No  | Specifies where to write the license utilization bundle. By default, the CLI uses a timestamped filename in the current directory: `./vault-utilization-[timestamp].json`
+`-message`    | Yes | Yes | An optional message to include in the server logs.
+`-today-only` | Yes | Yes | Limit the return data to snapshots from the last 24 hours.
 
-In addition, the CLI command supports an `-output` parameter to specify where to write the license utilization bundle. By default, the CLI uses a timestamped filename, `vault-utilization-[timestamp].json`.
+You should only use the `-today-only` flag if you have already run a base report
+and run subsequent reports daily. For example, if you run the report automatically
+as part of a cron job. Otherwise, omit the  `-today-only` flag to ensure the
+report includes all the necessary data.
 
 <Tabs>
 
 <Tab heading="CLI">
 
+Write a full-data utilization report to `vault-utilization-cluster-1` with the
+custom log message "Run utilization report for Cluster 1":
+
 ```shell-session
-$ vault operator utilization \
-    -today-only \
-    -output="vault-utilization.json"
+$ vault operator utilization                      \
+  -message "Run utilization report for Cluster 1" \
+  -output "vault-utilization-cluster-1.json"
+
 Success! License utilization reporting bundle written to: vault-utilization.json
 ```
 
@@ -111,12 +121,16 @@ Success! License utilization reporting bundle written to: vault-utilization.json
 
 <Tab heading="API">
 
+Write a full-data utilization report to `vault-utilization-cluster-1.json` with the
+custom log message "Run utilization report for Cluster 1":
+
 ```shell-session
-$ curl -X PUT -H "X-Vault-Token: $VAULT_TOKEN" \
-    -d '{"today_only": true}' \
-    "${VAULT_ADDR}/v1/sys/utilization" \
-  | jq -r '.data.utilization_bundle' \
-  | base64 -d -i - -o "vault-utilization.json"
+$ curl -X PUT                                       \
+  --header "X-Vault-Token: ${VAULT_TOKEN}"          \
+  --data '{"message": "Utilization for Cluster 1"}' \
+  "${VAULT_ADDR}/v1/sys/utilization"                \
+| jq -r '.data.utilization_bundle'                  \
+| base64 -d -i > "vault-utilization-cluster-1.json"
 ```
 
 </Tab>


### PR DESCRIPTION
Update the utilization info to clarify that customers should only use the `today-only` flag when running reports regularly
