### PR TITLE
Add badge to SPIFFE secrets engine documentation entry

### DIFF
--- a/content/vault/v2.x/data/docs-nav-data.json
+++ b/content/vault/v2.x/data/docs-nav-data.json
@@ -2587,6 +2587,11 @@
       {
         "title": "SPIFFE",
         "path": "secrets/spiffe"
+        "badge": {
+          "text": "ENT",
+          "type": "filled",
+          "color": "neutral"
+        }
       },
       {
         "title": "HCP Terraform",

--- a/content/vault/v2.x/data/docs-nav-data.json
+++ b/content/vault/v2.x/data/docs-nav-data.json
@@ -2586,7 +2586,7 @@
       },
       {
         "title": "SPIFFE",
-        "path": "secrets/spiffe"
+        "path": "secrets/spiffe",
         "badge": {
           "text": "ENT",
           "type": "filled",


### PR DESCRIPTION
- Adds ent label to spiffe secrets engine (reported via slack)