### PR TITLE
nomad: new `max_run_duration` field and associated metrics documentation

### DIFF
--- a/content/nomad/v2.0.x/content/docs/job-specification/group.mdx
+++ b/content/nomad/v2.0.x/content/docs/job-specification/group.mdx
@@ -58,16 +58,15 @@ job "docs" {
   regains connectivity is also specified here.
 
 - `max_run_duration` `(string: "")` - Specifies the maximum duration for which
-  allocations in this group are allowed to run. Only valid for `batch` and
+  each allocation in this group is allowed to run. Only valid for `batch` and
   `sysbatch` jobs. When the duration is exceeded, all tasks in the group are
-  killed and the allocation is marked as `complete` with a client description
-  of `allocation exceeded max_run_duration`. The job status transitions to
-  `dead`.
+  killed and the allocation is marked as `complete` with a client description of
+  `allocation exceeded max_run_duration`. 
 
-  The timer begins immediately when the allocation is created in the allocation
-  runner, regardless of individual task states. Tasks that take longer to start
-  than the configured timeout will therefore also be terminated — including
-  allocations that never finish downloading images or artifacts.
+  The timer begins immediately when the allocation is created in the client,
+  regardless of individual task states. Tasks that take longer to start than the
+  configured timeout will therefore also be terminated — including allocations
+  that never finish downloading images or artifacts.
 
   `prestart` and `poststart` lifecycle task runtimes count toward
   `max_run_duration`. `poststop` tasks will **not** be started if the

--- a/content/nomad/v2.0.x/content/docs/job-specification/group.mdx
+++ b/content/nomad/v2.0.x/content/docs/job-specification/group.mdx
@@ -73,6 +73,20 @@ job "docs" {
   `max_run_duration`. `poststop` tasks will **not** be started if the
   allocation is stopped due to this timeout.
 
+  Task [restarts][restart] do not reset the timer — once a deadline is
+  established it is not recalculated unless `max_run_duration` itself is
+  changed in a job update. All restart attempts therefore consume time from
+  the same budget. If the Nomad client process restarts mid-countdown, the
+  original deadline is reconstructed from each task runner's persisted
+  `StartedAt` timestamp, so the remaining budget is honoured rather than
+  reset to the full duration.
+
+  When the timeout fires, the allocation is marked `complete` rather than
+  `failed`, so the group's [`reschedule`][reschedule] policy is not
+  triggered. If an allocation is rescheduled for an independent reason (for
+  example, a node failure before the timeout), the replacement allocation
+  starts its own `max_run_duration` timer from zero.
+
 - `meta` <code>([Meta][]: nil)</code> - Specifies a key-value map that annotates
   with user-defined metadata.
 

--- a/content/nomad/v2.0.x/content/docs/job-specification/group.mdx
+++ b/content/nomad/v2.0.x/content/docs/job-specification/group.mdx
@@ -57,6 +57,22 @@ job "docs" {
   when the client disconnects. The policy for reconciliation in case the client
   regains connectivity is also specified here.
 
+- `max_run_duration` `(string: "")` - Specifies the maximum duration for which
+  allocations in this group are allowed to run. Only valid for `batch` and
+  `sysbatch` jobs. When the duration is exceeded, all tasks in the group are
+  killed and the allocation is marked as `complete` with a client description
+  of `allocation exceeded max_run_duration`. The job status transitions to
+  `dead`.
+
+  The timer begins immediately when the allocation is created in the allocation
+  runner, regardless of individual task states. Tasks that take longer to start
+  than the configured timeout will therefore also be terminated — including
+  allocations that never finish downloading images or artifacts.
+
+  `prestart` and `poststart` lifecycle task runtimes count toward
+  `max_run_duration`. `poststop` tasks will **not** be started if the
+  allocation is stopped due to this timeout.
+
 - `meta` <code>([Meta][]: nil)</code> - Specifies a key-value map that annotates
   with user-defined metadata.
 

--- a/content/nomad/v2.0.x/content/docs/job-specification/periodic.mdx
+++ b/content/nomad/v2.0.x/content/docs/job-specification/periodic.mdx
@@ -54,6 +54,9 @@ Refer to the [parameterized] documentation for how to use parameters with a peri
 - `prohibit_overlap` `(bool: false)` - Specifies if this job should wait until
   previous instances of this job have completed. This only applies to this job;
   it does not prevent other periodic jobs from running at the same time.
+  Consider combining this with [`group.max_run_duration`][max_run_duration] to
+  ensure that a previous run is forcefully terminated before the next scheduled
+  run is allowed to start.
 
 - `time_zone` `(string: "UTC")` - Specifies the time zone to evaluate the next
   launch interval against. [Daylight Saving Time][dst] affects scheduling, so
@@ -121,5 +124,6 @@ configuring time zones for periodic jobs.
 [batch-type]: /nomad/docs/job-specification/job#type 'Batch scheduler type'
 [cron]: https://github.com/hashicorp/cronexpr#implementation 'List of cron expressions'
 [dst]: #daylight-saving-time
+[max_run_duration]: /nomad/docs/job-specification/group#max_run_duration
 [multiregion]: /nomad/docs/job-specification/multiregion#periodic-time-zones
 [parameterized]: /nomad/docs/job-specification/parameterized#use-periodic-with-parameterized

--- a/content/nomad/v2.0.x/content/docs/reference/metrics.mdx
+++ b/content/nomad/v2.0.x/content/docs/reference/metrics.mdx
@@ -216,30 +216,32 @@ The following metrics are emitted for each allocation if allocation metrics
 are enabled. Note that allocation metrics available may be dependent on factors
 such as the task driver and control group (cgroup) version in use.
 
-| Metric                                        | Description                                                       | Unit        | Type    | Labels                                           |
-|-----------------------------------------------|-------------------------------------------------------------------|-------------|---------|--------------------------------------------------|
-| `nomad.client.allocs.complete`                | Number of complete allocations                                    | Integer     | Counter | alloc_id, host, job, namespace, task, task_group |
-| `nomad.client.allocs.cpu.allocated`           | Total CPU resources allocated by the task across all cores        | MHz         | Gauge   | alloc_id, host, job, namespace, task, task_group |
-| `nomad.client.allocs.cpu.system`              | Total CPU resources consumed by the task in system space          | Percentage  | Gauge   | alloc_id, host, job, namespace, task, task_group |
-| `nomad.client.allocs.cpu.throttled_periods`   | Total number of CPU periods that the task was throttled           | Nanoseconds | Gauge   | alloc_id, host, job, namespace, task, task_group |
-| `nomad.client.allocs.cpu.throttled_time`      | Total time that the task was throttled                            | Nanoseconds | Gauge   | alloc_id, host, job, namespace, task, task_group |
-| `nomad.client.allocs.cpu.total_percent`       | Total CPU resources consumed by the task across all cores         | Percentage  | Gauge   | alloc_id, host, job, namespace, task, task_group |
-| `nomad.client.allocs.cpu.total_ticks`         | CPU ticks consumed by the process in the last collection interval | Integer     | Gauge   | alloc_id, host, job, namespace, task, task_group |
-| `nomad.client.allocs.cpu.total_ticks_count`   | Total CPU ticks consumed by the task since startup                | Integer     | Counter | alloc_id, host, job, namespace, task, task_group |
-| `nomad.client.allocs.cpu.user`                | Total CPU resources consumed by the task in the user space        | Percentage  | Gauge   | alloc_id, host, job, namespace, task, task_group |
-| `nomad.client.allocs.failed`                  | Number of failed allocations                                      | Integer     | Counter | alloc_id, host, job, namespace, task, task_group |
-| `nomad.client.allocs.memory.allocated`        | Amount of memory allocated by the task                            | Bytes       | Gauge   | alloc_id, host, job, namespace, task, task_group |
-| `nomad.client.allocs.memory.cache`            | Amount of memory cached by the task                               | Bytes       | Gauge   | alloc_id, host, job, namespace, task, task_group |
-| `nomad.client.allocs.memory.kernel_max_usage` | Maximum amount of memory ever used by the kernel for this task    | Bytes       | Gauge   | alloc_id, host, job, namespace, task, task_group |
-| `nomad.client.allocs.memory.kernel_usage`     | Amount of memory used by the kernel for this task                 | Bytes       | Gauge   | alloc_id, host, job, namespace, task, task_group |
-| `nomad.client.allocs.memory.max_allocated`    | Maximum amount of oversubscription memory allocated by the task   | Bytes       | Gauge   | alloc_id, host, job, namespace, task, task_group |
-| `nomad.client.allocs.memory.max_usage`        | Maximum amount of memory ever used by the task                    | Bytes       | Gauge   | alloc_id, host, job, namespace, task, task_group |
-| `nomad.client.allocs.memory.rss`              | Amount of RSS memory consumed by the task                         | Bytes       | Gauge   | alloc_id, host, job, namespace, task, task_group |
-| `nomad.client.allocs.memory.swap`             | Amount of memory swapped by the task                              | Bytes       | Gauge   | alloc_id, host, job, namespace, task, task_group |
-| `nomad.client.allocs.memory.usage`            | Total amount of memory used by the task                           | Bytes       | Gauge   | alloc_id, host, job, namespace, task, task_group |
-| `nomad.client.allocs.oom_killed`              | Number of oom-killed allocations                                  | Integer     | Counter | alloc_id, host, job, namespace, task, task_group |
-| `nomad.client.allocs.restart`                 | Number of task restarts                                           | Integer     | Counter | alloc_id, host, job, namespace, task, task_group |
-| `nomad.client.allocs.running`                 | Number of running allocations                                     | Integer     | Counter | alloc_id, host, job, namespace, task, task_group |
+| Metric                                                    | Description                                                       | Unit        | Type    | Labels                                           |
+|-----------------------------------------------------------|-------------------------------------------------------------------|-------------|---------|--------------------------------------------------|
+| `nomad.client.allocs.complete`                            | Number of complete allocations                                    | Integer     | Counter | alloc_id, host, job, namespace, task, task_group |
+| `nomad.client.allocs.cpu.allocated`                       | Total CPU resources allocated by the task across all cores        | MHz         | Gauge   | alloc_id, host, job, namespace, task, task_group |
+| `nomad.client.allocs.cpu.system`                          | Total CPU resources consumed by the task in system space          | Percentage  | Gauge   | alloc_id, host, job, namespace, task, task_group |
+| `nomad.client.allocs.cpu.throttled_periods`               | Total number of CPU periods that the task was throttled           | Nanoseconds | Gauge   | alloc_id, host, job, namespace, task, task_group |
+| `nomad.client.allocs.cpu.throttled_time`                  | Total time that the task was throttled                            | Nanoseconds | Gauge   | alloc_id, host, job, namespace, task, task_group |
+| `nomad.client.allocs.cpu.total_percent`                   | Total CPU resources consumed by the task across all cores         | Percentage  | Gauge   | alloc_id, host, job, namespace, task, task_group |
+| `nomad.client.allocs.cpu.total_ticks`                     | CPU ticks consumed by the process in the last collection interval | Integer     | Gauge   | alloc_id, host, job, namespace, task, task_group |
+| `nomad.client.allocs.cpu.total_ticks_count`               | Total CPU ticks consumed by the task since startup                | Integer     | Counter | alloc_id, host, job, namespace, task, task_group |
+| `nomad.client.allocs.cpu.user`                            | Total CPU resources consumed by the task in the user space        | Percentage  | Gauge   | alloc_id, host, job, namespace, task, task_group |
+| `nomad.client.allocs.failed`                              | Number of failed allocations                                      | Integer     | Counter | alloc_id, host, job, namespace, task, task_group |
+| `nomad.client.allocs.max_run_duration.configured_seconds` | The configured `max_run_duration` for the allocation's task group | Seconds     | Gauge   | alloc_id, host, job, namespace, task_group       |
+| `nomad.client.allocs.max_run_duration.remaining_seconds`  | Seconds remaining before the `max_run_duration` timeout fires     | Seconds     | Gauge   | alloc_id, host, job, namespace, task_group       |
+| `nomad.client.allocs.memory.allocated`                    | Amount of memory allocated by the task                            | Bytes       | Gauge   | alloc_id, host, job, namespace, task, task_group |
+| `nomad.client.allocs.memory.cache`                        | Amount of memory cached by the task                               | Bytes       | Gauge   | alloc_id, host, job, namespace, task, task_group |
+| `nomad.client.allocs.memory.kernel_max_usage`             | Maximum amount of memory ever used by the kernel for this task    | Bytes       | Gauge   | alloc_id, host, job, namespace, task, task_group |
+| `nomad.client.allocs.memory.kernel_usage`                 | Amount of memory used by the kernel for this task                 | Bytes       | Gauge   | alloc_id, host, job, namespace, task, task_group |
+| `nomad.client.allocs.memory.max_allocated`                | Maximum amount of oversubscription memory allocated by the task   | Bytes       | Gauge   | alloc_id, host, job, namespace, task, task_group |
+| `nomad.client.allocs.memory.max_usage`                    | Maximum amount of memory ever used by the task                    | Bytes       | Gauge   | alloc_id, host, job, namespace, task, task_group |
+| `nomad.client.allocs.memory.rss`                          | Amount of RSS memory consumed by the task                         | Bytes       | Gauge   | alloc_id, host, job, namespace, task, task_group |
+| `nomad.client.allocs.memory.swap`                         | Amount of memory swapped by the task                              | Bytes       | Gauge   | alloc_id, host, job, namespace, task, task_group |
+| `nomad.client.allocs.memory.usage`                        | Total amount of memory used by the task                           | Bytes       | Gauge   | alloc_id, host, job, namespace, task, task_group |
+| `nomad.client.allocs.oom_killed`                          | Number of oom-killed allocations                                  | Integer     | Counter | alloc_id, host, job, namespace, task, task_group |
+| `nomad.client.allocs.restart`                             | Number of task restarts                                           | Integer     | Counter | alloc_id, host, job, namespace, task, task_group |
+| `nomad.client.allocs.running`                             | Number of running allocations                                     | Integer     | Counter | alloc_id, host, job, namespace, task, task_group |
 
 ## Job summary metrics
 

--- a/content/nomad/v2.0.x/content/docs/release-notes/v2-0-x.mdx
+++ b/content/nomad/v2.0.x/content/docs/release-notes/v2-0-x.mdx
@@ -42,6 +42,19 @@ following documentation for more details:
 Nomad emits a warning when a job is submitted with services defined but no service at
 the task level has `shutdown_delay` set.
 
+### New `max_run_duration` field added to job specification group
+
+For batch and system batch jobs, `max_run_duration` defines the
+maximum run time for allocations in the group. Refer to [the `max_run_duration`
+parameter documentation](/nomad/docs/job-specification/group#max_run_duration) for details.
+
+Additionally, we added the
+`nomad.client.allocs.max_run_duration.configured_seconds` and
+`nomad.client.allocs.max_run_duration.remaining_seconds` metrics. Refer to [the
+allocation metrics reference
+documentation](/nomad/docs/reference/metrics#allocation-metrics) for more
+information.
+
 ### Changelog
 
 Review improvements, security fixes, and breaking changes in the changelog.

--- a/content/nomad/v2.0.x/content/docs/release-notes/v2-0-x.mdx
+++ b/content/nomad/v2.0.x/content/docs/release-notes/v2-0-x.mdx
@@ -9,6 +9,21 @@ description: >-
 
 @include '../../../global/partials/version-eol-chart.mdx'
 
+## 2.0.2 release highlights
+
+### New `max_run_duration` field added to job specification group
+
+For batch and system batch jobs, `max_run_duration` defines the
+maximum run time for allocations in the group. Refer to [the `max_run_duration`
+parameter documentation](/nomad/docs/job-specification/group#max_run_duration) for details.
+
+Additionally, we added the
+`nomad.client.allocs.max_run_duration.configured_seconds` and
+`nomad.client.allocs.max_run_duration.remaining_seconds` metrics. Refer to [the
+allocation metrics reference
+documentation](/nomad/docs/reference/metrics#allocation-metrics) for more
+information.
+
 ## 2.0.1 release highlights
 
 Release Date: 12 May 2026
@@ -41,19 +56,6 @@ following documentation for more details:
 
 Nomad emits a warning when a job is submitted with services defined but no service at
 the task level has `shutdown_delay` set.
-
-### New `max_run_duration` field added to job specification group
-
-For batch and system batch jobs, `max_run_duration` defines the
-maximum run time for allocations in the group. Refer to [the `max_run_duration`
-parameter documentation](/nomad/docs/job-specification/group#max_run_duration) for details.
-
-Additionally, we added the
-`nomad.client.allocs.max_run_duration.configured_seconds` and
-`nomad.client.allocs.max_run_duration.remaining_seconds` metrics. Refer to [the
-allocation metrics reference
-documentation](/nomad/docs/reference/metrics#allocation-metrics) for more
-information.
 
 ### Changelog
 


### PR DESCRIPTION
<!--
**Merge branch**

Make sure you create your PR against the correct **base** branch. For instructions, refer to
GitHub's **Change the branch range and destination repository guide** (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request).

If your content is an update to:

- Currently published content

  Choose **base: main** when you are updating published documentation, and you
  want your changes published when the PR is merged. We publish Nomad content
  from the `main` branch.

- Upcoming Nomad release

  Choose the branch for the Nomad release that your content is for. Nomad
  release branches use the `nomad/<exact-release-number>` format. If you are not
  able to find the upcoming Nomad release branch that you are looking for,
  contact the tech writer that works with the Nomad team.

- Upcoming Nomad release but not sure which one

  - Choose the `main` branch.
  - Add the "do not merge" label.
  - Convert the PR to a DRAFT.
  - Put an explanation in the **Description** section.

  The tech writer coordinates with Nomad engineering and updates
  the docs PR base branch when the code is slotted into an upcoming release.

**Backports**

This repo stores previous version docs in folders instead of branches. There are
no backport labels.  If you backported your code PR to previous branches, update
the docs content in the corresponding folders. For example, if the current
release is 1.10.x and you backported your code to 1.9.x and 1.8.x, update the docs content
in the v1.10.x, v1.9.x, and v1.8.x folders. If you can't find the relevant files in previous versions,
add a note to your PR description. The tech writer will help ensure that the previous versions
receive the correct updates.
-->

## Description

<!-- 
Please describe why you're making this change and point out any important details the reviewers
should be aware of. A robust description helps the tech writer create a fabulous release note.
If your code PR has a splendid description, link to the code PR in the links section so that
the tech writer can update this PR's description. 

Include the target release as well as prior versions if applicable.
-->

Documentation for a new feature of (sys)batch jobs: allowing users to set their maximum duration. This lands in 2.0.2. 

## Links
<!--
**Please link to the related Nomad repo code PR!** if there is one. 
The tech writer does look at the code PR description, Jira ticket, and/or GH issue before reviewing docs content.

Include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a docs bug fix, please ensure related issues are linked so they will close when this PR is
merged.

// GH-Jira integration generates the link and updates the Jira ticket.
Jira: [<jira-ticket-number>]  // for example, Jira: [NMD-1234] 

GitHub Issue: <issue-link>

Deploy previews: The bot does publish a root-level link to the deploy preview, but the preview URL changes with each build.
-->

Nomad Code PR: https://github.com/hashicorp/nomad/pull/27803
Jira: https://hashicorp.atlassian.net/browse/NMD-551
GitHub Issue: https://github.com/hashicorp/nomad/issues/1782

## Contributor checklists

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [x] 3 days: Small changes, easy reviews
- [ ] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [ ] Verify that all status checks passed
- [ ] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [x] I added redirects for any moved or removed pages
- [x] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [x] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [ ] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.


[NMD-1234]: https://hashicorp.atlassian.net/browse/NMD-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ