### PR TITLE
docs(mssql-ekm): document new error codes 2051–2053 and add v0.3.2 changelog entry

### DIFF
--- a/content/vault/v2.x/content/docs/platform/mssql/changelog.mdx
+++ b/content/vault/v2.x/content/docs/platform/mssql/changelog.mdx
@@ -13,6 +13,12 @@ last_modified: 2026-04-15T00:15:34.000Z
 Each version is available to download from the
 [releases](https://releases.hashicorp.com/vault-mssql-ekm-provider/) page.
 
+## 0.3.2 (April 28th, 2026)
+
+BUGS
+
+* The provider now returns distinct error codes for each session-open failure mode instead of the generic 2050 error for all cases. Error code 2050 now indicates a missing EKM license feature specifically, while 2051, 2052, and 2053 indicate AppRole authentication failure, Vault connectivity failure, and license status lookup failure respectively.
+
 ## 0.3.1 (February 25th, 2026)
 
 FEATURES

--- a/content/vault/v2.x/content/docs/platform/mssql/troubleshooting.mdx
+++ b/content/vault/v2.x/content/docs/platform/mssql/troubleshooting.mdx
@@ -55,16 +55,32 @@ During installation, the EKM provider registers a manifest of coded event logs t
 
 ### 2050 license error
 
-The EKM provider was unable to verify that Vault has the correct license features. This
-could be due to:
+The EKM provider reached Vault and evaluated the license response, but the
+`Key Management Transparent Data Encryption` feature is not present on the Vault
+license. Refer to the installation [prerequisites](/vault/docs/platform/mssql/installation#prerequisites)
+for the required license feature.
 
-- An incompatible Vault Enterprise license - see the installation [prerequisites](/vault/docs/platform/mssql/installation#prerequisites) for the required license feature.
-- Lack of network connectivity - Check Vault's audit logs to see if any requests are made to
-   authenticate via AppRole or query the `/sys/license/status` API.
-- Misconfigured AppRole auth - Ensure you provided the correct Role ID and Secret ID when
-   configuring the SQL Server `CREDENTIAL`. See the
-   [installation instructions](/vault/docs/platform/mssql/installation) for an end-to-end working example.
-- Incorrect policy permissions - The EKM provider requires the `read` capability
-   on the path `sys/license/status`. See the `tde-policy` created in the
-   [installation instructions](/vault/docs/platform/mssql/installation#configuring-vault)
-   for an example of a working policy.
+### 2051 AppRole authentication failure
+
+The EKM provider cannot authenticate with Vault. Verify that the Role ID and Secret ID
+you provided when configuring the SQL Server `CREDENTIAL` are correct. Refer to the
+[installation instructions](/vault/docs/platform/mssql/installation) for an end-to-end
+working example.
+
+### 2052 Vault connectivity failure
+
+The EKM provider cannot connect to Vault. Check DNS resolution, network routing, TLS
+configuration, and general network access between the SQL Server host and the Vault
+server. Check the Vault audit logs to confirm whether any requests arrive from the SQL
+Server host.
+
+### 2053 License status lookup failure
+
+The EKM provider connected and authenticated successfully, but cannot retrieve the Vault
+license status. Verify that:
+
+- The policy assigned to the AppRole grants the `read` capability on the
+  `sys/license/status` path. Refer to the `tde-policy` in the
+  [installation instructions](/vault/docs/platform/mssql/installation#configuring-vault)
+  for an example of a working policy.
+- Your Vault version exposes the `/sys/license/status` endpoint.


### PR DESCRIPTION
# Summary
Updates the Vault EKM Provider documentation for the v0.3.2 release, which splits the generic 2050 error into four distinct error codes to make session-open failures easier to diagnose.

## Changes
`troubleshooting.mdx`

Narrowed the 2050 error description to mean only a missing EKM license feature (the provider reached Vault and evaluated the license, but the feature flag was absent)
Added new sections for:
2051 — AppRole authentication failure
2052 — Vault connectivity failure
2053 — License status lookup failure

`changelog.mdx`

Added v0.3.2 (April 28th, 2026) release entry
# References
Jira: [VAULT-23963](https://hashicorp.atlassian.net/browse/VAULT-23963)
Fix PR: [vault-mssql-ekm-provider-enterprise#53](https://github.com/hashicorp/vault-mssql-ekm-provider-enterprise/pull/53)
Release: [https://releases.hashicorp.com/vault-mssql-ekm-provider/0.3.2+ent/](https://releases.hashicorp.com/vault-mssql-ekm-provider/0.3.2+ent/)

Please go to the `Preview` tab and select the appropriate template:

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)


[VAULT-23963]: https://hashicorp.atlassian.net/browse/VAULT-23963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ