### PR TITLE
docs(mssql): add missing v0.3.2 release note for version reporting fix

### DIFF
--- a/content/vault/v2.x/content/docs/platform/mssql/changelog.mdx
+++ b/content/vault/v2.x/content/docs/platform/mssql/changelog.mdx
@@ -17,6 +17,7 @@ Each version is available to download from the
 
 BUGS
 
+* Fixed a bug where the provider reported version 0.2.2 to SQL Server instead of 0.3.2.
 * The provider now returns distinct error codes for each session-open failure mode instead of the generic 2050 error for all cases. Error code 2050 now indicates a missing EKM license feature specifically, while 2051, 2052, and 2053 indicate AppRole authentication failure, Vault connectivity failure, and license status lookup failure respectively.
 
 ## 0.3.1 (February 25th, 2026)


### PR DESCRIPTION
PR hashicorp/vault-mssql-ekm-provider-enterprise#56 was merged before the
v0.3.2 release but was not included in the public release notes.

This adds the missing entry under the 0.3.2 BUGS section documenting that
the provider was reporting version 0.2.2 to SQL Server instead of 0.3.2.
Jira: https://hashicorp.atlassian.net/browse/VAULT-23963

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
