### PR TITLE
docs: Adds `log-level` command option

### DIFF
--- a/content/boundary/v0.21.x/content/docs/client-cache/index.mdx
+++ b/content/boundary/v0.21.x/content/docs/client-cache/index.mdx
@@ -64,6 +64,22 @@ The client cache stores a log file in the **~/.boundary** directory.
 Boundary automatically rotates the log once it reaches 5 MB.
 It compresses and keeps the last 3 rotated logs before deleting a log.
 
+You can configure the log format and verbosity level using the following options:
+
+- `log-format=<string>` - Specifies the log format, mostly as a fallback for events.
+Supported values are `standard` and `json`.
+- `log-level=<string>` - Specifies the log verbosity level, mostly as a fallback for events. Supported values include the following in order of more detail to less:
+
+  - `trace`
+  - `debug`
+  - `info`
+  - `warn`
+  - `err`
+
+  You can also specify a log level using the **BOUNDARY_LOG_LEVEL** environment variable.
+
+For more information, refer to the [`cache start`](/boundary/docs/commands/cache/start) command documentation.
+
 ### Status
 
 You can check the status of the cache using the `boundary cache status` command.

--- a/content/boundary/v0.21.x/content/docs/commands/cache/start.mdx
+++ b/content/boundary/v0.21.x/content/docs/commands/cache/start.mdx
@@ -40,14 +40,16 @@ The default value is `false`.
 By default, the cache starts in the foreground.
 - `log-format=<string>` - Specifies the log format, mostly as a fallback for events.
 Supported values are `standard` and `json`.
-- `log-level=<string>` - Specifies the log verbosity level, mostly as a fallback for events.
-You can also specify the log level using the `BOUNDARY_LOG_LEVEL` environment variable.
-Supported values, listed in order of more detail to less, are:
-  - trace
-  - debug
-  - info
-  - warn
-  - err
+- `log-level=<string>` - Specifies the log verbosity level, mostly as a fallback for events. Supported values include the following in order of more detail to less:
+
+  - `trace`
+  - `debug`
+  - `info`
+  - `warn`
+  - `err`
+
+  You can also specify a log level using the **BOUNDARY_LOG_LEVEL** environment variable.
+
 - `max-search-refresh-timeout=<duration>` - If a search request triggers a best effort refresh, this value specifies how long the refresh should run before time out.
 In the event of a timeout, Boundary uses the stale data that is currently in the cache.
 The default value is 7 seconds.

--- a/content/boundary/v0.21.x/content/docs/commands/cache/start.mdx
+++ b/content/boundary/v0.21.x/content/docs/commands/cache/start.mdx
@@ -40,6 +40,14 @@ The default value is `false`.
 By default, the cache starts in the foreground.
 - `log-format=<string>` - Specifies the log format, mostly as a fallback for events.
 Supported values are `standard` and `json`.
+- `log-level=<string>` - Specifies the log verbosity level, mostly as a fallback for events.
+You can also specify the log level using the `BOUNDARY_LOG_LEVEL` environment variable.
+Supported values, listed in order of more detail to less, are:
+  - trace
+  - debug
+  - info
+  - warn
+  - err
 - `max-search-refresh-timeout=<duration>` - If a search request triggers a best effort refresh, this value specifies how long the refresh should run before time out.
 In the event of a timeout, Boundary uses the stale data that is currently in the cache.
 The default value is 7 seconds.


### PR DESCRIPTION
<!--
**Merge branch**

Make sure your PR uses the correct **base** branch for the merge destination.

For more information, refer to **Change the branch range and destination repository** (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request).

To update:

- Existing content

  Choose **base: main** to update existing documentation.
  Your content will be published when the PR is merged.

- Content for an upcoming Boundary release

  Choose the branch for the relevant upcoming Boundary release.
  Boundary release branches use the `boundary/<exact-release-number>` format.
  Your content will be published when the upcoming release goes live.

If you are not sure which base branch to use, or you cannot find the release branch you are looking for:

  - Choose the `main` branch.
  - Add the "do not merge" label.
  - Convert the PR to a DRAFT.
  - Explain the update in the **Description**.

**Back porting to older versions**

This repo stores versioned documentation in folders instead of branches.
There are no backport labels.
If your update applies to multiple versions, you must update the content in each of the corresponding version folders.

For example, you make an update to the Boundary code in the current release, 0.21.0, and back port it to versions 0.20.x and 0.19.x.
To document the update for each of the relevant versions, you would update the documentation in the v0.21.x, v0.20.x, and v0.19.x folders.
-->

## Description

The `boundary cache start` CLI docs are missing a description of the `log-level` option.

The option is documented in the CLI client help, and we use the same field-level definition for [`boundary database migrate`](https://developer.hashicorp.com/boundary/docs/commands/database/migrate#log-level) and the [**BOUNDARY_LOG_LEVEL**](https://developer.hashicorp.com/boundary/docs/commands#boundary_log_level) env variable. 

This PR adds the option with the pre-existing definition to the `boundary cache start` topic.

[View the update in the preview deployment](https://unified-docs-frontend-preview-rl3hll508-hashicorp.vercel.app/boundary/docs/commands/cache/start#log-level)

## Links
<!--
Include links to any associated pull requests, GitHub issues, or documentation that is relevant to this update.

// GH-Jira integration generates the link and updates the Jira ticket.
Jira: [<jira-ticket-number>]  // for example, Jira: [ICU-1234]

GitHub Issue: <issue-link>
-->

Code PR:
Jira:
GitHub issue:
RFC/PRD:

## Contributor checklists

<!--
Help your reviewer understand the type of review you need by selecting the scope and urgency.
-->

Review urgency:

- [x] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [ ] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [x] Verify that all status checks passed
- [x] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [ ] I added redirects for any moved or removed pages
- [x] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [x] I looked at the local or Vercel build to make sure the content rendered correctly


[ICU-1234]: https://hashicorp.atlassian.net/browse/ICU-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ