### PR TITLE
[VAULT] Adding LTS & SC2 Disclaimer to v1.19.x page

### DIFF
--- a/content/vault/v1.19.x/content/docs/enterprise/lts.mdx
+++ b/content/vault/v1.19.x/content/docs/enterprise/lts.mdx
@@ -16,6 +16,16 @@ last_modified: 2025-07-02T11:30:26-05:00
 Long-term support (LTS) eases upgrade requirements for installations that cannot
 upgrade frequently, quickly, or easily.
 
+<Note>
+
+Prior to 2026, HashiCorp offered Long-Term Support (LTS) for specific Vault
+Enterprise releases. Starting with the April 2026 (2.x.x) release, Vault
+Enterprise follows the IBM Support Cycle-2 (SC2) model.
+
+[Learn more about the SC2 model](https://developer.hashicorp.com/vault/docs/enterprise/support#what-is-support-cycle-2-sc2).
+
+</Note>
+
 ## LTS summary
 
 <table>


### PR DESCRIPTION

## Description

LTS support ended with the April 2026 2.x release, so this PR adds a disclaimer to the LTS page so customers are able to navigate and understand more information about this change. I referenced the official [page](https://developer.hashicorp.com/vault/docs/enterprise/support#what-is-support-cycle-2-sc2) on the 1.19.x to not duplicate effort in the note. 

## Contributor checklists

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [x] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [x] Verify that all status checks passed
- [x] Verify that the preview environment deployed successfully
- [x] Add additional reviewers if they are not part of assigned groups

Content:

- [x] I added redirects for any moved or removed pages
- [x] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [x] I looked at the local or Vercel build to make sure the content rendered correctly
