### PR TITLE
Document TerminatingGateway deployment fields

### DIFF
--- a/content/consul/v2.0.x/content/docs/reference/config-entry/terminating-gateway.mdx
+++ b/content/consul/v2.0.x/content/docs/reference/config-entry/terminating-gateway.mdx
@@ -577,6 +577,30 @@ spec:
 </Tab>
 </Tabs>
 
+### Deploy a terminating gateway pod
+
+The following Kubernetes resource links the gateway named "edge" with the billing service and configures the `TerminatingGateway` custom resource to deploy two gateway pods. Set `enabledDeployment` to `true` to enable the other `deployment` fields and let the custom resource deploy and manage the gateway runtime resources.
+
+```yaml
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: TerminatingGateway
+metadata:
+  name: edge
+  namespace: consul
+spec:
+  services:
+    - name: billing
+  deployment:
+    enabledDeployment: true
+    replicas: 2
+    resources:
+      requests:
+        cpu: 250m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+```
 ## Available Fields
 
 <ConfigEntryReference
@@ -640,6 +664,155 @@ spec:
         },
       ],
       hcl: false,
+    },
+    {
+      name: 'Deployment',
+      hcl: false,
+      yaml: true,
+      type: 'object: <optional>',
+      description:
+  '`(Kubernetes only)` Configures the Kubernetes runtime resources for the terminating gateway pod. Set `enabledDeployment` to `true` to enable the other `deployment` fields and let the `TerminatingGateway` custom resource deploy and manage the gateway pod. Consul ignores the other `deployment` fields when `enabledDeployment` is `false`.',
+      children: [
+        {
+          name: 'enabledDeployment',
+          type: 'bool: false',
+          description:
+  'Enables the `deployment` configuration when set to `true`. This field acts as a feature flag for the other `deployment` fields and lets the `TerminatingGateway` custom resource deploy and manage the terminating gateway pod.',
+        },
+        {
+          name: 'gatewayName',
+          type: 'string: ""',
+          description:
+            'Specifies the terminating gateway name to use. Use this field when the gateway name differs from the Kubernetes resource name.',
+        },
+        {
+          name: 'replicas',
+          type: 'int: 0',
+          description:
+            'Specifies the number of terminating gateway pods to run.',
+        },
+        {
+          name: 'resources',
+          type: 'object: nil',
+          description:
+            'Specifies CPU and memory requests and limits for the terminating gateway pod.',
+        },
+        {
+          name: 'affinity',
+          type: 'object: nil',
+          description:
+            'Specifies Kubernetes affinity rules that control pod placement for the terminating gateway.',
+        },
+        {
+          name: 'tolerations',
+          type: 'array<Toleration>: nil',
+          description:
+            'Specifies Kubernetes tolerations that let terminating gateway pods run on tainted nodes.',
+        },
+        {
+          name: 'topologySpreadConstraints',
+          type: 'array<TopologySpreadConstraint>: nil',
+          description:
+            'Specifies Kubernetes topology spread constraints that distribute terminating gateway pods across nodes, zones, or other topology domains.',
+        },
+        {
+          name: 'nodeSelector',
+          type: 'map<string|string>: nil',
+          description:
+            'Specifies node labels that restrict where Kubernetes schedules terminating gateway pods.',
+        },
+        {
+          name: 'priorityClassName',
+          type: 'string: ""',
+          description:
+            'Specifies the Kubernetes priority class for terminating gateway pods.',
+        },
+        {
+          name: 'annotations',
+          type: 'map<string|string>: nil',
+          description:
+            'Specifies annotations to add to the terminating gateway pod.',
+        },
+        {
+          name: 'extraVolumes',
+          type: 'array<ExtraVolume>: nil',
+          description:
+            'Specifies additional Kubernetes Secret or ConfigMap volumes to mount on the terminating gateway pod.',
+          children: [
+            {
+              name: 'name',
+              type: 'string: ""',
+              description:
+                'Specifies the name of the Kubernetes Secret or ConfigMap to use as the volume source.',
+            },
+            {
+              name: 'type',
+              type: 'string: ""',
+              description:
+                'Specifies the volume source type. Valid values are `secret` and `configMap`.',
+            },
+            {
+              name: 'load',
+              type: 'bool: false',
+              description:
+                'Indicates that the volume should be loaded for the terminating gateway.',
+            },
+            {
+              name: 'items',
+              type: 'array<VolumeItem>: nil',
+              description:
+                'Selects keys from the Kubernetes Secret or ConfigMap and maps them to file paths in the mounted volume.',
+              children: [
+                {
+                  name: 'key',
+                  type: 'string: ""',
+                  description:
+                    'Specifies the key to read from the Kubernetes Secret or ConfigMap.',
+                },
+                {
+                  name: 'path',
+                  type: 'string: ""',
+                  description:
+                    'Specifies the file path to create for the key inside the mounted volume.',
+                },
+              ],
+            },
+          ],
+        },
+        {
+          name: 'serviceAccount',
+          type: 'object: nil',
+          description:
+            'Configures the Kubernetes service account for the terminating gateway workload.',
+          children: [
+            {
+              name: 'annotations',
+              type: 'map<string|string>: nil',
+              description:
+                'Specifies annotations to add to the service account used by the terminating gateway workload.',
+            },
+          ],
+        },
+        {
+          name: 'consulNamespace',
+          enterprise: true,
+          type: 'string: ""',
+          description:
+            'Specifies the Consul namespace for the terminating gateway. The namespace must exist before you deploy the gateway.',
+        },
+        {
+          name: 'logLevel',
+          type: 'string: ""',
+          description:
+            'Specifies the log verbosity for the terminating gateway. Common values include `debug`, `info`, `warn`, and `error`.',
+        },
+        {
+          name: 'logJSON',
+          type: 'bool: false',
+          description:
+            'Emits terminating gateway logs in JSON format when set to `true`.',
+        },
+      ],
     },
     {
       name: 'Services',


### PR DESCRIPTION
## Description

This PR updates the Consul `TerminatingGateway` configuration entry reference for Consul 2.0.0.

The change documents the Kubernetes-only `spec.deployment` fields for the `TerminatingGateway` custom resource. It also adds a small YAML example that shows how to deploy terminating gateway pods from the custom resource by setting `spec.deployment.enabledDeployment` to `true`.

Important details:

- `enabledDeployment` acts as a feature flag for the other `spec.deployment` fields.
- The example keeps the configuration small and focuses on deploying gateway pods from the custom resource.
- The available fields reference now includes `deployment` and its nested fields.
- No redirects are required because this PR updates an existing page.

Target release: Consul 2.0.0


## Contributor checklists

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [x] 3 days: Small changes, easy reviews
- [ ] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [ ] Verify that all status checks passed
- [ ] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [x] I added redirects for any moved or removed pages
- [x] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [ ] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [ ] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.