### PR TITLE
ci(force-rebuild-dev-portal): deny-all permissions

### DIFF
--- a/.github/workflows/force-rebuild-dev-portal.yml
+++ b/.github/workflows/force-rebuild-dev-portal.yml
@@ -3,6 +3,10 @@ name: Force Rebuild Dev Portal
 on:
   workflow_dispatch:
 
+# Workflow has no checkout step and the deploy hook is an external POST
+# secret. The default GITHUB_TOKEN is unused.
+permissions: {}
+
 jobs:
   rebuild-dev-portal:
     runs-on: ubuntu-latest


### PR DESCRIPTION
`force-rebuild-dev-portal.yml` has no checkout step and makes no GitHub API calls — it just runs `curl -X POST ${{ secrets.DEV_PORTAL_DEPLOY_HOOK_PROD }}`. `permissions: {}` (deny-all) is the most accurate scope for the default `GITHUB_TOKEN` here.

YAML validated with `yaml.safe_load`.