### PR TITLE
[TF-37410] docs: differentiate Stacks and Workspaces in actions invocation docs

### DIFF
--- a/content/terraform-docs-common/docs/cloud-docs/workspaces/run/manage.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/workspaces/run/manage.mdx
@@ -37,7 +37,7 @@ HCP Terraform identifies runs that invoke actions on the run details page. Actio
 
 HCP Terraform indicates how many actions the run invoked and adds **action:** labels to the **Plan** operation output and **Invoked:** labels to the **Apply** operation output.  
 
-You can invoke actions either as part of a resource lifecycle configuration or manually target a specific action using the `-invoke` flag to a `terraform apply` or `terraform plan` command. Direct invocations using the `-invoke` flag are only supported for Workspaces. Stacks do not support the `-invoke` flag because Stack runs execute exclusively in HCP Terraform and cannot be run locally.
+You can invoke actions either as part of a resource lifecycle configuration or manually target a specific action using the `-invoke` flag to a `terraform apply` or `terraform plan` command. Direct invocations using the `-invoke` flag are currently only supported for Workspaces.
 
 <Note>
 

--- a/content/terraform-docs-common/docs/cloud-docs/workspaces/run/manage.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/workspaces/run/manage.mdx
@@ -37,7 +37,7 @@ HCP Terraform identifies runs that invoke actions on the run details page. Actio
 
 HCP Terraform indicates how many actions the run invoked and adds **action:** labels to the **Plan** operation output and **Invoked:** labels to the **Apply** operation output.  
 
-You can invoke actions either as part of a resource lifecycle configuration or manually target a specific action using the `-invoke` flag to a `terraform apply` or `terraform plan` command. Direct invocations using the `-invoke` flag are currently only supported for Workspaces.
+You can instruct Terraform to invoke actions automatically during the resource lifecycle. You can also add the `-invoke` flag to a `terraform apply` or `terraform plan` command to manually invoke an action. You can only target specific actions using the `-invoke` flag when your configuration is in a workspace.
 
 <Note>
 

--- a/content/terraform-docs-common/docs/cloud-docs/workspaces/run/manage.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/workspaces/run/manage.mdx
@@ -37,7 +37,7 @@ HCP Terraform identifies runs that invoke actions on the run details page. Actio
 
 HCP Terraform indicates how many actions the run invoked and adds **action:** labels to the **Plan** operation output and **Invoked:** labels to the **Apply** operation output.  
 
-You can invoke actions either as part of a resource lifecycle configuration or manually target a specific action using the `-invoke` flag to a `terraform apply` or `terraform plan` command.  
+You can invoke actions either as part of a resource lifecycle configuration or manually target a specific action using the `-invoke` flag to a `terraform apply` or `terraform plan` command. Direct invocations using the `-invoke` flag are only supported for Workspaces. Stacks do not support the `-invoke` flag because Stack runs execute exclusively in HCP Terraform and cannot be run locally.
 
 <Note>
 

--- a/content/terraform/v1.15.x/docs/language/invoke-actions.mdx
+++ b/content/terraform/v1.15.x/docs/language/invoke-actions.mdx
@@ -129,7 +129,7 @@ Because the  `event` argument includes `after_update`, Terraform also updates th
 
 ## View actions in HCP Terraform
 
-How you view action runs in HCP Terraform depends on whether you are using Workspaces or Stacks.
+You can view action runs in workspaces and Stacks.
 
 ### Workspaces
 

--- a/content/terraform/v1.15.x/docs/language/invoke-actions.mdx
+++ b/content/terraform/v1.15.x/docs/language/invoke-actions.mdx
@@ -19,6 +19,8 @@ Declare an `action` block in your Terraform configuration and apply your configu
 
 Provider developers must implement actions for them to be available. Refer to the provider documentation for information about actions that may be available in your provider.
 
+You can only target specific actions using the `-invoke` flag when your configuration is in a workspace. Stacks execute runs exclusively in HCP Terraform and do not support local CLI invocations. To invoke an action in a Stack, configure an [`action_trigger` block](#trigger-an-action-when-applying-a-configuration) in your resource lifecycle configuration instead.
+
 ### HCP Terraform 
 
 To monitor actions in HCP Terraform, you must configure a connection to HCP Terraform in your Terraform configuration. Refer to [Connect to HCP Terraform](/terraform/cli/cloud/settings) for instructions.
@@ -82,7 +84,7 @@ You can use the Terraform CLI to run an action or configure a `resource` block t
 
 ### Invoke an action from the CLI
 
-Direct action invocations using the `-invoke` flag are only supported for Workspaces. Stacks execute runs exclusively in HCP Terraform and do not support local CLI invocations. To invoke an action in a Stack, configure an [`action_trigger` block](#trigger-an-action-when-applying-a-configuration) in your resource lifecycle configuration instead.
+You can't directly invoke an action from a Stacks environment. Refer to [Requirements](#requirements) for more information.
 
 When you invoke an action using the CLI, Terraform runs only the action and excludes all other configurations. 
 

--- a/content/terraform/v1.15.x/docs/language/invoke-actions.mdx
+++ b/content/terraform/v1.15.x/docs/language/invoke-actions.mdx
@@ -82,6 +82,8 @@ You can use the Terraform CLI to run an action or configure a `resource` block t
 
 ### Invoke an action from the CLI
 
+Direct action invocations using the `-invoke` flag are only supported for Workspaces. Stacks execute runs exclusively in HCP Terraform and do not support local CLI invocations. To invoke an action in a Stack, configure an [`action_trigger` block](#trigger-an-action-when-applying-a-configuration) in your resource lifecycle configuration instead.
+
 When you invoke an action using the CLI, Terraform runs only the action and excludes all other configurations. 
 
 Add the `-invoke` flag and specify the address of an action when running the `terraform plan` or `terraform apply` command. 
@@ -127,4 +129,12 @@ Because the  `event` argument includes `after_update`, Terraform also updates th
 
 ## View actions in HCP Terraform
 
-If your workspace is connected to your HCP Terraform organization, you can monitor action runs in HCP Terraform. Refer to [Action runs](/terraform/cloud-docs/workspaces/run/manage#action-runs) in the HCP Terraform documentation for more information.
+How you view action runs in HCP Terraform depends on whether you are using Workspaces or Stacks.
+
+### Workspaces
+
+If your workspace is connected to your HCP Terraform organization, you can monitor action runs on the run details page. HCP Terraform identifies runs that invoke actions and displays how many actions the run invoked. Refer to [Action runs](/terraform/cloud-docs/workspaces/run/manage#action-runs) in the HCP Terraform documentation for more information.
+
+### Stacks
+
+HCP Terraform displays action output within the deployment run's plan and apply output. Refer to [Review deployment runs](/terraform/cloud-docs/stacks/deploy/runs) in the HCP Terraform documentation for more information.


### PR DESCRIPTION
 ### What

Updated the **Invoke an action** page (`invoke-actions.mdx`) for Terraform v1.15.x and the **Manage and view runs** page for HCP Terraform workspaces.

Changed pages:
- `content/terraform/v1.15.x/docs/language/invoke-actions.mdx`
- `content/terraform-docs-common/docs/cloud-docs/workspaces/run/manage.mdx`

### Why

The "Invoke an action from the CLI" section did not clarify that direct invocations using the `-invoke` flag are exclusive to Workspaces. The "View actions in HCP Terraform" section only covered Workspaces and had no Stacks context. These gaps could mislead users working with Stacks into expecting CLI invocation support that does not exist.

Changes made:
- Added a note to "Invoke an action from the CLI" clarifying the `-invoke` flag is Workspace-only, since Stacks execute runs exclusively in HCP Terraform
- Expanded "View actions in HCP Terraform" into Workspaces and Stacks subsections; the Stacks subsection points to deployment run output and links to [Review deployment runs](/terraform/cloud-docs/stacks/deploy/runs)
- Added an explicit workspace-only callout to the "Action runs" section in `workspaces/run/manage.mdx`

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] Jira ticket: https://hashicorp.atlassian.net/browse/TF-37410

#### Content
- [x] You added redirects to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages **across all affected versions**. (N/A — no pages moved, renamed, or deleted)
- [x] Links to related content where appropriate (e.g., CLI, language, API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages. (N/A — no pages added, deleted, or renamed)
- [x] New pages have metadata (page name and description) at the top. (N/A — no new pages)
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility. (N/A — no new images)
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars. (N/A — no new code blocks)
- [x] UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.