### PR TITLE
Chore: Fix typo in service events documentation

### DIFF
--- a/content/hcp-docs/content/docs/vault-radar/get-started/set-up-alerting/index.mdx
+++ b/content/hcp-docs/content/docs/vault-radar/get-started/set-up-alerting/index.mdx
@@ -18,7 +18,7 @@ posture. HCP Vault Radar allows you to set up alerts for service related events.
 The HCP Vault Radar service creates events to notify you of
 activity related to your Vault Radar service, such as when Vault Radar detects a
 new secret. Service events are distinct from [audit
-events](/hcp/docs/vault-radar/get-started/set-up-audit-streaming), and enabled
+events](/hcp/docs/vault-radar/get-started/set-up-audit-log-streaming), and enabled
 separately.
 
 Refer to the HCP Vault Radar integration targets for information on


### PR DESCRIPTION
## Description

We currently have a dead link, fixing it

### Requested review scope:

- [ ] Content touched by the PR _only_ (typos, clarifications, tips)
- [ ] Code test (command and code block changes)
- [ ] Flow and language near changes (new/rearranged steps)
- [ ] Review everything (rewrites, major changes)

### Review urgency:

- [ ] ASAP (bug fixes, broken content, imminent releases)
- [ ] 3 days (small changes, easy reviews)
- [ ] 1 week (default)
- [ ] Best effort (very non-urgent)

<!-- Fill out only the appropriate checklist for your type of feature (or both if necessary) and delete the other one! -->

## All updates:

<!-- This section is mandatory for all PRs: -->

I have:

- [ ] Verified that all status checks have passed
- [ ] Verified that preview environment has successfully deployed
- [ ] Verified appropriate `label` applied (`hcp` + `product name`)
- [ ] Added all required reviewers (code owners and external)

## Content checklist (optional)

Please do these things before requesting a review. I have:

- [ ] Made any associated code repositories public
- [ ] Added the `hashicorp-education/teamName` to any additional code or example repos as repo admin
- [ ] Added redirects for any moved or removed pages
- [ ] Spell checked the tutorial(s)
- [ ] Followed the [unified style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [ ] Linted code snippets (Details per language [here](https://github.com/hashicorp/engineering-docs/blob/master/writing/markdown.md#code-blocks))
- [ ] Checked the steps for completeness (no steps are implied or hidden)
- [ ] Looked at the local or vercel build and checked each new or changed page for:
  - display on the product curriculum page
  - callout box formatting
  - code block highlighting
  - right-hand navigation
  - next and back buttons
  - URL path
