### PR TITLE
Update installation.mdx to callout Server URL Text limitation

### DIFF
--- a/content/vault/v2.x/content/docs/platform/mssql/installation.mdx
+++ b/content/vault/v2.x/content/docs/platform/mssql/installation.mdx
@@ -106,8 +106,9 @@ The remaining steps are all run on the database server.
 
 1. Download and run the latest Vault EKM provider installer from
   [releases.hashicorp.com](https://releases.hashicorp.com/vault-mssql-ekm-provider/)
-1. Run the installer to create an initial configuration. If your server URL is
-   too long for the input field, you can set it manually in the next step.
+1. Run the installer to create an initial configuration. The server URL text field is 
+   limited to 80 characters, If your server URL is too long for the input field, 
+   you can set it manually in the next step.
 1. If you need to configure non-default namespaces or mount paths or your server
    URL exceeds the character limit in the installer, set the relevant
    [EKM configuration parameters](/vault/docs/platform/mssql/configuration)


### PR DESCRIPTION
Update installation.mdx to explicitly callout that EKM Provider installer's Server URL text field is limited to 80 characters