### PR TITLE
VAULT-44543: add agent-registry count metric

### DIFF
--- a/content/vault/v2.x/content/docs/license/product-usage-reporting.mdx
+++ b/content/vault/v2.x/content/docs/license/product-usage-reporting.mdx
@@ -80,6 +80,7 @@ IBM collects the following product usage metrics as numerical data. Vault does n
 | Metric Name | Description |
 | --- | --- |
 | `adaptive_overload_protection_enabled` | Whether Adaptive Overload Protection is enabled on Enterprise clusters. |
+| `vault.agentregistry.agent.registrations.count` | Number of agent registrations across all namespaces. |
 | `audit.device.file.count` | The total number of audit devices of type file configured for this cluster. |
 | `audit.device.socket.tcp.count` | The total number of audit devices of type TCP socket configured for this cluster. |
 | `audit.device.socket.udp.count` | The total number of audit devices of type UDP socket configured for this cluster. |

--- a/content/vault/v2.x/content/docs/updates/release-notes.mdx
+++ b/content/vault/v2.x/content/docs/updates/release-notes.mdx
@@ -66,9 +66,9 @@ create policies, and discover Vault capabilities.
   - PKI External CA certificate units for duration-adjusted PKI External CA certificate issuance:
     `normalized_external_ca_cert_units.current_month_estimate` and `normalized_external_ca_cert_units.previous_month_complete`
 
-- **Product usage metrics**: Added a count of local account static roles
-  managed by mounts of OS secrets engine across all namespaces
-  (`secret.engine.os.local.account.static.role.count`).
+- **Product usage metrics**: 
+  - Added a count of local account static roles managed by mounts of OS secrets engine across all namespaces (`secret.engine.os.local.account.static.role.count`).
+  - Added a count of agent registrations across all namespaces (`vault.agentregistry.agent.registrations.count`).
 
 
 


### PR DESCRIPTION
Add `vault.agentregistry.agent.registrations.count` metric to `product-usage-reporting.mdx`.

Ticket: https://hashicorp.atlassian.net/browse/VAULT-44543

vault-enterprise PR: https://github.com/hashicorp/vault-enterprise/pull/14642
