### PR TITLE
vault(billing): add engines covered in 2.0.1

### DIFF
--- a/content/vault/v2.x/content/docs/restricted/concepts/billing/usage/metrics.mdx
+++ b/content/vault/v2.x/content/docs/restricted/concepts/billing/usage/metrics.mdx
@@ -124,14 +124,17 @@ If cluster A is the PR primary, it reports 2 secrets: the replicated secret in `
 | Google Cloud KMS | [Data protection operations](#data-protection-operations) |
 | Identity (JWTs)  | [Credential units](#credential-units)                     |
 | Identity (OIDC)  | [Credential units](#credential-units)                     |
-| KV               | [Secrets](#secrets-and-keys)                              |
-| KMSE             | [Keys](#secrets-and-keys)                                 |
+| Key Management   | [Keys](#secrets-and-keys)                                 |
+| Key/Value        | [Secrets](#secrets-and-keys)                              |
 | Kubernetes       | [Secrets](#secrets-and-keys) (roles)                      |
 | LDAP             | [Secrets](#secrets-and-keys) (roles)                      |
+| Local Accounts   | [Secrets](#secrets-and-keys) (local accounts)             |
 | MongoDB Atlas    | [Secrets](#secrets-and-keys) (roles)                      |
 | Nomad            | [Secrets](#secrets-and-keys) (roles)                      |
 | PKI              | [Credential units](#credential-units)                     |
+| PKI External CA  | [Credential units](#credential-units)                     |
 | RabbitMQ         | [Secrets](#secrets-and-keys) (roles)                      |
+| SPIFFE           | [Credential units](#credential-units)                     |
 | SSH              | [Credential units](#credential-units)                     |
 | Terraform        | [Secrets](#secrets-and-keys) (roles)                      |
 | TOTP             | [Keys](#secrets-and-keys)                                 |


### PR DESCRIPTION
Update the Vault usage-based billing metrics to reflect the new metrics available in Vault 2.0.1.