### PR TITLE
Nomad docs - updates missing hyphen from token-name-format acl option

### DIFF
--- a/content/nomad/v1.10.x/content/commands/acl/auth-method/create.mdx
+++ b/content/nomad/v1.10.x/content/commands/acl/auth-method/create.mdx
@@ -38,7 +38,7 @@ via flags detailed below.
 - `-token-locality`: Defines the kind of token that this auth method should
   produce. This can be either `local` or `global`.
 
-- `token-name-format`: Sets the token format for the authenticated users.
+- `-token-name-format`: Sets the token format for the authenticated users.
   This can be lightly templated using HIL '${foo}' syntax. Defaults to
   '${auth_method_type}-${auth_method_name}'.
 

--- a/content/nomad/v1.10.x/content/commands/acl/auth-method/update.mdx
+++ b/content/nomad/v1.10.x/content/commands/acl/auth-method/update.mdx
@@ -48,7 +48,7 @@ The `acl auth-method update` command requires an existing method's name.
 - `-token-locality`: Updates the kind of token that this auth method should
   produce. This can be either `local` or `global`.
 
-- `token-name-format`: Sets the token format for the authenticated users.
+- `-token-name-format`: Sets the token format for the authenticated users.
   This can be lightly templated using HIL '${foo}' syntax. Defaults to
   '${auth_method_type}-${auth_method_name}'.
 

--- a/content/nomad/v1.11.x/content/commands/acl/auth-method/create.mdx
+++ b/content/nomad/v1.11.x/content/commands/acl/auth-method/create.mdx
@@ -38,7 +38,7 @@ via flags detailed below.
 - `-token-locality`: Defines the kind of token that this auth method should
   produce. This can be either `local` or `global`.
 
-- `token-name-format`: Sets the token format for the authenticated users.
+- `-token-name-format`: Sets the token format for the authenticated users.
   This can be lightly templated using HIL '${foo}' syntax. Defaults to
   '${auth_method_type}-${auth_method_name}'.
 

--- a/content/nomad/v1.11.x/content/commands/acl/auth-method/update.mdx
+++ b/content/nomad/v1.11.x/content/commands/acl/auth-method/update.mdx
@@ -48,7 +48,7 @@ The `acl auth-method update` command requires an existing method's name.
 - `-token-locality`: Updates the kind of token that this auth method should
   produce. This can be either `local` or `global`.
 
-- `token-name-format`: Sets the token format for the authenticated users.
+- `-token-name-format`: Sets the token format for the authenticated users.
   This can be lightly templated using HIL '${foo}' syntax. Defaults to
   '${auth_method_type}-${auth_method_name}'.
 

--- a/content/nomad/v1.7.x/content/docs/commands/acl/auth-method/create.mdx
+++ b/content/nomad/v1.7.x/content/docs/commands/acl/auth-method/create.mdx
@@ -41,7 +41,7 @@ via flags detailed below.
 - `-token-locality`: Defines the kind of token that this auth method should
   produce. This can be either `local` or `global`.
 
-- `token-name-format`: Sets the token format for the authenticated users.
+- `-token-name-format`: Sets the token format for the authenticated users.
   This can be lightly templated using HIL '${foo}' syntax. Defaults to
   '${auth_method_type}-${auth_method_name}'.
 

--- a/content/nomad/v1.7.x/content/docs/commands/acl/auth-method/update.mdx
+++ b/content/nomad/v1.7.x/content/docs/commands/acl/auth-method/update.mdx
@@ -49,7 +49,7 @@ The `acl auth-method update` command requires an existing method's name.
 - `-token-locality`: Updates the kind of token that this auth method should
   produce. This can be either `local` or `global`.
 
-- `token-name-format`: Sets the token format for the authenticated users.
+- `-token-name-format`: Sets the token format for the authenticated users.
   This can be lightly templated using HIL '${foo}' syntax. Defaults to
   '${auth_method_type}-${auth_method_name}'.
 

--- a/content/nomad/v1.8.x/content/commands/acl/auth-method/create.mdx
+++ b/content/nomad/v1.8.x/content/commands/acl/auth-method/create.mdx
@@ -41,7 +41,7 @@ via flags detailed below.
 - `-token-locality`: Defines the kind of token that this auth method should
   produce. This can be either `local` or `global`.
 
-- `token-name-format`: Sets the token format for the authenticated users.
+- `-token-name-format`: Sets the token format for the authenticated users.
   This can be lightly templated using HIL '${foo}' syntax. Defaults to
   '${auth_method_type}-${auth_method_name}'.
 

--- a/content/nomad/v1.8.x/content/commands/acl/auth-method/update.mdx
+++ b/content/nomad/v1.8.x/content/commands/acl/auth-method/update.mdx
@@ -49,7 +49,7 @@ The `acl auth-method update` command requires an existing method's name.
 - `-token-locality`: Updates the kind of token that this auth method should
   produce. This can be either `local` or `global`.
 
-- `token-name-format`: Sets the token format for the authenticated users.
+- `-token-name-format`: Sets the token format for the authenticated users.
   This can be lightly templated using HIL '${foo}' syntax. Defaults to
   '${auth_method_type}-${auth_method_name}'.
 

--- a/content/nomad/v1.9.x/content/commands/acl/auth-method/create.mdx
+++ b/content/nomad/v1.9.x/content/commands/acl/auth-method/create.mdx
@@ -42,7 +42,7 @@ via flags detailed below.
 - `-token-locality`: Defines the kind of token that this auth method should
   produce. This can be either `local` or `global`.
 
-- `token-name-format`: Sets the token format for the authenticated users.
+- `-token-name-format`: Sets the token format for the authenticated users.
   This can be lightly templated using HIL '${foo}' syntax. Defaults to
   '${auth_method_type}-${auth_method_name}'.
 

--- a/content/nomad/v1.9.x/content/commands/acl/auth-method/update.mdx
+++ b/content/nomad/v1.9.x/content/commands/acl/auth-method/update.mdx
@@ -51,7 +51,7 @@ The `acl auth-method update` command requires an existing method's name.
 - `-token-locality`: Updates the kind of token that this auth method should
   produce. This can be either `local` or `global`.
 
-- `token-name-format`: Sets the token format for the authenticated users.
+- `-token-name-format`: Sets the token format for the authenticated users.
   This can be lightly templated using HIL '${foo}' syntax. Defaults to
   '${auth_method_type}-${auth_method_name}'.
 

--- a/content/nomad/v2.0.x/content/commands/acl/auth-method/create.mdx
+++ b/content/nomad/v2.0.x/content/commands/acl/auth-method/create.mdx
@@ -38,7 +38,7 @@ via flags detailed below.
 - `-token-locality`: Defines the kind of token that this auth method should
   produce. This can be either `local` or `global`.
 
-- `token-name-format`: Sets the token format for the authenticated users.
+- `-token-name-format`: Sets the token format for the authenticated users.
   This can be lightly templated using HIL '${foo}' syntax. Defaults to
   '${auth_method_type}-${auth_method_name}'.
 

--- a/content/nomad/v2.0.x/content/commands/acl/auth-method/update.mdx
+++ b/content/nomad/v2.0.x/content/commands/acl/auth-method/update.mdx
@@ -48,7 +48,7 @@ The `acl auth-method update` command requires an existing method's name.
 - `-token-locality`: Updates the kind of token that this auth method should
   produce. This can be either `local` or `global`.
 
-- `token-name-format`: Sets the token format for the authenticated users.
+- `-token-name-format`: Sets the token format for the authenticated users.
   This can be lightly templated using HIL '${foo}' syntax. Defaults to
   '${auth_method_type}-${auth_method_name}'.
 


### PR DESCRIPTION


## Description

<!-- 
The docs are missing a hyphen from the command
-->


## Contributor checklists

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [ ] 1 week: Default expectation
- [ /] Best effort: No urgency

Pull request:

- [ /] Verify that the PR is set to merge into the correct base branch
- [ /] Verify that all status checks passed
- [ /] Verify that the preview environment deployed successfully
- [ /] Add additional reviewers if they are not part of assigned groups

Content:

- [/] I added redirects for any moved or removed pages
- [/] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [/] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [ ] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.
