### PR TITLE
updating outdated link paths

### DIFF
--- a/content/terraform-docs-common/docs/cloud-docs/users-teams-organizations/organizations/public-namespace/index.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/users-teams-organizations/organizations/public-namespace/index.mdx
@@ -41,15 +41,15 @@ Namespaces do not support publishing or managing [policy libraries](/terraform/r
 
 </Note>
 
-Linking a GitHub account to an HCP Terraform organization lets organization members collectively manage the linked GitHub account’s [public registry artifacts](/terraform/cloud-docs/public-namespace/artifacts) and the namespace itself.
+Linking a GitHub account to an HCP Terraform organization lets organization members collectively manage the linked GitHub account’s [public registry artifacts](/terraform/cloud-docs/users-teams-organizations/organizations/public-namespace/artifacts) and the namespace itself.
 
 Organization owners can manage claimed namespaces and specify which team members can interact with an organization's namespaces by setting [organization-level permissions](/terraform/cloud-docs/users-teams-organizations/permissions/organization#manage-public-registry) to either **Manage public modules** or **Manage public providers**.
 
 Organization owners and teams with **Manage public modules** and **Manage public providers** permissions can perform the following actions for every namespaces in their organization:
 
-* [Publish new providers or modules](/terraform/cloud-docs/public-namespace/artifacts#publish-artifacts) to the public registry under a namespace
-* [Publish new versions](/terraform/cloud-docs/public-namespace/artifacts#publish-new-artifact-versions) of existing public registry artifacts
-* [Add GPG keys](/terraform/cloud-docs/public-namespace/manage#manage-gpg-keys) to a namespace
-* [Resync](/terraform/cloud-docs/public-namespace/artifacts#resync-artifacts) a namespace’s public registry artifacts
-* [View usage metrics](/terraform/cloud-docs/public-namespace/artifacts#view-artifacts) for public registry artifacts
-* [Delete an artifact or an artifact version](/terraform/cloud-docs/public-namespace/artifacts#delete-artifacts-or-artifact-versions)
+* [Publish new providers or modules](/terraform/cloud-docs/users-teams-organizations/organizations/public-namespace/artifacts#publish-artifacts) to the public registry under a namespace
+* [Publish new versions](/terraform/cloud-docs/users-teams-organizations/organizations/public-namespace/artifacts#publish-new-artifact-versions) of existing public registry artifacts
+* [Add GPG keys](/terraform/cloud-docs/users-teams-organizations/organizations/public-namespace/manage#manage-gpg-keys) to a namespace
+* [Resync](/terraform/cloud-docs/users-teams-organizations/organizations/public-namespace/artifacts#resync-artifacts) a namespace’s public registry artifacts
+* [View usage metrics](/terraform/cloud-docs/users-teams-organizations/organizations/public-namespace/artifacts#view-artifacts) for public registry artifacts
+* [Delete an artifact or an artifact version](/terraform/cloud-docs/users-teams-organizations/organizations/public-namespace/artifacts#delete-artifacts-or-artifact-versions)


### PR DESCRIPTION
Updating these links related to [this support request](https://ibm-hashicorp.slack.com/archives/C09LU1THDDE/p1778728190205979). 

Reposting:

> [Here](https://github.com/hashicorp/web-unified-docs/blob/main/content/terraform-docs-common/docs/cloud-docs/users-teams-organizations/organizations/public-namespace/index.mdx?plain=1#L44-L55) the links referenced are using old paths.
> 
> Since the [redirect is already set up](https://github.com/hashicorp/web-unified-docs/blob/main/content/terraform-docs-common/redirects.jsonc#L704-L707), when you open the link in a new tab it will make a request to the server and actually follow the redirect. When you click it normally it will just stay as a client side request (default nextjs. behavior for speed) and the redirect functionality is never actually called until you refresh the page. The same behavior persists when you click the back button to go to the previous page, hence why it would continue to look broken. 
> 
> To fix this I created a PR that just updates the links on page, but I've also been looking into other link references on pages to see where this same discrepancy exists, and it's in a handful of other places. I found another example [here](https://developer.hashicorp.com/terraform/cloud-docs/registry#public-providers-and-modules) where the "Namespaces" link also references an outdated path.