### PR TITLE
Update explorer docs with source_module_id [TF-32003]

### DIFF
--- a/content/terraform-docs-common/docs/cloud-docs/api-docs/explorer.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/api-docs/explorer.mdx
@@ -106,11 +106,11 @@ fields available for each view type are detailed below:
 | Field                             | Type       | Description |
 | --------------------------------- | ---------- | ----------------------------------------------------------------------------- |
 | `all_checks_succeeded`            | `boolean`  | True if checks have succeeded for the workspace, false otherwise. |
-| `current_rum_count`               | `number`   | The number of [resources under management](/terraform/cloud-docs/overview/estimate-hcp-terraform-cost#what-is-a-managed-resource) (RUM). |
 | `checks_errored`                  | `number`   | The number of checks that errored without completing. |
 | `checks_failed`                   | `number`   | The number of checks that completed and failed. |
 | `checks_passed`                   | `number`   | The number of checks that completed and passed. |
 | `checks_unknown`                  | `number`   | The number of checks that could not be assessed. |
+| `current_rum_count`               | `number`   | The number of [resources under management](/terraform/cloud-docs/overview/estimate-hcp-terraform-cost#what-is-a-managed-resource) (RUM). |
 | `current_run_applied_at`          | `datetime` | Represents the time that this workspace's current run was applied. |
 | `current_run_external_id`         | `string`   | The external ID of this workspace's current run. |
 | `current_run_status`              | `string`   | The status of this workspace's current run. |
@@ -125,6 +125,7 @@ fields available for each view type are detailed below:
 | `providers`                       | `string`   | A comma separated list of providers used in this workspace. |
 | `resources_drifted`               | `number`   | The count of resources that drift was detected for. |
 | `resources_undrifted`             | `number`   | The count of resources that drift was not detected for. |
+| `source_module_id`                | `string`   | The workspace's source module identifier. |
 | `state_version_terraform_version` | `string`   | The Terraform version used to create the current run's state file. |
 | `tags`                            | `string`   | A comma separated list of tags (keys and key:value pairs) applied to this workspace. |
 | `vcs_repo_identifier`             | `string`   | The name of the repository configured for this workspace, if available. |
@@ -341,11 +342,11 @@ _Show data for all workspaces_
     {
       "attributes": {
         "all-checks-succeeded": true,
-        "current_rum_count": 0,
         "checks-errored": 0,
         "checks-failed": 0,
         "checks-passed": 0,
         "checks-unknown": 0,
+        "current-rum-count": 0,
         "current-run-applied-at": null,
         "current-run-external-id": "run-rdoEKh2Gy3K6SbCZ",
         "current-run-status": "planned_and_finished",
@@ -356,10 +357,11 @@ _Show data for all workspaces_
         "organization-name": "acme-corp",
         "project-external-id": "prj-V61QLE8tvs4NvVZG",
         "project-name": "Default Project",
-        "provider-count": 0,
-        "providers": null,
+        "provider-count": 2,
+        "providers": "registry.terraform.io/providers/hashicorp/aws/1.2.5, registry.terraform.io/providers/hashicorp/external/2.3.3",
         "resources-drifted": 0,
         "resources-undrifted": 0,
+        "source-module-id": "private/acmecorp/rds/aws/1.0.2",
         "state-version-terraform-version": "1.5.7",
         "tags": "",
         "vcs-repo-identifier": null,
@@ -374,11 +376,11 @@ _Show data for all workspaces_
     {
       "attributes": {
         "all-checks-succeeded": true,
-        "current_rum_count": 0,
         "checks-errored": 0,
         "checks-failed": 0,
         "checks-passed": 0,
         "checks-unknown": 0,
+        "current-rum-count": 0,
         "current-run-applied-at": "2023-08-18T16:24:59.000+00:00",
         "current-run-external-id": "run-9MmJaoQTvDCh5wUa",
         "current-run-status": "applied",
@@ -393,6 +395,7 @@ _Show data for all workspaces_
         "providers": null,
         "resources-drifted": 3,
         "resources-undrifted": 3,
+        "source-module-id": null,
         "state-version-terraform-version": "1.4.5",
         "tags": "billing:tier1, project_customer",
         "vcs-repo-identifier": "acmecorp/api",
@@ -786,6 +789,7 @@ curl \
         "checks-failed": 0,
         "checks-passed": 0,
         "checks-unknown": 0,
+        "current-rum-count": 0,
         "current-run-applied-at": null,
         "current-run-external-id": "run-rdoEKh2Gy3K6SbCZ",
         "current-run-status": "planned_and_finished",
@@ -800,6 +804,7 @@ curl \
         "providers": null,
         "resources-drifted": 0,
         "resources-undrifted": 0,
+        "source-module-id": "private/acmecorp/rds/aws/1.0.2",
         "state-version-terraform-version": "1.5.7",
         "vcs-repo-identifier": null,
         "workspace-created-at": "2023-10-17T21:56:45.570+00:00",
@@ -818,6 +823,7 @@ curl \
         "checks-failed": 0,
         "checks-passed": 0,
         "checks-unknown": 0,
+        "current-rum-count": 0,
         "current-run-applied-at": "2023-08-18T16:24:59.000+00:00",
         "current-run-external-id": "run-9MmJaoQTvDCh5wUa",
         "current-run-status": "applied",
@@ -832,6 +838,7 @@ curl \
         "providers": null,
         "resources-drifted": 3,
         "resources-undrifted": 3,
+        "source-module-id": null,
         "state-version-terraform-version": "1.4.5",
         "vcs-repo-identifier": "acmecorp/api",
         "workspace-created-at": "2023-04-25T17:09:14.960+00:00",
@@ -886,8 +893,7 @@ curl \
 ### Sample response
 
 ```csv
-all_checks_succeeded,checks_errored,checks_failed,checks_passed,checks_unknown,current_run_applied_at,current_run_external_id,current_run_status,drifted,external_id,module_count,modules,organization_name,project_external_id,project_name,provider_count,providers,resources_drifted,resources_undrifted,state_version_terraform_version,vcs_repo_identifier,workspace_created_at,workspace_name,workspace_terraform_version,workspace_updated_at
-"true","0","0","0","0","","run-rdoEKh2Gy3K6SbCZ","planned_and_finished","false","ws-j2sAeWRxou1b5HYf","0","","acme-corp","prj-V61QLE8tvs4NvVZG","Default Project","0","","0","0","1.5.7","","2023-10-17T21:56:45+00:00","candy distribution service","1.5.7","2023-12-13T15:48:16+00:00"
-"true","0","0","0","0","2023-08-18T16:24:59+00:00","run-9MmJaoQTvDCh5wUa","applied","true","ws-igUVNQSYVXRkhYuo","0","","acme-corp","prj-uU2xNqGeG86U9WgT","web","0","","3","3","1.4.5","acmecorp/api","2023-04-25T17:09:14+00:00","api-service","1.4.5","2023-12-13T15:29:03+00:00"
+all_checks_succeeded,checks_errored,checks_failed,checks_passed,checks_unknown,current_run_applied_at,current_run_external_id,current_run_status,drifted,external_id,module_count,modules,organization_name,project_external_id,project_name,provider_count,providers,resources_drifted,resources_undrifted,source_module_id,state_version_terraform_version,vcs_repo_identifier,workspace_created_at,workspace_name,workspace_terraform_version,workspace_updated_at
+"true","0","0","0","0","","run-rdoEKh2Gy3K6SbCZ","planned_and_finished","false","ws-j2sAeWRxou1b5HYf","0","","acme-corp","prj-V61QLE8tvs4NvVZG","Default Project","0","","0","0","private/acmecorp/rds/aws/1.0.2","1.5.7","","2023-10-17T21:56:45+00:00","candy distribution service","1.5.7","2023-12-13T15:48:16+00:00"
+"true","0","0","0","0","2023-08-18T16:24:59+00:00","run-9MmJaoQTvDCh5wUa","applied","true","ws-igUVNQSYVXRkhYuo","0","","acme-corp","prj-uU2xNqGeG86U9WgT","web","0","","3","3",null,"1.4.5","acmecorp/api","2023-04-25T17:09:14+00:00","api-service","1.4.5","2023-12-13T15:29:03+00:00"
 ```
-

--- a/content/terraform-enterprise/2.0.x/docs/enterprise/api-docs/explorer.mdx
+++ b/content/terraform-enterprise/2.0.x/docs/enterprise/api-docs/explorer.mdx
@@ -109,11 +109,11 @@ fields available for each view type are detailed below:
 | Field                             | Type       | Description                                                                                                                              |
 | --------------------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
 | `all_checks_succeeded`            | `boolean`  | True if checks have succeeded for the workspace, false otherwise.                                                                        |
-| `current_rum_count`               | `number`   | The number of [resources under management](/terraform/enterprise/overview/estimate-hcp-terraform-cost#what-is-a-managed-resource) (RUM). |
 | `checks_errored`                  | `number`   | The number of checks that errored without completing.                                                                                    |
 | `checks_failed`                   | `number`   | The number of checks that completed and failed.                                                                                          |
 | `checks_passed`                   | `number`   | The number of checks that completed and passed.                                                                                          |
 | `checks_unknown`                  | `number`   | The number of checks that could not be assessed.                                                                                         |
+| `current_rum_count`               | `number`   | The number of [resources under management](/terraform/enterprise/overview/estimate-hcp-terraform-cost#what-is-a-managed-resource) (RUM). |
 | `current_run_applied_at`          | `datetime` | Represents the time that this workspace's current run was applied.                                                                       |
 | `current_run_external_id`         | `string`   | The external ID of this workspace's current run.                                                                                         |
 | `current_run_status`              | `string`   | The status of this workspace's current run.                                                                                              |
@@ -128,6 +128,7 @@ fields available for each view type are detailed below:
 | `providers`                       | `string`   | A comma separated list of providers used in this workspace.                                                                              |
 | `resources_drifted`               | `number`   | The count of resources that drift was detected for.                                                                                      |
 | `resources_undrifted`             | `number`   | The count of resources that drift was not detected for.                                                                                  |
+| `source_module_id`                | `string`   | The workspace's source module identifier. |
 | `state_version_terraform_version` | `string`   | The Terraform version used to create the current run's state file.                                                                       |
 | `tags`                            | `string`   | A comma separated list of tags (keys and key:value pairs) applied to this workspace.                                                     |
 | `vcs_repo_identifier`             | `string`   | The name of the repository configured for this workspace, if available.                                                                  |
@@ -336,11 +337,11 @@ _Show data for all workspaces_
     {
       "attributes": {
         "all-checks-succeeded": true,
-        "current_rum_count": 0,
         "checks-errored": 0,
         "checks-failed": 0,
         "checks-passed": 0,
         "checks-unknown": 0,
+        "current-rum-count": 0,
         "current-run-applied-at": null,
         "current-run-external-id": "run-rdoEKh2Gy3K6SbCZ",
         "current-run-status": "planned_and_finished",
@@ -351,10 +352,11 @@ _Show data for all workspaces_
         "organization-name": "acme-corp",
         "project-external-id": "prj-V61QLE8tvs4NvVZG",
         "project-name": "Default Project",
-        "provider-count": 0,
-        "providers": null,
+        "provider-count": 2,
+        "providers": "registry.terraform.io/providers/hashicorp/aws/1.2.5, registry.terraform.io/providers/hashicorp/external/2.3.3",
         "resources-drifted": 0,
         "resources-undrifted": 0,
+        "source-module-id": "private/acmecorp/rds/aws/1.0.2",
         "state-version-terraform-version": "1.5.7",
         "tags": "",
         "vcs-repo-identifier": null,
@@ -369,11 +371,11 @@ _Show data for all workspaces_
     {
       "attributes": {
         "all-checks-succeeded": true,
-        "current_rum_count": 0,
         "checks-errored": 0,
         "checks-failed": 0,
         "checks-passed": 0,
         "checks-unknown": 0,
+        "current-rum-count": 0,
         "current-run-applied-at": "2023-08-18T16:24:59.000+00:00",
         "current-run-external-id": "run-9MmJaoQTvDCh5wUa",
         "current-run-status": "applied",
@@ -388,6 +390,7 @@ _Show data for all workspaces_
         "providers": null,
         "resources-drifted": 3,
         "resources-undrifted": 3,
+        "source-module-id": null,
         "state-version-terraform-version": "1.4.5",
         "tags": "billing:tier1, project_customer",
         "vcs-repo-identifier": "acmecorp/api",
@@ -773,11 +776,11 @@ curl \
     {
       "attributes": {
         "all-checks-succeeded": true,
-        "current_rum_count": 0,
         "checks-errored": 0,
         "checks-failed": 0,
         "checks-passed": 0,
         "checks-unknown": 0,
+        "current-rum-count": 0,
         "current-run-applied-at": null,
         "current-run-external-id": "run-rdoEKh2Gy3K6SbCZ",
         "current-run-status": "planned_and_finished",
@@ -792,6 +795,7 @@ curl \
         "providers": null,
         "resources-drifted": 0,
         "resources-undrifted": 0,
+        "source-module-id": "private/acmecorp/rds/aws/1.0.2",
         "state-version-terraform-version": "1.5.7",
         "vcs-repo-identifier": null,
         "workspace-created-at": "2023-10-17T21:56:45.570+00:00",
@@ -805,11 +809,11 @@ curl \
     {
       "attributes": {
         "all-checks-succeeded": true,
-        "current_rum_count": 0,
         "checks-errored": 0,
         "checks-failed": 0,
         "checks-passed": 0,
         "checks-unknown": 0,
+        "current-rum-count": 0,
         "current-run-applied-at": "2023-08-18T16:24:59.000+00:00",
         "current-run-external-id": "run-9MmJaoQTvDCh5wUa",
         "current-run-status": "applied",
@@ -824,6 +828,7 @@ curl \
         "providers": null,
         "resources-drifted": 3,
         "resources-undrifted": 3,
+        "source-module-id": null,
         "state-version-terraform-version": "1.4.5",
         "vcs-repo-identifier": "acmecorp/api",
         "workspace-created-at": "2023-04-25T17:09:14.960+00:00",
@@ -878,7 +883,7 @@ curl \
 ### Sample response
 
 ```csv
-all_checks_succeeded,checks_errored,checks_failed,checks_passed,checks_unknown,current_run_applied_at,current_run_external_id,current_run_status,drifted,external_id,module_count,modules,organization_name,project_external_id,project_name,provider_count,providers,resources_drifted,resources_undrifted,state_version_terraform_version,vcs_repo_identifier,workspace_created_at,workspace_name,workspace_terraform_version,workspace_updated_at
-"true","0","0","0","0","","run-rdoEKh2Gy3K6SbCZ","planned_and_finished","false","ws-j2sAeWRxou1b5HYf","0","","acme-corp","prj-V61QLE8tvs4NvVZG","Default Project","0","","0","0","1.5.7","","2023-10-17T21:56:45+00:00","candy distribution service","1.5.7","2023-12-13T15:48:16+00:00"
-"true","0","0","0","0","2023-08-18T16:24:59+00:00","run-9MmJaoQTvDCh5wUa","applied","true","ws-igUVNQSYVXRkhYuo","0","","acme-corp","prj-uU2xNqGeG86U9WgT","web","0","","3","3","1.4.5","acmecorp/api","2023-04-25T17:09:14+00:00","api-service","1.4.5","2023-12-13T15:29:03+00:00"
+all_checks_succeeded,checks_errored,checks_failed,checks_passed,checks_unknown,current_run_applied_at,current_run_external_id,current_run_status,drifted,external_id,module_count,modules,organization_name,project_external_id,project_name,provider_count,providers,resources_drifted,resources_undrifted,source_module_id,state_version_terraform_version,vcs_repo_identifier,workspace_created_at,workspace_name,workspace_terraform_version,workspace_updated_at
+"true","0","0","0","0","","run-rdoEKh2Gy3K6SbCZ","planned_and_finished","false","ws-j2sAeWRxou1b5HYf","0","","acme-corp","prj-V61QLE8tvs4NvVZG","Default Project","0","","0","0","private/acmecorp/rds/aws/1.0.2","1.5.7","","2023-10-17T21:56:45+00:00","candy distribution service","1.5.7","2023-12-13T15:48:16+00:00"
+"true","0","0","0","0","2023-08-18T16:24:59+00:00","run-9MmJaoQTvDCh5wUa","applied","true","ws-igUVNQSYVXRkhYuo","0","","acme-corp","prj-uU2xNqGeG86U9WgT","web","0","","3","3",null,"1.4.5","acmecorp/api","2023-04-25T17:09:14+00:00","api-service","1.4.5","2023-12-13T15:29:03+00:00"
 ```


### PR DESCRIPTION
### What

Update explorer documentation to show new `source_module_id` field.
- Cloud API docs `content/terraform-docs-common/docs/cloud-docs/api-docs/explorer.mdx`
- Enterprise API docs `content/terraform-docs-common/docs/cloud-docs/api-docs/explorer.mdx`

[JIRA](https://hashicorp.atlassian.net/browse/TF-32003)

This also fixes some typos (`current_rum_count` to `current-rum-count` in API output) and alphabetical ordering.

### Why

New field added, needs documentation.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] N/A Redirects have been added to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages. 
- [x] API documentation and the API Changelog have been updated.
- [x] N/A Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] N/A Pages with related content are updated and link to this content when appropriate.
- [x] N/A Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] N/A New pages have metadata (page name and description) at the top.
- [x] N/A New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] N/A UI elements (button names, page names, etc.) are bolded.
- [x] N/A The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.

