### PR TITLE
VAULT-44544: add oauth server registrations count metric to vault

### DIFF
--- a/content/vault/v1.20.x/content/docs/license/product-usage-reporting.mdx
+++ b/content/vault/v1.20.x/content/docs/license/product-usage-reporting.mdx
@@ -230,6 +230,7 @@ All of these metrics are numerical, and contain no sensitive values or additiona
 | `vault.ui.custom_banners.authenticated`                             | How many authenticated custom banners have been enabled across all namespaces.                             |
 | `vault.ui.custom_banners.unauthenticated`                           | How many unauthenticated custom banners have been enabled across all namespaces.                           |
 | `vault.storage.max_entry_size`                                      | The value of `max_entry_size` parameter for the storage stanza in the config.                              |
+| `vault.oauth.resource.server.config.count`                          | The total number of OAauth resource server configurations across all namespaces.                           |
 | `vault.storage.max_mount_and_namespace_table_entry_size`            | The value of `max_mount_and_namespace_table_entry_size` parameter for the storage stanza in the config.    |
 | `vault.operator.import.kv.version2.secrets.source.vault.count`      | The total number of secrets imported from Vault using operator import command.                             |
 | `vault.operator.import.kv.version2.secrets.source.aws.count`        | The total number of secrets imported from AWS using operator import command.                               |


### PR DESCRIPTION
Add OAuth server registrations count Census metric to Vault.
Vault PR has been merged and backported to `2.x.x`.

Ticket: https://hashicorp.atlassian.net/browse/VAULT-44544
Vault PR: https://github.com/hashicorp/vault-enterprise/pull/14886