### PR TITLE
Added release note for Vault JWKS cache improvement

### DIFF
--- a/content/vault/v2.x/content/docs/updates/release-notes.mdx
+++ b/content/vault/v2.x/content/docs/updates/release-notes.mdx
@@ -71,7 +71,6 @@ create policies, and discover Vault capabilities.
   - Added a count of agent registrations across all namespaces (`vault.agentregistry.agent.registrations.count`).
 
 - **JWT/OIDC auth plugin - Added multi-JWKS key ID cache:**
-
   JWT authentication with multiple JWKS URLs (`jwks_pairs`) now uses a
   key ID cache so Vault skips unnecessary JWKS endpoint refreshes
   during login. The plugin first checks all in-memory caches for the token's

--- a/content/vault/v2.x/content/docs/updates/release-notes.mdx
+++ b/content/vault/v2.x/content/docs/updates/release-notes.mdx
@@ -70,6 +70,12 @@ create policies, and discover Vault capabilities.
   - Added a count of local account static roles managed by mounts of OS secrets engine across all namespaces (`secret.engine.os.local.account.static.role.count`).
   - Added a count of agent registrations across all namespaces (`vault.agentregistry.agent.registrations.count`).
 
+- **JWT/OIDC auth plugin: Added multi-JWKS key ID cache**
+  JWT authentication with multiple JWKS URLs (`jwks_pairs`) now uses a
+  two-phase key ID cache so Vault skips unnecessary JWKS endpoint refreshes
+  during login. The plugin first checks all in-memory caches for the token's key ID
+  before making any network calls. Remote JWKS endpoints are only re-fetched
+  when no cache contains the key ID, such as after a key rotation.
 
 
 ## Vault 2.0.0

--- a/content/vault/v2.x/content/docs/updates/release-notes.mdx
+++ b/content/vault/v2.x/content/docs/updates/release-notes.mdx
@@ -70,12 +70,13 @@ create policies, and discover Vault capabilities.
   - Added a count of local account static roles managed by mounts of OS secrets engine across all namespaces (`secret.engine.os.local.account.static.role.count`).
   - Added a count of agent registrations across all namespaces (`vault.agentregistry.agent.registrations.count`).
 
-- **JWT/OIDC auth plugin: Added multi-JWKS key ID cache**
+- **JWT/OIDC auth plugin - Added multi-JWKS key ID cache:**
+
   JWT authentication with multiple JWKS URLs (`jwks_pairs`) now uses a
-  two-phase key ID cache so Vault skips unnecessary JWKS endpoint refreshes
-  during login. The plugin first checks all in-memory caches for the token's key ID
-  before making any network calls. Remote JWKS endpoints are only re-fetched
-  when no cache contains the key ID, such as after a key rotation.
+  key ID cache so Vault skips unnecessary JWKS endpoint refreshes
+  during login. The plugin first checks all in-memory caches for the token's
+  key ID before making any network calls. Remote JWKS endpoints are only
+  re-fetched when no cache contains the key ID, such as after a key rotation.
 
 
 ## Vault 2.0.0


### PR DESCRIPTION
This PR updates the release note of vault 2.0.1 to include an improvement that was made to add a cache in jwt auth plugin.

Please go to the `Preview` tab and select the appropriate template:

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
