### PR TITLE
Add HCP TF metrics service usage documentation [IPE-1493]

### DIFF
--- a/content/terraform-docs-common/data/cloud-docs-nav-data.json
+++ b/content/terraform-docs-common/data/cloud-docs-nav-data.json
@@ -74,7 +74,8 @@
               "path": "users-teams-organizations/organizations/public-namespace/artifacts"
               }
             ]
-          }
+          },
+          { "title": "Collect metrics", "path": "users-teams-organizations/organizations/metrics" }
         ]
       },
       {

--- a/content/terraform-docs-common/docs/cloud-docs/users-teams-organizations/organizations/metrics.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/users-teams-organizations/organizations/metrics.mdx
@@ -1,0 +1,92 @@
+---
+page_title: Collect organization metrics
+description: Learn how to create a metrics service token and collect metrics from your HCP Terraform organization.
+tfc_only: true
+---
+
+# Collect organization metrics
+
+HCP Terraform provides an API endpoint that you can use to gather metrics related to your HCP Terraform organization.
+
+## Introduction
+
+When you create a metrics service token, HCP Terraform automatically begins gathering metrics from your organization and makes them available in a Prometheus-compatible format. If your organization has no valid metrics service tokens, HCP Terraform stops gathering metrics until you create a new valid token.
+
+### Workflow
+
+To gather metrics from your HCP Terraform organization, complete the following steps:
+
+1. Create a metrics service API token. Refer to [Create a metrics service token](#create-a-metrics-service-token) for more information.
+1. Configure your metrics collection software to gather metrics from HCP Terraform. Refer to [Gather metrics](#gather-metrics) for more information.
+
+## Requirements
+
+To manage your organization's metrics service API token, you must be a member of your organization's "owners" team. Refer to the [Organization owners](/terraform/cloud-docs/users-teams-organizations/permissions/organization#organization-owners) documentation for more information on the owners team.
+
+## Create a metrics service token
+
+To gather metrics from HCP Terraform, you must provide a metrics service token for your organization. Complete the follow steps to generate a metrics service API token:
+
+1. Sign in to [HCP Terraform](https://app.terraform.io/) and navigate to your organization.
+1. Choose **Settings** from the sidebar, then **API tokens**.
+1. Choose the **Metrics Service Tokens** tab.
+1. Click **Generate a token**.
+1. Give the token a **Name** and **Expiration**. 
+1. Click **Generate**.
+
+Save this token in a safe place since HCP Terraform only displays it once. You will use it to authenticate your metrics collection software.
+
+You can also manage your metrics service API tokens with the HCP Terraform API. Refer to the [Metrics service tokens API reference](/terraform/cloud-docs/api-docs/metrics-service-tokens) for more information.
+
+## Gather metrics
+
+To read metrics from HCP Terraform, configure your metrics collection software to send a `GET` request with your organization ID and metrics service token to the `/metrics` endpoint.
+
+`GET https://api.cloud.hashicorp.com/telemetry/hcpt/$ORG_ID/metrics`
+
+| Header key | Value |
+| ---------- | ----- |
+| `Authorization` | `Bearer $TOKEN` |
+
+The following is example Prometheus configuration to gather metrics from HCP Terraform.
+
+<CodeBlockConfig filename="prometheus.yml">
+
+```yaml
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'hcp_telemetry'
+    scheme: https
+    metrics_path: '/telemetry/hcpt/org-XXXXXXXXXXXXX/metrics'
+
+    authorization:
+      type: 'Bearer'
+      credentials: 'hcpt_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+
+    static_configs:
+      - targets:
+        - 'api.cloud.hashicorp.com:443
+```
+
+</CodeBlockConfig>
+
+## Metrics reference
+
+HCP Terraform collects the following metrics:
+
+| Metric | Labels | Type | Description | Update Interval |
+| ------ | ------ | ---- | ----------- | --------------- |
+| `tfc_vcs_requests_total` | organization_id, workspace, project, status, vcs.provider | count | Total number of requests from HCP Terraform to VCS providers | 60s | 
+| `tfc_vcs_webhook_exists_checks_total` | organization_id, workspace, project, status, vcs.provider | count | Total webhook existence checks from HCP Terraform to VCS providers | 60s | 
+| `vcs_tfc_requests_total` | organization_id, workspace, project, status, vcs.provider | count | Webhook requests from VCS providers to HCP Terraform | 60s | 
+| `tfc_vcs_requests_duration_seconds` | organization_id, workspace, project, vcs.provider | histogram | Duration of HCP Terraform-to-VCS API requests in seconds | 60s | 
+| `tfc_vcs_webhook_exists_checks_duration_seconds` | organization_id, project, workspace, vcs.provider | histogram | Duration of webhook existence checks in seconds | 60s | 
+| `tfc_terraform_agent_count` | organization_id, status (idle/busy/unknown/errored/exited), agent_pool_id | gauge | Number of agents in different status by pool. | 60s | 
+| `terraform_run_phase_transitions_total` | organization_id, workspace_id, phase | count | Cumulative count of run transitions into each Terraform execution phase | 60s | 
+| `terraform_run_status_total` | organization_id, workspace_id, run_status | count | Cumulative count of completed runs by final status | 60s | 
+| `terraform_run_phase_duration_seconds` | organization_id, workspace_id, phase | histogram | Time spent in each Terraform run phase, recorded on phase exit | 60s | 
+| `terraform_workspace_resource_count` | organization_id, workspace_id | gauge | Current number of managed resources in a workspace | 60s | 
+
+ 

--- a/content/terraform-docs-common/docs/cloud-docs/users-teams-organizations/organizations/metrics.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/users-teams-organizations/organizations/metrics.mdx
@@ -8,6 +8,8 @@ tfc_only: true
 
 HCP Terraform provides an API endpoint that you can use to gather metrics related to your HCP Terraform organization.
 
+@include 'tfc-package-callouts/metrics.mdx'
+
 ## Introduction
 
 When you create a metrics service token, HCP Terraform automatically begins gathering metrics from your organization and makes them available in a Prometheus-compatible format. If your organization has no valid metrics service tokens, HCP Terraform stops gathering metrics until you create a new valid token.

--- a/content/terraform-docs-common/docs/cloud-docs/users-teams-organizations/organizations/metrics.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/users-teams-organizations/organizations/metrics.mdx
@@ -73,11 +73,11 @@ HCP Terraform collects the following metrics:
 
 | Metric | Labels | Type | Description | Update Interval |
 | ------ | ------ | ---- | ----------- | --------------- |
-| `tfc_vcs_requests_total` | organization_id, workspace, project, status, vcs.provider | count | Total number of requests from HCP Terraform to VCS providers | 60s | 
-| `tfc_vcs_webhook_exists_checks_total` | organization_id, workspace, project, status, vcs.provider | count | Total number of checks that verify existing webhooks from HCP Terraform to VCS providers | 60s | 
-| `vcs_tfc_requests_total` | organization_id, workspace, project, status, vcs.provider | count | Webhook requests from VCS providers to HCP Terraform | 60s | 
-| `tfc_vcs_requests_duration_seconds` | organization_id, workspace, project, vcs.provider | histogram | Duration of HCP Terraform-to-VCS API requests in seconds | 60s | 
-| `tfc_vcs_webhook_exists_checks_duration_seconds` | organization_id, project, workspace, vcs.provider | histogram | Duration in seconds of checks that verify existing webhooks  | 60s | 
+| `terraform_vcs_egress_request_total` | organization_id, workspace, project, status, vcs.provider | count | Total number of requests from HCP Terraform to VCS providers | 60s | 
+| `terraform_vcs_webhook_exists_check_total` | organization_id, workspace, project, status, vcs.provider | count | Total number of checks that verify existing webhooks from HCP Terraform to VCS providers | 60s | 
+| `terraform_vcs_ingress_request_total` | organization_id, workspace, project, status, vcs.provider | count | Webhook requests from VCS providers to HCP Terraform | 60s | 
+| `terraform_vcs_egress_request_duration_seconds` | organization_id, workspace, project, vcs.provider | histogram | Duration of HCP Terraform-to-VCS API requests in seconds | 60s | 
+| `terraform_vcs_webhook_exists_check_duration_seconds` | organization_id, workspace, project, vcs.provider | histogram | Duration in seconds of checks that verify existing webhooks  | 60s | 
 | `tfc_terraform_agent_count` | organization_id, status (idle/busy/unknown/errored/exited), agent_pool_id | gauge | Number of agents in any status by pool. | 60s | 
 | `terraform_run_phase_transitions_total` | organization_id, workspace_id, phase | count | Cumulative count of run transitions into each Terraform execution phase | 60s | 
 | `terraform_run_status_total` | organization_id, workspace_id, run_status | count | Cumulative count of completed runs by final status | 60s | 

--- a/content/terraform-docs-common/docs/cloud-docs/users-teams-organizations/organizations/metrics.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/users-teams-organizations/organizations/metrics.mdx
@@ -21,7 +21,7 @@ To gather metrics from your HCP Terraform organization, complete the following s
 
 ## Requirements
 
-To manage your organization's metrics service API token, you must be a member of your organization's "owners" team. Refer to the [Organization owners](/terraform/cloud-docs/users-teams-organizations/permissions/organization#organization-owners) documentation for more information on the owners team.
+To manage your organization's metrics service API token, you must be a member of your organization's **owners** team. Refer to the [Organization owners](/terraform/cloud-docs/users-teams-organizations/permissions/organization#organization-owners) documentation for more information on the owners team.
 
 ## Create a metrics service token
 
@@ -34,21 +34,16 @@ To gather metrics from HCP Terraform, you must provide a metrics service token f
 1. Give the token a **Name** and **Expiration**. 
 1. Click **Generate**.
 
-Save this token in a safe place since HCP Terraform only displays it once. You will use it to authenticate your metrics collection software.
+Save this token in a safe place since HCP Terraform only displays it once. You must present the token to authenticate your metrics collection software.
 
 You can also manage your metrics service API tokens with the HCP Terraform API. Refer to the [Metrics service tokens API reference](/terraform/cloud-docs/api-docs/metrics-service-tokens) for more information.
 
 ## Gather metrics
 
-To read metrics from HCP Terraform, configure your metrics collection software to send a `GET` request with your organization ID and metrics service token to the `/metrics` endpoint.
+To read metrics from HCP Terraform, configure your metrics collection software to send a `GET` request with your organization ID and metrics service token to the [`/metrics`]() endpoint. You must present the metrics service token you generated in [Generate metrics service token](#generate-metrics-service-token) to call the endpoint.
 
-`GET https://api.cloud.hashicorp.com/telemetry/hcpt/$ORG_ID/metrics`
+For example:
 
-| Header key | Value |
-| ---------- | ----- |
-| `Authorization` | `Bearer $TOKEN` |
-
-The following is example Prometheus configuration to gather metrics from HCP Terraform.
 
 <CodeBlockConfig filename="prometheus.yml">
 
@@ -79,11 +74,11 @@ HCP Terraform collects the following metrics:
 | Metric | Labels | Type | Description | Update Interval |
 | ------ | ------ | ---- | ----------- | --------------- |
 | `tfc_vcs_requests_total` | organization_id, workspace, project, status, vcs.provider | count | Total number of requests from HCP Terraform to VCS providers | 60s | 
-| `tfc_vcs_webhook_exists_checks_total` | organization_id, workspace, project, status, vcs.provider | count | Total webhook existence checks from HCP Terraform to VCS providers | 60s | 
+| `tfc_vcs_webhook_exists_checks_total` | organization_id, workspace, project, status, vcs.provider | count | Total number of checks that verify existing webhooks from HCP Terraform to VCS providers | 60s | 
 | `vcs_tfc_requests_total` | organization_id, workspace, project, status, vcs.provider | count | Webhook requests from VCS providers to HCP Terraform | 60s | 
 | `tfc_vcs_requests_duration_seconds` | organization_id, workspace, project, vcs.provider | histogram | Duration of HCP Terraform-to-VCS API requests in seconds | 60s | 
-| `tfc_vcs_webhook_exists_checks_duration_seconds` | organization_id, project, workspace, vcs.provider | histogram | Duration of webhook existence checks in seconds | 60s | 
-| `tfc_terraform_agent_count` | organization_id, status (idle/busy/unknown/errored/exited), agent_pool_id | gauge | Number of agents in different status by pool. | 60s | 
+| `tfc_vcs_webhook_exists_checks_duration_seconds` | organization_id, project, workspace, vcs.provider | histogram | Duration in seconds of checks that verify existing webhooks  | 60s | 
+| `tfc_terraform_agent_count` | organization_id, status (idle/busy/unknown/errored/exited), agent_pool_id | gauge | Number of agents in any status by pool. | 60s | 
 | `terraform_run_phase_transitions_total` | organization_id, workspace_id, phase | count | Cumulative count of run transitions into each Terraform execution phase | 60s | 
 | `terraform_run_status_total` | organization_id, workspace_id, run_status | count | Cumulative count of completed runs by final status | 60s | 
 | `terraform_run_phase_duration_seconds` | organization_id, workspace_id, phase | histogram | Time spent in each Terraform run phase, recorded on phase exit | 60s | 

--- a/content/terraform-docs-common/docs/partials/tfc-package-callouts/metrics.mdx
+++ b/content/terraform-docs-common/docs/partials/tfc-package-callouts/metrics.mdx
@@ -1,0 +1,1 @@
+-> **Note:** Metrics are available in HCP Terraform **Standard** and **Premium** editions. Refer to [HCP Terraform pricing](https://www.hashicorp.com/products/terraform/pricing) for details.


### PR DESCRIPTION
### What

Add usage documentation for HCP Terraform metrics service

### Why

Compliment the API reference documentation to instruct users how to enable and use the metrics service.



----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages.
- [x] API documentation and the API Changelog have been updated.
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] New pages have metadata (page name and description) at the top.
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
