### PR TITLE
Changed HCP terraform  to Terraform Enterprise

### DIFF
--- a/content/terraform-enterprise/2.0.x/docs/enterprise/workspaces/health.mdx
+++ b/content/terraform-enterprise/2.0.x/docs/enterprise/workspaces/health.mdx
@@ -13,12 +13,12 @@ last_modified: 2026-04-08T18:54:47.000Z
 
 # Health
 
-HCP Terraform can perform automatic health assessments in a workspace to assess whether its real infrastructure matches the requirements defined in its Terraform configuration. Health assessments include the following types of evaluations:
+Terraform Enterprise can perform automatic health assessments in a workspace to assess whether its real infrastructure matches the requirements defined in its Terraform configuration. Health assessments include the following types of evaluations:
 
 -   [Drift detection](#drift-detection) determines whether your real-world infrastructure matches your Terraform configuration.
 -   [Continuous validation](#continuous-validation) determines whether custom conditions in the workspace’s configuration continue to pass after Terraform provisions the infrastructure.
 
-When you enable health assessments, HCP Terraform periodically runs health assessments for your workspace. Refer to [Health Assessment Scheduling](#health-assessment-scheduling) for details.
+When you enable health assessments, Terraform Enterprise periodically runs health assessments for your workspace. Refer to [Health Assessment Scheduling](#health-assessment-scheduling) for details.
 
 <!-- BEGIN: TFC:only name:pnp-callout -->
 
@@ -45,17 +45,17 @@ Workspaces require the following settings to receive health assessments:
 -   Terraform version 1.3.0+ for drift detection and continuous validation
 -   [Remote execution mode](/terraform/enterprise/workspaces/settings#execution-mode) or [Agent execution mode](/terraform/cloud-docs/agents/agent-pools#configure-workspaces-to-use-the-agent) for Terraform runs
 
-The latest Terraform run in the workspace must have been successful. If the most recent run ended in an errored, canceled, or discarded state, HCP Terraform pauses health assessments until there is a successfully applied run.
+The latest Terraform run in the workspace must have been successful. If the most recent run ended in an errored, canceled, or discarded state, Terraform Enterprise pauses health assessments until there is a successfully applied run.
 
-The workspace must also have at least one run in which Terraform successfully applies a configuration. HCP Terraform does not perform health assessments in workspaces with no real-world infrastructure.
+The workspace must also have at least one run in which Terraform successfully applies a configuration. Terraform Enterprise does not perform health assessments in workspaces with no real-world infrastructure.
 
 ## Enable health assessments
 
-You can enforce health assessments across all eligible workspaces in an organization within the [organization settings](/terraform/enterprise/users-teams-organizations/organizations/settings#health). Enforcing health assessments at an organization-level overrides workspace-level settings. You can only enable health assessments within a specific workspace when HCP Terraform is not enforcing health assessments at the organization level.
+You can enforce health assessments across all eligible workspaces in an organization within the [organization settings](/terraform/enterprise/users-teams-organizations/organizations/settings#health). Enforcing health assessments at an organization-level overrides workspace-level settings. You can only enable health assessments within a specific workspace when Terraform Enterprise is not enforcing health assessments at the organization level.
 
 To enable health assessments within a workspace:
 
-1.  Sign in to [HCP Terraform](https://app.terraform.io/) or Terraform Enterprise and navigate to the workspace you want to enable health assessments on.
+1.  Sign in to Terraform Enterprise and navigate to the workspace you want to enable health assessments on.
 2.  Verify that your workspace satisfies the [requirements](#workspace-requirements).
 3.  Go to the workspace and click **Settings**, then click **Health**.
 4.  Select **Enable** under **Health Assessments**.
@@ -63,17 +63,17 @@ To enable health assessments within a workspace:
 
 ## Health assessment scheduling
 
-When you enable health assessments for a workspace, HCP Terraform runs the first health assessment based on whether there are active Terraform runs for the workspace:
+When you enable health assessments for a workspace, Terraform Enterprise runs the first health assessment based on whether there are active Terraform runs for the workspace:
 
 -   **No active runs:** A few minutes after you enable the feature.
 -   **Active speculative plan:** A few minutes after that plan is complete.
 -   **Other active runs:** During the next assessment period.
 
-After the first health assessment, HCP Terraform starts a new health assessment during the next assessment period if there are no active runs in the workspace. Health assessments may take longer to complete when you enable health assessments in many workspaces at once or your workspace contains a complex configuration with many resources.
+After the first health assessment, Terraform Enterprise starts a new health assessment during the next assessment period if there are no active runs in the workspace. Health assessments may take longer to complete when you enable health assessments in many workspaces at once or your workspace contains a complex configuration with many resources.
 
-A health assessment never interrupts or interferes with runs. If you start a new run during a health assessment, HCP Terraform cancels the current assessment and runs the next assessment during the next assessment period. This behavior may prevent HCP Terraform from performing health assessments in workspaces with frequent runs.
+A health assessment never interrupts or interferes with runs. If you start a new run during a health assessment, Terraform Enterprise cancels the current assessment and runs the next assessment during the next assessment period. This behavior may prevent Terraform Enterprise from performing health assessments in workspaces with frequent runs.
 
-HCP Terraform pauses health assessments if the latest run ended in an errored state. This behavior occurs for all run types, including plan-only runs and speculative plans. Once the workspace completes a successful run, HCP Terraform restarts health assessments during the next assessment period.
+Terraform Enterprise pauses health assessments if the latest run ended in an errored state. This behavior occurs for all run types, including plan-only runs and speculative plans. Once the workspace completes a successful run, Terraform Enterprise restarts health assessments during the next assessment period.
 
 Terraform Enterprise administrators can modify their installation's [assessment frequency  and number of maximum concurrent assessments](/terraform/enterprise/admin/application/general#health-assessments) from the admin settings console.
 
@@ -81,29 +81,29 @@ Terraform Enterprise administrators can modify their installation's [assessment 
 
 ### On-demand assessments
 
--> **Note:** On-demand assessments are only available in the HCP Terraform user interface.
+-> **Note:** On-demand assessments are only available in the Terraform Enterprise user interface.
 
 If you are an administrator for a workspace and it satisfies all [assessment requirements](/terraform/enterprise/workspaces/health#workspace-requirements), you can trigger a new assessment by clicking **Start health assessment** on the workspace's **Health** page.
 
 After clicking **Start health assessment**, the workspace displays a message in the bottom lefthand corner of the page to indicate if it successfully triggered a new assessment. The time it takes to complete an assessment can vary based on network latency and the number of resources managed by the workspace.
 
-You cannot trigger another assessment while one is in progress. An on-demand assessment resets the scheduling for automated assessments, so HCP Terraform waits to run the next assessment until the next scheduled period.
+You cannot trigger another assessment while one is in progress. An on-demand assessment resets the scheduling for automated assessments, so Terraform Enterprise waits to run the next assessment until the next scheduled period.
 
 <!-- END: TFC:only name:health-assessments -->
 
 ### Concurrency
 
-If you enable health assessments on multiple workspaces, assessments may run concurrently. Health assessments do not affect your concurrency limit. HCP Terraform also monitors and controls health assessment concurrency to avoid issues for large-scale deployments with thousands of workspaces. However, HCP Terraform performs health assessments in batches, so health assessments may take longer to complete when you enable them in a large number of workspaces.
+If you enable health assessments on multiple workspaces, assessments may run concurrently. Health assessments do not affect your concurrency limit. Terraform Enterprise also monitors and controls health assessment concurrency to avoid issues for large-scale deployments with thousands of workspaces. However, Terraform Enterprise performs health assessments in batches, so health assessments may take longer to complete when you enable them in a large number of workspaces.
 
 ### Notifications
 
-HCP Terraform sends [notifications](/terraform/enterprise/workspaces/settings/notifications) about health assessment results according to your workspace’s settings.
+Terraform Enterprise sends [notifications](/terraform/enterprise/workspaces/settings/notifications) about health assessment results according to your workspace's settings.
 
 ## Workspace health status
 
-On the organization's **Workspaces** page, HCP Terraform displays a **Health warning** status for workspaces with infrastructure drift or failed continuous validation checks.
+On the organization's **Workspaces** page, Terraform Enterprise displays a **Health warning** status for workspaces with infrastructure drift or failed continuous validation checks.
 
-On the right of a workspace’s overview page, HCP Terraform displays a **Health** bar that summarizes the results of the last health assessment.
+On the right of a workspace's overview page, Terraform Enterprise displays a **Health** bar that summarizes the results of the last health assessment.
 
 -   The **Drift** summary shows the total number of resources in the configuration and the number of resources that have drifted.
 -   The **Checks** summary shows the number of passed, failed, and unknown statuses for objects with continuous validation checks.
@@ -136,7 +136,7 @@ Configuration drift happens when external changes affecting remote objects inval
 
 ### View workspace drift
 
-To view the drift detection results from the latest health assessment, go to the workspace and click **Health > Drift**. If there is configuration drift, HCP Terraform proposes the necessary changes to bring the infrastructure back in sync with its configuration.
+To view the drift detection results from the latest health assessment, go to the workspace and click **Health > Drift**. If there is configuration drift, Terraform Enterprise proposes the necessary changes to bring the infrastructure back in sync with its configuration.
 
 ### Resolve drift
 
@@ -153,7 +153,7 @@ Continuous validation evaluates preconditions, postconditions, and check blocks 
 
 ### Preventing false positives
 
-Health assessments create a speculative plan to access the current state of your infrastructure. Terraform evaluates any check blocks in your configuration as the last step of creating the speculative plan. If your configuration relies on data sources and the values queried by a data source change between the time of your last run and the assessment, the speculative plan will include those changes. HCP Terraform will not modify your infrastructure as part of an assessment, but it can use those updated values to evaluate checks. This may lead to false positive results for alerts since your infrastructure did not yet change.
+Health assessments create a speculative plan to access the current state of your infrastructure. Terraform evaluates any check blocks in your configuration as the last step of creating the speculative plan. If your configuration relies on data sources and the values queried by a data source change between the time of your last run and the assessment, the speculative plan will include those changes. Terraform Enterprise does not modify your infrastructure as part of an assessment, but it can use those updated values to evaluate checks. This may lead to false positive results for alerts since your infrastructure did not yet change.
 
 To ensure your checks evaluate the current state of your configuration instead of against a possible future change, use nested data sources that query your actual resource configuration, rather than a computed latest value. Refer to the [AMI image scenario](#asserting-up-to-date-amis-for-compute-instances) below for an example.
 
@@ -242,8 +242,8 @@ check "ami_version_check" {
 
 To view the continuous validation results from the latest health assessment, go to the workspace and click **Health > Continuous validation**.
 
-The page shows all of the resources, outputs, and data sources with custom assertions that HCP Terraform evaluated. Next to each object, HCP Terraform reports whether the assertion passed or failed. If one or more assertions fail, HCP Terraform displays the error messages for each assertion.
+The page shows all of the resources, outputs, and data sources with custom assertions that Terraform Enterprise evaluated. Next to each object, Terraform Enterprise reports whether the assertion passed or failed. If one or more assertions fail, Terraform Enterprise displays the error messages for each assertion.
 
 The health assessment page displays each assertion by its [named value](/terraform/language/expressions/references). A `check` block's named value combines the prefix `check` with its configuration name.
 
-If your configuration contains multiple [preconditions and postconditions](/terraform/language/expressions/custom-conditions#preconditions-and-postconditions) within a single resource, output, or data source, HCP Terraform will not show the results of individual conditions unless they fail. If all custom conditions on the object pass, HCP Terraform reports that the entire check passed. The assessment results will display the results of any precondition and postconditions alongside the results of any assertions from `check` blocks, identified by the named values of their parent block.
+If your configuration contains multiple [preconditions and postconditions](/terraform/language/expressions/custom-conditions#preconditions-and-postconditions) within a single resource, output, or data source, Terraform Enterprise does not show the results of individual conditions unless they fail. If all custom conditions on the object pass, Terraform Enterprise reports that the entire check passed. The assessment results will display the results of any precondition and postconditions alongside the results of any assertions from `check` blocks, identified by the named values of their parent block.


### PR DESCRIPTION
# Terraform Enterprise 2.x.x

The health page was consistently mentioning HCP Terraform instead of Terraform Enterprise. This caused confusion. Altered the documentation page to mention Terraform Enterprise. 

For HCP terraform there is another page. 
