### PR TITLE
VAULT-42829: Create a new billing config endpoint to set custom retention months

### DIFF
--- a/content/boundary/v0.21.x/content/docs/client-cache/index.mdx
+++ b/content/boundary/v0.21.x/content/docs/client-cache/index.mdx
@@ -64,6 +64,22 @@ The client cache stores a log file in the **~/.boundary** directory.
 Boundary automatically rotates the log once it reaches 5 MB.
 It compresses and keeps the last 3 rotated logs before deleting a log.
 
+You can configure the log format and verbosity level using the following options:
+
+- `log-format=<string>` - Specifies the log format, mostly as a fallback for events.
+Supported values are `standard` and `json`.
+- `log-level=<string>` - Specifies the log verbosity level, mostly as a fallback for events. Supported values include the following in order of more detail to less:
+
+  - `trace`
+  - `debug`
+  - `info`
+  - `warn`
+  - `err`
+
+  You can also specify a log level using the **BOUNDARY_LOG_LEVEL** environment variable.
+
+For more information, refer to the [`cache start`](/boundary/docs/commands/cache/start) command documentation.
+
 ### Status
 
 You can check the status of the cache using the `boundary cache status` command.

--- a/content/boundary/v0.21.x/content/docs/commands/cache/start.mdx
+++ b/content/boundary/v0.21.x/content/docs/commands/cache/start.mdx
@@ -40,14 +40,16 @@ The default value is `false`.
 By default, the cache starts in the foreground.
 - `log-format=<string>` - Specifies the log format, mostly as a fallback for events.
 Supported values are `standard` and `json`.
-- `log-level=<string>` - Specifies the log verbosity level, mostly as a fallback for events.
-You can also specify the log level using the `BOUNDARY_LOG_LEVEL` environment variable.
-Supported values, listed in order of more detail to less, are:
-  - trace
-  - debug
-  - info
-  - warn
-  - err
+- `log-level=<string>` - Specifies the log verbosity level, mostly as a fallback for events. Supported values include the following in order of more detail to less:
+
+  - `trace`
+  - `debug`
+  - `info`
+  - `warn`
+  - `err`
+
+  You can also specify a log level using the **BOUNDARY_LOG_LEVEL** environment variable.
+
 - `max-search-refresh-timeout=<duration>` - If a search request triggers a best effort refresh, this value specifies how long the refresh should run before time out.
 In the event of a timeout, Boundary uses the stale data that is currently in the cache.
 The default value is 7 seconds.

--- a/content/boundary/v0.21.x/content/docs/commands/cache/start.mdx
+++ b/content/boundary/v0.21.x/content/docs/commands/cache/start.mdx
@@ -40,6 +40,14 @@ The default value is `false`.
 By default, the cache starts in the foreground.
 - `log-format=<string>` - Specifies the log format, mostly as a fallback for events.
 Supported values are `standard` and `json`.
+- `log-level=<string>` - Specifies the log verbosity level, mostly as a fallback for events.
+You can also specify the log level using the `BOUNDARY_LOG_LEVEL` environment variable.
+Supported values, listed in order of more detail to less, are:
+  - trace
+  - debug
+  - info
+  - warn
+  - err
 - `max-search-refresh-timeout=<duration>` - If a search request triggers a best effort refresh, this value specifies how long the refresh should run before time out.
 In the event of a timeout, Boundary uses the stale data that is currently in the cache.
 The default value is 7 seconds.

--- a/content/hcp-docs/content/docs/vault-radar/cli/changelog.mdx
+++ b/content/hcp-docs/content/docs/vault-radar/cli/changelog.mdx
@@ -14,7 +14,7 @@ last_modified: 2026-01-26T11:19:05-08:00
 Keep track of changes to the Vault Radar CLI
 
 ### 0.48.0
-- Added support for GitHub App Installation Tokens
+- Added support for GitHub App installation tokens
 - Minor bug fixes and performance improvements
 
 ### 0.47.0

--- a/content/hcp-docs/content/docs/vault-radar/cli/changelog.mdx
+++ b/content/hcp-docs/content/docs/vault-radar/cli/changelog.mdx
@@ -13,6 +13,10 @@ last_modified: 2026-01-26T11:19:05-08:00
 
 Keep track of changes to the Vault Radar CLI
 
+### 0.48.0
+- Added support for GitHub App Installation Tokens
+- Minor bug fixes and performance improvements
+
 ### 0.47.0
 - AWS EBS Runtime Scanning (Beta) support added for existing customers
 - Minor bug fixes and performance improvements

--- a/content/terraform/v1.15.x/docs/language/import/index.mdx
+++ b/content/terraform/v1.15.x/docs/language/import/index.mdx
@@ -13,6 +13,9 @@ last_modified: 2025-11-19T19:11:19Z
 
 If you have existing infrastructure resources, you can import them to your Terraform workspace so that you can begin managing the resources as code.
 
+<script src="https://fast.wistia.com/player.js" async></script><script src="https://fast.wistia.com/embed/eip2283u0b.js" async type="module"></script><style>wistia-player[media-id='eip2283u0b']:not(:defined) { background: center / contain no-repeat url('https://fast.wistia.com/embed/medias/eip2283u0b/swatch'); display: block; filter: blur(5px); padding-top:56.25%; }</style> <wistia-player media-id="eip2283u0b" aspect="1.7777777777777777"></wistia-player>
+
+<!--
 <iframe
   src="https://fast.wistia.net/embed/iframe/6smx1efz5fis5q6"
   frameborder="0"
@@ -20,7 +23,7 @@ If you have existing infrastructure resources, you can import them to your Terra
   width="100%"
   height="100%"
 ></iframe>
-
+-->
 
 ## Workflows
 

--- a/content/terraform/v1.15.x/docs/language/import/index.mdx
+++ b/content/terraform/v1.15.x/docs/language/import/index.mdx
@@ -1,6 +1,8 @@
 ---
 page_title: Import resources overview
 description: Learn about importing existing infrastructure resources to your Terraform workspace using the bulk import workflow or the single-resource import workflow
+video_id: 6smx1efz5fis5q6
+video_host: wistia
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-11-19T19:11:19Z
 last_modified: 2025-11-19T19:11:19Z
@@ -10,6 +12,8 @@ last_modified: 2025-11-19T19:11:19Z
 # Import resources overview
 
 If you have existing infrastructure resources, you can import them to your Terraform workspace so that you can begin managing the resources as code.
+
+<VideoEmbed url="https://hashicorp.wistia.com/s/6smx1efz5fis5q6" />
 
 ## Workflows
 

--- a/content/terraform/v1.15.x/docs/language/import/index.mdx
+++ b/content/terraform/v1.15.x/docs/language/import/index.mdx
@@ -17,8 +17,8 @@ If you have existing infrastructure resources, you can import them to your Terra
   src="https://fast.wistia.com/embed/medias/eip2283u0b"
   frameborder="0"
   allowfullscreen="true"
-  width="720px"
-  height="405px"
+  width="720"
+  height="405"
 ></iframe>
 
 ## Workflows

--- a/content/terraform/v1.15.x/docs/language/import/index.mdx
+++ b/content/terraform/v1.15.x/docs/language/import/index.mdx
@@ -14,7 +14,7 @@ last_modified: 2025-11-19T19:11:19Z
 If you have existing infrastructure resources, you can import them to your Terraform workspace so that you can begin managing the resources as code.
 
 <iframe
-  src="https://hashicorp.wistia.com/s/6smx1efz5fis5q6"
+  src="https://fast.wistia.net/embed/iframe/6smx1efz5fis5q6"
   frameborder="0"
   allowfullscreen="true"
   width="100%"

--- a/content/terraform/v1.15.x/docs/language/import/index.mdx
+++ b/content/terraform/v1.15.x/docs/language/import/index.mdx
@@ -13,17 +13,13 @@ last_modified: 2025-11-19T19:11:19Z
 
 If you have existing infrastructure resources, you can import them to your Terraform workspace so that you can begin managing the resources as code.
 
-<script src="https://fast.wistia.com/player.js" async></script><script src="https://fast.wistia.com/embed/eip2283u0b.js" async type="module"></script><style>wistia-player[media-id='eip2283u0b']:not(:defined) { background: center / contain no-repeat url('https://fast.wistia.com/embed/medias/eip2283u0b/swatch'); display: block; filter: blur(5px); padding-top:56.25%; }</style> <wistia-player media-id="eip2283u0b" aspect="1.7777777777777777"></wistia-player>
-
-<!--
 <iframe
-  src="https://fast.wistia.net/embed/iframe/6smx1efz5fis5q6"
+  src="https://fast.wistia.com/embed/medias/eip2283u0b"
   frameborder="0"
   allowfullscreen="true"
   width="100%"
   height="100%"
 ></iframe>
--->
 
 ## Workflows
 

--- a/content/terraform/v1.15.x/docs/language/import/index.mdx
+++ b/content/terraform/v1.15.x/docs/language/import/index.mdx
@@ -13,7 +13,14 @@ last_modified: 2025-11-19T19:11:19Z
 
 If you have existing infrastructure resources, you can import them to your Terraform workspace so that you can begin managing the resources as code.
 
-<VideoEmbed url="https://hashicorp.wistia.com/s/6smx1efz5fis5q6" />
+<iframe
+  src="https://hashicorp.wistia.com/s/6smx1efz5fis5q6"
+  frameborder="0"
+  allowfullscreen="true"
+  width="100%"
+  height="100%"
+></iframe>
+
 
 ## Workflows
 

--- a/content/terraform/v1.15.x/docs/language/import/index.mdx
+++ b/content/terraform/v1.15.x/docs/language/import/index.mdx
@@ -17,8 +17,8 @@ If you have existing infrastructure resources, you can import them to your Terra
   src="https://fast.wistia.com/embed/medias/eip2283u0b"
   frameborder="0"
   allowfullscreen="true"
-  width="100%"
-  height="100%"
+  width="720px"
+  height="405px"
 ></iframe>
 
 ## Workflows

--- a/content/vault/global/partials/important-changes/breaking-changes/no-setcap-without-root.mdx
+++ b/content/vault/global/partials/important-changes/breaking-changes/no-setcap-without-root.mdx
@@ -1,8 +1,36 @@
 ### Docker image requires IPC_LOCK capability ((#docker-image-requires-ipc_lock-capability))
 
-| Change       | Affected version                     | Vault edition
-| ------------ | ------------------------------------ | -------------
-| Breaking     | 1.19.17+, 1.20.11+, 1.21.6+, 2.0.1+  | All
+<!-- BEGIN: Vault:=v2.x -->
+
+| Change       | Affected version | Vault edition
+| ------------ | ---------------- | -------------
+| Breaking     | 2.0.1+           | All
+
+<!-- END: Vault:=v2.x -->
+
+<!-- BEGIN: Vault:=v1.21.x -->
+
+| Change       | Affected version | Vault edition
+| ------------ | ---------------- | -------------
+| Breaking     | 1.21.6+          | All
+
+<!-- END: Vault:=v1.21.x -->
+
+<!-- BEGIN: Vault:=v1.20.x -->
+
+| Change       | Affected version | Vault edition
+| ------------ | ---------------- | -------------
+| Breaking     | 1.20.11+         | All
+
+<!-- END: Vault:=v1.20.x -->
+
+<!-- BEGIN: Vault:=v1.19.x -->
+
+| Change       | Affected version | Vault edition
+| ------------ | ---------------- | -------------
+| Breaking     | 1.19.17+         | All
+
+<!-- END: Vault:=v1.19.x -->
 
 The Vault docker image now requires the `IPC_LOCK` capability to run.
 In prior versions of the Vault container we'd set `IPC_LOCK` on the vault

--- a/content/vault/global/partials/important-changes/breaking-changes/no-setcap-without-root.mdx
+++ b/content/vault/global/partials/important-changes/breaking-changes/no-setcap-without-root.mdx
@@ -1,0 +1,17 @@
+### Docker image requires IPC_LOCK capability ((#docker-image-requires-ipc_lock-capability))
+
+| Change       | Affected version                     | Vault edition
+| ------------ | ------------------------------------ | -------------
+| Breaking     | 1.19.17+, 1.20.11+, 1.21.6+, 2.0.1+  | All
+
+The Vault docker image now requires the `IPC_LOCK` capability to run.
+In prior versions of the Vault container we'd set `IPC_LOCK` on the vault
+binary at runtime via the entrypoint scripts. As we now run the Vault
+container as an unprivileged user we have to set it at build time in
+order for the binary to have the capabilities necessary to lock the
+memory.
+
+#### Recommendation
+
+Add the `IPC_LOCK` capability to the container or pod, or run the container as root.
+The latter is not recommended from a security perspective, but is an option if you are unable to add the capability to the container or pod.

--- a/content/vault/global/partials/important-changes/summary-tables/1_19.mdx
+++ b/content/vault/global/partials/important-changes/summary-tables/1_19.mdx
@@ -13,6 +13,7 @@ Introduced | Recommendations | Edition    | Change
 1.19.6     | **Yes**         | All        | [Rekey cancellations use a nonce](/vault/docs/v1.19.x/updates/important-changes#rekey-cancel-nonce)
 1.19.7     | **Yes**         | All        | [CVE-2025-6000: File audit devices cannot use executable file permissions](/vault/docs/v1.19.x/updates/important-changes#cve-2025-6000)
 1.19.17    | **Yes**         | All        | [Previously unauthenticated endpoints require authentication](/vault/docs/v1.19.x/updates/important-changes#sys-endpoint-auth)
+1.19.17    | **Yes**         | All        | [Docker image requires IPC_LOCK capability](/vault/docs/v1.19.x/updates/important-changes#docker-image-requires-ipc_lock-capability)
 
 ### New behavior
 

--- a/content/vault/global/partials/important-changes/summary-tables/1_20.mdx
+++ b/content/vault/global/partials/important-changes/summary-tables/1_20.mdx
@@ -7,6 +7,7 @@ Introduced | Recommendations | Edition    | Change
 1.20.0     | No              | All        | [Azure authentication requires bound group or service principal ID](/vault/docs/v1.20.x/updates/important-changes##azure-auth)
 1.20.1     | **Yes**         | All        | [CVE-2025-6000: File audit devices cannot use executable file permissions](/vault/docs/v1.20.x/updates/important-changes#cve-2025-6000)
 1.20.4     | **Yes**         | CE         | [Go mod tidy command fails on the community edition](/vault/docs/v1.20.x/updates/important-changes#go-mod-tidy)
+1.20.11    | **Yes**         | All        | [Docker image requires IPC_LOCK capability](/vault/docs/v1.20.x/updates/important-changes#docker-image-requires-ipc_lock-capability)
 
 
 ### New behavior

--- a/content/vault/global/partials/important-changes/summary-tables/1_21.mdx
+++ b/content/vault/global/partials/important-changes/summary-tables/1_21.mdx
@@ -3,7 +3,7 @@
 Introduced | Recommendations | Edition    | Change
 ---------- | --------------- | ---------- | ------
 1.21.0     | **Yes**         | All        | [Item-by-item list comparison for allowed_parameters and denied_parameters](/vault/docs/v1.21.x/updates/important-changes#allowed-parameters-list)
-
+1.21.6     | **Yes**         | All        | [Docker image requires IPC_LOCK capability](/vault/docs/v1.21.x/updates/important-changes#docker-image-requires-ipc_lock-capability)
 
 ### New behavior
 

--- a/content/vault/global/partials/important-changes/summary-tables/2xx.mdx
+++ b/content/vault/global/partials/important-changes/summary-tables/2xx.mdx
@@ -4,6 +4,7 @@ Introduced | Recommendations | Edition    | Change
 ---------- | --------------- | ---------- | ------
 2.0.0      | **Yes**         | All        | [Azure auth configuration takes precedence over environment variables](/vault/docs/v2.x/updates/important-changes#azure-auth-precedence)
 2.0.0      | **Yes**         | All        | [Previously unauthenticated endpoints require authentication](/vault/docs/v2.x/updates/important-changes#sys-endpoint-auth)
+2.0.1      | **Yes**         | All        | [Docker image requires IPC_LOCK capability](/vault/docs/v2.x/updates/important-changes#docker-image-requires-ipc_lock-capability)
 
 
 ### New behavior

--- a/content/vault/v1.17.x/content/docs/enterprise/lease-count-quotas.mdx
+++ b/content/vault/v1.17.x/content/docs/enterprise/lease-count-quotas.mdx
@@ -97,7 +97,7 @@ and through enabling optional audit logging.
 
 Vault returns a `429 - Too Many Requests` response if a new lease request
 violates the quota limit. For more information on this error, refer to [the
-error document](/vault/docs/concepts/lease-count-quota-exceeded).
+error document](/vault/docs/troubleshoot/lease-issues).
 
 ## Tutorial
 

--- a/content/vault/v1.18.x/content/docs/enterprise/lease-count-quotas.mdx
+++ b/content/vault/v1.18.x/content/docs/enterprise/lease-count-quotas.mdx
@@ -97,7 +97,7 @@ and through enabling optional audit logging.
 
 Vault returns a `429 - Too Many Requests` response if a new lease request
 violates the quota limit. For more information on this error, refer to [the
-error document](/vault/docs/concepts/lease-count-quota-exceeded).
+error document](/vault/docs/troubleshoot/lease-issues).
 
 ## Tutorial
 

--- a/content/vault/v1.19.x/content/docs/enterprise/lease-count-quotas.mdx
+++ b/content/vault/v1.19.x/content/docs/enterprise/lease-count-quotas.mdx
@@ -97,7 +97,7 @@ and through enabling optional audit logging.
 
 Vault returns a `429 - Too Many Requests` response if a new lease request
 violates the quota limit. For more information on this error, refer to [the
-error document](/vault/docs/concepts/lease-count-quota-exceeded).
+error document](/vault/docs/troubleshoot/lease-issues).
 
 ## Tutorial
 

--- a/content/vault/v1.19.x/content/docs/updates/important-changes.mdx
+++ b/content/vault/v1.19.x/content/docs/updates/important-changes.mdx
@@ -13,7 +13,7 @@ valid_change_types: >-
   - Change in support
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-07-01T14:39:24-05:00
-last_modified: 2026-03-16T22:36:15.000Z
+last_modified: 2026-05-20T23:10:10.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -31,8 +31,6 @@ before upgrading Vault.
 | Change       | Affected version                 | Vault edition |
 |--------------|----------------------------------|---------------|
 | New behavior | 1.16.25, 1.18.14, 1.19.9, 1.20.3 | All           |
-|              |                                  |               |
-|              |                                  |               |
 
 To guard against potential Denial-of-Service (DoS) attacks, Vault now supports
 several listener options to enforce payload size limits for to incoming JSON

--- a/content/vault/v1.19.x/content/docs/updates/important-changes.mdx
+++ b/content/vault/v1.19.x/content/docs/updates/important-changes.mdx
@@ -190,6 +190,8 @@ token created by `sys/replication/dr/secondary/generate-operation-token`.
 
 @include '../../../global/partials/important-changes/breaking-changes/cve-2025-6000.mdx'
 
+@include '../../../global/partials/important-changes/breaking-changes/no-setcap-without-root.mdx'
+
 ### Rekey cancellations use a nonce ((#rekey-cancel-nonce))
 | Change       | Affected version | Affected deployments
 | ------------ | ---------------- | --------------------

--- a/content/vault/v1.20.x/content/docs/enterprise/lease-count-quotas.mdx
+++ b/content/vault/v1.20.x/content/docs/enterprise/lease-count-quotas.mdx
@@ -97,7 +97,7 @@ and through enabling optional audit logging.
 
 Vault returns a `429 - Too Many Requests` response if a new lease request
 violates the quota limit. For more information on this error, refer to [the
-error document](/vault/docs/concepts/lease-count-quota-exceeded).
+error document](/vault/docs/troubleshoot/lease-issues).
 
 ## Tutorial
 

--- a/content/vault/v1.20.x/content/docs/updates/important-changes.mdx
+++ b/content/vault/v1.20.x/content/docs/updates/important-changes.mdx
@@ -146,6 +146,8 @@ command to fail.
 Update the `go.mod` file to remove the line referencing
 `hashicorp/go-cmp` or build from `main`.
 
+@include '../../../global/partials/important-changes/breaking-changes/no-setcap-without-root.mdx'
+
 ---
 
 

--- a/content/vault/v1.21.x/content/docs/updates/important-changes.mdx
+++ b/content/vault/v1.21.x/content/docs/updates/important-changes.mdx
@@ -23,6 +23,8 @@ before upgrading Vault.
 
 @include '../../../global/partials/important-changes/breaking-changes/allowed-parameters-list.mdx'
 
+@include '../../../global/partials/important-changes/breaking-changes/no-setcap-without-root.mdx'
+
 ---
 
 ## New behavior

--- a/content/vault/v2.x/content/api-docs/system/billing/config.mdx
+++ b/content/vault/v2.x/content/api-docs/system/billing/config.mdx
@@ -17,7 +17,7 @@ The `/sys/billing/config` endpoint allows you to configure how long Vault retain
 
 By default, Vault retains billing data for 37 months, including the current month. You can configure the retention period to be between 13 months (minimum) and 72 months (maximum).
 
-~> **Note:** Increasing the retention period will not restore historical data for months that were previously outside the retention period. Only data within the previous retention period will be available.
+Increasing the retention period cannot restore historical data for months that was previously outside the retention period, but will retain data from the previous retention period.
 
 | Method | Path                  |
 | :----- | :-------------------- |

--- a/content/vault/v2.x/content/api-docs/system/billing/config.mdx
+++ b/content/vault/v2.x/content/api-docs/system/billing/config.mdx
@@ -26,7 +26,7 @@ Increasing the retention period cannot restore historical data for months that w
 
 ## Read billing configuration
 
-This endpoint returns the current billing data retention configuration.
+Return the current billing data retention configuration.
 
 | Method | Path                  |
 | :----- | :-------------------- |

--- a/content/vault/v2.x/content/api-docs/system/billing/config.mdx
+++ b/content/vault/v2.x/content/api-docs/system/billing/config.mdx
@@ -1,0 +1,93 @@
+---
+layout: api
+page_title: /sys/billing/config - HTTP API
+description: >-
+  The `/sys/billing/config` endpoint manages billing data retention configuration.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-05-21T14:00:00-05:00
+last_modified: 2026-05-21T14:00:00-05:00
+# END AUTO GENERATED METADATA
+---
+
+# `/sys/billing/config`
+
+@include 'alerts/restricted-root.mdx'
+
+The `/sys/billing/config` endpoint allows you to configure how long Vault retains billing data. This endpoint is only accessible from the root namespace.
+
+By default, Vault retains billing data for 37 months, including the current month. You can configure the retention period to be between 13 months (minimum) and 72 months (maximum).
+
+~> **Note:** Increasing the retention period will not restore historical data for months that were previously outside the retention period. Only data within the previous retention period will be available.
+
+| Method | Path                  |
+| :----- | :-------------------- |
+| `GET`  | `/sys/billing/config` |
+| `POST` | `/sys/billing/config` |
+
+## Read billing configuration
+
+This endpoint returns the current billing data retention configuration.
+
+| Method | Path                  |
+| :----- | :-------------------- |
+| `GET`  | `/sys/billing/config` |
+
+### Sample request
+
+```shell-session
+$ curl --header "X-Vault-Token: ${VAULT_TOKEN}" \
+    "${VAULT_ADDR}/v1/sys/billing/config"
+```
+
+### Sample response
+
+```json
+{
+  "data": {
+    "retention_months": 37
+  }
+}
+```
+
+## Update billing configuration
+
+This endpoint updates the billing data retention configuration.
+
+| Method | Path                  |
+| :----- | :-------------------- |
+| `POST` | `/sys/billing/config` |
+
+### Request parameters
+
+- `retention_months` `(int: required)` - The number of months to retain billing data, including the current month. Must be between 13 and 72 months.
+
+### Sample request
+
+```shell-session
+$ curl --header "X-Vault-Token: ${VAULT_TOKEN}" \
+    --request POST \
+    --data @payload.json \
+    "${VAULT_ADDR}/v1/sys/billing/config"
+```
+
+### Sample payload
+
+```json
+{
+  "retention_months": 48
+}
+```
+
+### Sample response
+
+When increasing the retention period above the current value, the response includes a warning:
+
+```json
+{
+  "warnings": [
+    "Retention period increased from 37 to 48 months. Historical data will only be available for months within the previous retention period. Data for months older than 37 months ago will not be restored."
+  ]
+}
+```
+
+When decreasing or maintaining the retention period, no warnings are returned.

--- a/content/vault/v2.x/content/api-docs/system/billing/config.mdx
+++ b/content/vault/v2.x/content/api-docs/system/billing/config.mdx
@@ -13,7 +13,7 @@ last_modified: 2026-05-21T14:00:00-05:00
 
 @include 'alerts/restricted-root.mdx'
 
-The `/sys/billing/config` endpoint allows you to configure how long Vault retains billing data. This endpoint is only accessible from the root namespace.
+The `/sys/billing/config` endpoint allows you to configure how long Vault retains billing data.
 
 By default, Vault retains billing data for 37 months, including the current month. You can configure the retention period to be between 13 months (minimum) and 72 months (maximum).
 

--- a/content/vault/v2.x/content/api-docs/system/billing/config.mdx
+++ b/content/vault/v2.x/content/api-docs/system/billing/config.mdx
@@ -47,7 +47,7 @@ $ curl --header "X-Vault-Token: ${VAULT_TOKEN}" \
 
 ## Update billing configuration
 
-This endpoint updates the billing data retention configuration.
+Update the billing data retention configuration.
 
 | Method | Path                  |
 | :----- | :-------------------- |

--- a/content/vault/v2.x/content/api-docs/system/billing/config.mdx
+++ b/content/vault/v2.x/content/api-docs/system/billing/config.mdx
@@ -19,10 +19,6 @@ By default, Vault retains billing data for 37 months, including the current mont
 
 Increasing the retention period cannot restore historical data for months that was previously outside the retention period, but will retain data from the previous retention period.
 
-| Method | Path                  |
-| :----- | :-------------------- |
-| `GET`  | `/sys/billing/config` |
-| `POST` | `/sys/billing/config` |
 
 ## Read billing configuration
 

--- a/content/vault/v2.x/content/api-docs/system/billing/config.mdx
+++ b/content/vault/v2.x/content/api-docs/system/billing/config.mdx
@@ -86,4 +86,4 @@ If you increase the retention period above the current value, the response inclu
 }
 ```
 
-When decreasing or maintaining the retention period, no warnings are returned.
+Vault does not return warnings when you decrease or maintain the existing retention period.

--- a/content/vault/v2.x/content/api-docs/system/billing/config.mdx
+++ b/content/vault/v2.x/content/api-docs/system/billing/config.mdx
@@ -76,7 +76,7 @@ $ curl --header "X-Vault-Token: ${VAULT_TOKEN}" \
 
 ### Sample response
 
-When increasing the retention period above the current value, the response includes a warning:
+If you increase the retention period above the current value, the response includes a warning:
 
 ```json
 {

--- a/content/vault/v2.x/content/api-docs/system/billing/index.mdx
+++ b/content/vault/v2.x/content/api-docs/system/billing/index.mdx
@@ -12,6 +12,7 @@ last_modified: 2026-04-15T00:13:58.000Z
 
 The `/sys/billing` family of API endpoints give you access to data related to license utilization:
 
+- **[`/sys/billing/config`](/vault/api-docs/system/billing/config)** configures billing data retention settings.
 - **[`/sys/billing/overview`](/vault/api-docs/system/billing/overview)** reports data for deployments using a usage-based pricing model.
 - **[`/sys/billing/certificates`](/vault/api-docs/system/billing/certificates)** reports data for deployments using a PKI-only pricing model.
 - **[`/sys/internal/counters`](/vault/api-docs/system/internal-counters)** reports data for deployments using the [client](/vault/docs/concepts/client-count) pricing model.

--- a/content/vault/v2.x/content/api-docs/system/billing/overview.mdx
+++ b/content/vault/v2.x/content/api-docs/system/billing/overview.mdx
@@ -13,9 +13,9 @@ last_modified: 2026-05-13T13:07:08.000Z
 
 @include 'alerts/restricted-admin.mdx'
 
-The `/sys/billing/overview` endpoint returns a monthly overview of usage data relevant to usage-based licensing. 
+The `/sys/billing/overview` endpoint returns a monthly overview of usage data relevant to usage-based licensing.
 
-Vault retains usage data for 37 months, including the current month.
+By default, Vault retains usage data for 37 months, including the current month. You can configure the retention period using the [`/sys/billing/config`](/vault/api-docs/system/billing/config) endpoint.
 
 Vault updates current-month metrics every 10 minutes. Refer to the `updated_at` field in monthly response data to determine when Vault last updated the billing metrics for each month.
 

--- a/content/vault/v2.x/content/api-docs/system/billing/overview.mdx
+++ b/content/vault/v2.x/content/api-docs/system/billing/overview.mdx
@@ -82,7 +82,7 @@ $ curl --header "X-Vault-Token: ${VAULT_TOKEN}" \
         {
           "metric_name": "auto_rotated_roles",
           "metric_data": {
-            "total": 70,
+            "total": 80,
             "metric_details": [
               { "type": "aws_static", "count": 10 },
               { "type": "azure_static", "count": 10 },

--- a/content/vault/v2.x/content/api-docs/system/billing/overview.mdx
+++ b/content/vault/v2.x/content/api-docs/system/billing/overview.mdx
@@ -133,7 +133,7 @@ $ curl --header "X-Vault-Token: ${VAULT_TOKEN}" \
         {
           "metric_name": "managed_keys",
           "metric_data": {
-            "total": 220,
+            "total": 420,
             "metric_details": [
               { "type": "kmse", "count": 200 },
               { "type": "totp", "count": 220 }

--- a/content/vault/v2.x/content/docs/enterprise/lease-count-quotas.mdx
+++ b/content/vault/v2.x/content/docs/enterprise/lease-count-quotas.mdx
@@ -97,7 +97,7 @@ and through enabling optional audit logging.
 
 Vault returns a `429 - Too Many Requests` response if a new lease request
 violates the quota limit. For more information on this error, refer to [the
-error document](/vault/docs/concepts/lease-count-quota-exceeded).
+error document](/vault/docs/troubleshoot/lease-issues).
 
 ## Tutorial
 

--- a/content/vault/v2.x/content/docs/updates/important-changes.mdx
+++ b/content/vault/v2.x/content/docs/updates/important-changes.mdx
@@ -64,6 +64,8 @@ If you must continue to use the endpoints unauthenticated, set the
 [`enable_unauthenticated_access`](/vault/docs/configuration#enable_unauthenticated_access), 
 configuration parameter to provide backward compatability with existing clients.
 
+@include '../../../global/partials/important-changes/breaking-changes/no-setcap-without-root.mdx'
+
 ---
 
 ## New behavior

--- a/content/vault/v2.x/content/docs/updates/release-notes.mdx
+++ b/content/vault/v2.x/content/docs/updates/release-notes.mdx
@@ -5,7 +5,7 @@ description: >-
   Key updates for Vault 2.x.x
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2026-04-14T17:13:42-07:00
-last_modified: 2026-05-19T16:12:54.000Z
+last_modified: 2026-05-20T23:09:39.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -37,6 +37,24 @@ create policies, and discover Vault capabilities.
 ## Vault 2.0.1
 
 **Released**: 2026-05-19
+
+
+<Note title="Limited CE artifact availability">
+
+The Vault 2.0.1 Community edition does not have artifacts for the following
+architectures:
+
+Operating system | architecture
+---------------- | ------------
+macOS            | darwin_amd64, darwin_arm64
+FreeBSD          | freebsd_386, freebsd_amd64
+Linux 32-bit     | linux_386
+Windows          | windows_386, windows_amd64.
+
+Users running Vault on those platforms should wait for the 2.0.2 CE release,
+which will include all missing artifacts.
+
+</Note>
 
 ### Bug fixes and security patches
 

--- a/content/vault/v2.x/data/api-docs-nav-data.json
+++ b/content/vault/v2.x/data/api-docs-nav-data.json
@@ -468,6 +468,10 @@
             "path": "system/billing"
           },
           {
+            "title": "<code>/sys/billing/config</code>",
+            "path": "system/billing/config"
+          },
+          {
             "title": "<code>/sys/billing/overview</code>",
             "path": "system/billing/overview"
           },


### PR DESCRIPTION
This PR adds updates to the docs about a new billing config endpoint we added to let customers set custom retention months for their consumption billing data.

Jira: https://hashicorp.atlassian.net/browse/VAULT-42829

Vault PR: https://github.com/hashicorp/vault-enterprise/pull/14785

<img width="996" height="521" alt="Screenshot 2026-05-21 at 3 26 57 PM" src="https://github.com/user-attachments/assets/b704f415-d3c3-4c00-930d-181bafc97b98" />
<img width="326" height="229" alt="Screenshot 2026-05-21 at 3 31 38 PM" src="https://github.com/user-attachments/assets/b77b119e-decd-4b74-af47-97497519cb12" />
<img width="1235" height="893" alt="Screenshot 2026-05-21 at 3 32 30 PM" src="https://github.com/user-attachments/assets/a5d4075a-1c67-40c9-8fee-9500ce2fc082" />
<img width="1164" height="1011" alt="Screenshot 2026-05-21 at 3 32 45 PM" src="https://github.com/user-attachments/assets/5ab06025-06b9-49c4-9496-8a21f3601833" />
<img width="937" height="843" alt="Screenshot 2026-05-21 at 3 32 50 PM" src="https://github.com/user-attachments/assets/f6391c09-4422-4745-be5c-f02b3fafbcd8" />

