### PR TITLE
Nomad: clarify behavior of template.change_mode=noop 

### DIFF
--- a/content/nomad/v1.10.x/content/docs/job-specification/template.mdx
+++ b/content/nomad/v1.10.x/content/docs/job-specification/template.mdx
@@ -54,7 +54,9 @@ refer to the [Learn Go Template Syntax][gt_learn] guide.
   the template to the specified destination. The following possible values describe
   Nomad's action after writing the template to disk.
 
-  - `"noop"` - take no action (continue running the task)
+  - `"noop"` - take no action, but continue running the task and monitoring
+    dependencies. If you instead want the template to only render once, use the
+    `once` field.
   - `"restart"` - restart the task
   - `"signal"` - send a configurable signal to the task
   - `"script"` - run a script

--- a/content/nomad/v1.11.x/content/docs/job-specification/template.mdx
+++ b/content/nomad/v1.11.x/content/docs/job-specification/template.mdx
@@ -54,7 +54,9 @@ refer to the [Learn Go Template Syntax][gt_learn] guide.
   the template to the specified destination. The following possible values describe
   Nomad's action after writing the template to disk.
 
-  - `"noop"` - take no action (continue running the task)
+  - `"noop"` - take no action, but continue running the task and monitoring
+    dependencies. If you instead want the template to only render once, use the
+    `once` field.
   - `"restart"` - restart the task
   - `"signal"` - send a configurable signal to the task
   - `"script"` - run a script

--- a/content/nomad/v2.0.x/content/docs/job-specification/template.mdx
+++ b/content/nomad/v2.0.x/content/docs/job-specification/template.mdx
@@ -54,7 +54,9 @@ refer to the [Learn Go Template Syntax][gt_learn] guide.
   the template to the specified destination. The following possible values describe
   Nomad's action after writing the template to disk.
 
-  - `"noop"` - take no action (continue running the task)
+  - `"noop"` - take no action, but continue running the task and monitoring
+    dependencies. If you instead want the template to only render once, use the
+    `once` field.
   - `"restart"` - restart the task
   - `"signal"` - send a configurable signal to the task
   - `"script"` - run a script


### PR DESCRIPTION
We recently fixed a bug in Nomad where `template.change_mode = "noop"` was exiting and no longer monitoring if a dependency was unreachable for longer than the wait window. This made us realize that the `"noop"` documentation was potentially ambiguous as to whether a dependency continued to be monitored. Add a note about that and point users to the `once` field if that's what they want.

Ref: https://github.com/hashicorp/nomad/pull/28016


## Contributor checklists

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [ ] 1 week: Default expectation
- [x] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [x] Verify that all status checks passed
- [x] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [ ] I added redirects for any moved or removed pages
- [ ] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [ ] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [ ] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.
