### PR TITLE
VAULT-42829: Create a new billing config endpoint to set custom retention months

### DIFF
--- a/content/vault/v2.x/content/api-docs/system/billing/config.mdx
+++ b/content/vault/v2.x/content/api-docs/system/billing/config.mdx
@@ -17,7 +17,11 @@ The `/sys/billing/config` endpoint allows you to configure how long Vault retain
 
 By default, Vault retains `sys/billing/overview` data for 37 months, including the current month. You can configure the retention period to be between 13 months (minimum) and 72 months (maximum).
 
-Increasing the retention period cannot restore historical data for months that was previously outside the retention period, but will retain data from the previous retention period.
+Vault does not restore historical data when you increase the retention period.
+Instead, Vault accumulates new data up to the new retention period before
+advancing the retention window. For example, if you increase your retention
+window from 13 months to 37 months, Vault does not advance the retention window
+until it accumulates 37 months of data.
 
 
 ## Read billing configuration

--- a/content/vault/v2.x/content/api-docs/system/billing/config.mdx
+++ b/content/vault/v2.x/content/api-docs/system/billing/config.mdx
@@ -15,7 +15,7 @@ last_modified: 2026-05-21T14:00:00-05:00
 
 The `/sys/billing/config` endpoint allows you to configure how long Vault retains `/sys/billing/overview` data.
 
-By default, Vault retains billing data for 37 months, including the current month. You can configure the retention period to be between 13 months (minimum) and 72 months (maximum).
+By default, Vault retains `sys/billing/overview` data for 37 months, including the current month. You can configure the retention period to be between 13 months (minimum) and 72 months (maximum).
 
 Increasing the retention period cannot restore historical data for months that was previously outside the retention period, but will retain data from the previous retention period.
 

--- a/content/vault/v2.x/content/api-docs/system/billing/config.mdx
+++ b/content/vault/v2.x/content/api-docs/system/billing/config.mdx
@@ -13,7 +13,7 @@ last_modified: 2026-05-21T14:00:00-05:00
 
 @include 'alerts/restricted-root.mdx'
 
-The `/sys/billing/config` endpoint allows you to configure how long Vault retains billing data.
+The `/sys/billing/config` endpoint allows you to configure how long Vault retains `/sys/billing/overview` data.
 
 By default, Vault retains billing data for 37 months, including the current month. You can configure the retention period to be between 13 months (minimum) and 72 months (maximum).
 

--- a/content/vault/v2.x/content/api-docs/system/billing/config.mdx
+++ b/content/vault/v2.x/content/api-docs/system/billing/config.mdx
@@ -1,0 +1,89 @@
+---
+layout: api
+page_title: /sys/billing/config - HTTP API
+description: >-
+  The `/sys/billing/config` endpoint manages billing data retention configuration.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-05-21T14:00:00-05:00
+last_modified: 2026-05-21T14:00:00-05:00
+# END AUTO GENERATED METADATA
+---
+
+# `/sys/billing/config`
+
+@include 'alerts/restricted-root.mdx'
+
+The `/sys/billing/config` endpoint allows you to configure how long Vault retains billing data.
+
+By default, Vault retains billing data for 37 months, including the current month. You can configure the retention period to be between 13 months (minimum) and 72 months (maximum).
+
+Increasing the retention period cannot restore historical data for months that was previously outside the retention period, but will retain data from the previous retention period.
+
+
+## Read billing configuration
+
+Return the current billing data retention configuration.
+
+| Method | Path                  |
+| :----- | :-------------------- |
+| `GET`  | `/sys/billing/config` |
+
+### Sample request
+
+```shell-session
+$ curl --header "X-Vault-Token: ${VAULT_TOKEN}" \
+    "${VAULT_ADDR}/v1/sys/billing/config"
+```
+
+### Sample response
+
+```json
+{
+  "data": {
+    "retention_months": 37
+  }
+}
+```
+
+## Update billing configuration
+
+Update the billing data retention configuration.
+
+| Method | Path                  |
+| :----- | :-------------------- |
+| `POST` | `/sys/billing/config` |
+
+### Request parameters
+
+- `retention_months` `(int: required)` - The number of months to retain billing data, including the current month. Must be between 13 and 72 months.
+
+### Sample request
+
+```shell-session
+$ curl --header "X-Vault-Token: ${VAULT_TOKEN}" \
+    --request POST \
+    --data @payload.json \
+    "${VAULT_ADDR}/v1/sys/billing/config"
+```
+
+### Sample payload
+
+```json
+{
+  "retention_months": 48
+}
+```
+
+### Sample response
+
+If you increase the retention period above the current value, the response includes a warning:
+
+```json
+{
+  "warnings": [
+    "Retention period increased from 37 to 48 months. Historical data will only be available for months within the previous retention period. Data for months older than 37 months ago will not be restored."
+  ]
+}
+```
+
+Vault does not return warnings when you decrease or maintain the existing retention period.

--- a/content/vault/v2.x/content/api-docs/system/billing/index.mdx
+++ b/content/vault/v2.x/content/api-docs/system/billing/index.mdx
@@ -12,6 +12,7 @@ last_modified: 2026-04-15T00:13:58.000Z
 
 The `/sys/billing` family of API endpoints give you access to data related to license utilization:
 
+- **[`/sys/billing/config`](/vault/api-docs/system/billing/config)** configures billing data retention settings.
 - **[`/sys/billing/overview`](/vault/api-docs/system/billing/overview)** reports data for deployments using a usage-based pricing model.
 - **[`/sys/billing/certificates`](/vault/api-docs/system/billing/certificates)** reports data for deployments using a PKI-only pricing model.
 - **[`/sys/internal/counters`](/vault/api-docs/system/internal-counters)** reports data for deployments using the [client](/vault/docs/concepts/client-count) pricing model.

--- a/content/vault/v2.x/content/api-docs/system/billing/overview.mdx
+++ b/content/vault/v2.x/content/api-docs/system/billing/overview.mdx
@@ -13,9 +13,9 @@ last_modified: 2026-05-13T13:07:08.000Z
 
 @include 'alerts/restricted-admin.mdx'
 
-The `/sys/billing/overview` endpoint returns a monthly overview of usage data relevant to usage-based licensing. 
+The `/sys/billing/overview` endpoint returns a monthly overview of usage data relevant to usage-based licensing.
 
-Vault retains usage data for 37 months, including the current month.
+By default, Vault retains usage data for 37 months, including the current month. You can configure the retention period using the [`/sys/billing/config`](/vault/api-docs/system/billing/config) endpoint.
 
 Vault updates current-month metrics every 10 minutes. Refer to the `updated_at` field in monthly response data to determine when Vault last updated the billing metrics for each month.
 
@@ -82,7 +82,7 @@ $ curl --header "X-Vault-Token: ${VAULT_TOKEN}" \
         {
           "metric_name": "auto_rotated_roles",
           "metric_data": {
-            "total": 70,
+            "total": 80,
             "metric_details": [
               { "type": "aws_static", "count": 10 },
               { "type": "azure_static", "count": 10 },
@@ -133,7 +133,7 @@ $ curl --header "X-Vault-Token: ${VAULT_TOKEN}" \
         {
           "metric_name": "managed_keys",
           "metric_data": {
-            "total": 220,
+            "total": 420,
             "metric_details": [
               { "type": "kmse", "count": 200 },
               { "type": "totp", "count": 220 }

--- a/content/vault/v2.x/content/docs/updates/release-notes.mdx
+++ b/content/vault/v2.x/content/docs/updates/release-notes.mdx
@@ -44,7 +44,9 @@ create policies, and discover Vault capabilities.
 
 ### Improvements
 
-- TBD
+- **[`/sys/billing/config`](/vault/api-docs/system/billing/config)**: New endpoint
+  to configure billing data retention period. Retention can now be set between 13
+  and 72 months (default: 37 months).
 
 
 ## Vault 2.0.1

--- a/content/vault/v2.x/data/api-docs-nav-data.json
+++ b/content/vault/v2.x/data/api-docs-nav-data.json
@@ -468,6 +468,10 @@
             "path": "system/billing"
           },
           {
+            "title": "<code>/sys/billing/config</code>",
+            "path": "system/billing/config"
+          },
+          {
             "title": "<code>/sys/billing/overview</code>",
             "path": "system/billing/overview"
           },


### PR DESCRIPTION
This PR adds updates to the docs about a new billing config endpoint we added to let customers set custom retention months for their consumption billing data.

Jira: https://hashicorp.atlassian.net/browse/VAULT-42829

Vault PR: https://github.com/hashicorp/vault-enterprise/pull/14785
Original Docs PR (closed in favor of this due to base change effects): https://github.com/hashicorp/web-unified-docs/pull/2490

<img width="996" height="521" alt="Screenshot 2026-05-21 at 3 26 57 PM" src="https://github.com/user-attachments/assets/b704f415-d3c3-4c00-930d-181bafc97b98" />
<img width="326" height="229" alt="Screenshot 2026-05-21 at 3 31 38 PM" src="https://github.com/user-attachments/assets/b77b119e-decd-4b74-af47-97497519cb12" />
<img width="1235" height="893" alt="Screenshot 2026-05-21 at 3 32 30 PM" src="https://github.com/user-attachments/assets/a5d4075a-1c67-40c9-8fee-9500ce2fc082" />
<img width="1164" height="1011" alt="Screenshot 2026-05-21 at 3 32 45 PM" src="https://github.com/user-attachments/assets/5ab06025-06b9-49c4-9496-8a21f3601833" />
<img width="937" height="843" alt="Screenshot 2026-05-21 at 3 32 50 PM" src="https://github.com/user-attachments/assets/f6391c09-4422-4745-be5c-f02b3fafbcd8" />
