### PR TITLE
fix bug: put correct total in 2 fields under sample of billing overview response

### DIFF
--- a/content/vault/v2.x/content/api-docs/system/billing/overview.mdx
+++ b/content/vault/v2.x/content/api-docs/system/billing/overview.mdx
@@ -82,7 +82,7 @@ $ curl --header "X-Vault-Token: ${VAULT_TOKEN}" \
         {
           "metric_name": "auto_rotated_roles",
           "metric_data": {
-            "total": 70,
+            "total": 80,
             "metric_details": [
               { "type": "aws_static", "count": 10 },
               { "type": "azure_static", "count": 10 },
@@ -133,7 +133,7 @@ $ curl --header "X-Vault-Token: ${VAULT_TOKEN}" \
         {
           "metric_name": "managed_keys",
           "metric_data": {
-            "total": 220,
+            "total": 420,
             "metric_details": [
               { "type": "kmse", "count": 200 },
               { "type": "totp", "count": 220 }


### PR DESCRIPTION
This PR fixes a bug by putting in the correct total in 2 fields' total value inside billing/overview sample response.
