### PR TITLE
Clarify how to leverage the Go KeyUsage constants within PKI generate intermediate

### DIFF
--- a/content/vault/v1.19.x/content/api-docs/secret/pki/index.mdx
+++ b/content/vault/v1.19.x/content/api-docs/secret/pki/index.mdx
@@ -2464,7 +2464,7 @@ based on this parameter.
 
 - `key_usage` `([]string: )` - Specifies key_usage to encode in the
   generated certificate. Must be
-  [a valid Golang crypto key](https://golang.org/pkg/crypto/x509/#KeyUsage) with
+  [a valid Golang key usage](https://golang.org/pkg/crypto/x509/#KeyUsage) with
   the `KeyUsage` prefix removed. Values are not case-sensitive. If you leave
   `key_usage` unset, Vault does not report key usage on the CSR.
 

--- a/content/vault/v1.19.x/content/api-docs/secret/pki/index.mdx
+++ b/content/vault/v1.19.x/content/api-docs/secret/pki/index.mdx
@@ -2463,10 +2463,10 @@ based on this parameter.
   scenarios with Active Directory Certificate Services.
 
 - `key_usage` `([]string: )` - Specifies key_usage to encode in the
-  generated certificate. Valid values can be found at
-  https://golang.org/pkg/crypto/x509/#KeyUsage - simply drop the `KeyUsage`
-  part of the value. Values are not case-sensitive.
-  If not set, key usage will not appear on the CSR.
+  generated certificate. Must be
+  [a valid Golang crypto key](https://golang.org/pkg/crypto/x509/#KeyUsage) with
+  the `KeyUsage` prefix removed. Values are not case-sensitive. If you leave
+  `key_usage` unset, Vault does not report key usage on the CSR.
 
 #### Managed keys parameters
 

--- a/content/vault/v1.19.x/content/api-docs/secret/pki/index.mdx
+++ b/content/vault/v1.19.x/content/api-docs/secret/pki/index.mdx
@@ -2463,9 +2463,10 @@ based on this parameter.
   scenarios with Active Directory Certificate Services.
 
 - `key_usage` `([]string: )` - Specifies key_usage to encode in the
-  generated certificate.  This is a list of the names of each key usage, valid
-  values can be found at https://golang.org/pkg/crypto/x509/#KeyUsage part of the
-  name.  If not set, key usage will not appear on the CSR.
+  generated certificate. Valid values can be found at
+  https://golang.org/pkg/crypto/x509/#KeyUsage - simply drop the `KeyUsage`
+  part of the value. Values are not case-sensitive.
+  If not set, key usage will not appear on the CSR.
 
 #### Managed keys parameters
 

--- a/content/vault/v1.20.x/content/api-docs/secret/pki/index.mdx
+++ b/content/vault/v1.20.x/content/api-docs/secret/pki/index.mdx
@@ -2464,9 +2464,10 @@ based on this parameter.
   scenarios with Active Directory Certificate Services.
 
 - `key_usage` `([]string: )` - Specifies key_usage to encode in the
-  generated certificate.  This is a list of the names of each key usage, valid
-  values can be found at https://golang.org/pkg/crypto/x509/#KeyUsage part of the
-  name.  If not set, key usage will not appear on the CSR.
+  generated certificate. Valid values can be found at
+  https://golang.org/pkg/crypto/x509/#KeyUsage - simply drop the `KeyUsage`
+  part of the value. Values are not case-sensitive.
+  If not set, key usage will not appear on the CSR.
 
 #### Managed keys parameters
 

--- a/content/vault/v1.20.x/content/api-docs/secret/pki/index.mdx
+++ b/content/vault/v1.20.x/content/api-docs/secret/pki/index.mdx
@@ -2465,7 +2465,7 @@ based on this parameter.
 
 - `key_usage` `([]string: )` - Specifies key_usage to encode in the
   generated certificate. Must be
-  [a valid Golang crypto key](https://golang.org/pkg/crypto/x509/#KeyUsage) with
+  [a valid Golang key usage](https://golang.org/pkg/crypto/x509/#KeyUsage) with
   the `KeyUsage` prefix removed. Values are not case-sensitive. If you leave
   `key_usage` unset, Vault does not report key usage on the CSR.
 

--- a/content/vault/v1.20.x/content/api-docs/secret/pki/index.mdx
+++ b/content/vault/v1.20.x/content/api-docs/secret/pki/index.mdx
@@ -2464,10 +2464,10 @@ based on this parameter.
   scenarios with Active Directory Certificate Services.
 
 - `key_usage` `([]string: )` - Specifies key_usage to encode in the
-  generated certificate. Valid values can be found at
-  https://golang.org/pkg/crypto/x509/#KeyUsage - simply drop the `KeyUsage`
-  part of the value. Values are not case-sensitive.
-  If not set, key usage will not appear on the CSR.
+  generated certificate. Must be
+  [a valid Golang crypto key](https://golang.org/pkg/crypto/x509/#KeyUsage) with
+  the `KeyUsage` prefix removed. Values are not case-sensitive. If you leave
+  `key_usage` unset, Vault does not report key usage on the CSR.
 
 #### Managed keys parameters
 

--- a/content/vault/v1.21.x/content/api-docs/secret/pki/index.mdx
+++ b/content/vault/v1.21.x/content/api-docs/secret/pki/index.mdx
@@ -2512,10 +2512,10 @@ based on this parameter.
   scenarios with Active Directory Certificate Services.
 
 - `key_usage` `([]string: )` - Specifies key_usage to encode in the
-  generated certificate. Valid values can be found at
-  https://golang.org/pkg/crypto/x509/#KeyUsage - simply drop the `KeyUsage`
-  part of the value. Values are not case-sensitive.
-  If not set, key usage will not appear on the CSR.
+  generated certificate. Must be
+  [a valid Golang crypto key](https://golang.org/pkg/crypto/x509/#KeyUsage) with
+  the `KeyUsage` prefix removed. Values are not case-sensitive. If you leave
+  `key_usage` unset, Vault does not report key usage on the CSR.
 
 #### Managed keys parameters
 

--- a/content/vault/v1.21.x/content/api-docs/secret/pki/index.mdx
+++ b/content/vault/v1.21.x/content/api-docs/secret/pki/index.mdx
@@ -2512,9 +2512,10 @@ based on this parameter.
   scenarios with Active Directory Certificate Services.
 
 - `key_usage` `([]string: )` - Specifies key_usage to encode in the
-  generated certificate.  This is a list of the names of each key usage, valid
-  values can be found at https://golang.org/pkg/crypto/x509/#KeyUsage part of the
-  name.  If not set, key usage will not appear on the CSR.
+  generated certificate. Valid values can be found at
+  https://golang.org/pkg/crypto/x509/#KeyUsage - simply drop the `KeyUsage`
+  part of the value. Values are not case-sensitive.
+  If not set, key usage will not appear on the CSR.
 
 #### Managed keys parameters
 

--- a/content/vault/v1.21.x/content/api-docs/secret/pki/index.mdx
+++ b/content/vault/v1.21.x/content/api-docs/secret/pki/index.mdx
@@ -2513,7 +2513,7 @@ based on this parameter.
 
 - `key_usage` `([]string: )` - Specifies key_usage to encode in the
   generated certificate. Must be
-  [a valid Golang crypto key](https://golang.org/pkg/crypto/x509/#KeyUsage) with
+  [a valid Golang key usage](https://golang.org/pkg/crypto/x509/#KeyUsage) with
   the `KeyUsage` prefix removed. Values are not case-sensitive. If you leave
   `key_usage` unset, Vault does not report key usage on the CSR.
 

--- a/content/vault/v2.x/content/api-docs/secret/pki/index.mdx
+++ b/content/vault/v2.x/content/api-docs/secret/pki/index.mdx
@@ -2512,10 +2512,10 @@ based on this parameter.
   scenarios with Active Directory Certificate Services.
 
 - `key_usage` `([]string: )` - Specifies key_usage to encode in the
-  generated certificate. Valid values can be found at
-  https://golang.org/pkg/crypto/x509/#KeyUsage - simply drop the `KeyUsage`
-  part of the value. Values are not case-sensitive.
-  If not set, key usage will not appear on the CSR.
+  generated certificate. Must be
+  [a valid Golang crypto key](https://golang.org/pkg/crypto/x509/#KeyUsage) with
+  the `KeyUsage` prefix removed. Values are not case-sensitive. If you leave
+  `key_usage` unset, Vault does not report key usage on the CSR.
 
 #### Managed keys parameters
 

--- a/content/vault/v2.x/content/api-docs/secret/pki/index.mdx
+++ b/content/vault/v2.x/content/api-docs/secret/pki/index.mdx
@@ -2512,9 +2512,10 @@ based on this parameter.
   scenarios with Active Directory Certificate Services.
 
 - `key_usage` `([]string: )` - Specifies key_usage to encode in the
-  generated certificate.  This is a list of the names of each key usage, valid
-  values can be found at https://golang.org/pkg/crypto/x509/#KeyUsage part of the
-  name.  If not set, key usage will not appear on the CSR.
+  generated certificate. Valid values can be found at
+  https://golang.org/pkg/crypto/x509/#KeyUsage - simply drop the `KeyUsage`
+  part of the value. Values are not case-sensitive.
+  If not set, key usage will not appear on the CSR.
 
 #### Managed keys parameters
 

--- a/content/vault/v2.x/content/api-docs/secret/pki/index.mdx
+++ b/content/vault/v2.x/content/api-docs/secret/pki/index.mdx
@@ -2513,7 +2513,7 @@ based on this parameter.
 
 - `key_usage` `([]string: )` - Specifies key_usage to encode in the
   generated certificate. Must be
-  [a valid Golang crypto key](https://golang.org/pkg/crypto/x509/#KeyUsage) with
+  [a valid Golang key usage](https://golang.org/pkg/crypto/x509/#KeyUsage) with
   the `KeyUsage` prefix removed. Values are not case-sensitive. If you leave
   `key_usage` unset, Vault does not report key usage on the CSR.
 


### PR DESCRIPTION
Update the `key_usage` parameter within the [Generate intermediate CSR](https://developer.hashicorp.com/vault/api-docs/secret/pki#generate-intermediate-csr) section on how to properly leverage the Go constants. This update matches how we document the `key_usage` parameter on other API calls.

<img width="819" height="110" alt="Screenshot 2026-05-25 at 17 17 43" src="https://github.com/user-attachments/assets/f3462154-0efb-45d3-8811-1b877b78d304" />
