### PR TITLE
docs(atlassian-api-tokens): Add warning about scoped Atlassian API Tokens

### DIFF
--- a/content/hcp-docs/content/docs/vault-radar/get-started/add-data-sources/confluence/confluence-cloud.mdx
+++ b/content/hcp-docs/content/docs/vault-radar/get-started/add-data-sources/confluence/confluence-cloud.mdx
@@ -20,9 +20,13 @@ Vault Radar allows you to connect to any organization on Confluence Cloud.
 - Token creator email address
 - [API token](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/)
 
-::warning:: Unfortunately, Scoped API Tokens are not currently supported for scanning Confluence Cloud.
+<Note>
+
+Unfortunately, Scoped API Tokens are not currently supported for scanning Confluence Cloud.
 Using a scoped API token will result in 401 errors. 
 Please use a non-scoped API token to connect your Confluence Cloud data source.
+
+</Note>
 
 ## Create a connection with Confluence Cloud
 

--- a/content/hcp-docs/content/docs/vault-radar/get-started/add-data-sources/confluence/confluence-cloud.mdx
+++ b/content/hcp-docs/content/docs/vault-radar/get-started/add-data-sources/confluence/confluence-cloud.mdx
@@ -20,13 +20,13 @@ Vault Radar allows you to connect to any organization on Confluence Cloud.
 - Token creator email address
 - [API token](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/)
 
-<Note>
+<Warning>
 
 Unfortunately, Scoped API Tokens are not currently supported for scanning Confluence Cloud.
 Using a scoped API token will result in 401 errors. 
 Please use a non-scoped API token to connect your Confluence Cloud data source.
 
-</Note>
+</Warning>
 
 ## Create a connection with Confluence Cloud
 

--- a/content/hcp-docs/content/docs/vault-radar/get-started/add-data-sources/confluence/confluence-cloud.mdx
+++ b/content/hcp-docs/content/docs/vault-radar/get-started/add-data-sources/confluence/confluence-cloud.mdx
@@ -22,9 +22,9 @@ Vault Radar allows you to connect to any organization on Confluence Cloud.
 
 <Warning>
 
-Unfortunately, Scoped API Tokens are not currently supported for scanning Confluence Cloud.
-Using a scoped API token will result in 401 errors. 
-Please use a non-scoped API token to connect your Confluence Cloud data source.
+HCP Vault Radar does not support scoped API tokens for scanning Confluence Cloud.
+Using a scoped API token results in 401 errors. 
+Use a non-scoped API token to connect your Confluence Cloud data source.
 
 </Warning>
 

--- a/content/hcp-docs/content/docs/vault-radar/get-started/add-data-sources/confluence/confluence-cloud.mdx
+++ b/content/hcp-docs/content/docs/vault-radar/get-started/add-data-sources/confluence/confluence-cloud.mdx
@@ -20,6 +20,10 @@ Vault Radar allows you to connect to any organization on Confluence Cloud.
 - Token creator email address
 - [API token](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/)
 
+::warning:: Unfortunately, Scoped API Tokens are not currently supported for scanning Confluence Cloud.
+Using a scoped API token will result in 401 errors. 
+Please use a non-scoped API token to connect your Confluence Cloud data source.
+
 ## Create a connection with Confluence Cloud
 
 ### Scan with HCP Cloud

--- a/content/hcp-docs/content/docs/vault-radar/get-started/add-data-sources/jira/jira-cloud.mdx
+++ b/content/hcp-docs/content/docs/vault-radar/get-started/add-data-sources/jira/jira-cloud.mdx
@@ -20,9 +20,13 @@ Vault Radar allows you to connect to any organization on Jira Cloud
 - Token creator email address
 - [API token](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/)
 
-::warning:: Unfortunately, Scoped API Tokens are not currently supported for scanning Confluence Cloud.
+<Note>
+
+Unfortunately, Scoped API Tokens are not currently supported for scanning Jira Cloud.
 Using a scoped API token will result in 401 errors. 
-Please use a non-scoped API token to connect your Confluence Cloud data source.
+Please use a non-scoped API token to connect your Jira Cloud data source.
+
+</Note>
 
 ## Create a connection with Jira Cloud
 

--- a/content/hcp-docs/content/docs/vault-radar/get-started/add-data-sources/jira/jira-cloud.mdx
+++ b/content/hcp-docs/content/docs/vault-radar/get-started/add-data-sources/jira/jira-cloud.mdx
@@ -22,9 +22,9 @@ Vault Radar allows you to connect to any organization on Jira Cloud
 
 <Warning>
 
-Unfortunately, Scoped API Tokens are not currently supported for scanning Jira Cloud.
-Using a scoped API token will result in 401 errors. 
-Please use a non-scoped API token to connect your Jira Cloud data source.
+HCP Vault Radar does not support scoped API tokens for scanning Jira Cloud.
+Using a scoped API token results in 401 errors. 
+Use a non-scoped API token to connect your Jira Cloud data source.
 
 </Warning>
 

--- a/content/hcp-docs/content/docs/vault-radar/get-started/add-data-sources/jira/jira-cloud.mdx
+++ b/content/hcp-docs/content/docs/vault-radar/get-started/add-data-sources/jira/jira-cloud.mdx
@@ -20,13 +20,13 @@ Vault Radar allows you to connect to any organization on Jira Cloud
 - Token creator email address
 - [API token](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/)
 
-<Note>
+<Warning>
 
 Unfortunately, Scoped API Tokens are not currently supported for scanning Jira Cloud.
 Using a scoped API token will result in 401 errors. 
 Please use a non-scoped API token to connect your Jira Cloud data source.
 
-</Note>
+</Warning>
 
 ## Create a connection with Jira Cloud
 

--- a/content/hcp-docs/content/docs/vault-radar/get-started/add-data-sources/jira/jira-cloud.mdx
+++ b/content/hcp-docs/content/docs/vault-radar/get-started/add-data-sources/jira/jira-cloud.mdx
@@ -20,6 +20,10 @@ Vault Radar allows you to connect to any organization on Jira Cloud
 - Token creator email address
 - [API token](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/)
 
+::warning:: Unfortunately, Scoped API Tokens are not currently supported for scanning Confluence Cloud.
+Using a scoped API token will result in 401 errors. 
+Please use a non-scoped API token to connect your Confluence Cloud data source.
+
 ## Create a connection with Jira Cloud
 
 ### Scan with HCP Cloud


### PR DESCRIPTION
We've gotten some requests to publish the minimum scopes required for our Atlassian Integrations. I took a stab at figuring this out, but learned that the way Atlassian rolled out the scopes was to upgrade their APIs. This means, to even support using that token we'd need to refactor the whole integration to use different APIs... That's a much bigger unit of work. 

For now, documenting the limitation.