### PR TITLE
Add Azure example tab to for_each meta-argument page

### DIFF
--- a/content/terraform/v1.14.x/docs/language/meta-arguments/for_each.mdx
+++ b/content/terraform/v1.14.x/docs/language/meta-arguments/for_each.mdx
@@ -45,7 +45,7 @@ resource "aws_iam_user" "the-accounts" {
 </Tab>
 
 <Tab heading="Azure">
-The following example creates multiple Azure resource groups by iterating over a set of environment names with the `for_each` meta-argument.
+The following example iterates over a set of environment names with the `for_each` meta-argument to create multiple Azure resource groups.
 
 ```hcl
 resource "azurerm_resource_group" "rg" {

--- a/content/terraform/v1.14.x/docs/language/meta-arguments/for_each.mdx
+++ b/content/terraform/v1.14.x/docs/language/meta-arguments/for_each.mdx
@@ -32,6 +32,8 @@ resource "azurerm_resource_group" "rg" {
 }
 ```
 
+<Tabs>
+<Tab heading="aws">
 The following example creates four `aws_iam_user` resources using a set created with the `toset()` function:
 
 ```hcl
@@ -40,6 +42,20 @@ resource "aws_iam_user" "the-accounts" {
   name     = each.key
 }
 ```
+</Tab>
+
+<Tab heading="Azure">
+The following example creates multiple Azure resource groups by iterating over a set of environment names with the `for_each` meta-argument.
+
+```hcl
+resource "azurerm_resource_group" "rg" {
+ for_each = toset(["dev", "test", "staging", "prod"])
+ name     = "rg-${each.key}"
+ location = "eastus"
+}
+```
+</Tab>
+</Tabs>
 
 ### Limitations on values
 

--- a/content/terraform/v1.14.x/docs/language/meta-arguments/for_each.mdx
+++ b/content/terraform/v1.14.x/docs/language/meta-arguments/for_each.mdx
@@ -54,6 +54,7 @@ resource "azurerm_resource_group" "rg" {
  location = "eastus"
 }
 ```
+
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
Adds an Azure example tab to the for_each meta-argument documentation.
The Azure example demonstrates using for_each with a set of environment names to create multiple Azure resource groups, mirroring the intent of the existing AWS example.