### PR TITLE
Fix typo in JWT auto-auth documentation

### DIFF
--- a/content/vault/v1.18.x/content/docs/agent-and-proxy/autoauth/methods/jwt.mdx
+++ b/content/vault/v1.18.x/content/docs/agent-and-proxy/autoauth/methods/jwt.mdx
@@ -2,7 +2,7 @@
 layout: docs
 page_title: Auto-auth with JSW
 description: >-
-  Use JSON web tokens (JSW) for auto-authentication with Vault Agent or Vault
+  Use JSON web tokens (JWT) for auto-authentication with Vault Agent or Vault
   Proxy.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-07-02T11:30:26-05:00
@@ -10,7 +10,7 @@ last_modified: 2025-07-02T11:30:26-05:00
 # END AUTO GENERATED METADATA
 ---
 
-# Auto-auth method: JSON web tokens (JSW)
+# Auto-auth method: JSON web tokens (JWT)
 
 The `jwt` method reads in a JWT from a file and sends it to the [JWT Auth
 method](/vault/docs/auth/jwt).

--- a/content/vault/v1.19.x/content/docs/agent-and-proxy/autoauth/methods/jwt.mdx
+++ b/content/vault/v1.19.x/content/docs/agent-and-proxy/autoauth/methods/jwt.mdx
@@ -2,7 +2,7 @@
 layout: docs
 page_title: Auto-auth with JSW
 description: >-
-  Use JSON web tokens (JSW) for auto-authentication with Vault Agent or Vault
+  Use JSON web tokens (JWT) for auto-authentication with Vault Agent or Vault
   Proxy.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-07-01T14:39:24-05:00
@@ -10,7 +10,7 @@ last_modified: 2025-07-02T11:30:26-05:00
 # END AUTO GENERATED METADATA
 ---
 
-# Auto-auth method: JSON web tokens (JSW)
+# Auto-auth method: JSON web tokens (JWT)
 
 The `jwt` method reads in a JWT from a file and sends it to the [JWT Auth
 method](/vault/docs/auth/jwt).

--- a/content/vault/v1.20.x/content/docs/agent-and-proxy/autoauth/methods/jwt.mdx
+++ b/content/vault/v1.20.x/content/docs/agent-and-proxy/autoauth/methods/jwt.mdx
@@ -2,7 +2,7 @@
 layout: docs
 page_title: Auto-auth with JSW
 description: >-
-  Use JSON web tokens (JSW) for auto-authentication with Vault Agent or Vault
+  Use JSON web tokens (JWT) for auto-authentication with Vault Agent or Vault
   Proxy.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-07-01T14:39:24-05:00
@@ -10,7 +10,7 @@ last_modified: 2025-07-01T14:39:24-05:00
 # END AUTO GENERATED METADATA
 ---
 
-# Auto-auth method: JSON web tokens (JSW)
+# Auto-auth method: JSON web tokens (JWT)
 
 The `jwt` method reads in a JWT from a file and sends it to the [JWT Auth
 method](/vault/docs/auth/jwt).

--- a/content/vault/v1.21.x/content/docs/agent-and-proxy/autoauth/methods/jwt.mdx
+++ b/content/vault/v1.21.x/content/docs/agent-and-proxy/autoauth/methods/jwt.mdx
@@ -2,7 +2,7 @@
 layout: docs
 page_title: Auto-auth with JSW
 description: >-
-  Use JSON web tokens (JSW) for auto-authentication with Vault Agent or Vault
+  Use JSON web tokens (JWT) for auto-authentication with Vault Agent or Vault
   Proxy.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-07-22T12:58:23-07:00
@@ -10,7 +10,7 @@ last_modified: 2025-10-22T13:53:42-07:00
 # END AUTO GENERATED METADATA
 ---
 
-# Auto-auth method: JSON web tokens (JSW)
+# Auto-auth method: JSON web tokens (JWT)
 
 The `jwt` method reads in a JWT from a file and sends it to the [JWT Auth
 method](/vault/docs/auth/jwt).

--- a/content/vault/v2.x/content/docs/agent-and-proxy/autoauth/methods/jwt.mdx
+++ b/content/vault/v2.x/content/docs/agent-and-proxy/autoauth/methods/jwt.mdx
@@ -2,7 +2,7 @@
 layout: docs
 page_title: Auto-auth with JSW
 description: >-
-  Use JSON web tokens (JSW) for auto-authentication with Vault Agent or Vault
+  Use JSON web tokens (JWT) for auto-authentication with Vault Agent or Vault
   Proxy.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2026-04-15T00:14:19.000Z

--- a/content/vault/v2.x/content/docs/agent-and-proxy/autoauth/methods/jwt.mdx
+++ b/content/vault/v2.x/content/docs/agent-and-proxy/autoauth/methods/jwt.mdx
@@ -10,7 +10,7 @@ last_modified: 2026-04-15T00:14:19.000Z
 # END AUTO GENERATED METADATA
 ---
 
-# Auto-auth method: JSON web tokens (JSW)
+# Auto-auth method: JSON web tokens (JWT)
 
 The `jwt` method reads in a JWT from a file and sends it to the [JWT Auth
 method](/vault/docs/auth/jwt).


### PR DESCRIPTION
See this [slack message](https://ibm-hashicorp.slack.com/archives/C09KSS52PEF/p1780053711155129).

Updated versions 1.18 - 2.  Previous versions of the doc did not include the typo.