### PR TITLE
Terraform Docs

### DIFF
--- a/content/consul/v2.0.x/content/docs/integrate/index.mdx
+++ b/content/consul/v2.0.x/content/docs/integrate/index.mdx
@@ -161,7 +161,7 @@ The only knowledge necessary to write a plugin is basic command-line skills and 
 
 ### 4. Review and Approval
 
-HashiCorp will review and approve your Consul integration. Please send an email to [technologypartners@hashicorp.com](mailto:technologypartners@hashicorp.com) with any relevant documentation, demos or other resources and let us know your integration is ready for review.
+HashiCorp will review and approve your Consul integration. Please send an email to [hashicorp-tech-partners@wwpdl.vnet.ibm.com](mailto:hashicorp-tech-partners@wwpdl.vnet.ibm.com) with any relevant documentation, demos or other resources and let us know your integration is ready for review.
 
 ### 5. Release
 
@@ -179,9 +179,9 @@ Below is a checklist of steps that should be followed during the Consul integrat
 
 - Complete the [Consul Integration Program webform](https://docs.google.com/forms/d/e/1FAIpQLSf-RyVR9F0lmosao8Nnur0TTDjnl99gttnK3QP1OkfRefVKSw/viewform)
 - Develop and test your Consul integration following examples, documentation and best practices
-- When the integration is completed and ready for HashiCorp review, send us the documentation, demos and any other resources for review at: [technologypartners@hashicorp.com](mailto:technologypartners@hashicorp.com)
+- When the integration is completed and ready for HashiCorp review, send us the documentation, demos and any other resources for review at: [hashicorp-tech-partners@wwpdl.vnet.ibm.com](mailto:hashicorp-tech-partners@wwpdl.vnet.ibm.com)
 - Plan to continue to support the integration with additional functionality and responding to customer issues.
 
 ## Contact Us
 
-For any questions or feedback, please contact us at: [technologypartners@hashicorp.com](mailto:technologypartners@hashicorp.com)
+For any questions or feedback, please contact us at: [hashicorp-tech-partners@wwpdl.vnet.ibm.com](mailto:hashicorp-tech-partners@wwpdl.vnet.ibm.com)

--- a/content/nomad/v2.0.x/content/docs/partnerships.mdx
+++ b/content/nomad/v2.0.x/content/docs/partnerships.mdx
@@ -108,7 +108,7 @@ Observability & Analysis
 
 ## 4. Review
 
-During the review process, HashiCorp will provide feedback on the newly developed integration. This is an important step to allow HashiCorp to review and verify your Nomad integration. Please send the integration code and other relevant logs for verification to: [Nomad-integration-dev@hashicorp.com](mailto:Nomad-integration-dev@hashicorp.com).
+During the review process, HashiCorp will provide feedback on the newly developed integration. This is an important step to allow HashiCorp to review and verify your Nomad integration. Please send the integration code and other relevant logs for verification to: [hashicorp-tech-partners@wwpdl.vnet.ibm.com](mailto:hashicorp-tech-partners@wwpdl.vnet.ibm.com).
 
 For task, device, storage, and autoscaling plugins, please submit a GitHub pull request (PR) against the [Nomad project](https://github.com/hashicorp/nomad). In some cases the vendor may need to provide HashiCorp with a permanent test account so that the integration can be verified on an ongoing basis.
 
@@ -133,13 +133,13 @@ Below is an ordered checklist of steps that should be followed during the integr
 - Fill out the Nomad integration [webform](https://docs.google.com/forms/d/e/1FAIpQLSflmhg8lkY5QyH3CB5TUMi4I1ZFQFx_GP_TVDtsbxMaFEMWpw/viewform)
 - Execute the HashiCorp MNDA (Mutual Non-Disclosure Agreement) if needed
 - Develop and test Nomad integration along with the acceptance tests and documentation
-- Send email to [Nomad-integration-dev@hashicorp.com](mailto:Nomad-integration-dev@hashicorp.com) to schedule an initial review
+- Send email to [hashicorp-tech-partners@wwpdl.vnet.ibm.com](mailto:hashicorp-tech-partners@wwpdl.vnet.ibm.com) to schedule an initial review
 - Address review feedback and finalize the development process
 - Provide HashiCorp with credentials for underlying infrastructure for test purposes
-- Demo the integration and/or send the test logs to HashiCorp at: [Nomad-integration-dev@hashicorp.com](mailto:Nomad-integration-dev@hashicorp.com)
+- Demo the integration and/or send the test logs to HashiCorp at: [hashicorp-tech-partners@wwpdl.vnet.ibm.com](mailto:hashicorp-tech-partners@wwpdl.vnet.ibm.com)
 - Execute HashiCorp Partner Agreement Documents, review logo guidelines, partner listing and more
 - Plan to continue supporting the integration with additional functionality and responding to customer issues.
 
 ## Contact Us
 
-For any questions or feedback, please contact us at: [Nomad-integration-dev@hashicorp.com](mailto:Nomad-integration-dev@hashicorp.com).
+For any questions or feedback, please contact us at: [hashicorp-tech-partners@wwpdl.vnet.ibm.com](mailto:hashicorp-tech-partners@wwpdl.vnet.ibm.com).

--- a/content/packer/v1.15.x/content/docs/partnerships.mdx
+++ b/content/packer/v1.15.x/content/docs/partnerships.mdx
@@ -110,7 +110,7 @@ Packer-Plugin-SDK
 
 ### Review
 
-During the review process, HashiCorp will provide feedback on the newly developed integration. This is an important step to allow HashiCorp to review and verify your Packer integration. Please send the integration code and other relevant logs for verification to: [Packer-integration-dev@hashicorp.com](mailto:packer-integration-dev@hashicorp.com).
+During the review process, HashiCorp will provide feedback on the newly developed integration. This is an important step to allow HashiCorp to review and verify your Packer integration. Please send the integration code and other relevant logs for verification to: [hashicorp-tech-partners@wwpdl.vnet.ibm.com](mailto:hashicorp-tech-partners@wwpdl.vnet.ibm.com).
 
 In order to document your plugins with Packer, please submit a GitHub pull request (PR) against the [Packer project](https://github.com/hashicorp/packer). See [Registering Plugin Documentation](/packer/docs/plugins/creation#registering-plugin-documentation) for instructions on how to register your remote plugin documentation with Packer.
 The review process can take a while to complete and may require some iterations through the code to address any problems identified by the HashiCorp team.
@@ -136,10 +136,10 @@ Below is an ordered checklist of steps that should be followed during the integr
 - Fill out the Packer integration [webform](https://docs.google.com/forms/d/e/1FAIpQLSfgq3HJ9Rfsi7LgPLFln28ZrmarATGlD_6A47-Io-bPUftKUw/viewform)
 - Execute the HashiCorp MNDA (Mutual Non-Disclosure Agreement) if needed
 - Develop and test Packer integration along with the acceptance tests and documentation
-- Send email to [packer-integration-dev@hashicorp.com](mailto:packer-integration-dev@hashicorp.com) to schedule an initial review
+- Send email to [hashicorp-tech-partners@wwpdl.vnet.ibm.com](mailto:hashicorp-tech-partners@wwpdl.vnet.ibm.com) to schedule an initial review
 - Address review feedback and finalize the development process
 - Provide HashiCorp with credentials for underlying infrastructure for test purposes
-- Demo the integration and/or send the test logs to HashiCorp at: [packer-integration-dev@hashicorp.com](mailto:packer-integration-dev@hashicorp.com)
+- Demo the integration and/or send the test logs to HashiCorp at: [hashicorp-tech-partners@wwpdl.vnet.ibm.com](mailto:hashicorp-tech-partners@wwpdl.vnet.ibm.com)
 - Execute HashiCorp Partner Agreement Documents, review logo guidelines, partner listing and more
 - Plan to continue supporting the integration with additional functionality and responding to customer issues.
 
@@ -147,4 +147,4 @@ Below is an ordered checklist of steps that should be followed during the integr
 
 ## Contact Us
 
-For any questions or feedback, please contact us at: packer-integration-dev@hashicorp.com.
+For any questions or feedback, please contact us at: hashicorp-tech-partners@wwpdl.vnet.ibm.com.

--- a/content/terraform-docs-common/docs/docs/partnerships.mdx
+++ b/content/terraform-docs-common/docs/docs/partnerships.mdx
@@ -244,7 +244,7 @@ You should consider network access configuration when integrating with Terraform
 
 ### 3. Review
 
-Schedule time with your Partner Alliance manager to review your integration. The review should include enabling the integration on the partner’s platform and HCP Terraform or Terraform Enterprise, explaining the use case for the integration, and a live demonstration of the functionality. If you are unable to engage with your Partner Alliances manager, you can also reach out to <technologypartners@hashicorp.com>.
+Schedule time with your Partner Alliance manager to review your integration. The review should include enabling the integration on the partner’s platform and HCP Terraform or Terraform Enterprise, explaining the use case for the integration, and a live demonstration of the functionality. If you are unable to engage with your Product Partnerships manager, you can also reach out to <hashicorp-tech-partners@wwpdl.vnet.ibm.com>.
 
 ### 4. Release
 
@@ -260,4 +260,4 @@ At HashiCorp, we view the release step to be the beginning of the journey. Getti
 
 We expect that partners will create a mechanism to track and resolve all critical issues as soon as possible (ideally within 48 hours) and all other issues within 5 business days. This is a requirement given the critical nature of HCP Terraform to a customer’s operation. If you choose not to support your integration, we cannot consider it verified and will not list it on the Terraform Registry website.
 
--> Contact us at [technologypartners@hashicorp.com](mailto:technologypartners@hashicorp.com) with any questions or feedback.
+-> Contact us at [hashicorp-tech-partners@wwpdl.vnet.ibm.com](mailto:hashicorp-tech-partners@wwpdl.vnet.ibm.com) with any questions or feedback.


### PR DESCRIPTION
Updating to new tech partners email per IBM migration

### What
Updating to new tech partners email per IBM migration

### Why
IBM migration away from Google Workspaces

### Screenshots
NA

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] You added redirects to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages **across all affected versions**. Refer to [Redirects](https://github.com/hashicorp/web-unified-docs/blob/main/docs/content-guide/redirects.md#example-redirects) for examples and guidance. 
- [ ] Links to related content where appropriate (e.g., CLI, language, API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
