### PR TITLE
Nomad Docs - update tech partners email on Nomad Integration page

### DIFF
--- a/content/nomad/v2.0.x/content/docs/partnerships.mdx
+++ b/content/nomad/v2.0.x/content/docs/partnerships.mdx
@@ -108,7 +108,7 @@ Observability & Analysis
 
 ## 4. Review
 
-During the review process, HashiCorp will provide feedback on the newly developed integration. This is an important step to allow HashiCorp to review and verify your Nomad integration. Please send the integration code and other relevant logs for verification to: [Nomad-integration-dev@hashicorp.com](mailto:Nomad-integration-dev@hashicorp.com).
+During the review process, HashiCorp will provide feedback on the newly developed integration. This is an important step to allow HashiCorp to review and verify your Nomad integration. Please send the integration code and other relevant logs for verification to: [hashicorp-tech-partners@wwpdl.vnet.ibm.com](mailto:hashicorp-tech-partners@wwpdl.vnet.ibm.com).
 
 For task, device, storage, and autoscaling plugins, please submit a GitHub pull request (PR) against the [Nomad project](https://github.com/hashicorp/nomad). In some cases the vendor may need to provide HashiCorp with a permanent test account so that the integration can be verified on an ongoing basis.
 
@@ -133,13 +133,13 @@ Below is an ordered checklist of steps that should be followed during the integr
 - Fill out the Nomad integration [webform](https://docs.google.com/forms/d/e/1FAIpQLSflmhg8lkY5QyH3CB5TUMi4I1ZFQFx_GP_TVDtsbxMaFEMWpw/viewform)
 - Execute the HashiCorp MNDA (Mutual Non-Disclosure Agreement) if needed
 - Develop and test Nomad integration along with the acceptance tests and documentation
-- Send email to [Nomad-integration-dev@hashicorp.com](mailto:Nomad-integration-dev@hashicorp.com) to schedule an initial review
+- Send email to [hashicorp-tech-partners@wwpdl.vnet.ibm.com](mailto:hashicorp-tech-partners@wwpdl.vnet.ibm.com) to schedule an initial review
 - Address review feedback and finalize the development process
 - Provide HashiCorp with credentials for underlying infrastructure for test purposes
-- Demo the integration and/or send the test logs to HashiCorp at: [Nomad-integration-dev@hashicorp.com](mailto:Nomad-integration-dev@hashicorp.com)
+- Demo the integration and/or send the test logs to HashiCorp at: [hashicorp-tech-partners@wwpdl.vnet.ibm.com](mailto:hashicorp-tech-partners@wwpdl.vnet.ibm.com)
 - Execute HashiCorp Partner Agreement Documents, review logo guidelines, partner listing and more
 - Plan to continue supporting the integration with additional functionality and responding to customer issues.
 
 ## Contact Us
 
-For any questions or feedback, please contact us at: [Nomad-integration-dev@hashicorp.com](mailto:Nomad-integration-dev@hashicorp.com).
+For any questions or feedback, please contact us at: [hashicorp-tech-partners@wwpdl.vnet.ibm.com](mailto:hashicorp-tech-partners@wwpdl.vnet.ibm.com).


### PR DESCRIPTION
Updating tech partners email due to Google migration

<!--
**Merge branch**

Make sure you create your PR against the correct **base** branch. For instructions, refer to
GitHub's **Change the branch range and destination repository guide** (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request).

If your content is an update to:

- Currently published content

  Choose **base: main** when you are updating published documentation, and you
  want your changes published when the PR is merged. We publish Nomad content
  from the `main` branch.

- Upcoming Nomad release

  Choose the branch for the Nomad release that your content is for. Nomad
  release branches use the `nomad/<exact-release-number>` format. If you are not
  able to find the upcoming Nomad release branch that you are looking for,
  contact the tech writer that works with the Nomad team.

- Upcoming Nomad release but not sure which one

  - Choose the `main` branch.
  - Add the "do not merge" label.
  - Convert the PR to a DRAFT.
  - Put an explanation in the **Description** section.

  The tech writer coordinates with Nomad engineering and updates
  the docs PR base branch when the code is slotted into an upcoming release.

**Backports**

This repo stores previous version docs in folders instead of branches. There are
no backport labels.  If you backported your code PR to previous branches, update
the docs content in the corresponding folders. For example, if the current
release is 1.10.x and you backported your code to 1.9.x and 1.8.x, update the docs content
in the v1.10.x, v1.9.x, and v1.8.x folders. If you can't find the relevant files in previous versions,
add a note to your PR description. The tech writer will help ensure that the previous versions
receive the correct updates.
-->

## Description

<!-- 
Please describe why you're making this change and point out any important details the reviewers
should be aware of. A robust description helps the tech writer create a fabulous release note.
If your code PR has a splendid description, link to the code PR in the links section so that
the tech writer can update this PR's description. 

Include the target release as well as prior versions if applicable.
-->

## Links
<!--
**Please link to the related Nomad repo code PR!** if there is one. 
The tech writer does look at the code PR description, Jira ticket, and/or GH issue before reviewing docs content.

Include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a docs bug fix, please ensure related issues are linked so they will close when this PR is
merged.

// GH-Jira integration generates the link and updates the Jira ticket.
Jira: [<jira-ticket-number>]  // for example, Jira: [NMD-1234] 

GitHub Issue: <issue-link>

Deploy previews: The bot does publish a root-level link to the deploy preview, but the preview URL changes with each build.
-->

Nomad Code PR:
Jira:
GitHub Issue:

## Contributor checklists

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [ ] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [ ] Verify that the PR is set to merge into the correct base branch
- [ ] Verify that all status checks passed
- [ ] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [ ] I added redirects for any moved or removed pages
- [ ] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [ ] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [ ] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.


[NMD-1234]: https://hashicorp.atlassian.net/browse/NMD-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ