### PR TITLE
IPE-1512: Specify agent version required for OPA 1.4.x and later

### DIFF
--- a/content/terraform-docs-common/docs/cloud-docs/workspaces/policy-enforcement/define-policies/opa.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/workspaces/policy-enforcement/define-policies/opa.mdx
@@ -22,7 +22,7 @@ This topic describes how to create and manage custom policies using the open pol
 
 > **Hands-on:** Try the [Detect Infrastructure Drift and Enforce OPA Policies](/terraform/tutorials/cloud/drift-and-policy) tutorial.
 
-You can write OPA policies using the Rego policy language, which is the native query language for the OPA framework. Refer to the following topics in the [OPA documentation](https://www.openpolicyagent.org/docs/latest/policy-language/) for additional information:
+You can write OPA policies using the Rego policy language, which is the native query language for the OPA framework. If you use OPA version 1.4.x or later, you must use [HCP Terraform agent](/terraform/cloud-docs/agents) version 1.28.1 or later. Refer to the following topics in the [OPA documentation](https://www.openpolicyagent.org/docs/latest/policy-language/) for additional information:
 
 - [How Do I Write Rego Policies?](https://www.openpolicyagent.org/docs/v0.13.5/how-do-i-write-policies/)
 - [Rego Policy Playground](https://play.openpolicyagent.org/)


### PR DESCRIPTION
Add a note in the Overview section clarifying that OPA version 1.4.x and later requires HCP Terraform agent version 1.28.1 or later.

Please go to the `Preview` tab and select the appropriate template:

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
