### PR TITLE
docs: Update auto-vivify statement

### DIFF
--- a/content/boundary/v0.19.x/content/docs/rbac/users/manage-users-groups.mdx
+++ b/content/boundary/v0.19.x/content/docs/rbac/users/manage-users-groups.mdx
@@ -35,14 +35,7 @@ method in the default generated org in a `dev` mode server. (If you're not
 running `dev` mode, you'll need to substitute appropriate generated IDs in the
 steps below.)
 
-~> Currently, all auth methods auto-vivify users on authentication; that is, on
-successful authentication against an account, if there is no user already linked
-with that account, a user will be automatically created. This may be a nice
-time-saver, but in other situations (such as when you want Terraform to fully
-describe the Boundary resources) this may be undesirable, so the steps below
-walk you through manually making these resources and linking them. A future
-Boundary update will allow turning off auto-vivification on a per-auth-method
-basis.
+The [primary auth method](/boundary/docs/commands/scopes/update#primary-auth-method-id) for a scope auto-vivifies users on authentication. That is, on successful authentication against an account, if there is no user already linked with that account, Boundary automatically creates a user. This may be a nice time-saver, but in other situations (such as when you want Terraform to fully describe the resources) it may be undesirable, so the following steps walk you through manually creating these resources and linking them.
 
 ## Create an auth method
 

--- a/content/boundary/v0.20.x/content/docs/rbac/users/manage-users-groups.mdx
+++ b/content/boundary/v0.20.x/content/docs/rbac/users/manage-users-groups.mdx
@@ -35,14 +35,7 @@ method in the default generated org in a `dev` mode server. (If you're not
 running `dev` mode, you'll need to substitute appropriate generated IDs in the
 steps below.)
 
-~> Currently, all auth methods auto-vivify users on authentication; that is, on
-successful authentication against an account, if there is no user already linked
-with that account, a user will be automatically created. This may be a nice
-time-saver, but in other situations (such as when you want Terraform to fully
-describe the Boundary resources) this may be undesirable, so the steps below
-walk you through manually making these resources and linking them. A future
-Boundary update will allow turning off auto-vivification on a per-auth-method
-basis.
+The [primary auth method](/boundary/docs/commands/scopes/update#primary-auth-method-id) for a scope auto-vivifies users on authentication. That is, on successful authentication against an account, if there is no user already linked with that account, Boundary automatically creates a user. This may be a nice time-saver, but in other situations (such as when you want Terraform to fully describe the resources) it may be undesirable, so the following steps walk you through manually creating these resources and linking them.
 
 ## Create an auth method
 

--- a/content/boundary/v0.21.x/content/docs/rbac/users/manage-users-groups.mdx
+++ b/content/boundary/v0.21.x/content/docs/rbac/users/manage-users-groups.mdx
@@ -35,14 +35,7 @@ method in the default generated org in a `dev` mode server. (If you're not
 running `dev` mode, you'll need to substitute appropriate generated IDs in the
 steps below.)
 
-~> Currently, all auth methods auto-vivify users on authentication; that is, on
-successful authentication against an account, if there is no user already linked
-with that account, a user will be automatically created. This may be a nice
-time-saver, but in other situations (such as when you want Terraform to fully
-describe the Boundary resources) this may be undesirable, so the steps below
-walk you through manually making these resources and linking them. A future
-Boundary update will allow turning off auto-vivification on a per-auth-method
-basis.
+The [primary auth method](/boundary/docs/commands/scopes/update#primary-auth-method-id) for a scope auto-vivifies users on authentication. That is, on successful authentication against an account, if there is no user already linked with that account, Boundary automatically creates a user. This may be a nice time-saver, but in other situations (such as when you want Terraform to fully describe the resources) it may be undesirable, so the following steps walk you through manually creating these resources and linking them.
 
 ## Create an auth method
 


### PR DESCRIPTION
<!--
**Merge branch**

Make sure your PR uses the correct **base** branch for the merge destination.

For more information, refer to **Change the branch range and destination repository** (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request).

To update:

- Existing content

  Choose **base: main** to update existing documentation.
  Your content will be published when the PR is merged.

- Content for an upcoming Boundary release

  Choose the branch for the relevant upcoming Boundary release.
  Boundary release branches use the `boundary/<exact-release-number>` format.
  Your content will be published when the upcoming release goes live.

If you are not sure which base branch to use, or you cannot find the release branch you are looking for:

  - Choose the `main` branch.
  - Add the "do not merge" label.
  - Convert the PR to a DRAFT.
  - Explain the update in the **Description**.

**Back porting to older versions**

This repo stores versioned documentation in folders instead of branches.
There are no backport labels.
If your update applies to multiple versions, you must update the content in each of the corresponding version folders.

For example, you make an update to the Boundary code in the current release, 0.21.0, and back port it to versions 0.20.x and 0.19.x.
To document the update for each of the relevant versions, you would update the documentation in the v0.21.x, v0.20.x, and v0.19.x folders.
-->

## Description

From a Slack conversation: https://ibm-hashicorp.slack.com/archives/C09L3DN152Q/p1780347193630629

The docs say that all auth methods auto-vivify, but it is only true for the primary auth method for a scope. This PR updates the relevant paragraph in the version 0.19.x, 0.20.x, and 0.21.x docs.

View the update in the preview deployment:

- Manage users and groups > [Users](https://unified-docs-frontend-preview-a30150r4s-hashicorp.vercel.app/boundary/docs/rbac/users/manage-users-groups#users)

## Links
<!--
Include links to any associated pull requests, GitHub issues, or documentation that is relevant to this update.

// GH-Jira integration generates the link and updates the Jira ticket.
Jira: [<jira-ticket-number>]  // for example, Jira: [ICU-1234]

GitHub Issue: <issue-link>
-->

Code PR:
Jira:
GitHub issue:
RFC/PRD:

## Contributor checklists

<!--
Help your reviewer understand the type of review you need by selecting the scope and urgency.
-->

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [x] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [x] Verify that all status checks passed
- [x] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [ ] I added redirects for any moved or removed pages
- [x] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [x] I looked at the local or Vercel build to make sure the content rendered correctly


[ICU-1234]: https://hashicorp.atlassian.net/browse/ICU-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ