### PR TITLE
Add information about vault-pkcs11-provider release v0.2.3.

### DIFF
--- a/content/vault/v2.x/content/docs/enterprise/pkcs11-provider/index.mdx
+++ b/content/vault/v2.x/content/docs/enterprise/pkcs11-provider/index.mdx
@@ -30,13 +30,15 @@ The PKCS#11 library connects to Vault's [KMIP Secrets Engine](/vault/docs/secret
 This library works with Vault Enterprise 1.11+ with the advanced data protection module in the license
 with the KMIP Secrets Engine.
 
-| Operating System | Architecture | Distribution      | glibc   |
-| ---------------- | ------------ | ----------------- | ------- |
-| Linux            | x86-64       | RHEL 7 compatible | 2.17    |
-| Linux            | x86-64       | RHEL 8 compatible | 2.28    |
-| Linux            | x86-64       | RHEL 9 compatible | 2.34    |
-| macOS            | x86-64       | &mdash;           | &mdash; |
-| macOS            | arm64        | &mdash;           | &mdash; |
+| Operating System | Architecture | Distribution       | glibc   |
+| ---------------- | ------------ | ------------------ | ------- |
+| Linux            | x86-64       | RHEL  8 compatible | 2.28    |
+| Linux            | x86-64       | RHEL  9 compatible | 2.34    |
+| Linux            | x86-64       | RHEL 10 compatible | 2.34    |
+| Linux            | s390X        | RHEL  9 compatible | 2.34    |
+| Linux            | s390X        | RHEL 10 compatible | 2.34    |
+| macOS            | x86-64       | &mdash;            | &mdash; |
+| macOS            | arm64        | &mdash;            | &mdash; |
 
 _Note:_ `vault-pkcs11-provider` runs on _any_ glibc-based Linux distribution. The versions above are given in RHEL-compatible GLIBC versions; for your
 distro's glibc version, choose the `vault-pkcs11-provider` built against the same or older version as what your distro provides.
@@ -435,6 +437,11 @@ Due to the nature of Vault, the KMIP Secrets Engine, and PKCS#11, there are some
   and does **not** call Vault.
 
 ## Changelog
+
+### v0.2.3
+
+  * Add support for IBM s390X CPU architecture.
+  * Remove support for EL7.
 
 ### v0.2.2
 


### PR DESCRIPTION
Update Vault's PKCS11 Provider page with information about the new v0.2.3 release, which adds support for s390x.
