### PR TITLE
Fixing forward port manual run issues

### DIFF
--- a/.github/forward-port-config.yml
+++ b/.github/forward-port-config.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 
 # Keys are slugs — the part after "forward-port:" in the PR label.
-# e.g. the label "forward-port:vault-new" maps to the "vault-new" entry below.
+# e.g. the label "forward-port:vault-test" maps to the "vault-test" entry below.
 # Every entry requires: sourceVersionFolder, targetProduct, targetBranch, targetVersionFolder.
 # the targetProduct needs to match exactly with the product name folder used in the content directory
 # i.e. "boundary" from "/content/boundary" , etc... NOT "Boundary"

--- a/.github/workflows/forward-port-pr.yml
+++ b/.github/workflows/forward-port-pr.yml
@@ -7,10 +7,10 @@ on:
         description: 'Number of the already-merged PR to forward-port'
         required: true
       labelSlug:
-        description: 'Config slug to look up (e.g. vault-next). Use this OR overrideJson, not both.'
+        description: 'Config slug to look up (e.g. vault-test). Use this OR overrideJson, not both.'
         required: false
       overrideJson:
-        description: 'JSON object with routing fields, e.g. {"sourceVersionFolder":"v1.0.0","targetProduct":"Vault","targetBranch":"vault-next","targetVersionFolder":"v1.1.0"}. Use this OR labelSlug, not both.'
+        description: 'JSON object with routing fields, e.g. {"sourceVersionFolder":"v1.0.0","targetProduct":"Vault","targetBranch":"vault-test","targetVersionFolder":"v1.1.0"}. Use this OR labelSlug, not both.'
         required: false
 
   pull_request:

--- a/.github/workflows/forward-port-pr.yml
+++ b/.github/workflows/forward-port-pr.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           PR_JSON="$(gh pr view "${PR_NUMBER}" \
             --repo "${{ github.repository }}" \
-            --json number,title,url,mergeCommitSha,author,state)"
+            --json number,title,url,mergeCommit,author,state)"
 
           if [ -z "${PR_JSON}" ] || [ "${PR_JSON}" = "null" ]; then
             echo "::error::PR #${PR_NUMBER} not found."
@@ -77,7 +77,7 @@ jobs:
           fi
 
           {
-            echo "MERGED_SHA=$(echo "${PR_JSON}" | jq -r '.mergeCommitSha')"
+            echo "MERGED_SHA=$(echo "${PR_JSON}" | jq -r '.mergeCommit.oid')"
             echo "SOURCE_PR_NUMBER=$(echo "${PR_JSON}" | jq -r '.number')"
             echo "SOURCE_PR_TITLE=$(echo "${PR_JSON}" | jq -r '.title')"
             echo "SOURCE_PR_URL=$(echo "${PR_JSON}" | jq -r '.url')"

--- a/.github/workflows/forward-port-pr.yml
+++ b/.github/workflows/forward-port-pr.yml
@@ -7,7 +7,7 @@ on:
         description: 'Number of the already-merged PR to forward-port'
         required: true
       labelSlug:
-        description: 'Config slug to look up (e.g. vault-test). Use this OR overrideJson, not both.'
+        description: 'Config slug to look up from the config file (e.g. vault-test, boundary-placeholder-label, etc...). Use this OR overrideJson, not both.'
         required: false
       overrideJson:
         description: 'JSON object with routing fields, e.g. {"sourceVersionFolder":"v1.0.0","targetProduct":"Vault","targetBranch":"vault-test","targetVersionFolder":"v1.1.0"}. Use this OR labelSlug, not both.'

--- a/scripts/forward-port/forward-port.e2e.integration.ts
+++ b/scripts/forward-port/forward-port.e2e.integration.ts
@@ -31,9 +31,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
 const RESOLVE_TARGET = path.resolve('scripts/forward-port/resolve-target.mjs')
 const GET_CHANGED = path.resolve('scripts/utils/get-changed-content-files.mjs')
-const APPLY_CHANGES = path.resolve(
-	'scripts/forward-port/apply-forward-port-changes.mjs',
-)
+const APPLY_CHANGES = path.resolve('scripts/forward-port/apply-forward-port-changes.mjs')
 
 const FORWARD_PORT_CONFIG = `
 tf-forward-porting-testing:
@@ -65,213 +63,182 @@ function commitAll(dir: string, message: string): string {
 // Happy path — three sequential steps that chain state from step to step
 // ---------------------------------------------------------------------------
 
-describe.sequential(
-	'Forward-port pipeline — happy path (add + modify + remove)',
-	() => {
-		let tmpDir: string
-		let configPath: string
-		let githubEnvPath: string
-		let changesFilePath: string
+describe.sequential('Forward-port pipeline — happy path (add + modify + remove)', () => {
+	let tmpDir: string
+	let configPath: string
+	let githubEnvPath: string
+	let changesFilePath: string
 
-		// baseSha is set in beforeAll. This is the SHA that
-		// github.event.pull_request.base.sha provides — the state of the repo
-		// BEFORE the PR's commits landed.
-		let baseSha: string
+	// baseSha is set in beforeAll. This is the SHA that
+	// github.event.pull_request.base.sha provides — the state of the repo
+	// BEFORE the PR's commits landed.
+	let baseSha: string
 
-		beforeAll(() => {
-			tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fp-e2e-happy-'))
-			configPath = path.join(tmpDir, 'forward-port-config.yml')
-			githubEnvPath = path.join(tmpDir, 'github_env')
-			changesFilePath = path.join(tmpDir, 'changedContentFiles.json')
+	beforeAll(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fp-e2e-happy-'))
+		configPath = path.join(tmpDir, 'forward-port-config.yml')
+		githubEnvPath = path.join(tmpDir, 'github_env')
+		changesFilePath = path.join(tmpDir, 'changedContentFiles.json')
 
-			fs.writeFileSync(configPath, FORWARD_PORT_CONFIG)
-			fs.writeFileSync(githubEnvPath, '')
+		fs.writeFileSync(configPath, FORWARD_PORT_CONFIG)
+		fs.writeFileSync(githubEnvPath, '')
 
-			initRepo(tmpDir)
+		initRepo(tmpDir)
 
-			// ------------------------------------------------------------------
-			// Base state — what existed before the PR
-			// source: content/terraform/v1.14.x   target: content/terraform/v1.15.x
-			// ------------------------------------------------------------------
-			const src = path.join(tmpDir, 'content/terraform/v1.14.x/docs')
-			const tgt = path.join(tmpDir, 'content/terraform/v1.15.x/docs')
-			fs.mkdirSync(src, { recursive: true })
-			fs.mkdirSync(tgt, { recursive: true })
+		// ------------------------------------------------------------------
+		// Base state — what existed before the PR
+		// source: content/terraform/v1.14.x   target: content/terraform/v1.15.x
+		// ------------------------------------------------------------------
+		const src = path.join(tmpDir, 'content/terraform/v1.14.x/docs')
+		const tgt = path.join(tmpDir, 'content/terraform/v1.15.x/docs')
+		fs.mkdirSync(src, { recursive: true })
+		fs.mkdirSync(tgt, { recursive: true })
 
-			// A file that the PR will modify
-			fs.writeFileSync(path.join(src, 'existing.mdx'), '# Existing (original)')
-			fs.writeFileSync(path.join(tgt, 'existing.mdx'), '# Existing (original)')
+		// A file that the PR will modify
+		fs.writeFileSync(path.join(src, 'existing.mdx'), '# Existing (original)')
+		fs.writeFileSync(path.join(tgt, 'existing.mdx'), '# Existing (original)')
 
-			// A file that the PR will delete
-			fs.writeFileSync(path.join(src, 'to-be-removed.mdx'), '# Will be deleted')
-			fs.writeFileSync(path.join(tgt, 'to-be-removed.mdx'), '# Will be deleted')
+		// A file that the PR will delete
+		fs.writeFileSync(path.join(src, 'to-be-removed.mdx'), '# Will be deleted')
+		fs.writeFileSync(path.join(tgt, 'to-be-removed.mdx'), '# Will be deleted')
 
-			// Commit — this SHA is what github.event.pull_request.base.sha provides
-			baseSha = commitAll(tmpDir, 'Base state before PR changes')
+		// Commit — this SHA is what github.event.pull_request.base.sha provides
+		baseSha = commitAll(tmpDir, 'Base state before PR changes')
 
-			// ------------------------------------------------------------------
-			// PR changes land (simulating the merge commit arriving on origin/main)
-			// ------------------------------------------------------------------
-			// 1. New file added
-			fs.writeFileSync(path.join(src, 'new-feature.mdx'), '# New Feature')
-			// 2. Existing file modified
-			fs.writeFileSync(
-				path.join(src, 'existing.mdx'),
-				'# Existing (updated by PR)',
-			)
-			// 3. File removed
-			fs.rmSync(path.join(src, 'to-be-removed.mdx'))
+		// ------------------------------------------------------------------
+		// PR changes land (simulating the merge commit arriving on origin/main)
+		// ------------------------------------------------------------------
+		// 1. New file added
+		fs.writeFileSync(path.join(src, 'new-feature.mdx'), '# New Feature')
+		// 2. Existing file modified
+		fs.writeFileSync(path.join(src, 'existing.mdx'), '# Existing (updated by PR)')
+		// 3. File removed
+		fs.rmSync(path.join(src, 'to-be-removed.mdx'))
 
-			commitAll(
-				tmpDir,
-				'PR: add new-feature, update existing, remove to-be-removed',
-			)
-		})
+		commitAll(tmpDir, 'PR: add new-feature, update existing, remove to-be-removed')
+	})
 
-		afterAll(() => {
-			fs.rmSync(tmpDir, { recursive: true, force: true })
-		})
+	afterAll(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true })
+	})
 
-		it('Step 1 — resolve-target: resolves TARGET_BRANCH, TARGET_VERSION_FOLDER, SOURCE_VERSION_FOLDER, and TARGET_PRODUCT from PR labels', () => {
-			const labels = JSON.stringify(['forward-port:tf-forward-porting-testing'])
+	it('Step 1 — resolve-target: resolves TARGET_BRANCH, TARGET_VERSION_FOLDER, SOURCE_VERSION_FOLDER, and TARGET_PRODUCT from PR labels', () => {
+		const labels = JSON.stringify(['forward-port:tf-forward-porting-testing'])
 
-			const result = spawnSync(
-				'node',
-				[RESOLVE_TARGET, '--config', configPath, '--labels', labels],
-				{ encoding: 'utf-8' },
-			)
+		const result = spawnSync(
+			'node',
+			[RESOLVE_TARGET, '--config', configPath, '--labels', labels],
+			{ encoding: 'utf-8' },
+		)
 
-			expect(result.status, result.stderr).toBe(0)
+		expect(result.status, result.stderr).toBe(0)
 
-			// Script now outputs JSON to stdout
-			const routing = JSON.parse(result.stdout.trim()) as Record<string, string>
-			expect(routing.TARGET_BRANCH).toBe('rn-forward-porting-test-rc')
-			expect(routing.TARGET_VERSION_FOLDER).toBe('v1.15.x')
-			expect(routing.SOURCE_VERSION_FOLDER).toBe('v1.14.x')
-			expect(routing.TARGET_PRODUCT).toBe('terraform')
+		// Script now outputs JSON to stdout
+		const routing = JSON.parse(result.stdout.trim()) as Record<string, string>
+		expect(routing.TARGET_BRANCH).toBe('rn-forward-porting-test-rc')
+		expect(routing.TARGET_VERSION_FOLDER).toBe('v1.15.x')
+		expect(routing.SOURCE_VERSION_FOLDER).toBe('v1.14.x')
+		expect(routing.TARGET_PRODUCT).toBe('terraform')
 
-			// Simulate what the workflow shell does: write KEY=VALUE lines to
-			// githubEnvPath so Step 3 can read them (mirrors jq parsing in the workflow).
-			fs.writeFileSync(
-				githubEnvPath,
-				Object.entries(routing)
-					.map(([k, v]) => {
-						return `${k}=${v}`
-					})
-					.join('\n') + '\n',
-				'utf-8',
-			)
-		})
+		// Simulate what the workflow shell does: write KEY=VALUE lines to
+		// githubEnvPath so Step 3 can read them (mirrors jq parsing in the workflow).
+		fs.writeFileSync(
+			githubEnvPath,
+			Object.entries(routing).map(([k, v]) => {return `${k}=${v}`}).join('\n') + '\n',
+			'utf-8',
+		)
+	})
 
-		it('Step 2 — get-changed-content-files: diffs against pre-merge base SHA, excludes partial fan-out', () => {
+	it('Step 2 — get-changed-content-files: diffs against pre-merge base SHA, excludes partial fan-out', () => {
+		const result = spawnSync(
+			'node',
+			[
+				GET_CHANGED,
+				'--merge-base',
+				baseSha,
+				'--include-partials',
+				'false',
+				'--output',
+				changesFilePath,
+			],
+			{ cwd: tmpDir, encoding: 'utf-8' },
+		)
+
+		expect(result.status, result.stderr).toBe(0)
+
+		const changes = JSON.parse(fs.readFileSync(changesFilePath, 'utf-8'))
+
+		expect(changes.added).toContain('content/terraform/v1.14.x/docs/new-feature.mdx')
+		expect(changes.modified).toContain('content/terraform/v1.14.x/docs/existing.mdx')
+		expect(changes.removed).toContain('content/terraform/v1.14.x/docs/to-be-removed.mdx')
+
+		// Partial fan-out is disabled — only the 3 directly changed files
+		expect(changes.added.length + changes.modified.length + changes.removed.length).toBe(3)
+	})
+
+	it('Step 3 — apply-forward-port-changes: ports files into target version using --source-dir (simulating post-checkout state)', () => {
+		// Read TARGET_VERSION and SOURCE_VERSION from the GITHUB_ENV file step 1 wrote
+		// after parsing resolve-target's JSON output.
+		// In the real workflow these become shell env vars for subsequent steps.
+		const envContent = fs.readFileSync(githubEnvPath, 'utf-8')
+		const targetVersion = envContent.match(/TARGET_VERSION_FOLDER=(.+)/)?.[1].trim()
+		const sourceVersion = envContent.match(/SOURCE_VERSION_FOLDER=(.+)/)?.[1].trim()
+		const targetProduct = envContent.match(/TARGET_PRODUCT=(.+)/)?.[1].trim()
+		expect(targetVersion).toBe('v1.15.x')
+		expect(sourceVersion).toBe('v1.14.x')
+		expect(targetProduct).toBe('terraform')
+
+		// Simulate the "Save source files" step: copy changed source files to a
+		// temp dir before the working directory is replaced by the target checkout.
+		const sourceSaveDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fp-e2e-source-'))
+		try {
+			const changes = JSON.parse(fs.readFileSync(changesFilePath, 'utf-8'))
+			for (const srcPath of [...changes.added, ...changes.modified]) {
+				const src = path.join(tmpDir, srcPath)
+				const dest = path.join(sourceSaveDir, srcPath)
+				fs.mkdirSync(path.dirname(dest), { recursive: true })
+				if (fs.existsSync(src)) {fs.copyFileSync(src, dest)}
+			}
+
+			// Simulate "Check out target branch": delete the source version directory
+			// so the script cannot read source files from the working tree.
+			fs.rmSync(path.join(tmpDir, `content/terraform/${sourceVersion!}`), {
+				recursive: true,
+				force: true,
+			})
+
 			const result = spawnSync(
 				'node',
 				[
-					GET_CHANGED,
-					'--merge-base',
-					baseSha,
-					'--include-partials',
-					'false',
-					'--output',
+					APPLY_CHANGES,
+					'--changes-file',
 					changesFilePath,
+					'--target-product',
+					targetProduct!,
+					'--source-version',
+					sourceVersion!,
+					'--target-version',
+					targetVersion!,
+					'--source-dir',
+					sourceSaveDir,
 				],
 				{ cwd: tmpDir, encoding: 'utf-8' },
 			)
 
 			expect(result.status, result.stderr).toBe(0)
 
-			const changes = JSON.parse(fs.readFileSync(changesFilePath, 'utf-8'))
-
-			expect(changes.added).toContain(
-				'content/terraform/v1.14.x/docs/new-feature.mdx',
+			const tgt = path.join(tmpDir, 'content/terraform/v1.15.x/docs')
+			expect(fs.existsSync(path.join(tgt, 'new-feature.mdx'))).toBe(true)
+			expect(fs.readFileSync(path.join(tgt, 'new-feature.mdx'), 'utf-8')).toBe('# New Feature')
+			expect(fs.readFileSync(path.join(tgt, 'existing.mdx'), 'utf-8')).toBe(
+				'# Existing (updated by PR)',
 			)
-			expect(changes.modified).toContain(
-				'content/terraform/v1.14.x/docs/existing.mdx',
-			)
-			expect(changes.removed).toContain(
-				'content/terraform/v1.14.x/docs/to-be-removed.mdx',
-			)
-
-			// Partial fan-out is disabled — only the 3 directly changed files
-			expect(
-				changes.added.length + changes.modified.length + changes.removed.length,
-			).toBe(3)
-		})
-
-		it('Step 3 — apply-forward-port-changes: ports files into target version using --source-dir (simulating post-checkout state)', () => {
-			// Read TARGET_VERSION and SOURCE_VERSION from the GITHUB_ENV file step 1 wrote
-			// after parsing resolve-target's JSON output.
-			// In the real workflow these become shell env vars for subsequent steps.
-			const envContent = fs.readFileSync(githubEnvPath, 'utf-8')
-			const targetVersion = envContent
-				.match(/TARGET_VERSION_FOLDER=(.+)/)?.[1]
-				.trim()
-			const sourceVersion = envContent
-				.match(/SOURCE_VERSION_FOLDER=(.+)/)?.[1]
-				.trim()
-			const targetProduct = envContent.match(/TARGET_PRODUCT=(.+)/)?.[1].trim()
-			expect(targetVersion).toBe('v1.15.x')
-			expect(sourceVersion).toBe('v1.14.x')
-			expect(targetProduct).toBe('terraform')
-
-			// Simulate the "Save source files" step: copy changed source files to a
-			// temp dir before the working directory is replaced by the target checkout.
-			const sourceSaveDir = fs.mkdtempSync(
-				path.join(os.tmpdir(), 'fp-e2e-source-'),
-			)
-			try {
-				const changes = JSON.parse(fs.readFileSync(changesFilePath, 'utf-8'))
-				for (const srcPath of [...changes.added, ...changes.modified]) {
-					const src = path.join(tmpDir, srcPath)
-					const dest = path.join(sourceSaveDir, srcPath)
-					fs.mkdirSync(path.dirname(dest), { recursive: true })
-					if (fs.existsSync(src)) {
-						fs.copyFileSync(src, dest)
-					}
-				}
-
-				// Simulate "Check out target branch": delete the source version directory
-				// so the script cannot read source files from the working tree.
-				fs.rmSync(path.join(tmpDir, `content/terraform/${sourceVersion!}`), {
-					recursive: true,
-					force: true,
-				})
-
-				const result = spawnSync(
-					'node',
-					[
-						APPLY_CHANGES,
-						'--changes-file',
-						changesFilePath,
-						'--target-product',
-						targetProduct!,
-						'--source-version',
-						sourceVersion!,
-						'--target-version',
-						targetVersion!,
-						'--source-dir',
-						sourceSaveDir,
-					],
-					{ cwd: tmpDir, encoding: 'utf-8' },
-				)
-
-				expect(result.status, result.stderr).toBe(0)
-
-				const tgt = path.join(tmpDir, 'content/terraform/v1.15.x/docs')
-				expect(fs.existsSync(path.join(tgt, 'new-feature.mdx'))).toBe(true)
-				expect(
-					fs.readFileSync(path.join(tgt, 'new-feature.mdx'), 'utf-8'),
-				).toBe('# New Feature')
-				expect(fs.readFileSync(path.join(tgt, 'existing.mdx'), 'utf-8')).toBe(
-					'# Existing (updated by PR)',
-				)
-				expect(fs.existsSync(path.join(tgt, 'to-be-removed.mdx'))).toBe(false)
-			} finally {
-				fs.rmSync(sourceSaveDir, { recursive: true, force: true })
-			}
-		})
-	},
-)
+			expect(fs.existsSync(path.join(tgt, 'to-be-removed.mdx'))).toBe(false)
+		} finally {
+			fs.rmSync(sourceSaveDir, { recursive: true, force: true })
+		}
+	})
+})
 
 // ---------------------------------------------------------------------------
 // Failure cases — each is self-contained with its own repo setup
@@ -319,10 +286,7 @@ describe('Forward-port pipeline — failure cases', () => {
 			// Commit and immediately use HEAD as baseSha — no subsequent changes
 			const headSha = commitAll(emptyRepoDir, 'Unchanged state')
 
-			const emptyChangesFile = path.join(
-				emptyRepoDir,
-				'changedContentFiles.json',
-			)
+			const emptyChangesFile = path.join(emptyRepoDir, 'changedContentFiles.json')
 
 			const getResult = spawnSync(
 				'node',
@@ -372,122 +336,111 @@ describe('Forward-port pipeline — failure cases', () => {
 // These tests verify that the diff + apply steps work correctly in that mode.
 // ---------------------------------------------------------------------------
 
-describe.sequential(
-	'Forward-port pipeline — workflow_dispatch (SOURCE_VERSION from inputs, no resolve-target)',
-	() => {
-		let dispatchDir: string
-		let changesFilePath: string
-		let sourceSaveDir: string
-		let baseSha: string
+describe.sequential('Forward-port pipeline — workflow_dispatch (SOURCE_VERSION from inputs, no resolve-target)', () => {
+	let dispatchDir: string
+	let changesFilePath: string
+	let sourceSaveDir: string
+	let baseSha: string
 
-		beforeAll(() => {
-			dispatchDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fp-e2e-dispatch-'))
-			changesFilePath = path.join(dispatchDir, 'changedContentFiles.json')
+	beforeAll(() => {
+		dispatchDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fp-e2e-dispatch-'))
+		changesFilePath = path.join(dispatchDir, 'changedContentFiles.json')
 
-			initRepo(dispatchDir)
+		initRepo(dispatchDir)
 
-			const src = path.join(dispatchDir, 'content/terraform/v1.14.x/docs')
-			const tgt = path.join(dispatchDir, 'content/terraform/v1.15.x/docs')
-			fs.mkdirSync(src, { recursive: true })
-			fs.mkdirSync(tgt, { recursive: true })
+		const src = path.join(dispatchDir, 'content/terraform/v1.14.x/docs')
+		const tgt = path.join(dispatchDir, 'content/terraform/v1.15.x/docs')
+		fs.mkdirSync(src, { recursive: true })
+		fs.mkdirSync(tgt, { recursive: true })
 
-			fs.writeFileSync(path.join(src, 'stable.mdx'), '# Stable (original)')
-			fs.writeFileSync(path.join(tgt, 'stable.mdx'), '# Stable (original)')
+		fs.writeFileSync(path.join(src, 'stable.mdx'), '# Stable (original)')
+		fs.writeFileSync(path.join(tgt, 'stable.mdx'), '# Stable (original)')
 
-			baseSha = commitAll(dispatchDir, 'Base state before PR')
+		baseSha = commitAll(dispatchDir, 'Base state before PR')
 
-			// PR changes
-			fs.writeFileSync(path.join(src, 'stable.mdx'), '# Stable (updated by PR)')
-			fs.writeFileSync(path.join(src, 'new-dispatch.mdx'), '# New via dispatch')
+		// PR changes
+		fs.writeFileSync(path.join(src, 'stable.mdx'), '# Stable (updated by PR)')
+		fs.writeFileSync(path.join(src, 'new-dispatch.mdx'), '# New via dispatch')
 
-			commitAll(dispatchDir, 'PR changes for dispatch test')
+		commitAll(dispatchDir, 'PR changes for dispatch test')
+	})
+
+	afterAll(() => {
+		fs.rmSync(dispatchDir, { recursive: true, force: true })
+		if (sourceSaveDir && fs.existsSync(sourceSaveDir)) {
+			fs.rmSync(sourceSaveDir, { recursive: true, force: true })
+		}
+	})
+
+	it('Step 2 (dispatch) — get-changed-content-files diffs against the provided merge-base SHA', () => {
+		const result = spawnSync(
+			'node',
+			[
+				GET_CHANGED,
+				'--merge-base',
+				baseSha,
+				'--include-partials',
+				'false',
+				'--output',
+				changesFilePath,
+			],
+			{ cwd: dispatchDir, encoding: 'utf-8' },
+		)
+
+		expect(result.status, result.stderr).toBe(0)
+
+		const changes = JSON.parse(fs.readFileSync(changesFilePath, 'utf-8'))
+		expect(changes.added).toContain('content/terraform/v1.14.x/docs/new-dispatch.mdx')
+		expect(changes.modified).toContain('content/terraform/v1.14.x/docs/stable.mdx')
+	})
+
+	it('Step 3 (dispatch) — apply uses SOURCE_VERSION from inputs and --source-dir for file reads', () => {
+		// Simulate "Save source files" before checkout switch
+		sourceSaveDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fp-dispatch-source-'))
+		const changes = JSON.parse(fs.readFileSync(changesFilePath, 'utf-8'))
+		for (const srcPath of [...changes.added, ...changes.modified]) {
+			const src = path.join(dispatchDir, srcPath)
+			const dest = path.join(sourceSaveDir, srcPath)
+			fs.mkdirSync(path.dirname(dest), { recursive: true })
+			if (fs.existsSync(src)) {fs.copyFileSync(src, dest)}
+		}
+
+		// Simulate "Check out target branch" — source version directory is gone
+		fs.rmSync(path.join(dispatchDir, 'content/terraform/v1.14.x'), {
+			recursive: true,
+			force: true,
 		})
-
-		afterAll(() => {
-			fs.rmSync(dispatchDir, { recursive: true, force: true })
-			if (sourceSaveDir && fs.existsSync(sourceSaveDir)) {
-				fs.rmSync(sourceSaveDir, { recursive: true, force: true })
-			}
-		})
-
-		it('Step 2 (dispatch) — get-changed-content-files diffs against the provided merge-base SHA', () => {
-			const result = spawnSync(
-				'node',
-				[
-					GET_CHANGED,
-					'--merge-base',
-					baseSha,
-					'--include-partials',
-					'false',
-					'--output',
-					changesFilePath,
-				],
-				{ cwd: dispatchDir, encoding: 'utf-8' },
-			)
-
-			expect(result.status, result.stderr).toBe(0)
-
-			const changes = JSON.parse(fs.readFileSync(changesFilePath, 'utf-8'))
-			expect(changes.added).toContain(
-				'content/terraform/v1.14.x/docs/new-dispatch.mdx',
-			)
-			expect(changes.modified).toContain(
-				'content/terraform/v1.14.x/docs/stable.mdx',
-			)
-		})
-
-		it('Step 3 (dispatch) — apply uses SOURCE_VERSION from inputs and --source-dir for file reads', () => {
-			// Simulate "Save source files" before checkout switch
-			sourceSaveDir = fs.mkdtempSync(
-				path.join(os.tmpdir(), 'fp-dispatch-source-'),
-			)
-			const changes = JSON.parse(fs.readFileSync(changesFilePath, 'utf-8'))
-			for (const srcPath of [...changes.added, ...changes.modified]) {
-				const src = path.join(dispatchDir, srcPath)
-				const dest = path.join(sourceSaveDir, srcPath)
-				fs.mkdirSync(path.dirname(dest), { recursive: true })
-				if (fs.existsSync(src)) {
-					fs.copyFileSync(src, dest)
-				}
-			}
-
-			// Simulate "Check out target branch" — source version directory is gone
-			fs.rmSync(path.join(dispatchDir, 'content/terraform/v1.14.x'), {
-				recursive: true,
-				force: true,
-			})
 
 			// SOURCE_VERSION_FOLDER and TARGET_VERSION_FOLDER come from workflow_dispatch inputs
-			// (written to GITHUB_ENV via jq or labelSlug config lookup) — simulated here as
-			// hardcoded strings, not read from GITHUB_ENV.
-			const result = spawnSync(
-				'node',
-				[
-					APPLY_CHANGES,
-					'--changes-file',
-					changesFilePath,
-					'--target-product',
-					'terraform',
-					'--source-version',
-					'v1.14.x',
-					'--target-version',
-					'v1.15.x',
-					'--source-dir',
-					sourceSaveDir,
-				],
-				{ cwd: dispatchDir, encoding: 'utf-8' },
-			)
+		// (written to GITHUB_ENV via jq or labelSlug config lookup) — simulated here as
+		// hardcoded strings, not read from GITHUB_ENV.
+		const result = spawnSync(
+			'node',
+			[
+				APPLY_CHANGES,
+				'--changes-file',
+				changesFilePath,
+				'--target-product',
+				'terraform',
+				'--source-version',
+				'v1.14.x',
+				'--target-version',
+				'v1.15.x',
+				'--source-dir',
+				sourceSaveDir,
+			],
+			{ cwd: dispatchDir, encoding: 'utf-8' },
+		)
 
-			expect(result.status, result.stderr).toBe(0)
+		expect(result.status, result.stderr).toBe(0)
 
-			const tgt = path.join(dispatchDir, 'content/terraform/v1.15.x/docs')
-			expect(fs.readFileSync(path.join(tgt, 'stable.mdx'), 'utf-8')).toBe(
-				'# Stable (updated by PR)',
-			)
-			expect(fs.existsSync(path.join(tgt, 'new-dispatch.mdx'))).toBe(true)
-			expect(fs.readFileSync(path.join(tgt, 'new-dispatch.mdx'), 'utf-8')).toBe(
-				'# New via dispatch',
-			)
-		})
-	},
-)
+		const tgt = path.join(dispatchDir, 'content/terraform/v1.15.x/docs')
+		expect(fs.readFileSync(path.join(tgt, 'stable.mdx'), 'utf-8')).toBe(
+			'# Stable (updated by PR)',
+		)
+		expect(fs.existsSync(path.join(tgt, 'new-dispatch.mdx'))).toBe(true)
+		expect(fs.readFileSync(path.join(tgt, 'new-dispatch.mdx'), 'utf-8')).toBe(
+			'# New via dispatch',
+		)
+	})
+})

--- a/scripts/forward-port/forward-port.e2e.integration.ts
+++ b/scripts/forward-port/forward-port.e2e.integration.ts
@@ -31,7 +31,9 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
 const RESOLVE_TARGET = path.resolve('scripts/forward-port/resolve-target.mjs')
 const GET_CHANGED = path.resolve('scripts/utils/get-changed-content-files.mjs')
-const APPLY_CHANGES = path.resolve('scripts/forward-port/apply-forward-port-changes.mjs')
+const APPLY_CHANGES = path.resolve(
+	'scripts/forward-port/apply-forward-port-changes.mjs',
+)
 
 const FORWARD_PORT_CONFIG = `
 tf-forward-porting-testing:
@@ -40,7 +42,7 @@ tf-forward-porting-testing:
   targetBranch: rn-forward-porting-test-rc
   targetVersionFolder: v1.15.x
 
-vault-next:
+vault-test:
   sourceVersionFolder: v1.19.x
   targetProduct: vault
   targetBranch: rn-test-vault
@@ -63,182 +65,213 @@ function commitAll(dir: string, message: string): string {
 // Happy path — three sequential steps that chain state from step to step
 // ---------------------------------------------------------------------------
 
-describe.sequential('Forward-port pipeline — happy path (add + modify + remove)', () => {
-	let tmpDir: string
-	let configPath: string
-	let githubEnvPath: string
-	let changesFilePath: string
+describe.sequential(
+	'Forward-port pipeline — happy path (add + modify + remove)',
+	() => {
+		let tmpDir: string
+		let configPath: string
+		let githubEnvPath: string
+		let changesFilePath: string
 
-	// baseSha is set in beforeAll. This is the SHA that
-	// github.event.pull_request.base.sha provides — the state of the repo
-	// BEFORE the PR's commits landed.
-	let baseSha: string
+		// baseSha is set in beforeAll. This is the SHA that
+		// github.event.pull_request.base.sha provides — the state of the repo
+		// BEFORE the PR's commits landed.
+		let baseSha: string
 
-	beforeAll(() => {
-		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fp-e2e-happy-'))
-		configPath = path.join(tmpDir, 'forward-port-config.yml')
-		githubEnvPath = path.join(tmpDir, 'github_env')
-		changesFilePath = path.join(tmpDir, 'changedContentFiles.json')
+		beforeAll(() => {
+			tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fp-e2e-happy-'))
+			configPath = path.join(tmpDir, 'forward-port-config.yml')
+			githubEnvPath = path.join(tmpDir, 'github_env')
+			changesFilePath = path.join(tmpDir, 'changedContentFiles.json')
 
-		fs.writeFileSync(configPath, FORWARD_PORT_CONFIG)
-		fs.writeFileSync(githubEnvPath, '')
+			fs.writeFileSync(configPath, FORWARD_PORT_CONFIG)
+			fs.writeFileSync(githubEnvPath, '')
 
-		initRepo(tmpDir)
+			initRepo(tmpDir)
 
-		// ------------------------------------------------------------------
-		// Base state — what existed before the PR
-		// source: content/terraform/v1.14.x   target: content/terraform/v1.15.x
-		// ------------------------------------------------------------------
-		const src = path.join(tmpDir, 'content/terraform/v1.14.x/docs')
-		const tgt = path.join(tmpDir, 'content/terraform/v1.15.x/docs')
-		fs.mkdirSync(src, { recursive: true })
-		fs.mkdirSync(tgt, { recursive: true })
+			// ------------------------------------------------------------------
+			// Base state — what existed before the PR
+			// source: content/terraform/v1.14.x   target: content/terraform/v1.15.x
+			// ------------------------------------------------------------------
+			const src = path.join(tmpDir, 'content/terraform/v1.14.x/docs')
+			const tgt = path.join(tmpDir, 'content/terraform/v1.15.x/docs')
+			fs.mkdirSync(src, { recursive: true })
+			fs.mkdirSync(tgt, { recursive: true })
 
-		// A file that the PR will modify
-		fs.writeFileSync(path.join(src, 'existing.mdx'), '# Existing (original)')
-		fs.writeFileSync(path.join(tgt, 'existing.mdx'), '# Existing (original)')
+			// A file that the PR will modify
+			fs.writeFileSync(path.join(src, 'existing.mdx'), '# Existing (original)')
+			fs.writeFileSync(path.join(tgt, 'existing.mdx'), '# Existing (original)')
 
-		// A file that the PR will delete
-		fs.writeFileSync(path.join(src, 'to-be-removed.mdx'), '# Will be deleted')
-		fs.writeFileSync(path.join(tgt, 'to-be-removed.mdx'), '# Will be deleted')
+			// A file that the PR will delete
+			fs.writeFileSync(path.join(src, 'to-be-removed.mdx'), '# Will be deleted')
+			fs.writeFileSync(path.join(tgt, 'to-be-removed.mdx'), '# Will be deleted')
 
-		// Commit — this SHA is what github.event.pull_request.base.sha provides
-		baseSha = commitAll(tmpDir, 'Base state before PR changes')
+			// Commit — this SHA is what github.event.pull_request.base.sha provides
+			baseSha = commitAll(tmpDir, 'Base state before PR changes')
 
-		// ------------------------------------------------------------------
-		// PR changes land (simulating the merge commit arriving on origin/main)
-		// ------------------------------------------------------------------
-		// 1. New file added
-		fs.writeFileSync(path.join(src, 'new-feature.mdx'), '# New Feature')
-		// 2. Existing file modified
-		fs.writeFileSync(path.join(src, 'existing.mdx'), '# Existing (updated by PR)')
-		// 3. File removed
-		fs.rmSync(path.join(src, 'to-be-removed.mdx'))
+			// ------------------------------------------------------------------
+			// PR changes land (simulating the merge commit arriving on origin/main)
+			// ------------------------------------------------------------------
+			// 1. New file added
+			fs.writeFileSync(path.join(src, 'new-feature.mdx'), '# New Feature')
+			// 2. Existing file modified
+			fs.writeFileSync(
+				path.join(src, 'existing.mdx'),
+				'# Existing (updated by PR)',
+			)
+			// 3. File removed
+			fs.rmSync(path.join(src, 'to-be-removed.mdx'))
 
-		commitAll(tmpDir, 'PR: add new-feature, update existing, remove to-be-removed')
-	})
+			commitAll(
+				tmpDir,
+				'PR: add new-feature, update existing, remove to-be-removed',
+			)
+		})
 
-	afterAll(() => {
-		fs.rmSync(tmpDir, { recursive: true, force: true })
-	})
+		afterAll(() => {
+			fs.rmSync(tmpDir, { recursive: true, force: true })
+		})
 
-	it('Step 1 — resolve-target: resolves TARGET_BRANCH, TARGET_VERSION_FOLDER, SOURCE_VERSION_FOLDER, and TARGET_PRODUCT from PR labels', () => {
-		const labels = JSON.stringify(['forward-port:tf-forward-porting-testing'])
-
-		const result = spawnSync(
-			'node',
-			[RESOLVE_TARGET, '--config', configPath, '--labels', labels],
-			{ encoding: 'utf-8' },
-		)
-
-		expect(result.status, result.stderr).toBe(0)
-
-		// Script now outputs JSON to stdout
-		const routing = JSON.parse(result.stdout.trim()) as Record<string, string>
-		expect(routing.TARGET_BRANCH).toBe('rn-forward-porting-test-rc')
-		expect(routing.TARGET_VERSION_FOLDER).toBe('v1.15.x')
-		expect(routing.SOURCE_VERSION_FOLDER).toBe('v1.14.x')
-		expect(routing.TARGET_PRODUCT).toBe('terraform')
-
-		// Simulate what the workflow shell does: write KEY=VALUE lines to
-		// githubEnvPath so Step 3 can read them (mirrors jq parsing in the workflow).
-		fs.writeFileSync(
-			githubEnvPath,
-			Object.entries(routing).map(([k, v]) => `${k}=${v}`).join('\n') + '\n',
-			'utf-8',
-		)
-	})
-
-	it('Step 2 — get-changed-content-files: diffs against pre-merge base SHA, excludes partial fan-out', () => {
-		const result = spawnSync(
-			'node',
-			[
-				GET_CHANGED,
-				'--merge-base',
-				baseSha,
-				'--include-partials',
-				'false',
-				'--output',
-				changesFilePath,
-			],
-			{ cwd: tmpDir, encoding: 'utf-8' },
-		)
-
-		expect(result.status, result.stderr).toBe(0)
-
-		const changes = JSON.parse(fs.readFileSync(changesFilePath, 'utf-8'))
-
-		expect(changes.added).toContain('content/terraform/v1.14.x/docs/new-feature.mdx')
-		expect(changes.modified).toContain('content/terraform/v1.14.x/docs/existing.mdx')
-		expect(changes.removed).toContain('content/terraform/v1.14.x/docs/to-be-removed.mdx')
-
-		// Partial fan-out is disabled — only the 3 directly changed files
-		expect(changes.added.length + changes.modified.length + changes.removed.length).toBe(3)
-	})
-
-	it('Step 3 — apply-forward-port-changes: ports files into target version using --source-dir (simulating post-checkout state)', () => {
-		// Read TARGET_VERSION and SOURCE_VERSION from the GITHUB_ENV file step 1 wrote
-		// after parsing resolve-target's JSON output.
-		// In the real workflow these become shell env vars for subsequent steps.
-		const envContent = fs.readFileSync(githubEnvPath, 'utf-8')
-		const targetVersion = envContent.match(/TARGET_VERSION_FOLDER=(.+)/)?.[1].trim()
-		const sourceVersion = envContent.match(/SOURCE_VERSION_FOLDER=(.+)/)?.[1].trim()
-		const targetProduct = envContent.match(/TARGET_PRODUCT=(.+)/)?.[1].trim()
-		expect(targetVersion).toBe('v1.15.x')
-		expect(sourceVersion).toBe('v1.14.x')
-		expect(targetProduct).toBe('terraform')
-
-		// Simulate the "Save source files" step: copy changed source files to a
-		// temp dir before the working directory is replaced by the target checkout.
-		const sourceSaveDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fp-e2e-source-'))
-		try {
-			const changes = JSON.parse(fs.readFileSync(changesFilePath, 'utf-8'))
-			for (const srcPath of [...changes.added, ...changes.modified]) {
-				const src = path.join(tmpDir, srcPath)
-				const dest = path.join(sourceSaveDir, srcPath)
-				fs.mkdirSync(path.dirname(dest), { recursive: true })
-				if (fs.existsSync(src)) {fs.copyFileSync(src, dest)}
-			}
-
-			// Simulate "Check out target branch": delete the source version directory
-			// so the script cannot read source files from the working tree.
-			fs.rmSync(path.join(tmpDir, `content/terraform/${sourceVersion!}`), {
-				recursive: true,
-				force: true,
-			})
+		it('Step 1 — resolve-target: resolves TARGET_BRANCH, TARGET_VERSION_FOLDER, SOURCE_VERSION_FOLDER, and TARGET_PRODUCT from PR labels', () => {
+			const labels = JSON.stringify(['forward-port:tf-forward-porting-testing'])
 
 			const result = spawnSync(
 				'node',
+				[RESOLVE_TARGET, '--config', configPath, '--labels', labels],
+				{ encoding: 'utf-8' },
+			)
+
+			expect(result.status, result.stderr).toBe(0)
+
+			// Script now outputs JSON to stdout
+			const routing = JSON.parse(result.stdout.trim()) as Record<string, string>
+			expect(routing.TARGET_BRANCH).toBe('rn-forward-porting-test-rc')
+			expect(routing.TARGET_VERSION_FOLDER).toBe('v1.15.x')
+			expect(routing.SOURCE_VERSION_FOLDER).toBe('v1.14.x')
+			expect(routing.TARGET_PRODUCT).toBe('terraform')
+
+			// Simulate what the workflow shell does: write KEY=VALUE lines to
+			// githubEnvPath so Step 3 can read them (mirrors jq parsing in the workflow).
+			fs.writeFileSync(
+				githubEnvPath,
+				Object.entries(routing)
+					.map(([k, v]) => {
+						return `${k}=${v}`
+					})
+					.join('\n') + '\n',
+				'utf-8',
+			)
+		})
+
+		it('Step 2 — get-changed-content-files: diffs against pre-merge base SHA, excludes partial fan-out', () => {
+			const result = spawnSync(
+				'node',
 				[
-					APPLY_CHANGES,
-					'--changes-file',
+					GET_CHANGED,
+					'--merge-base',
+					baseSha,
+					'--include-partials',
+					'false',
+					'--output',
 					changesFilePath,
-					'--target-product',
-					targetProduct!,
-					'--source-version',
-					sourceVersion!,
-					'--target-version',
-					targetVersion!,
-					'--source-dir',
-					sourceSaveDir,
 				],
 				{ cwd: tmpDir, encoding: 'utf-8' },
 			)
 
 			expect(result.status, result.stderr).toBe(0)
 
-			const tgt = path.join(tmpDir, 'content/terraform/v1.15.x/docs')
-			expect(fs.existsSync(path.join(tgt, 'new-feature.mdx'))).toBe(true)
-			expect(fs.readFileSync(path.join(tgt, 'new-feature.mdx'), 'utf-8')).toBe('# New Feature')
-			expect(fs.readFileSync(path.join(tgt, 'existing.mdx'), 'utf-8')).toBe(
-				'# Existing (updated by PR)',
+			const changes = JSON.parse(fs.readFileSync(changesFilePath, 'utf-8'))
+
+			expect(changes.added).toContain(
+				'content/terraform/v1.14.x/docs/new-feature.mdx',
 			)
-			expect(fs.existsSync(path.join(tgt, 'to-be-removed.mdx'))).toBe(false)
-		} finally {
-			fs.rmSync(sourceSaveDir, { recursive: true, force: true })
-		}
-	})
-})
+			expect(changes.modified).toContain(
+				'content/terraform/v1.14.x/docs/existing.mdx',
+			)
+			expect(changes.removed).toContain(
+				'content/terraform/v1.14.x/docs/to-be-removed.mdx',
+			)
+
+			// Partial fan-out is disabled — only the 3 directly changed files
+			expect(
+				changes.added.length + changes.modified.length + changes.removed.length,
+			).toBe(3)
+		})
+
+		it('Step 3 — apply-forward-port-changes: ports files into target version using --source-dir (simulating post-checkout state)', () => {
+			// Read TARGET_VERSION and SOURCE_VERSION from the GITHUB_ENV file step 1 wrote
+			// after parsing resolve-target's JSON output.
+			// In the real workflow these become shell env vars for subsequent steps.
+			const envContent = fs.readFileSync(githubEnvPath, 'utf-8')
+			const targetVersion = envContent
+				.match(/TARGET_VERSION_FOLDER=(.+)/)?.[1]
+				.trim()
+			const sourceVersion = envContent
+				.match(/SOURCE_VERSION_FOLDER=(.+)/)?.[1]
+				.trim()
+			const targetProduct = envContent.match(/TARGET_PRODUCT=(.+)/)?.[1].trim()
+			expect(targetVersion).toBe('v1.15.x')
+			expect(sourceVersion).toBe('v1.14.x')
+			expect(targetProduct).toBe('terraform')
+
+			// Simulate the "Save source files" step: copy changed source files to a
+			// temp dir before the working directory is replaced by the target checkout.
+			const sourceSaveDir = fs.mkdtempSync(
+				path.join(os.tmpdir(), 'fp-e2e-source-'),
+			)
+			try {
+				const changes = JSON.parse(fs.readFileSync(changesFilePath, 'utf-8'))
+				for (const srcPath of [...changes.added, ...changes.modified]) {
+					const src = path.join(tmpDir, srcPath)
+					const dest = path.join(sourceSaveDir, srcPath)
+					fs.mkdirSync(path.dirname(dest), { recursive: true })
+					if (fs.existsSync(src)) {
+						fs.copyFileSync(src, dest)
+					}
+				}
+
+				// Simulate "Check out target branch": delete the source version directory
+				// so the script cannot read source files from the working tree.
+				fs.rmSync(path.join(tmpDir, `content/terraform/${sourceVersion!}`), {
+					recursive: true,
+					force: true,
+				})
+
+				const result = spawnSync(
+					'node',
+					[
+						APPLY_CHANGES,
+						'--changes-file',
+						changesFilePath,
+						'--target-product',
+						targetProduct!,
+						'--source-version',
+						sourceVersion!,
+						'--target-version',
+						targetVersion!,
+						'--source-dir',
+						sourceSaveDir,
+					],
+					{ cwd: tmpDir, encoding: 'utf-8' },
+				)
+
+				expect(result.status, result.stderr).toBe(0)
+
+				const tgt = path.join(tmpDir, 'content/terraform/v1.15.x/docs')
+				expect(fs.existsSync(path.join(tgt, 'new-feature.mdx'))).toBe(true)
+				expect(
+					fs.readFileSync(path.join(tgt, 'new-feature.mdx'), 'utf-8'),
+				).toBe('# New Feature')
+				expect(fs.readFileSync(path.join(tgt, 'existing.mdx'), 'utf-8')).toBe(
+					'# Existing (updated by PR)',
+				)
+				expect(fs.existsSync(path.join(tgt, 'to-be-removed.mdx'))).toBe(false)
+			} finally {
+				fs.rmSync(sourceSaveDir, { recursive: true, force: true })
+			}
+		})
+	},
+)
 
 // ---------------------------------------------------------------------------
 // Failure cases — each is self-contained with its own repo setup
@@ -286,7 +319,10 @@ describe('Forward-port pipeline — failure cases', () => {
 			// Commit and immediately use HEAD as baseSha — no subsequent changes
 			const headSha = commitAll(emptyRepoDir, 'Unchanged state')
 
-			const emptyChangesFile = path.join(emptyRepoDir, 'changedContentFiles.json')
+			const emptyChangesFile = path.join(
+				emptyRepoDir,
+				'changedContentFiles.json',
+			)
 
 			const getResult = spawnSync(
 				'node',
@@ -336,111 +372,122 @@ describe('Forward-port pipeline — failure cases', () => {
 // These tests verify that the diff + apply steps work correctly in that mode.
 // ---------------------------------------------------------------------------
 
-describe.sequential('Forward-port pipeline — workflow_dispatch (SOURCE_VERSION from inputs, no resolve-target)', () => {
-	let dispatchDir: string
-	let changesFilePath: string
-	let sourceSaveDir: string
-	let baseSha: string
+describe.sequential(
+	'Forward-port pipeline — workflow_dispatch (SOURCE_VERSION from inputs, no resolve-target)',
+	() => {
+		let dispatchDir: string
+		let changesFilePath: string
+		let sourceSaveDir: string
+		let baseSha: string
 
-	beforeAll(() => {
-		dispatchDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fp-e2e-dispatch-'))
-		changesFilePath = path.join(dispatchDir, 'changedContentFiles.json')
+		beforeAll(() => {
+			dispatchDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fp-e2e-dispatch-'))
+			changesFilePath = path.join(dispatchDir, 'changedContentFiles.json')
 
-		initRepo(dispatchDir)
+			initRepo(dispatchDir)
 
-		const src = path.join(dispatchDir, 'content/terraform/v1.14.x/docs')
-		const tgt = path.join(dispatchDir, 'content/terraform/v1.15.x/docs')
-		fs.mkdirSync(src, { recursive: true })
-		fs.mkdirSync(tgt, { recursive: true })
+			const src = path.join(dispatchDir, 'content/terraform/v1.14.x/docs')
+			const tgt = path.join(dispatchDir, 'content/terraform/v1.15.x/docs')
+			fs.mkdirSync(src, { recursive: true })
+			fs.mkdirSync(tgt, { recursive: true })
 
-		fs.writeFileSync(path.join(src, 'stable.mdx'), '# Stable (original)')
-		fs.writeFileSync(path.join(tgt, 'stable.mdx'), '# Stable (original)')
+			fs.writeFileSync(path.join(src, 'stable.mdx'), '# Stable (original)')
+			fs.writeFileSync(path.join(tgt, 'stable.mdx'), '# Stable (original)')
 
-		baseSha = commitAll(dispatchDir, 'Base state before PR')
+			baseSha = commitAll(dispatchDir, 'Base state before PR')
 
-		// PR changes
-		fs.writeFileSync(path.join(src, 'stable.mdx'), '# Stable (updated by PR)')
-		fs.writeFileSync(path.join(src, 'new-dispatch.mdx'), '# New via dispatch')
+			// PR changes
+			fs.writeFileSync(path.join(src, 'stable.mdx'), '# Stable (updated by PR)')
+			fs.writeFileSync(path.join(src, 'new-dispatch.mdx'), '# New via dispatch')
 
-		commitAll(dispatchDir, 'PR changes for dispatch test')
-	})
-
-	afterAll(() => {
-		fs.rmSync(dispatchDir, { recursive: true, force: true })
-		if (sourceSaveDir && fs.existsSync(sourceSaveDir)) {
-			fs.rmSync(sourceSaveDir, { recursive: true, force: true })
-		}
-	})
-
-	it('Step 2 (dispatch) — get-changed-content-files diffs against the provided merge-base SHA', () => {
-		const result = spawnSync(
-			'node',
-			[
-				GET_CHANGED,
-				'--merge-base',
-				baseSha,
-				'--include-partials',
-				'false',
-				'--output',
-				changesFilePath,
-			],
-			{ cwd: dispatchDir, encoding: 'utf-8' },
-		)
-
-		expect(result.status, result.stderr).toBe(0)
-
-		const changes = JSON.parse(fs.readFileSync(changesFilePath, 'utf-8'))
-		expect(changes.added).toContain('content/terraform/v1.14.x/docs/new-dispatch.mdx')
-		expect(changes.modified).toContain('content/terraform/v1.14.x/docs/stable.mdx')
-	})
-
-	it('Step 3 (dispatch) — apply uses SOURCE_VERSION from inputs and --source-dir for file reads', () => {
-		// Simulate "Save source files" before checkout switch
-		sourceSaveDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fp-dispatch-source-'))
-		const changes = JSON.parse(fs.readFileSync(changesFilePath, 'utf-8'))
-		for (const srcPath of [...changes.added, ...changes.modified]) {
-			const src = path.join(dispatchDir, srcPath)
-			const dest = path.join(sourceSaveDir, srcPath)
-			fs.mkdirSync(path.dirname(dest), { recursive: true })
-			if (fs.existsSync(src)) {fs.copyFileSync(src, dest)}
-		}
-
-		// Simulate "Check out target branch" — source version directory is gone
-		fs.rmSync(path.join(dispatchDir, 'content/terraform/v1.14.x'), {
-			recursive: true,
-			force: true,
+			commitAll(dispatchDir, 'PR changes for dispatch test')
 		})
 
+		afterAll(() => {
+			fs.rmSync(dispatchDir, { recursive: true, force: true })
+			if (sourceSaveDir && fs.existsSync(sourceSaveDir)) {
+				fs.rmSync(sourceSaveDir, { recursive: true, force: true })
+			}
+		})
+
+		it('Step 2 (dispatch) — get-changed-content-files diffs against the provided merge-base SHA', () => {
+			const result = spawnSync(
+				'node',
+				[
+					GET_CHANGED,
+					'--merge-base',
+					baseSha,
+					'--include-partials',
+					'false',
+					'--output',
+					changesFilePath,
+				],
+				{ cwd: dispatchDir, encoding: 'utf-8' },
+			)
+
+			expect(result.status, result.stderr).toBe(0)
+
+			const changes = JSON.parse(fs.readFileSync(changesFilePath, 'utf-8'))
+			expect(changes.added).toContain(
+				'content/terraform/v1.14.x/docs/new-dispatch.mdx',
+			)
+			expect(changes.modified).toContain(
+				'content/terraform/v1.14.x/docs/stable.mdx',
+			)
+		})
+
+		it('Step 3 (dispatch) — apply uses SOURCE_VERSION from inputs and --source-dir for file reads', () => {
+			// Simulate "Save source files" before checkout switch
+			sourceSaveDir = fs.mkdtempSync(
+				path.join(os.tmpdir(), 'fp-dispatch-source-'),
+			)
+			const changes = JSON.parse(fs.readFileSync(changesFilePath, 'utf-8'))
+			for (const srcPath of [...changes.added, ...changes.modified]) {
+				const src = path.join(dispatchDir, srcPath)
+				const dest = path.join(sourceSaveDir, srcPath)
+				fs.mkdirSync(path.dirname(dest), { recursive: true })
+				if (fs.existsSync(src)) {
+					fs.copyFileSync(src, dest)
+				}
+			}
+
+			// Simulate "Check out target branch" — source version directory is gone
+			fs.rmSync(path.join(dispatchDir, 'content/terraform/v1.14.x'), {
+				recursive: true,
+				force: true,
+			})
+
 			// SOURCE_VERSION_FOLDER and TARGET_VERSION_FOLDER come from workflow_dispatch inputs
-		// (written to GITHUB_ENV via jq or labelSlug config lookup) — simulated here as
-		// hardcoded strings, not read from GITHUB_ENV.
-		const result = spawnSync(
-			'node',
-			[
-				APPLY_CHANGES,
-				'--changes-file',
-				changesFilePath,
-				'--target-product',
-				'terraform',
-				'--source-version',
-				'v1.14.x',
-				'--target-version',
-				'v1.15.x',
-				'--source-dir',
-				sourceSaveDir,
-			],
-			{ cwd: dispatchDir, encoding: 'utf-8' },
-		)
+			// (written to GITHUB_ENV via jq or labelSlug config lookup) — simulated here as
+			// hardcoded strings, not read from GITHUB_ENV.
+			const result = spawnSync(
+				'node',
+				[
+					APPLY_CHANGES,
+					'--changes-file',
+					changesFilePath,
+					'--target-product',
+					'terraform',
+					'--source-version',
+					'v1.14.x',
+					'--target-version',
+					'v1.15.x',
+					'--source-dir',
+					sourceSaveDir,
+				],
+				{ cwd: dispatchDir, encoding: 'utf-8' },
+			)
 
-		expect(result.status, result.stderr).toBe(0)
+			expect(result.status, result.stderr).toBe(0)
 
-		const tgt = path.join(dispatchDir, 'content/terraform/v1.15.x/docs')
-		expect(fs.readFileSync(path.join(tgt, 'stable.mdx'), 'utf-8')).toBe(
-			'# Stable (updated by PR)',
-		)
-		expect(fs.existsSync(path.join(tgt, 'new-dispatch.mdx'))).toBe(true)
-		expect(fs.readFileSync(path.join(tgt, 'new-dispatch.mdx'), 'utf-8')).toBe(
-			'# New via dispatch',
-		)
-	})
-})
+			const tgt = path.join(dispatchDir, 'content/terraform/v1.15.x/docs')
+			expect(fs.readFileSync(path.join(tgt, 'stable.mdx'), 'utf-8')).toBe(
+				'# Stable (updated by PR)',
+			)
+			expect(fs.existsSync(path.join(tgt, 'new-dispatch.mdx'))).toBe(true)
+			expect(fs.readFileSync(path.join(tgt, 'new-dispatch.mdx'), 'utf-8')).toBe(
+				'# New via dispatch',
+			)
+		})
+	},
+)

--- a/scripts/forward-port/forward-port.e2e.integration.ts
+++ b/scripts/forward-port/forward-port.e2e.integration.ts
@@ -144,7 +144,11 @@ describe.sequential('Forward-port pipeline — happy path (add + modify + remove
 		// githubEnvPath so Step 3 can read them (mirrors jq parsing in the workflow).
 		fs.writeFileSync(
 			githubEnvPath,
-			Object.entries(routing).map(([k, v]) => {return `${k}=${v}`}).join('\n') + '\n',
+			Object.entries(routing)
+				.map(([k, v]: [string, string]): string => {
+					return `${k}=${v}`
+				})
+				.join('\n') + '\n',
 			'utf-8',
 		)
 	})


### PR DESCRIPTION
Adding necessary bug fixes for the manual forward port dispatch. Was incorrectly using `mergeCommitSha` instead of `mergeCommit`. Also changed the language of some test names that were used before to sound more like tests.