### PR TITLE
Nomad Docs : Add API for Reload

### DIFF
--- a/content/nomad/v2.0.x/content/api-docs/agent.mdx
+++ b/content/nomad/v2.0.x/content/api-docs/agent.mdx
@@ -475,7 +475,7 @@ $ curl \
 ## Reload Agent
 
 This allows a Nomad operator to trigger a reload of the agent's configuration with the API. 
-See the [configuration documentation](/nomad/docs/configuration#configuration-reload) 
+Refer to the [configuration documentation](/nomad/docs/configuration#configuration-reload) 
 for more details on what configuration changes are applied on reload. 
 
 | Method | Path                       | Produces           |

--- a/content/nomad/v2.0.x/content/api-docs/agent.mdx
+++ b/content/nomad/v2.0.x/content/api-docs/agent.mdx
@@ -472,6 +472,33 @@ $ curl \
     https://localhost:4646/v1/agent/force-leave?node=client-ab2e23dc&prune=true
 ```
 
+## Reload Agent
+
+This allows a Nomad operator to trigger a reload of the agent's configuration with the API. 
+See the [configuration documentation](/nomad/docs/configuration#configuration-reload) 
+for more details on what configuration changes are applied on reload. 
+
+| Method | Path                       | Produces           |
+| ------ | -------------------------- | ------------------ |
+| `PUT`  |     `/v1/agent/reload`     | `application/json` |
+
+
+The table below shows this endpoint's support for
+[blocking queries](/nomad/api-docs#blocking-queries) and
+[required ACLs](/nomad/api-docs#acls).
+
+| Blocking Queries | ACL Required  |
+| ---------------- | ------------- |
+| `NO`             | `agent:write` |
+
+### Sample Request
+
+```shell-session
+$ curl \
+    --request PUT \
+    https://localhost:4646/v1/agent/reload
+```
+
 ## Health
 
 This endpoint returns whether or not the agent is healthy. When using Consul it


### PR DESCRIPTION
## Description

Updated API documentation for API endpoint to trigger agent reloads. 

*Reopening, previous did not branch off nomad/2.0.3 

## Links

Nomad Code PR:
-- https://github.com/hashicorp/nomad/pull/27106

GitHub Issue:
-- https://github.com/hashicorp/nomad/issues/24048

## Contributor checklists

Review urgency:

- [x] 1 week: Default expectation

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [x] Verify that all status checks passed
- [x] Verify that the preview environment deployed successfully
- [x] Add additional reviewers if they are not part of assigned groups

Content:

- [x] I added redirects for any moved or removed pages
- [x] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [ ] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [ ] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.
