### PR TITLE
Update census metrics tables

### DIFF
--- a/content/nomad/v1.10.x/content/docs/enterprise/license/utilization-reporting.mdx
+++ b/content/nomad/v1.10.x/content/docs/enterprise/license/utilization-reporting.mdx
@@ -164,145 +164,161 @@ that might identify proprietary information.
      https://github.com/hashicorp/hashicorp-census-registry/tree/main/nomad/v2/cmd
 -->
 
-| Key                                       | Description                                               |
-|-------------------------------------------|-----------------------------------------------------------|
-| acl.auth.method.count                     | ACL Auth Methods                                          |
-| acl.auth.method.jwt.count                 | ACL Auth Methods of type JWT                              |
-| acl.auth.method.oidc.count                | ACL Auth Methods of type OIDC                             |
-| acl.policy.count                          | ACL policies                                              |
-| acl.role.count                            | ACL roles                                                 |
-| acl.token.count                           | ACL tokens                                                |
-| alloc.count                               | All allocations                                           |
-| alloc.status.complete.count               | Allocations with client status "complete"                 |
-| alloc.status.failed.count                 | Allocations with client status "failed"                   |
-| alloc.status.lost.count                   | Allocations with client status "lost"                     |
-| alloc.status.pending.count                | Allocations with client status "pending"                  |
-| alloc.status.running.count                | Allocations with client status "running"                  |
-| alloc.status.unknown.count                | Allocations with client status "unknown"                  |
-| alloc.task.count                          | All tasks in allocations                                  |
-| alloc.task.running.count                  | Running tasks in allocations                              |
-| client.count                              | Client nodes in the cluster                               |
-| client.driver.docker.count                | Clients with the "docker" driver                          |
-| client.driver.exec.count                  | Clients with the "exec" driver                            |
-| client.driver.exec2.count                 | Clients with the "exec2" driver                           |
-| client.driver.java.count                  | Clients with the "java" driver                            |
-| client.driver.nomad-driver-virt.count     | Clients with the "nomad-driver-virt" driver               |
-| client.driver.other.count                 | Clients with some other driver                            |
-| client.driver.pledge.count                | Clients with the "pledge" driver                          |
-| client.driver.podman.count                | Clients with the "podman" driver                          |
-| client.driver.qemu.count                  | Clients with the "qemu" driver                            |
-| client.driver.raw_exec.count              | Clients with the "raw_exec" driver                        |
-| client.plugin.cni.unique.count            | Unique CNI plugins on client nodes                        |
-| client.plugin.driver.unique.count         | Unique task drivers on client nodes                       |
-| client.plugin.host_volume.unique.count    | Unique host volume plugins on client nodes                |
-| client.plugin.secret.unique.count         | Unique secret plugins on client nodes                     |
-| client.resources.compute                  | Total client compute                                      |
-| client.resources.core.count               | Total client CPU cores                                    |
-| client.resources.memory                   | Total client memory in MB                                 |
-| client.vault.enabled.count                | Clients with Vault enabled                                |
-| job.count                                 | All jobs                                                  |
-| job.driver.docker.count                   | Jobs with the "docker" driver                             |
-| job.driver.exec.count                     | Jobs with the "exec" driver                               |
-| job.driver.exec2.count                    | Jobs with the "exec2" driver                              |
-| job.driver.java.count                     | Jobs with the "java" driver                               |
-| job.driver.nomad-driver-virt.count        | Jobs with the "nomad-driver-virt" driver                  |
-| job.driver.other.count                    | Jobs with some other driver                               |
-| job.driver.pledge.count                   | Jobs with the "pledge" driver                             |
-| job.driver.podman.count                   | Jobs with the "podman" driver                             |
-| job.driver.qemu.count                     | Jobs with the "qemu" driver                               |
-| job.driver.raw_exec.count                 | Jobs with the "raw_exec" driver                           |
-| job.group.count                           | Task groups in jobs                                       |
-| job.network.cni.args.count                | Networks in jobs with custom CNI args                     |
-| job.network.mode.bridge.count             | Networks in jobs with mode "bridge"                       |
-| job.network.mode.cni.count                | Networks in jobs with mode "cni"                          |
-| job.network.mode.host.count               | Networks in jobs with mode "host"                         |
-| job.network.mode.other.count              | Networks in jobs with some other mode                     |
-| job.parameterized.count                   | Parameterized jobs                                        |
-| job.parameterized.dispatched.count        | Dispatched parameterized jobs                             |
-| job.periodic.count                        | Periodic jobs                                             |
-| job.periodic.dispatched.count             | Dispatched periodic jobs                                  |
-| job.service.consul.connect.count          | Connect services in jobs                                  |
-| job.service.consul.count                  | Consul services in jobs                                   |
-| job.service.nomad.count                   | Nomad provider services in jobs                           |
-| job.task.identity.count                   | Tasks in jobs with identity enabled                       |
-| job.task.template.count                   | Tasks in jobs with templates                              |
-| job.task.vault.count                      | Tasks in jobs with Vault enabled                          |
-| job.type.batch.count                      | Jobs of type "batch"                                      |
-| job.type.service.count                    | Jobs of type "service"                                    |
-| job.type.sysbatch.count                   | Jobs of type "sysbatch"                                   |
-| job.type.system.count                     | Jobs of type "system"                                     |
-| job.volume.csi.count                      | CSI volumes in jobs                                       |
-| job.volume.host.count                     | Host volumes in jobs                                      |
-| job.volume.sticky.count                   | Sticky volumes in jobs                                    |
-| namespace.count                           | Namespaces                                                |
-| namespace.quotas.count                    | Quotas                                                    |
-| node.cpu.arch.amd64.count                 | Clients with "amd64" CPU architecture                     |
-| node.cpu.arch.arm64.count                 | Clients with "arm64" CPU architecture                     |
-| node.cpu.arch.other.count                 | Clients with some other CPU architecture                  |
-| node.cpu.arch.s390x.count                 | Clients with "s390x" CPU architecture                     |
-| node.cpu.arch.unique.count                | Unique CPU architectures on client nodes                  |
-| node.kernel.name.aix.count                | Clients with "aix" kernel                                 |
-| node.kernel.name.darwin.count             | Clients with "darwin" kernel                              |
-| node.kernel.name.freebsd.count            | Clients with "freebsd" kernel                             |
-| node.kernel.name.linux.count              | Clients with "linux" kernel                               |
-| node.kernel.name.other.count              | Clients with some other kernel                            |
-| node.kernel.name.plan9.count              | Clients with "plan9" kernel                               |
-| node.kernel.name.solaris.count            | Clients with "solaris" kernel                             |
-| node.kernel.name.unique.count             | Unique kernels on client nodes                            |
-| node.os.name.alpine.count                 | Clients with "alpine" operating system                    |
-| node.os.name.amazon.count                 | Clients with "amazon" operating system                    |
-| node.os.name.arch.count                   | Clients with "arch" operating system                      |
-| node.os.name.centos.count                 | Clients with "centos" operating system                    |
-| node.os.name.cloudlinux.count             | Clients with "cloudlinux" operating system                |
-| node.os.name.coreos.count                 | Clients with "coreos" operating system                    |
-| node.os.name.darwin.count                 | Clients with "darwin" operating system                    |
-| node.os.name.debian.count                 | Clients with "debian" operating system                    |
-| node.os.name.fedora.count                 | Clients with "fedora" operating system                    |
-| node.os.name.gentoo.count                 | Clients with "gentoo" operating system                    |
-| node.os.name.opensuse.count               | Clients with "opensuse" operating system                  |
-| node.os.name.oracle.count                 | Clients with "oracle" operating system                    |
-| node.os.name.other.count                  | Clients with some other operating system                  |
-| node.os.name.raspbian.count               | Clients with "raspbian" operating system                  |
-| node.os.name.redhat.count                 | Clients with "redhat" operating system                    |
-| node.os.name.suse.count                   | Clients with "suse" operating system                      |
-| node.os.name.ubuntu.count                 | Clients with "ubuntu" operating system                    |
-| node.os.name.unique.count                 | Unique operating systems on client nodes                  |
-| node.os.name.windows.count                | Clients with "windows" operating system                   |
-| node.pool.count                           | Node pools                                                |
-| node.status.disconnected.count            | Clients with status "disconnected"                        |
-| node.status.down.count                    | Clients with status "down"                                |
-| node.status.initializing.count            | Clients with status "initializing"                        |
-| node.status.ready.count                   | Clients with status "ready"                               |
-| node.status.unknown.count                 | Clients with status "unknown"                             |
-| nomad.billable.clients                    | Number of client nodes in the cluster                     |
-| nomad.billable.cores.s390x                | Active client s390x CPU cores in the cluster              |
-| nomad.billable.cores.total                | Active client CPU cores in the cluster                    |
-| plugin.csi.unique.count                   | Unique CSI plugins                                        |
-| policy.sentinel.count                     | Sentinel policies                                         |
-| sentinel.enforcement.advisory.count       | Sentinel policies with "advisory" enforcement level       |
-| sentinel.enforcement.hard-mandatory.count | Sentinel policies with "hard-mandatory" enforcement level |
-| sentinel.enforcement.soft-mandatory.count | Sentinel policies with "soft-mandatory" enforcement level |
-| sentinel.scope.submit-csi-volume.count    | Sentinel policies with "submit-csi-volume" scope          |
-| sentinel.scope.submit-host-volume.count   | Sentinel policies with "submit-host-volume" scope         |
-| sentinel.scope.submit-job.count           | Sentinel policies with "submit-job" scope                 |
-| task.driver.docker.count                  | Tasks with the "docker" driver                            |
-| task.driver.exec.count                    | Tasks with the "exec" driver                              |
-| task.driver.exec2.count                   | Tasks with the "exec2" driver                             |
-| task.driver.java.count                    | Tasks with the "java" driver                              |
-| task.driver.nomad-driver-virt.count       | Tasks with the "nomad-driver-virt" driver                 |
-| task.driver.other.count                   | Tasks with some other driver                              |
-| task.driver.pledge.count                  | Tasks with the "pledge" driver                            |
-| task.driver.podman.count                  | Tasks with the "podman" driver                            |
-| task.driver.qemu.count                    | Tasks with the "qemu" driver                              |
-| task.driver.raw_exec.count                | Tasks with the "raw_exec" driver                          |
-| variable.count                            | Nomad Variables                                           |
-| variable.lock.count                       | Nomad Variable Locks                                      |
-| volume.csi.capacity                       | Capacity of all CSI volumes in MB                         |
-| volume.csi.count                          | Number of "csi" volumes                                   |
-| volume.dhv.capacity                       | Capacity of all dynamic host volumes in MB                |
-| volume.dhv.plugin.other.count             | Dynamic host volumes with non-standard plugins            |
-| volume.dynamic.count                      | Number of "dynamic" volumes                               |
-| volume.static.count                       | Number of "static" volumes                                |
+| Key                                       | Description                                             |
+|-------------------------------------------|---------------------------------------------------------|
+| acl.auth.method.count                    | ACL Auth Methods                                         |
+| acl.auth.method.jwt.count                | ACL Auth Methods of type JWT                             |
+| acl.auth.method.oidc.count               | ACL Auth Methods of type OIDC                            |
+| acl.policy.count                         | ACL policies                                             |
+| acl.role.count                           | ACL roles                                                |
+| acl.token.count                          | ACL tokens                                               |
+| alloc.count                              | All allocations                                          |
+| alloc.status.complete.count              | Allocations with client status "complete"                |
+| alloc.status.failed.count                | Allocations with client status "failed"                  |
+| alloc.status.lost.count                  | Allocations with client status "lost"                    |
+| alloc.status.pending.count               | Allocations with client status "pending"                 |
+| alloc.status.running.count               | Allocations with client status "running"                 |
+| alloc.status.unknown.count               | Allocations with client status "unknown"                 |
+| alloc.task.count                         | All tasks in allocations                                 |
+| alloc.task.running.count                 | Running tasks in allocations                             |
+| client.count                             | Client nodes in the cluster                              |
+| client.device.gpu.amd.count              | Clients with the "amd" gpu device driver                 |
+| client.device.gpu.nvidia.count           | Clients with the "nvidia" gpu device driver              |
+| client.device.gpu.other.count            | Clients with a gpu device driver of unknown vendor       |
+| client.device.other.other.count          | Clients with some other device driver                    |
+| client.device.usb.other.count            | Clients with a usb device driver of unknown vendor       |
+| client.driver.docker.count               | Clients with the docker driver                           |
+| client.driver.exec.count                 | Clients with the exec driver                             |
+| client.driver.exec2.count                | Clients with the exec2 driver                            |
+| client.driver.java.count                 | Clients with the java driver                             |
+| client.driver.nomad-driver-virt.count    | Clients with the nomad-driver-virt driver                |
+| client.driver.other.count                | Clients with the other driver                            |
+| client.driver.pledge.count               | Clients with the pledge driver                           |
+| client.driver.podman.count               | Clients with the podman driver                           |
+| client.driver.qemu.count                 | Clients with the qemu driver                             |
+| client.driver.raw_exec.count             | Clients with the raw_exec driver                         |
+| client.plugin.cni.unique.count           | Unique CNI plugins on client nodes                       |
+| client.plugin.driver.unique.count        | Unique task drivers on client nodes                      |
+| client.plugin.host_volume.unique.count   | Unique host volume plugins on client nodes               |
+| client.plugin.secret.unique.count        | Unique secret plugins on client nodes                    |
+| client.resources.compute                 | Total client compute                                     |
+| client.resources.core.count              | Total client CPU cores                                   |
+| client.resources.memory                  | Total client memory in MB                                |
+| client.vault.enabled.count               | Clients with Vault enabled                               |
+| job.count                                | All jobs                                                 |
+| job.device.gpu.amd.count                 | Jobs with the "amd" gpu device driver                    |
+| job.device.gpu.nvidia.count              | Jobs with the "nvidia" gpu device driver                 |
+| job.device.gpu.other.count               | Jobs with a gpu device driver of unknown vendor          |
+| job.device.other.other.count             | Jobs with some other device driver                       |
+| job.device.usb.other.count               | Jobs with a usb device driver of unknown vendor          |
+| job.driver.docker.count                  | Tasks defined with the docker driver                     |
+| job.driver.exec.count                    | Tasks defined with the exec driver                       |
+| job.driver.exec2.count                   | Tasks defined with the exec2 driver                      |
+| job.driver.java.count                    | Tasks defined with the java driver                       |
+| job.driver.nomad-driver-virt.count       | Tasks defined with the nomad-driver-virt driver          |
+| job.driver.other.count                   | Tasks defined with the other driver                      |
+| job.driver.pledge.count                  | Tasks defined with the pledge driver                     |
+| job.driver.podman.count                  | Tasks defined with the podman driver                     |
+| job.driver.qemu.count                    | Tasks defined with the qemu driver                       |
+| job.driver.raw_exec.count                | Tasks defined with the raw_exec driver                   |
+| job.group.count                          | Task groups in jobs                                      |
+| job.network.cni.args.count               | Networks in jobs with custom CNI args                    |
+| job.network.mode.bridge.count            | Networks in jobs with mode "bridge"                      |
+| job.network.mode.cni.count               | Networks in jobs with mode "cni"                         |
+| job.network.mode.host.count              | Networks in jobs with mode "host"                        |
+| job.network.mode.other.count             | Networks in jobs with some other mode                    |
+| job.parameterized.count                  | Parameterized jobs                                       |
+| job.parameterized.dispatched.count       | Dispatched parameterized jobs                            |
+| job.periodic.count                       | Periodic jobs                                            |
+| job.periodic.dispatched.count            | Dispatched periodic jobs                                 |
+| job.service.consul.connect.count         | Connect services in jobs                                 |
+| job.service.consul.count                 | Consul services in jobs                                  |
+| job.service.nomad.count                  | Nomad provider services in jobs                          |
+| job.task.identity.count                  | Tasks in jobs with identity enabled                      |
+| job.task.template.count                  | Tasks in jobs with templates                             |
+| job.task.vault.count                     | Tasks in jobs with Vault enabled                         |
+| job.type.batch.count                     | Jobs of type "batch"                                     |
+| job.type.service.count                   | Jobs of type "service"                                   |
+| job.type.sysbatch.count                  | Jobs of type "sysbatch"                                  |
+| job.type.system.count                    | Jobs of type "system"                                    |
+| job.volume.csi.count                     | CSI volumes in jobs                                      |
+| job.volume.host.count                    | Host volumes in jobs                                     |
+| job.volume.sticky.count                  | Sticky volumes in jobs                                   |
+| namespace.count                          | Namespaces                                               |
+| namespace.quotas.count                   | Quotas                                                   |
+| node.cpu.arch.amd64.count                | Clients with "amd64" CPU architecture                    |
+| node.cpu.arch.arm64.count                | Clients with "arm64" CPU architecture                    |
+| node.cpu.arch.other.count                | Clients with some other CPU architecture                 |
+| node.cpu.arch.s390x.count                | Clients with "s390x" CPU architecture                    |
+| node.cpu.arch.unique.count               | Unique CPU architectures on client nodes                 |
+| node.kernel.name.aix.count               | Clients with "aix" kernel                                |
+| node.kernel.name.darwin.count            | Clients with "darwin" kernel                             |
+| node.kernel.name.freebsd.count           | Clients with "freebsd" kernel                            |
+| node.kernel.name.linux.count             | Clients with "linux" kernel                              |
+| node.kernel.name.other.count             | Clients with some other kernel                           |
+| node.kernel.name.plan9.count             | Clients with "plan9" kernel                              |
+| node.kernel.name.solaris.count           | Clients with "solaris" kernel                            |
+| node.kernel.name.unique.count            | Unique kernels on client nodes                           |
+| node.os.name.alpine.count                | Clients with "alpine" operating system                   |
+| node.os.name.amazon.count                | Clients with "amazon" operating system                   |
+| node.os.name.arch.count                  | Clients with "arch" operating system                     |
+| node.os.name.centos.count                | Clients with "centos" operating system                   |
+| node.os.name.cloudlinux.count            | Clients with "cloudlinux" operating system               |
+| node.os.name.coreos.count                | Clients with "coreos" operating system                   |
+| node.os.name.darwin.count                | Clients with "darwin" operating system                   |
+| node.os.name.debian.count                | Clients with "debian" operating system                   |
+| node.os.name.fedora.count                | Clients with "fedora" operating system                   |
+| node.os.name.gentoo.count                | Clients with "gentoo" operating system                   |
+| node.os.name.opensuse.count              | Clients with "opensuse" operating system                 |
+| node.os.name.oracle.count                | Clients with "oracle" operating system                   |
+| node.os.name.other.count                 | Clients with some other operating system                 |
+| node.os.name.raspbian.count              | Clients with "raspbian" operating system                 |
+| node.os.name.redhat.count                | Clients with "redhat" operating system                   |
+| node.os.name.suse.count                  | Clients with "suse" operating system                     |
+| node.os.name.ubuntu.count                | Clients with "ubuntu" operating system                   |
+| node.os.name.unique.count                | Unique operating systems on client nodes                 |
+| node.os.name.windows.count               | Clients with "windows" operating system                  |
+| node.pool.count                          | Node pools                                               |
+| node.status.disconnected.count           | Clients with status "disconnected"                       |
+| node.status.down.count                   | Clients with status "down"                               |
+| node.status.initializing.count           | Clients with status "initializing"                       |
+| node.status.ready.count                  | Clients with status "ready"                              |
+| node.status.unknown.count                | Clients with status "unknown"                            |
+| nomad.billable.clients                   | Number of client nodes in the cluster                    |
+| nomad.billable.cores.s390x               | Active client s390x CPU cores in the cluster             |
+| nomad.billable.cores.total               | Active client CPU cores in the cluster                   |
+| plugin.csi.unique.count                  | Unique CSI plugins                                       |
+| policy.sentinel.count                    | Sentinel policies                                        |
+| sentinel.enforcement.advisory.count      | Sentinel policies with "advisory" enforcement level      |
+| sentinel.enforcement.hard-mandatory.count| Sentinel policies with "hard-mandatory" enforcement level|
+| sentinel.enforcement.soft-mandatory.count| Sentinel policies with "soft-mandatory" enforcement level|
+| sentinel.scope.submit-csi-volume.count   | Sentinel policies with "submit-csi-volume" scope         |
+| sentinel.scope.submit-host-volume.count  | Sentinel policies with "submit-host-volume" scope        |
+| sentinel.scope.submit-job.count          | Sentinel policies with "submit-job" scope                |
+| task.device.gpu.amd.count                | Tasks with the "amd" gpu device driver                   |
+| task.device.gpu.nvidia.count             | Tasks with the "nvidia" gpu device driver                |
+| task.device.gpu.other.count              | Tasks with a gpu device driver of unknown vendor         |
+| task.device.other.other.count            | Tasks with some other device driver                      |
+| task.device.usb.other.count              | Tasks with a usb device driver of unknown vendor         |
+| task.driver.docker.count                 | Allocated tasks running with the docker driver           |
+| task.driver.exec.count                   | Allocated tasks running with the exec driver             |
+| task.driver.exec2.count                  | Allocated tasks running with the exec2 driver            |
+| task.driver.java.count                   | Allocated tasks running with the java driver             |
+| task.driver.nomad-driver-virt.count      | Allocated tasks running with the nomad-driver-virt driver|
+| task.driver.other.count                  | Allocated tasks running with the other driver            |
+| task.driver.pledge.count                 | Allocated tasks running with the pledge driver           |
+| task.driver.podman.count                 | Allocated tasks running with the podman driver           |
+| task.driver.qemu.count                   | Allocated tasks running with the qemu driver             |
+| task.driver.raw_exec.count               | Allocated tasks running with the raw_exec driver         |
+| variable.count                           | Nomad Variables                                          |
+| variable.lock.count                      | Nomad Variable Locks                                     |
+| volume.csi.capacity                      | Capacity of all CSI volumes in MB                        |
+| volume.csi.count                         | Number of "csi" volumes                                  |
+| volume.dhv.capacity                      | Capacity of all dynamic host volumes in MB               |
+| volume.dhv.plugin.other.count            | Dynamic host volumes with non-standard plugins           |
+| volume.dynamic.count                     | Number of "dynamic" volumes                              |
+| volume.static.count                      | Number of "static" volumes                               |
+
 
 
 ## Example payload

--- a/content/nomad/v1.10.x/content/docs/enterprise/license/utilization-reporting.mdx
+++ b/content/nomad/v1.10.x/content/docs/enterprise/license/utilization-reporting.mdx
@@ -166,158 +166,159 @@ that might identify proprietary information.
 
 | Key                                       | Description                                             |
 |-------------------------------------------|---------------------------------------------------------|
-| acl.auth.method.count                    | ACL Auth Methods                                         |
-| acl.auth.method.jwt.count                | ACL Auth Methods of type JWT                             |
-| acl.auth.method.oidc.count               | ACL Auth Methods of type OIDC                            |
-| acl.policy.count                         | ACL policies                                             |
-| acl.role.count                           | ACL roles                                                |
-| acl.token.count                          | ACL tokens                                               |
-| alloc.count                              | All allocations                                          |
-| alloc.status.complete.count              | Allocations with client status "complete"                |
-| alloc.status.failed.count                | Allocations with client status "failed"                  |
-| alloc.status.lost.count                  | Allocations with client status "lost"                    |
-| alloc.status.pending.count               | Allocations with client status "pending"                 |
-| alloc.status.running.count               | Allocations with client status "running"                 |
-| alloc.status.unknown.count               | Allocations with client status "unknown"                 |
-| alloc.task.count                         | All tasks in allocations                                 |
-| alloc.task.running.count                 | Running tasks in allocations                             |
-| client.count                             | Client nodes in the cluster                              |
-| client.device.gpu.amd.count              | Clients with the "amd" gpu device driver                 |
-| client.device.gpu.nvidia.count           | Clients with the "nvidia" gpu device driver              |
-| client.device.gpu.other.count            | Clients with a gpu device driver of unknown vendor       |
-| client.device.other.other.count          | Clients with some other device driver                    |
-| client.device.usb.other.count            | Clients with a usb device driver of unknown vendor       |
-| client.driver.docker.count               | Clients with the docker driver                           |
-| client.driver.exec.count                 | Clients with the exec driver                             |
-| client.driver.exec2.count                | Clients with the exec2 driver                            |
-| client.driver.java.count                 | Clients with the java driver                             |
-| client.driver.nomad-driver-virt.count    | Clients with the nomad-driver-virt driver                |
-| client.driver.other.count                | Clients with the other driver                            |
-| client.driver.pledge.count               | Clients with the pledge driver                           |
-| client.driver.podman.count               | Clients with the podman driver                           |
-| client.driver.qemu.count                 | Clients with the qemu driver                             |
-| client.driver.raw_exec.count             | Clients with the raw_exec driver                         |
-| client.plugin.cni.unique.count           | Unique CNI plugins on client nodes                       |
-| client.plugin.driver.unique.count        | Unique task drivers on client nodes                      |
-| client.plugin.host_volume.unique.count   | Unique host volume plugins on client nodes               |
-| client.plugin.secret.unique.count        | Unique secret plugins on client nodes                    |
-| client.resources.compute                 | Total client compute                                     |
-| client.resources.core.count              | Total client CPU cores                                   |
-| client.resources.memory                  | Total client memory in MB                                |
-| client.vault.enabled.count               | Clients with Vault enabled                               |
-| job.count                                | All jobs                                                 |
-| job.device.gpu.amd.count                 | Jobs with the "amd" gpu device driver                    |
-| job.device.gpu.nvidia.count              | Jobs with the "nvidia" gpu device driver                 |
-| job.device.gpu.other.count               | Jobs with a gpu device driver of unknown vendor          |
-| job.device.other.other.count             | Jobs with some other device driver                       |
-| job.device.usb.other.count               | Jobs with a usb device driver of unknown vendor          |
-| job.driver.docker.count                  | Tasks defined with the docker driver                     |
-| job.driver.exec.count                    | Tasks defined with the exec driver                       |
-| job.driver.exec2.count                   | Tasks defined with the exec2 driver                      |
-| job.driver.java.count                    | Tasks defined with the java driver                       |
-| job.driver.nomad-driver-virt.count       | Tasks defined with the nomad-driver-virt driver          |
-| job.driver.other.count                   | Tasks defined with the other driver                      |
-| job.driver.pledge.count                  | Tasks defined with the pledge driver                     |
-| job.driver.podman.count                  | Tasks defined with the podman driver                     |
-| job.driver.qemu.count                    | Tasks defined with the qemu driver                       |
-| job.driver.raw_exec.count                | Tasks defined with the raw_exec driver                   |
-| job.group.count                          | Task groups in jobs                                      |
-| job.network.cni.args.count               | Networks in jobs with custom CNI args                    |
-| job.network.mode.bridge.count            | Networks in jobs with mode "bridge"                      |
-| job.network.mode.cni.count               | Networks in jobs with mode "cni"                         |
-| job.network.mode.host.count              | Networks in jobs with mode "host"                        |
-| job.network.mode.other.count             | Networks in jobs with some other mode                    |
-| job.parameterized.count                  | Parameterized jobs                                       |
-| job.parameterized.dispatched.count       | Dispatched parameterized jobs                            |
-| job.periodic.count                       | Periodic jobs                                            |
-| job.periodic.dispatched.count            | Dispatched periodic jobs                                 |
-| job.service.consul.connect.count         | Connect services in jobs                                 |
-| job.service.consul.count                 | Consul services in jobs                                  |
-| job.service.nomad.count                  | Nomad provider services in jobs                          |
-| job.task.identity.count                  | Tasks in jobs with identity enabled                      |
-| job.task.template.count                  | Tasks in jobs with templates                             |
-| job.task.vault.count                     | Tasks in jobs with Vault enabled                         |
-| job.type.batch.count                     | Jobs of type "batch"                                     |
-| job.type.service.count                   | Jobs of type "service"                                   |
-| job.type.sysbatch.count                  | Jobs of type "sysbatch"                                  |
-| job.type.system.count                    | Jobs of type "system"                                    |
-| job.volume.csi.count                     | CSI volumes in jobs                                      |
-| job.volume.host.count                    | Host volumes in jobs                                     |
-| job.volume.sticky.count                  | Sticky volumes in jobs                                   |
-| namespace.count                          | Namespaces                                               |
-| namespace.quotas.count                   | Quotas                                                   |
-| node.cpu.arch.amd64.count                | Clients with "amd64" CPU architecture                    |
-| node.cpu.arch.arm64.count                | Clients with "arm64" CPU architecture                    |
-| node.cpu.arch.other.count                | Clients with some other CPU architecture                 |
-| node.cpu.arch.s390x.count                | Clients with "s390x" CPU architecture                    |
-| node.cpu.arch.unique.count               | Unique CPU architectures on client nodes                 |
-| node.kernel.name.aix.count               | Clients with "aix" kernel                                |
-| node.kernel.name.darwin.count            | Clients with "darwin" kernel                             |
-| node.kernel.name.freebsd.count           | Clients with "freebsd" kernel                            |
-| node.kernel.name.linux.count             | Clients with "linux" kernel                              |
-| node.kernel.name.other.count             | Clients with some other kernel                           |
-| node.kernel.name.plan9.count             | Clients with "plan9" kernel                              |
-| node.kernel.name.solaris.count           | Clients with "solaris" kernel                            |
-| node.kernel.name.unique.count            | Unique kernels on client nodes                           |
-| node.os.name.alpine.count                | Clients with "alpine" operating system                   |
-| node.os.name.amazon.count                | Clients with "amazon" operating system                   |
-| node.os.name.arch.count                  | Clients with "arch" operating system                     |
-| node.os.name.centos.count                | Clients with "centos" operating system                   |
-| node.os.name.cloudlinux.count            | Clients with "cloudlinux" operating system               |
-| node.os.name.coreos.count                | Clients with "coreos" operating system                   |
-| node.os.name.darwin.count                | Clients with "darwin" operating system                   |
-| node.os.name.debian.count                | Clients with "debian" operating system                   |
-| node.os.name.fedora.count                | Clients with "fedora" operating system                   |
-| node.os.name.gentoo.count                | Clients with "gentoo" operating system                   |
-| node.os.name.opensuse.count              | Clients with "opensuse" operating system                 |
-| node.os.name.oracle.count                | Clients with "oracle" operating system                   |
-| node.os.name.other.count                 | Clients with some other operating system                 |
-| node.os.name.raspbian.count              | Clients with "raspbian" operating system                 |
-| node.os.name.redhat.count                | Clients with "redhat" operating system                   |
-| node.os.name.suse.count                  | Clients with "suse" operating system                     |
-| node.os.name.ubuntu.count                | Clients with "ubuntu" operating system                   |
-| node.os.name.unique.count                | Unique operating systems on client nodes                 |
-| node.os.name.windows.count               | Clients with "windows" operating system                  |
-| node.pool.count                          | Node pools                                               |
-| node.status.disconnected.count           | Clients with status "disconnected"                       |
-| node.status.down.count                   | Clients with status "down"                               |
-| node.status.initializing.count           | Clients with status "initializing"                       |
-| node.status.ready.count                  | Clients with status "ready"                              |
-| node.status.unknown.count                | Clients with status "unknown"                            |
-| nomad.billable.clients                   | Number of client nodes in the cluster                    |
-| nomad.billable.cores.s390x               | Active client s390x CPU cores in the cluster             |
-| nomad.billable.cores.total               | Active client CPU cores in the cluster                   |
-| plugin.csi.unique.count                  | Unique CSI plugins                                       |
-| policy.sentinel.count                    | Sentinel policies                                        |
-| sentinel.enforcement.advisory.count      | Sentinel policies with "advisory" enforcement level      |
-| sentinel.enforcement.hard-mandatory.count| Sentinel policies with "hard-mandatory" enforcement level|
-| sentinel.enforcement.soft-mandatory.count| Sentinel policies with "soft-mandatory" enforcement level|
-| sentinel.scope.submit-csi-volume.count   | Sentinel policies with "submit-csi-volume" scope         |
-| sentinel.scope.submit-host-volume.count  | Sentinel policies with "submit-host-volume" scope        |
-| sentinel.scope.submit-job.count          | Sentinel policies with "submit-job" scope                |
-| task.device.gpu.amd.count                | Tasks with the "amd" gpu device driver                   |
-| task.device.gpu.nvidia.count             | Tasks with the "nvidia" gpu device driver                |
-| task.device.gpu.other.count              | Tasks with a gpu device driver of unknown vendor         |
-| task.device.other.other.count            | Tasks with some other device driver                      |
-| task.device.usb.other.count              | Tasks with a usb device driver of unknown vendor         |
-| task.driver.docker.count                 | Allocated tasks running with the docker driver           |
-| task.driver.exec.count                   | Allocated tasks running with the exec driver             |
-| task.driver.exec2.count                  | Allocated tasks running with the exec2 driver            |
-| task.driver.java.count                   | Allocated tasks running with the java driver             |
-| task.driver.nomad-driver-virt.count      | Allocated tasks running with the nomad-driver-virt driver|
-| task.driver.other.count                  | Allocated tasks running with the other driver            |
-| task.driver.pledge.count                 | Allocated tasks running with the pledge driver           |
-| task.driver.podman.count                 | Allocated tasks running with the podman driver           |
-| task.driver.qemu.count                   | Allocated tasks running with the qemu driver             |
-| task.driver.raw_exec.count               | Allocated tasks running with the raw_exec driver         |
-| variable.count                           | Nomad Variables                                          |
-| variable.lock.count                      | Nomad Variable Locks                                     |
-| volume.csi.capacity                      | Capacity of all CSI volumes in MB                        |
-| volume.csi.count                         | Number of "csi" volumes                                  |
-| volume.dhv.capacity                      | Capacity of all dynamic host volumes in MB               |
-| volume.dhv.plugin.other.count            | Dynamic host volumes with non-standard plugins           |
-| volume.dynamic.count                     | Number of "dynamic" volumes                              |
-| volume.static.count                      | Number of "static" volumes                               |
+| acl.auth.method.count                    | ACL Auth Methods                                           |
+| acl.auth.method.jwt.count                | ACL Auth Methods of type JWT                               |
+| acl.auth.method.oidc.count               | ACL Auth Methods of type OIDC                              |
+| acl.policy.count                         | ACL policies                                               |
+| acl.role.count                           | ACL roles                                                  |
+| acl.token.count                          | ACL tokens                                                 |
+| alloc.count                              | All allocations                                            |
+| alloc.status.complete.count              | Allocations with client status "complete"                  |
+| alloc.status.failed.count                | Allocations with client status "failed"                    |
+| alloc.status.lost.count                  | Allocations with client status "lost"                      |
+| alloc.status.pending.count               | Allocations with client status "pending"                   |
+| alloc.status.running.count               | Allocations with client status "running"                   |
+| alloc.status.unknown.count               | Allocations with client status "unknown"                   |
+| alloc.task.count                         | All tasks in allocations                                   |
+| alloc.task.running.count                 | Running tasks in allocations                               |
+| client.count                             | Client nodes in the cluster                                |
+| client.device.gpu.amd.count              | Clients with the "amd" gpu device driver                   |
+| client.device.gpu.nvidia.count           | Clients with the "nvidia" gpu device driver                |
+| client.device.gpu.other.count            | Clients with a gpu device driver of unknown vendor         |
+| client.device.other.other.count          | Clients with some other device driver                      |
+| client.device.usb.other.count            | Clients with a usb device driver of unknown vendor         |
+| client.driver.docker.count               | Clients with the "docker" driver                           |
+| client.driver.exec.count                 | Clients with the "exec" driver                             |
+| client.driver.exec2.count                | Clients with the "exec2" driver                            |
+| client.driver.java.count                 | Clients with the "java" driver                             |
+| client.driver.nomad-driver-virt.count    | Clients with the "nomad-driver-virt" driver                |
+| client.driver.other.count                | Clients with the "other" driver                            |
+| client.driver.pledge.count               | Clients with the "pledge" driver                           |
+| client.driver.podman.count               | Clients with the "podman" driver                           |
+| client.driver.qemu.count                 | Clients with the "qemu" driver                             |
+| client.driver.raw_exec.count             | Clients with the "raw_exec" driver                         |
+| client.plugin.cni.unique.count           | Unique CNI plugins on client nodes                         |
+| client.plugin.driver.unique.count        | Unique task drivers on client nodes                        |
+| client.plugin.host_volume.unique.count   | Unique host volume plugins on client nodes                 |
+| client.plugin.secret.unique.count        | Unique secret plugins on client nodes                      |
+| client.resources.compute                 | Total client compute                                       |
+| client.resources.core.count              | Total client CPU cores                                     |
+| client.resources.memory                  | Total client memory in MB                                  |
+| client.vault.enabled.count               | Clients with Vault enabled                                 |
+| job.count                                | All jobs                                                   |
+| job.device.gpu.amd.count                 | Jobs with the "amd" gpu device driver                      |
+| job.device.gpu.nvidia.count              | Jobs with the "nvidia" gpu device driver                   |
+| job.device.gpu.other.count               | Jobs with a gpu device driver of unknown vendor            |
+| job.device.other.other.count             | Jobs with some other device driver                         |
+| job.device.usb.other.count               | Jobs with a usb device driver of unknown vendor            |
+| job.driver.docker.count                  | Tasks defined with the "docker" driver                     |
+| job.driver.exec.count                    | Tasks defined with the "exec" driver                       |
+| job.driver.exec2.count                   | Tasks defined with the "exec2" driver                      |
+| job.driver.java.count                    | Tasks defined with the "java" driver                       |
+| job.driver.nomad-driver-virt.count       | Tasks defined with the "nomad-driver-virt" driver          |
+| job.driver.other.count                   | Jobs with the "other" driver                               |
+| job.driver.pledge.count                  | Tasks defined with the "pledge" driver                     |
+| job.driver.podman.count                  | Tasks defined with the "podman" driver                     |
+| job.driver.qemu.count                    | Tasks defined with the "qemu" driver                       |
+| job.driver.raw_exec.count                | Tasks defined with the "raw_exec" driver                   |
+| job.group.count                          | Task groups in jobs                                        |
+| job.network.cni.args.count               | Networks in jobs with custom CNI args                      |
+| job.network.mode.bridge.count            | Networks in jobs with mode "bridge"                        |
+| job.network.mode.cni.count               | Networks in jobs with mode "cni"                           |
+| job.network.mode.host.count              | Networks in jobs with mode "host"                          |
+| job.network.mode.other.count             | Networks in jobs with some other mode                      |
+| job.parameterized.count                  | Parameterized jobs                                         |
+| job.parameterized.dispatched.count       | Dispatched parameterized jobs                              |
+| job.periodic.count                       | Periodic jobs                                              |
+| job.periodic.dispatched.count            | Dispatched periodic jobs                                   |
+| job.service.consul.connect.count         | Connect services in jobs                                   |
+| job.service.consul.count                 | Consul services in jobs                                    |
+| job.service.nomad.count                  | Nomad provider services in jobs                            |
+| job.task.identity.count                  | Tasks in jobs with identity enabled                        |
+| job.task.template.count                  | Tasks in jobs with templates                               |
+| job.task.vault.count                     | Tasks in jobs with Vault enabled                           |
+| job.type.batch.count                     | Jobs of type "batch"                                       |
+| job.type.service.count                   | Jobs of type "service"                                     |
+| job.type.sysbatch.count                  | Jobs of type "sysbatch"                                    |
+| job.type.system.count                    | Jobs of type "system"                                      |
+| job.volume.csi.count                     | CSI volumes in jobs                                        |
+| job.volume.host.count                    | Host volumes in jobs                                       |
+| job.volume.sticky.count                  | Sticky volumes in jobs                                     |
+| namespace.count                          | Namespaces                                                 |
+| namespace.quotas.count                   | Quotas                                                     |
+| node.cpu.arch.amd64.count                | Clients with "amd64" CPU architecture                      |
+| node.cpu.arch.arm64.count                | Clients with "arm64" CPU architecture                      |
+| node.cpu.arch.other.count                | Clients with some other CPU architecture                   |
+| node.cpu.arch.s390x.count                | Clients with "s390x" CPU architecture                      |
+| node.cpu.arch.unique.count               | Unique CPU architectures on client nodes                   |
+| node.kernel.name.aix.count               | Clients with "aix" kernel                                  |
+| node.kernel.name.darwin.count            | Clients with "darwin" kernel                               |
+| node.kernel.name.freebsd.count           | Clients with "freebsd" kernel                              |
+| node.kernel.name.linux.count             | Clients with "linux" kernel                                |
+| node.kernel.name.other.count             | Clients with some other kernel                             |
+| node.kernel.name.plan9.count             | Clients with "plan9" kernel                                |
+| node.kernel.name.solaris.count           | Clients with "solaris" kernel                              |
+| node.kernel.name.unique.count            | Unique kernels on client nodes                             |
+| node.os.name.alpine.count                | Clients with "alpine" operating system                     |
+| node.os.name.amazon.count                | Clients with "amazon" operating system                     |
+| node.os.name.arch.count                  | Clients with "arch" operating system                       |
+| node.os.name.centos.count                | Clients with "centos" operating system                     |
+| node.os.name.cloudlinux.count            | Clients with "cloudlinux" operating system                 |
+| node.os.name.coreos.count                | Clients with "coreos" operating system                     |
+| node.os.name.darwin.count                | Clients with "darwin" operating system                     |
+| node.os.name.debian.count                | Clients with "debian" operating system                     |
+| node.os.name.fedora.count                | Clients with "fedora" operating system                     |
+| node.os.name.gentoo.count                | Clients with "gentoo" operating system                     |
+| node.os.name.opensuse.count              | Clients with "opensuse" operating system                   |
+| node.os.name.oracle.count                | Clients with "oracle" operating system                     |
+| node.os.name.other.count                 | Clients with some other operating system                   |
+| node.os.name.raspbian.count              | Clients with "raspbian" operating system                   |
+| node.os.name.redhat.count                | Clients with "redhat" operating system                     |
+| node.os.name.suse.count                  | Clients with "suse" operating system                       |
+| node.os.name.ubuntu.count                | Clients with "ubuntu" operating system                     |
+| node.os.name.unique.count                | Unique operating systems on client nodes                   |
+| node.os.name.windows.count               | Clients with "windows" operating system                    |
+| node.pool.count                          | Node pools                                                 |
+| node.status.disconnected.count           | Clients with status "disconnected"                         |
+| node.status.down.count                   | Clients with status "down"                                 |
+| node.status.initializing.count           | Clients with status "initializing"                         |
+| node.status.ready.count                  | Clients with status "ready"                                |
+| node.status.unknown.count                | Clients with status "unknown"                              |
+| nomad.billable.clients                   | Number of client nodes in the cluster                      |
+| nomad.billable.cores.s390x               | Active client s390x CPU cores in the cluster               |
+| nomad.billable.cores.total               | Active client CPU cores in the cluster                     |
+| plugin.csi.unique.count                  | Unique CSI plugins                                         |
+| policy.sentinel.count                    | Sentinel policies                                          |
+| sentinel.enforcement.advisory.count      | Sentinel policies with "advisory" enforcement level        |
+| sentinel.enforcement.hard-mandatory.count| Sentinel policies with "hard-mandatory" enforcement level  |
+| sentinel.enforcement.soft-mandatory.count| Sentinel policies with "soft-mandatory" enforcement level  |
+| sentinel.scope.submit-csi-volume.count   | Sentinel policies with "submit-csi-volume" scope           |
+| sentinel.scope.submit-host-volume.count  | Sentinel policies with "submit-host-volume" scope          |
+| sentinel.scope.submit-job.count          | Sentinel policies with "submit-job" scope                  |
+| task.device.gpu.amd.count                | Tasks with the "amd" gpu device driver                     |
+| task.device.gpu.nvidia.count             | Tasks with the "nvidia" gpu device driver                  |
+| task.device.gpu.other.count              | Tasks with a gpu device driver of unknown vendor           |
+| task.device.other.other.count            | Tasks with some other device driver                        |
+| task.device.usb.other.count              | Tasks with a usb device driver of unknown vendor           |
+| task.driver.docker.count                 | Allocated tasks running with the "docker" driver           |
+| task.driver.exec.count                   | Allocated tasks running with the "exec" driver             |
+| task.driver.exec2.count                  | Allocated tasks running with the "exec2" driver            |
+| task.driver.java.count                   | Allocated tasks running with the "java" driver             |
+| task.driver.nomad-driver-virt.count      | Allocated tasks running with the "nomad-driver-virt" driver|
+| task.driver.other.count                  | Tasks with the "other" driver                              |
+| task.driver.pledge.count                 | Allocated tasks running with the "pledge" driver           |
+| task.driver.podman.count                 | Allocated tasks running with the "podman" driver           |
+| task.driver.qemu.count                   | Allocated tasks running with the "qemu" driver             |
+| task.driver.raw_exec.count               | Allocated tasks running with the "raw_exec" driver         |
+| variable.count                           | Nomad Variables                                            |
+| variable.lock.count                      | Nomad Variable Locks                                       |
+| volume.csi.capacity                      | Capacity of all CSI volumes in MB                          |
+| volume.csi.count                         | Number of "csi" volumes                                    |
+| volume.dhv.capacity                      | Capacity of all dynamic host volumes in MB                 |
+| volume.dhv.plugin.other.count            | Dynamic host volumes with non-standard plugins             |
+| volume.dynamic.count                     | Number of "dynamic" volumes                                |
+| volume.static.count                      | Number of "static" volumes                                 |
+
 
 
 

--- a/content/nomad/v1.11.x/content/docs/enterprise/license/utilization-reporting.mdx
+++ b/content/nomad/v1.11.x/content/docs/enterprise/license/utilization-reporting.mdx
@@ -166,158 +166,158 @@ that might identify proprietary information.
 
 | Key                                       | Description                                             |
 |-------------------------------------------|---------------------------------------------------------|
-| acl.auth.method.count                    | ACL Auth Methods                                         |
-| acl.auth.method.jwt.count                | ACL Auth Methods of type JWT                             |
-| acl.auth.method.oidc.count               | ACL Auth Methods of type OIDC                            |
-| acl.policy.count                         | ACL policies                                             |
-| acl.role.count                           | ACL roles                                                |
-| acl.token.count                          | ACL tokens                                               |
-| alloc.count                              | All allocations                                          |
-| alloc.status.complete.count              | Allocations with client status "complete"                |
-| alloc.status.failed.count                | Allocations with client status "failed"                  |
-| alloc.status.lost.count                  | Allocations with client status "lost"                    |
-| alloc.status.pending.count               | Allocations with client status "pending"                 |
-| alloc.status.running.count               | Allocations with client status "running"                 |
-| alloc.status.unknown.count               | Allocations with client status "unknown"                 |
-| alloc.task.count                         | All tasks in allocations                                 |
-| alloc.task.running.count                 | Running tasks in allocations                             |
-| client.count                             | Client nodes in the cluster                              |
-| client.device.gpu.amd.count              | Clients with the "amd" gpu device driver                 |
-| client.device.gpu.nvidia.count           | Clients with the "nvidia" gpu device driver              |
-| client.device.gpu.other.count            | Clients with a gpu device driver of unknown vendor       |
-| client.device.other.other.count          | Clients with some other device driver                    |
-| client.device.usb.other.count            | Clients with a usb device driver of unknown vendor       |
-| client.driver.docker.count               | Clients with the docker driver                           |
-| client.driver.exec.count                 | Clients with the exec driver                             |
-| client.driver.exec2.count                | Clients with the exec2 driver                            |
-| client.driver.java.count                 | Clients with the java driver                             |
-| client.driver.nomad-driver-virt.count    | Clients with the nomad-driver-virt driver                |
-| client.driver.other.count                | Clients with the other driver                            |
-| client.driver.pledge.count               | Clients with the pledge driver                           |
-| client.driver.podman.count               | Clients with the podman driver                           |
-| client.driver.qemu.count                 | Clients with the qemu driver                             |
-| client.driver.raw_exec.count             | Clients with the raw_exec driver                         |
-| client.plugin.cni.unique.count           | Unique CNI plugins on client nodes                       |
-| client.plugin.driver.unique.count        | Unique task drivers on client nodes                      |
-| client.plugin.host_volume.unique.count   | Unique host volume plugins on client nodes               |
-| client.plugin.secret.unique.count        | Unique secret plugins on client nodes                    |
-| client.resources.compute                 | Total client compute                                     |
-| client.resources.core.count              | Total client CPU cores                                   |
-| client.resources.memory                  | Total client memory in MB                                |
-| client.vault.enabled.count               | Clients with Vault enabled                               |
-| job.count                                | All jobs                                                 |
-| job.device.gpu.amd.count                 | Jobs with the "amd" gpu device driver                    |
-| job.device.gpu.nvidia.count              | Jobs with the "nvidia" gpu device driver                 |
-| job.device.gpu.other.count               | Jobs with a gpu device driver of unknown vendor          |
-| job.device.other.other.count             | Jobs with some other device driver                       |
-| job.device.usb.other.count               | Jobs with a usb device driver of unknown vendor          |
-| job.driver.docker.count                  | Tasks defined with the docker driver                     |
-| job.driver.exec.count                    | Tasks defined with the exec driver                       |
-| job.driver.exec2.count                   | Tasks defined with the exec2 driver                      |
-| job.driver.java.count                    | Tasks defined with the java driver                       |
-| job.driver.nomad-driver-virt.count       | Tasks defined with the nomad-driver-virt driver          |
-| job.driver.other.count                   | Tasks defined with the other driver                      |
-| job.driver.pledge.count                  | Tasks defined with the pledge driver                     |
-| job.driver.podman.count                  | Tasks defined with the podman driver                     |
-| job.driver.qemu.count                    | Tasks defined with the qemu driver                       |
-| job.driver.raw_exec.count                | Tasks defined with the raw_exec driver                   |
-| job.group.count                          | Task groups in jobs                                      |
-| job.network.cni.args.count               | Networks in jobs with custom CNI args                    |
-| job.network.mode.bridge.count            | Networks in jobs with mode "bridge"                      |
-| job.network.mode.cni.count               | Networks in jobs with mode "cni"                         |
-| job.network.mode.host.count              | Networks in jobs with mode "host"                        |
-| job.network.mode.other.count             | Networks in jobs with some other mode                    |
-| job.parameterized.count                  | Parameterized jobs                                       |
-| job.parameterized.dispatched.count       | Dispatched parameterized jobs                            |
-| job.periodic.count                       | Periodic jobs                                            |
-| job.periodic.dispatched.count            | Dispatched periodic jobs                                 |
-| job.service.consul.connect.count         | Connect services in jobs                                 |
-| job.service.consul.count                 | Consul services in jobs                                  |
-| job.service.nomad.count                  | Nomad provider services in jobs                          |
-| job.task.identity.count                  | Tasks in jobs with identity enabled                      |
-| job.task.template.count                  | Tasks in jobs with templates                             |
-| job.task.vault.count                     | Tasks in jobs with Vault enabled                         |
-| job.type.batch.count                     | Jobs of type "batch"                                     |
-| job.type.service.count                   | Jobs of type "service"                                   |
-| job.type.sysbatch.count                  | Jobs of type "sysbatch"                                  |
-| job.type.system.count                    | Jobs of type "system"                                    |
-| job.volume.csi.count                     | CSI volumes in jobs                                      |
-| job.volume.host.count                    | Host volumes in jobs                                     |
-| job.volume.sticky.count                  | Sticky volumes in jobs                                   |
-| namespace.count                          | Namespaces                                               |
-| namespace.quotas.count                   | Quotas                                                   |
-| node.cpu.arch.amd64.count                | Clients with "amd64" CPU architecture                    |
-| node.cpu.arch.arm64.count                | Clients with "arm64" CPU architecture                    |
-| node.cpu.arch.other.count                | Clients with some other CPU architecture                 |
-| node.cpu.arch.s390x.count                | Clients with "s390x" CPU architecture                    |
-| node.cpu.arch.unique.count               | Unique CPU architectures on client nodes                 |
-| node.kernel.name.aix.count               | Clients with "aix" kernel                                |
-| node.kernel.name.darwin.count            | Clients with "darwin" kernel                             |
-| node.kernel.name.freebsd.count           | Clients with "freebsd" kernel                            |
-| node.kernel.name.linux.count             | Clients with "linux" kernel                              |
-| node.kernel.name.other.count             | Clients with some other kernel                           |
-| node.kernel.name.plan9.count             | Clients with "plan9" kernel                              |
-| node.kernel.name.solaris.count           | Clients with "solaris" kernel                            |
-| node.kernel.name.unique.count            | Unique kernels on client nodes                           |
-| node.os.name.alpine.count                | Clients with "alpine" operating system                   |
-| node.os.name.amazon.count                | Clients with "amazon" operating system                   |
-| node.os.name.arch.count                  | Clients with "arch" operating system                     |
-| node.os.name.centos.count                | Clients with "centos" operating system                   |
-| node.os.name.cloudlinux.count            | Clients with "cloudlinux" operating system               |
-| node.os.name.coreos.count                | Clients with "coreos" operating system                   |
-| node.os.name.darwin.count                | Clients with "darwin" operating system                   |
-| node.os.name.debian.count                | Clients with "debian" operating system                   |
-| node.os.name.fedora.count                | Clients with "fedora" operating system                   |
-| node.os.name.gentoo.count                | Clients with "gentoo" operating system                   |
-| node.os.name.opensuse.count              | Clients with "opensuse" operating system                 |
-| node.os.name.oracle.count                | Clients with "oracle" operating system                   |
-| node.os.name.other.count                 | Clients with some other operating system                 |
-| node.os.name.raspbian.count              | Clients with "raspbian" operating system                 |
-| node.os.name.redhat.count                | Clients with "redhat" operating system                   |
-| node.os.name.suse.count                  | Clients with "suse" operating system                     |
-| node.os.name.ubuntu.count                | Clients with "ubuntu" operating system                   |
-| node.os.name.unique.count                | Unique operating systems on client nodes                 |
-| node.os.name.windows.count               | Clients with "windows" operating system                  |
-| node.pool.count                          | Node pools                                               |
-| node.status.disconnected.count           | Clients with status "disconnected"                       |
-| node.status.down.count                   | Clients with status "down"                               |
-| node.status.initializing.count           | Clients with status "initializing"                       |
-| node.status.ready.count                  | Clients with status "ready"                              |
-| node.status.unknown.count                | Clients with status "unknown"                            |
-| nomad.billable.clients                   | Number of client nodes in the cluster                    |
-| nomad.billable.cores.s390x               | Active client s390x CPU cores in the cluster             |
-| nomad.billable.cores.total               | Active client CPU cores in the cluster                   |
-| plugin.csi.unique.count                  | Unique CSI plugins                                       |
-| policy.sentinel.count                    | Sentinel policies                                        |
-| sentinel.enforcement.advisory.count      | Sentinel policies with "advisory" enforcement level      |
-| sentinel.enforcement.hard-mandatory.count| Sentinel policies with "hard-mandatory" enforcement level|
-| sentinel.enforcement.soft-mandatory.count| Sentinel policies with "soft-mandatory" enforcement level|
-| sentinel.scope.submit-csi-volume.count   | Sentinel policies with "submit-csi-volume" scope         |
-| sentinel.scope.submit-host-volume.count  | Sentinel policies with "submit-host-volume" scope        |
-| sentinel.scope.submit-job.count          | Sentinel policies with "submit-job" scope                |
-| task.device.gpu.amd.count                | Tasks with the "amd" gpu device driver                   |
-| task.device.gpu.nvidia.count             | Tasks with the "nvidia" gpu device driver                |
-| task.device.gpu.other.count              | Tasks with a gpu device driver of unknown vendor         |
-| task.device.other.other.count            | Tasks with some other device driver                      |
-| task.device.usb.other.count              | Tasks with a usb device driver of unknown vendor         |
-| task.driver.docker.count                 | Allocated tasks running with the docker driver           |
-| task.driver.exec.count                   | Allocated tasks running with the exec driver             |
-| task.driver.exec2.count                  | Allocated tasks running with the exec2 driver            |
-| task.driver.java.count                   | Allocated tasks running with the java driver             |
-| task.driver.nomad-driver-virt.count      | Allocated tasks running with the nomad-driver-virt driver|
-| task.driver.other.count                  | Allocated tasks running with the other driver            |
-| task.driver.pledge.count                 | Allocated tasks running with the pledge driver           |
-| task.driver.podman.count                 | Allocated tasks running with the podman driver           |
-| task.driver.qemu.count                   | Allocated tasks running with the qemu driver             |
-| task.driver.raw_exec.count               | Allocated tasks running with the raw_exec driver         |
-| variable.count                           | Nomad Variables                                          |
-| variable.lock.count                      | Nomad Variable Locks                                     |
-| volume.csi.capacity                      | Capacity of all CSI volumes in MB                        |
-| volume.csi.count                         | Number of "csi" volumes                                  |
-| volume.dhv.capacity                      | Capacity of all dynamic host volumes in MB               |
-| volume.dhv.plugin.other.count            | Dynamic host volumes with non-standard plugins           |
-| volume.dynamic.count                     | Number of "dynamic" volumes                              |
-| volume.static.count                      | Number of "static" volumes                               |
+| acl.auth.method.count                    | ACL Auth Methods                                           |
+| acl.auth.method.jwt.count                | ACL Auth Methods of type JWT                               |
+| acl.auth.method.oidc.count               | ACL Auth Methods of type OIDC                              |
+| acl.policy.count                         | ACL policies                                               |
+| acl.role.count                           | ACL roles                                                  |
+| acl.token.count                          | ACL tokens                                                 |
+| alloc.count                              | All allocations                                            |
+| alloc.status.complete.count              | Allocations with client status "complete"                  |
+| alloc.status.failed.count                | Allocations with client status "failed"                    |
+| alloc.status.lost.count                  | Allocations with client status "lost"                      |
+| alloc.status.pending.count               | Allocations with client status "pending"                   |
+| alloc.status.running.count               | Allocations with client status "running"                   |
+| alloc.status.unknown.count               | Allocations with client status "unknown"                   |
+| alloc.task.count                         | All tasks in allocations                                   |
+| alloc.task.running.count                 | Running tasks in allocations                               |
+| client.count                             | Client nodes in the cluster                                |
+| client.device.gpu.amd.count              | Clients with the "amd" gpu device driver                   |
+| client.device.gpu.nvidia.count           | Clients with the "nvidia" gpu device driver                |
+| client.device.gpu.other.count            | Clients with a gpu device driver of unknown vendor         |
+| client.device.other.other.count          | Clients with some other device driver                      |
+| client.device.usb.other.count            | Clients with a usb device driver of unknown vendor         |
+| client.driver.docker.count               | Clients with the "docker" driver                           |
+| client.driver.exec.count                 | Clients with the "exec" driver                             |
+| client.driver.exec2.count                | Clients with the "exec2" driver                            |
+| client.driver.java.count                 | Clients with the "java" driver                             |
+| client.driver.nomad-driver-virt.count    | Clients with the "nomad-driver-virt" driver                |
+| client.driver.other.count                | Clients with the "other" driver                            |
+| client.driver.pledge.count               | Clients with the "pledge" driver                           |
+| client.driver.podman.count               | Clients with the "podman" driver                           |
+| client.driver.qemu.count                 | Clients with the "qemu" driver                             |
+| client.driver.raw_exec.count             | Clients with the "raw_exec" driver                         |
+| client.plugin.cni.unique.count           | Unique CNI plugins on client nodes                         |
+| client.plugin.driver.unique.count        | Unique task drivers on client nodes                        |
+| client.plugin.host_volume.unique.count   | Unique host volume plugins on client nodes                 |
+| client.plugin.secret.unique.count        | Unique secret plugins on client nodes                      |
+| client.resources.compute                 | Total client compute                                       |
+| client.resources.core.count              | Total client CPU cores                                     |
+| client.resources.memory                  | Total client memory in MB                                  |
+| client.vault.enabled.count               | Clients with Vault enabled                                 |
+| job.count                                | All jobs                                                   |
+| job.device.gpu.amd.count                 | Jobs with the "amd" gpu device driver                      |
+| job.device.gpu.nvidia.count              | Jobs with the "nvidia" gpu device driver                   |
+| job.device.gpu.other.count               | Jobs with a gpu device driver of unknown vendor            |
+| job.device.other.other.count             | Jobs with some other device driver                         |
+| job.device.usb.other.count               | Jobs with a usb device driver of unknown vendor            |
+| job.driver.docker.count                  | Tasks defined with the "docker" driver                     |
+| job.driver.exec.count                    | Tasks defined with the "exec" driver                       |
+| job.driver.exec2.count                   | Tasks defined with the "exec2" driver                      |
+| job.driver.java.count                    | Tasks defined with the "java" driver                       |
+| job.driver.nomad-driver-virt.count       | Tasks defined with the "nomad-driver-virt" driver          |
+| job.driver.other.count                   | Jobs with the "other" driver                               |
+| job.driver.pledge.count                  | Tasks defined with the "pledge" driver                     |
+| job.driver.podman.count                  | Tasks defined with the "podman" driver                     |
+| job.driver.qemu.count                    | Tasks defined with the "qemu" driver                       |
+| job.driver.raw_exec.count                | Tasks defined with the "raw_exec" driver                   |
+| job.group.count                          | Task groups in jobs                                        |
+| job.network.cni.args.count               | Networks in jobs with custom CNI args                      |
+| job.network.mode.bridge.count            | Networks in jobs with mode "bridge"                        |
+| job.network.mode.cni.count               | Networks in jobs with mode "cni"                           |
+| job.network.mode.host.count              | Networks in jobs with mode "host"                          |
+| job.network.mode.other.count             | Networks in jobs with some other mode                      |
+| job.parameterized.count                  | Parameterized jobs                                         |
+| job.parameterized.dispatched.count       | Dispatched parameterized jobs                              |
+| job.periodic.count                       | Periodic jobs                                              |
+| job.periodic.dispatched.count            | Dispatched periodic jobs                                   |
+| job.service.consul.connect.count         | Connect services in jobs                                   |
+| job.service.consul.count                 | Consul services in jobs                                    |
+| job.service.nomad.count                  | Nomad provider services in jobs                            |
+| job.task.identity.count                  | Tasks in jobs with identity enabled                        |
+| job.task.template.count                  | Tasks in jobs with templates                               |
+| job.task.vault.count                     | Tasks in jobs with Vault enabled                           |
+| job.type.batch.count                     | Jobs of type "batch"                                       |
+| job.type.service.count                   | Jobs of type "service"                                     |
+| job.type.sysbatch.count                  | Jobs of type "sysbatch"                                    |
+| job.type.system.count                    | Jobs of type "system"                                      |
+| job.volume.csi.count                     | CSI volumes in jobs                                        |
+| job.volume.host.count                    | Host volumes in jobs                                       |
+| job.volume.sticky.count                  | Sticky volumes in jobs                                     |
+| namespace.count                          | Namespaces                                                 |
+| namespace.quotas.count                   | Quotas                                                     |
+| node.cpu.arch.amd64.count                | Clients with "amd64" CPU architecture                      |
+| node.cpu.arch.arm64.count                | Clients with "arm64" CPU architecture                      |
+| node.cpu.arch.other.count                | Clients with some other CPU architecture                   |
+| node.cpu.arch.s390x.count                | Clients with "s390x" CPU architecture                      |
+| node.cpu.arch.unique.count               | Unique CPU architectures on client nodes                   |
+| node.kernel.name.aix.count               | Clients with "aix" kernel                                  |
+| node.kernel.name.darwin.count            | Clients with "darwin" kernel                               |
+| node.kernel.name.freebsd.count           | Clients with "freebsd" kernel                              |
+| node.kernel.name.linux.count             | Clients with "linux" kernel                                |
+| node.kernel.name.other.count             | Clients with some other kernel                             |
+| node.kernel.name.plan9.count             | Clients with "plan9" kernel                                |
+| node.kernel.name.solaris.count           | Clients with "solaris" kernel                              |
+| node.kernel.name.unique.count            | Unique kernels on client nodes                             |
+| node.os.name.alpine.count                | Clients with "alpine" operating system                     |
+| node.os.name.amazon.count                | Clients with "amazon" operating system                     |
+| node.os.name.arch.count                  | Clients with "arch" operating system                       |
+| node.os.name.centos.count                | Clients with "centos" operating system                     |
+| node.os.name.cloudlinux.count            | Clients with "cloudlinux" operating system                 |
+| node.os.name.coreos.count                | Clients with "coreos" operating system                     |
+| node.os.name.darwin.count                | Clients with "darwin" operating system                     |
+| node.os.name.debian.count                | Clients with "debian" operating system                     |
+| node.os.name.fedora.count                | Clients with "fedora" operating system                     |
+| node.os.name.gentoo.count                | Clients with "gentoo" operating system                     |
+| node.os.name.opensuse.count              | Clients with "opensuse" operating system                   |
+| node.os.name.oracle.count                | Clients with "oracle" operating system                     |
+| node.os.name.other.count                 | Clients with some other operating system                   |
+| node.os.name.raspbian.count              | Clients with "raspbian" operating system                   |
+| node.os.name.redhat.count                | Clients with "redhat" operating system                     |
+| node.os.name.suse.count                  | Clients with "suse" operating system                       |
+| node.os.name.ubuntu.count                | Clients with "ubuntu" operating system                     |
+| node.os.name.unique.count                | Unique operating systems on client nodes                   |
+| node.os.name.windows.count               | Clients with "windows" operating system                    |
+| node.pool.count                          | Node pools                                                 |
+| node.status.disconnected.count           | Clients with status "disconnected"                         |
+| node.status.down.count                   | Clients with status "down"                                 |
+| node.status.initializing.count           | Clients with status "initializing"                         |
+| node.status.ready.count                  | Clients with status "ready"                                |
+| node.status.unknown.count                | Clients with status "unknown"                              |
+| nomad.billable.clients                   | Number of client nodes in the cluster                      |
+| nomad.billable.cores.s390x               | Active client s390x CPU cores in the cluster               |
+| nomad.billable.cores.total               | Active client CPU cores in the cluster                     |
+| plugin.csi.unique.count                  | Unique CSI plugins                                         |
+| policy.sentinel.count                    | Sentinel policies                                          |
+| sentinel.enforcement.advisory.count      | Sentinel policies with "advisory" enforcement level        |
+| sentinel.enforcement.hard-mandatory.count| Sentinel policies with "hard-mandatory" enforcement level  |
+| sentinel.enforcement.soft-mandatory.count| Sentinel policies with "soft-mandatory" enforcement level  |
+| sentinel.scope.submit-csi-volume.count   | Sentinel policies with "submit-csi-volume" scope           |
+| sentinel.scope.submit-host-volume.count  | Sentinel policies with "submit-host-volume" scope          |
+| sentinel.scope.submit-job.count          | Sentinel policies with "submit-job" scope                  |
+| task.device.gpu.amd.count                | Tasks with the "amd" gpu device driver                     |
+| task.device.gpu.nvidia.count             | Tasks with the "nvidia" gpu device driver                  |
+| task.device.gpu.other.count              | Tasks with a gpu device driver of unknown vendor           |
+| task.device.other.other.count            | Tasks with some other device driver                        |
+| task.device.usb.other.count              | Tasks with a usb device driver of unknown vendor           |
+| task.driver.docker.count                 | Allocated tasks running with the "docker" driver           |
+| task.driver.exec.count                   | Allocated tasks running with the "exec" driver             |
+| task.driver.exec2.count                  | Allocated tasks running with the "exec2" driver            |
+| task.driver.java.count                   | Allocated tasks running with the "java" driver             |
+| task.driver.nomad-driver-virt.count      | Allocated tasks running with the "nomad-driver-virt" driver|
+| task.driver.other.count                  | Tasks with the "other" driver                              |
+| task.driver.pledge.count                 | Allocated tasks running with the "pledge" driver           |
+| task.driver.podman.count                 | Allocated tasks running with the "podman" driver           |
+| task.driver.qemu.count                   | Allocated tasks running with the "qemu" driver             |
+| task.driver.raw_exec.count               | Allocated tasks running with the "raw_exec" driver         |
+| variable.count                           | Nomad Variables                                            |
+| variable.lock.count                      | Nomad Variable Locks                                       |
+| volume.csi.capacity                      | Capacity of all CSI volumes in MB                          |
+| volume.csi.count                         | Number of "csi" volumes                                    |
+| volume.dhv.capacity                      | Capacity of all dynamic host volumes in MB                 |
+| volume.dhv.plugin.other.count            | Dynamic host volumes with non-standard plugins             |
+| volume.dynamic.count                     | Number of "dynamic" volumes                                |
+| volume.static.count                      | Number of "static" volumes                                 |
 
 
 ## Example payload

--- a/content/nomad/v1.11.x/content/docs/enterprise/license/utilization-reporting.mdx
+++ b/content/nomad/v1.11.x/content/docs/enterprise/license/utilization-reporting.mdx
@@ -164,145 +164,160 @@ that might identify proprietary information.
      https://github.com/hashicorp/hashicorp-census-registry/tree/main/nomad/v2/cmd
 -->
 
-| Key                                       | Description                                               |
-|-------------------------------------------|-----------------------------------------------------------|
-| acl.auth.method.count                     | ACL Auth Methods                                          |
-| acl.auth.method.jwt.count                 | ACL Auth Methods of type JWT                              |
-| acl.auth.method.oidc.count                | ACL Auth Methods of type OIDC                             |
-| acl.policy.count                          | ACL policies                                              |
-| acl.role.count                            | ACL roles                                                 |
-| acl.token.count                           | ACL tokens                                                |
-| alloc.count                               | All allocations                                           |
-| alloc.status.complete.count               | Allocations with client status "complete"                 |
-| alloc.status.failed.count                 | Allocations with client status "failed"                   |
-| alloc.status.lost.count                   | Allocations with client status "lost"                     |
-| alloc.status.pending.count                | Allocations with client status "pending"                  |
-| alloc.status.running.count                | Allocations with client status "running"                  |
-| alloc.status.unknown.count                | Allocations with client status "unknown"                  |
-| alloc.task.count                          | All tasks in allocations                                  |
-| alloc.task.running.count                  | Running tasks in allocations                              |
-| client.count                              | Client nodes in the cluster                               |
-| client.driver.docker.count                | Clients with the "docker" driver                          |
-| client.driver.exec.count                  | Clients with the "exec" driver                            |
-| client.driver.exec2.count                 | Clients with the "exec2" driver                           |
-| client.driver.java.count                  | Clients with the "java" driver                            |
-| client.driver.nomad-driver-virt.count     | Clients with the "nomad-driver-virt" driver               |
-| client.driver.other.count                 | Clients with some other driver                            |
-| client.driver.pledge.count                | Clients with the "pledge" driver                          |
-| client.driver.podman.count                | Clients with the "podman" driver                          |
-| client.driver.qemu.count                  | Clients with the "qemu" driver                            |
-| client.driver.raw_exec.count              | Clients with the "raw_exec" driver                        |
-| client.plugin.cni.unique.count            | Unique CNI plugins on client nodes                        |
-| client.plugin.driver.unique.count         | Unique task drivers on client nodes                       |
-| client.plugin.host_volume.unique.count    | Unique host volume plugins on client nodes                |
-| client.plugin.secret.unique.count         | Unique secret plugins on client nodes                     |
-| client.resources.compute                  | Total client compute                                      |
-| client.resources.core.count               | Total client CPU cores                                    |
-| client.resources.memory                   | Total client memory in MB                                 |
-| client.vault.enabled.count                | Clients with Vault enabled                                |
-| job.count                                 | All jobs                                                  |
-| job.driver.docker.count                   | Jobs with the "docker" driver                             |
-| job.driver.exec.count                     | Jobs with the "exec" driver                               |
-| job.driver.exec2.count                    | Jobs with the "exec2" driver                              |
-| job.driver.java.count                     | Jobs with the "java" driver                               |
-| job.driver.nomad-driver-virt.count        | Jobs with the "nomad-driver-virt" driver                  |
-| job.driver.other.count                    | Jobs with some other driver                               |
-| job.driver.pledge.count                   | Jobs with the "pledge" driver                             |
-| job.driver.podman.count                   | Jobs with the "podman" driver                             |
-| job.driver.qemu.count                     | Jobs with the "qemu" driver                               |
-| job.driver.raw_exec.count                 | Jobs with the "raw_exec" driver                           |
-| job.group.count                           | Task groups in jobs                                       |
-| job.network.cni.args.count                | Networks in jobs with custom CNI args                     |
-| job.network.mode.bridge.count             | Networks in jobs with mode "bridge"                       |
-| job.network.mode.cni.count                | Networks in jobs with mode "cni"                          |
-| job.network.mode.host.count               | Networks in jobs with mode "host"                         |
-| job.network.mode.other.count              | Networks in jobs with some other mode                     |
-| job.parameterized.count                   | Parameterized jobs                                        |
-| job.parameterized.dispatched.count        | Dispatched parameterized jobs                             |
-| job.periodic.count                        | Periodic jobs                                             |
-| job.periodic.dispatched.count             | Dispatched periodic jobs                                  |
-| job.service.consul.connect.count          | Connect services in jobs                                  |
-| job.service.consul.count                  | Consul services in jobs                                   |
-| job.service.nomad.count                   | Nomad provider services in jobs                           |
-| job.task.identity.count                   | Tasks in jobs with identity enabled                       |
-| job.task.template.count                   | Tasks in jobs with templates                              |
-| job.task.vault.count                      | Tasks in jobs with Vault enabled                          |
-| job.type.batch.count                      | Jobs of type "batch"                                      |
-| job.type.service.count                    | Jobs of type "service"                                    |
-| job.type.sysbatch.count                   | Jobs of type "sysbatch"                                   |
-| job.type.system.count                     | Jobs of type "system"                                     |
-| job.volume.csi.count                      | CSI volumes in jobs                                       |
-| job.volume.host.count                     | Host volumes in jobs                                      |
-| job.volume.sticky.count                   | Sticky volumes in jobs                                    |
-| namespace.count                           | Namespaces                                                |
-| namespace.quotas.count                    | Quotas                                                    |
-| node.cpu.arch.amd64.count                 | Clients with "amd64" CPU architecture                     |
-| node.cpu.arch.arm64.count                 | Clients with "arm64" CPU architecture                     |
-| node.cpu.arch.other.count                 | Clients with some other CPU architecture                  |
-| node.cpu.arch.s390x.count                 | Clients with "s390x" CPU architecture                     |
-| node.cpu.arch.unique.count                | Unique CPU architectures on client nodes                  |
-| node.kernel.name.aix.count                | Clients with "aix" kernel                                 |
-| node.kernel.name.darwin.count             | Clients with "darwin" kernel                              |
-| node.kernel.name.freebsd.count            | Clients with "freebsd" kernel                             |
-| node.kernel.name.linux.count              | Clients with "linux" kernel                               |
-| node.kernel.name.other.count              | Clients with some other kernel                            |
-| node.kernel.name.plan9.count              | Clients with "plan9" kernel                               |
-| node.kernel.name.solaris.count            | Clients with "solaris" kernel                             |
-| node.kernel.name.unique.count             | Unique kernels on client nodes                            |
-| node.os.name.alpine.count                 | Clients with "alpine" operating system                    |
-| node.os.name.amazon.count                 | Clients with "amazon" operating system                    |
-| node.os.name.arch.count                   | Clients with "arch" operating system                      |
-| node.os.name.centos.count                 | Clients with "centos" operating system                    |
-| node.os.name.cloudlinux.count             | Clients with "cloudlinux" operating system                |
-| node.os.name.coreos.count                 | Clients with "coreos" operating system                    |
-| node.os.name.darwin.count                 | Clients with "darwin" operating system                    |
-| node.os.name.debian.count                 | Clients with "debian" operating system                    |
-| node.os.name.fedora.count                 | Clients with "fedora" operating system                    |
-| node.os.name.gentoo.count                 | Clients with "gentoo" operating system                    |
-| node.os.name.opensuse.count               | Clients with "opensuse" operating system                  |
-| node.os.name.oracle.count                 | Clients with "oracle" operating system                    |
-| node.os.name.other.count                  | Clients with some other operating system                  |
-| node.os.name.raspbian.count               | Clients with "raspbian" operating system                  |
-| node.os.name.redhat.count                 | Clients with "redhat" operating system                    |
-| node.os.name.suse.count                   | Clients with "suse" operating system                      |
-| node.os.name.ubuntu.count                 | Clients with "ubuntu" operating system                    |
-| node.os.name.unique.count                 | Unique operating systems on client nodes                  |
-| node.os.name.windows.count                | Clients with "windows" operating system                   |
-| node.pool.count                           | Node pools                                                |
-| node.status.disconnected.count            | Clients with status "disconnected"                        |
-| node.status.down.count                    | Clients with status "down"                                |
-| node.status.initializing.count            | Clients with status "initializing"                        |
-| node.status.ready.count                   | Clients with status "ready"                               |
-| node.status.unknown.count                 | Clients with status "unknown"                             |
-| nomad.billable.clients                    | Number of client nodes in the cluster                     |
-| nomad.billable.cores.s390x                | Active client s390x CPU cores in the cluster              |
-| nomad.billable.cores.total                | Active client CPU cores in the cluster                    |
-| plugin.csi.unique.count                   | Unique CSI plugins                                        |
-| policy.sentinel.count                     | Sentinel policies                                         |
-| sentinel.enforcement.advisory.count       | Sentinel policies with "advisory" enforcement level       |
-| sentinel.enforcement.hard-mandatory.count | Sentinel policies with "hard-mandatory" enforcement level |
-| sentinel.enforcement.soft-mandatory.count | Sentinel policies with "soft-mandatory" enforcement level |
-| sentinel.scope.submit-csi-volume.count    | Sentinel policies with "submit-csi-volume" scope          |
-| sentinel.scope.submit-host-volume.count   | Sentinel policies with "submit-host-volume" scope         |
-| sentinel.scope.submit-job.count           | Sentinel policies with "submit-job" scope                 |
-| task.driver.docker.count                  | Tasks with the "docker" driver                            |
-| task.driver.exec.count                    | Tasks with the "exec" driver                              |
-| task.driver.exec2.count                   | Tasks with the "exec2" driver                             |
-| task.driver.java.count                    | Tasks with the "java" driver                              |
-| task.driver.nomad-driver-virt.count       | Tasks with the "nomad-driver-virt" driver                 |
-| task.driver.other.count                   | Tasks with some other driver                              |
-| task.driver.pledge.count                  | Tasks with the "pledge" driver                            |
-| task.driver.podman.count                  | Tasks with the "podman" driver                            |
-| task.driver.qemu.count                    | Tasks with the "qemu" driver                              |
-| task.driver.raw_exec.count                | Tasks with the "raw_exec" driver                          |
-| variable.count                            | Nomad Variables                                           |
-| variable.lock.count                       | Nomad Variable Locks                                      |
-| volume.csi.capacity                       | Capacity of all CSI volumes in MB                         |
-| volume.csi.count                          | Number of "csi" volumes                                   |
-| volume.dhv.capacity                       | Capacity of all dynamic host volumes in MB                |
-| volume.dhv.plugin.other.count             | Dynamic host volumes with non-standard plugins            |
-| volume.dynamic.count                      | Number of "dynamic" volumes                               |
-| volume.static.count                       | Number of "static" volumes                                |
+| Key                                       | Description                                             |
+|-------------------------------------------|---------------------------------------------------------|
+| acl.auth.method.count                    | ACL Auth Methods                                         |
+| acl.auth.method.jwt.count                | ACL Auth Methods of type JWT                             |
+| acl.auth.method.oidc.count               | ACL Auth Methods of type OIDC                            |
+| acl.policy.count                         | ACL policies                                             |
+| acl.role.count                           | ACL roles                                                |
+| acl.token.count                          | ACL tokens                                               |
+| alloc.count                              | All allocations                                          |
+| alloc.status.complete.count              | Allocations with client status "complete"                |
+| alloc.status.failed.count                | Allocations with client status "failed"                  |
+| alloc.status.lost.count                  | Allocations with client status "lost"                    |
+| alloc.status.pending.count               | Allocations with client status "pending"                 |
+| alloc.status.running.count               | Allocations with client status "running"                 |
+| alloc.status.unknown.count               | Allocations with client status "unknown"                 |
+| alloc.task.count                         | All tasks in allocations                                 |
+| alloc.task.running.count                 | Running tasks in allocations                             |
+| client.count                             | Client nodes in the cluster                              |
+| client.device.gpu.amd.count              | Clients with the "amd" gpu device driver                 |
+| client.device.gpu.nvidia.count           | Clients with the "nvidia" gpu device driver              |
+| client.device.gpu.other.count            | Clients with a gpu device driver of unknown vendor       |
+| client.device.other.other.count          | Clients with some other device driver                    |
+| client.device.usb.other.count            | Clients with a usb device driver of unknown vendor       |
+| client.driver.docker.count               | Clients with the docker driver                           |
+| client.driver.exec.count                 | Clients with the exec driver                             |
+| client.driver.exec2.count                | Clients with the exec2 driver                            |
+| client.driver.java.count                 | Clients with the java driver                             |
+| client.driver.nomad-driver-virt.count    | Clients with the nomad-driver-virt driver                |
+| client.driver.other.count                | Clients with the other driver                            |
+| client.driver.pledge.count               | Clients with the pledge driver                           |
+| client.driver.podman.count               | Clients with the podman driver                           |
+| client.driver.qemu.count                 | Clients with the qemu driver                             |
+| client.driver.raw_exec.count             | Clients with the raw_exec driver                         |
+| client.plugin.cni.unique.count           | Unique CNI plugins on client nodes                       |
+| client.plugin.driver.unique.count        | Unique task drivers on client nodes                      |
+| client.plugin.host_volume.unique.count   | Unique host volume plugins on client nodes               |
+| client.plugin.secret.unique.count        | Unique secret plugins on client nodes                    |
+| client.resources.compute                 | Total client compute                                     |
+| client.resources.core.count              | Total client CPU cores                                   |
+| client.resources.memory                  | Total client memory in MB                                |
+| client.vault.enabled.count               | Clients with Vault enabled                               |
+| job.count                                | All jobs                                                 |
+| job.device.gpu.amd.count                 | Jobs with the "amd" gpu device driver                    |
+| job.device.gpu.nvidia.count              | Jobs with the "nvidia" gpu device driver                 |
+| job.device.gpu.other.count               | Jobs with a gpu device driver of unknown vendor          |
+| job.device.other.other.count             | Jobs with some other device driver                       |
+| job.device.usb.other.count               | Jobs with a usb device driver of unknown vendor          |
+| job.driver.docker.count                  | Tasks defined with the docker driver                     |
+| job.driver.exec.count                    | Tasks defined with the exec driver                       |
+| job.driver.exec2.count                   | Tasks defined with the exec2 driver                      |
+| job.driver.java.count                    | Tasks defined with the java driver                       |
+| job.driver.nomad-driver-virt.count       | Tasks defined with the nomad-driver-virt driver          |
+| job.driver.other.count                   | Tasks defined with the other driver                      |
+| job.driver.pledge.count                  | Tasks defined with the pledge driver                     |
+| job.driver.podman.count                  | Tasks defined with the podman driver                     |
+| job.driver.qemu.count                    | Tasks defined with the qemu driver                       |
+| job.driver.raw_exec.count                | Tasks defined with the raw_exec driver                   |
+| job.group.count                          | Task groups in jobs                                      |
+| job.network.cni.args.count               | Networks in jobs with custom CNI args                    |
+| job.network.mode.bridge.count            | Networks in jobs with mode "bridge"                      |
+| job.network.mode.cni.count               | Networks in jobs with mode "cni"                         |
+| job.network.mode.host.count              | Networks in jobs with mode "host"                        |
+| job.network.mode.other.count             | Networks in jobs with some other mode                    |
+| job.parameterized.count                  | Parameterized jobs                                       |
+| job.parameterized.dispatched.count       | Dispatched parameterized jobs                            |
+| job.periodic.count                       | Periodic jobs                                            |
+| job.periodic.dispatched.count            | Dispatched periodic jobs                                 |
+| job.service.consul.connect.count         | Connect services in jobs                                 |
+| job.service.consul.count                 | Consul services in jobs                                  |
+| job.service.nomad.count                  | Nomad provider services in jobs                          |
+| job.task.identity.count                  | Tasks in jobs with identity enabled                      |
+| job.task.template.count                  | Tasks in jobs with templates                             |
+| job.task.vault.count                     | Tasks in jobs with Vault enabled                         |
+| job.type.batch.count                     | Jobs of type "batch"                                     |
+| job.type.service.count                   | Jobs of type "service"                                   |
+| job.type.sysbatch.count                  | Jobs of type "sysbatch"                                  |
+| job.type.system.count                    | Jobs of type "system"                                    |
+| job.volume.csi.count                     | CSI volumes in jobs                                      |
+| job.volume.host.count                    | Host volumes in jobs                                     |
+| job.volume.sticky.count                  | Sticky volumes in jobs                                   |
+| namespace.count                          | Namespaces                                               |
+| namespace.quotas.count                   | Quotas                                                   |
+| node.cpu.arch.amd64.count                | Clients with "amd64" CPU architecture                    |
+| node.cpu.arch.arm64.count                | Clients with "arm64" CPU architecture                    |
+| node.cpu.arch.other.count                | Clients with some other CPU architecture                 |
+| node.cpu.arch.s390x.count                | Clients with "s390x" CPU architecture                    |
+| node.cpu.arch.unique.count               | Unique CPU architectures on client nodes                 |
+| node.kernel.name.aix.count               | Clients with "aix" kernel                                |
+| node.kernel.name.darwin.count            | Clients with "darwin" kernel                             |
+| node.kernel.name.freebsd.count           | Clients with "freebsd" kernel                            |
+| node.kernel.name.linux.count             | Clients with "linux" kernel                              |
+| node.kernel.name.other.count             | Clients with some other kernel                           |
+| node.kernel.name.plan9.count             | Clients with "plan9" kernel                              |
+| node.kernel.name.solaris.count           | Clients with "solaris" kernel                            |
+| node.kernel.name.unique.count            | Unique kernels on client nodes                           |
+| node.os.name.alpine.count                | Clients with "alpine" operating system                   |
+| node.os.name.amazon.count                | Clients with "amazon" operating system                   |
+| node.os.name.arch.count                  | Clients with "arch" operating system                     |
+| node.os.name.centos.count                | Clients with "centos" operating system                   |
+| node.os.name.cloudlinux.count            | Clients with "cloudlinux" operating system               |
+| node.os.name.coreos.count                | Clients with "coreos" operating system                   |
+| node.os.name.darwin.count                | Clients with "darwin" operating system                   |
+| node.os.name.debian.count                | Clients with "debian" operating system                   |
+| node.os.name.fedora.count                | Clients with "fedora" operating system                   |
+| node.os.name.gentoo.count                | Clients with "gentoo" operating system                   |
+| node.os.name.opensuse.count              | Clients with "opensuse" operating system                 |
+| node.os.name.oracle.count                | Clients with "oracle" operating system                   |
+| node.os.name.other.count                 | Clients with some other operating system                 |
+| node.os.name.raspbian.count              | Clients with "raspbian" operating system                 |
+| node.os.name.redhat.count                | Clients with "redhat" operating system                   |
+| node.os.name.suse.count                  | Clients with "suse" operating system                     |
+| node.os.name.ubuntu.count                | Clients with "ubuntu" operating system                   |
+| node.os.name.unique.count                | Unique operating systems on client nodes                 |
+| node.os.name.windows.count               | Clients with "windows" operating system                  |
+| node.pool.count                          | Node pools                                               |
+| node.status.disconnected.count           | Clients with status "disconnected"                       |
+| node.status.down.count                   | Clients with status "down"                               |
+| node.status.initializing.count           | Clients with status "initializing"                       |
+| node.status.ready.count                  | Clients with status "ready"                              |
+| node.status.unknown.count                | Clients with status "unknown"                            |
+| nomad.billable.clients                   | Number of client nodes in the cluster                    |
+| nomad.billable.cores.s390x               | Active client s390x CPU cores in the cluster             |
+| nomad.billable.cores.total               | Active client CPU cores in the cluster                   |
+| plugin.csi.unique.count                  | Unique CSI plugins                                       |
+| policy.sentinel.count                    | Sentinel policies                                        |
+| sentinel.enforcement.advisory.count      | Sentinel policies with "advisory" enforcement level      |
+| sentinel.enforcement.hard-mandatory.count| Sentinel policies with "hard-mandatory" enforcement level|
+| sentinel.enforcement.soft-mandatory.count| Sentinel policies with "soft-mandatory" enforcement level|
+| sentinel.scope.submit-csi-volume.count   | Sentinel policies with "submit-csi-volume" scope         |
+| sentinel.scope.submit-host-volume.count  | Sentinel policies with "submit-host-volume" scope        |
+| sentinel.scope.submit-job.count          | Sentinel policies with "submit-job" scope                |
+| task.device.gpu.amd.count                | Tasks with the "amd" gpu device driver                   |
+| task.device.gpu.nvidia.count             | Tasks with the "nvidia" gpu device driver                |
+| task.device.gpu.other.count              | Tasks with a gpu device driver of unknown vendor         |
+| task.device.other.other.count            | Tasks with some other device driver                      |
+| task.device.usb.other.count              | Tasks with a usb device driver of unknown vendor         |
+| task.driver.docker.count                 | Allocated tasks running with the docker driver           |
+| task.driver.exec.count                   | Allocated tasks running with the exec driver             |
+| task.driver.exec2.count                  | Allocated tasks running with the exec2 driver            |
+| task.driver.java.count                   | Allocated tasks running with the java driver             |
+| task.driver.nomad-driver-virt.count      | Allocated tasks running with the nomad-driver-virt driver|
+| task.driver.other.count                  | Allocated tasks running with the other driver            |
+| task.driver.pledge.count                 | Allocated tasks running with the pledge driver           |
+| task.driver.podman.count                 | Allocated tasks running with the podman driver           |
+| task.driver.qemu.count                   | Allocated tasks running with the qemu driver             |
+| task.driver.raw_exec.count               | Allocated tasks running with the raw_exec driver         |
+| variable.count                           | Nomad Variables                                          |
+| variable.lock.count                      | Nomad Variable Locks                                     |
+| volume.csi.capacity                      | Capacity of all CSI volumes in MB                        |
+| volume.csi.count                         | Number of "csi" volumes                                  |
+| volume.dhv.capacity                      | Capacity of all dynamic host volumes in MB               |
+| volume.dhv.plugin.other.count            | Dynamic host volumes with non-standard plugins           |
+| volume.dynamic.count                     | Number of "dynamic" volumes                              |
+| volume.static.count                      | Number of "static" volumes                               |
 
 
 ## Example payload

--- a/content/nomad/v1.8.x/content/docs/enterprise/license/utilization-reporting.mdx
+++ b/content/nomad/v1.8.x/content/docs/enterprise/license/utilization-reporting.mdx
@@ -164,145 +164,160 @@ that might identify proprietary information.
      https://github.com/hashicorp/hashicorp-census-registry/tree/main/nomad/v2/cmd
 -->
 
-| Key                                       | Description                                               |
-|-------------------------------------------|-----------------------------------------------------------|
-| acl.auth.method.count                     | ACL Auth Methods                                          |
-| acl.auth.method.jwt.count                 | ACL Auth Methods of type JWT                              |
-| acl.auth.method.oidc.count                | ACL Auth Methods of type OIDC                             |
-| acl.policy.count                          | ACL policies                                              |
-| acl.role.count                            | ACL roles                                                 |
-| acl.token.count                           | ACL tokens                                                |
-| alloc.count                               | All allocations                                           |
-| alloc.status.complete.count               | Allocations with client status "complete"                 |
-| alloc.status.failed.count                 | Allocations with client status "failed"                   |
-| alloc.status.lost.count                   | Allocations with client status "lost"                     |
-| alloc.status.pending.count                | Allocations with client status "pending"                  |
-| alloc.status.running.count                | Allocations with client status "running"                  |
-| alloc.status.unknown.count                | Allocations with client status "unknown"                  |
-| alloc.task.count                          | All tasks in allocations                                  |
-| alloc.task.running.count                  | Running tasks in allocations                              |
-| client.count                              | Client nodes in the cluster                               |
-| client.driver.docker.count                | Clients with the "docker" driver                          |
-| client.driver.exec.count                  | Clients with the "exec" driver                            |
-| client.driver.exec2.count                 | Clients with the "exec2" driver                           |
-| client.driver.java.count                  | Clients with the "java" driver                            |
-| client.driver.nomad-driver-virt.count     | Clients with the "nomad-driver-virt" driver               |
-| client.driver.other.count                 | Clients with some other driver                            |
-| client.driver.pledge.count                | Clients with the "pledge" driver                          |
-| client.driver.podman.count                | Clients with the "podman" driver                          |
-| client.driver.qemu.count                  | Clients with the "qemu" driver                            |
-| client.driver.raw_exec.count              | Clients with the "raw_exec" driver                        |
-| client.plugin.cni.unique.count            | Unique CNI plugins on client nodes                        |
-| client.plugin.driver.unique.count         | Unique task drivers on client nodes                       |
-| client.plugin.host_volume.unique.count    | Unique host volume plugins on client nodes                |
-| client.plugin.secret.unique.count         | Unique secret plugins on client nodes                     |
-| client.resources.compute                  | Total client compute                                      |
-| client.resources.core.count               | Total client CPU cores                                    |
-| client.resources.memory                   | Total client memory in MB                                 |
-| client.vault.enabled.count                | Clients with Vault enabled                                |
-| job.count                                 | All jobs                                                  |
-| job.driver.docker.count                   | Jobs with the "docker" driver                             |
-| job.driver.exec.count                     | Jobs with the "exec" driver                               |
-| job.driver.exec2.count                    | Jobs with the "exec2" driver                              |
-| job.driver.java.count                     | Jobs with the "java" driver                               |
-| job.driver.nomad-driver-virt.count        | Jobs with the "nomad-driver-virt" driver                  |
-| job.driver.other.count                    | Jobs with some other driver                               |
-| job.driver.pledge.count                   | Jobs with the "pledge" driver                             |
-| job.driver.podman.count                   | Jobs with the "podman" driver                             |
-| job.driver.qemu.count                     | Jobs with the "qemu" driver                               |
-| job.driver.raw_exec.count                 | Jobs with the "raw_exec" driver                           |
-| job.group.count                           | Task groups in jobs                                       |
-| job.network.cni.args.count                | Networks in jobs with custom CNI args                     |
-| job.network.mode.bridge.count             | Networks in jobs with mode "bridge"                       |
-| job.network.mode.cni.count                | Networks in jobs with mode "cni"                          |
-| job.network.mode.host.count               | Networks in jobs with mode "host"                         |
-| job.network.mode.other.count              | Networks in jobs with some other mode                     |
-| job.parameterized.count                   | Parameterized jobs                                        |
-| job.parameterized.dispatched.count        | Dispatched parameterized jobs                             |
-| job.periodic.count                        | Periodic jobs                                             |
-| job.periodic.dispatched.count             | Dispatched periodic jobs                                  |
-| job.service.consul.connect.count          | Connect services in jobs                                  |
-| job.service.consul.count                  | Consul services in jobs                                   |
-| job.service.nomad.count                   | Nomad provider services in jobs                           |
-| job.task.identity.count                   | Tasks in jobs with identity enabled                       |
-| job.task.template.count                   | Tasks in jobs with templates                              |
-| job.task.vault.count                      | Tasks in jobs with Vault enabled                          |
-| job.type.batch.count                      | Jobs of type "batch"                                      |
-| job.type.service.count                    | Jobs of type "service"                                    |
-| job.type.sysbatch.count                   | Jobs of type "sysbatch"                                   |
-| job.type.system.count                     | Jobs of type "system"                                     |
-| job.volume.csi.count                      | CSI volumes in jobs                                       |
-| job.volume.host.count                     | Host volumes in jobs                                      |
-| job.volume.sticky.count                   | Sticky volumes in jobs                                    |
-| namespace.count                           | Namespaces                                                |
-| namespace.quotas.count                    | Quotas                                                    |
-| node.cpu.arch.amd64.count                 | Clients with "amd64" CPU architecture                     |
-| node.cpu.arch.arm64.count                 | Clients with "arm64" CPU architecture                     |
-| node.cpu.arch.other.count                 | Clients with some other CPU architecture                  |
-| node.cpu.arch.s390x.count                 | Clients with "s390x" CPU architecture                     |
-| node.cpu.arch.unique.count                | Unique CPU architectures on client nodes                  |
-| node.kernel.name.aix.count                | Clients with "aix" kernel                                 |
-| node.kernel.name.darwin.count             | Clients with "darwin" kernel                              |
-| node.kernel.name.freebsd.count            | Clients with "freebsd" kernel                             |
-| node.kernel.name.linux.count              | Clients with "linux" kernel                               |
-| node.kernel.name.other.count              | Clients with some other kernel                            |
-| node.kernel.name.plan9.count              | Clients with "plan9" kernel                               |
-| node.kernel.name.solaris.count            | Clients with "solaris" kernel                             |
-| node.kernel.name.unique.count             | Unique kernels on client nodes                            |
-| node.os.name.alpine.count                 | Clients with "alpine" operating system                    |
-| node.os.name.amazon.count                 | Clients with "amazon" operating system                    |
-| node.os.name.arch.count                   | Clients with "arch" operating system                      |
-| node.os.name.centos.count                 | Clients with "centos" operating system                    |
-| node.os.name.cloudlinux.count             | Clients with "cloudlinux" operating system                |
-| node.os.name.coreos.count                 | Clients with "coreos" operating system                    |
-| node.os.name.darwin.count                 | Clients with "darwin" operating system                    |
-| node.os.name.debian.count                 | Clients with "debian" operating system                    |
-| node.os.name.fedora.count                 | Clients with "fedora" operating system                    |
-| node.os.name.gentoo.count                 | Clients with "gentoo" operating system                    |
-| node.os.name.opensuse.count               | Clients with "opensuse" operating system                  |
-| node.os.name.oracle.count                 | Clients with "oracle" operating system                    |
-| node.os.name.other.count                  | Clients with some other operating system                  |
-| node.os.name.raspbian.count               | Clients with "raspbian" operating system                  |
-| node.os.name.redhat.count                 | Clients with "redhat" operating system                    |
-| node.os.name.suse.count                   | Clients with "suse" operating system                      |
-| node.os.name.ubuntu.count                 | Clients with "ubuntu" operating system                    |
-| node.os.name.unique.count                 | Unique operating systems on client nodes                  |
-| node.os.name.windows.count                | Clients with "windows" operating system                   |
-| node.pool.count                           | Node pools                                                |
-| node.status.disconnected.count            | Clients with status "disconnected"                        |
-| node.status.down.count                    | Clients with status "down"                                |
-| node.status.initializing.count            | Clients with status "initializing"                        |
-| node.status.ready.count                   | Clients with status "ready"                               |
-| node.status.unknown.count                 | Clients with status "unknown"                             |
-| nomad.billable.clients                    | Number of client nodes in the cluster                     |
-| nomad.billable.cores.s390x                | Active client s390x CPU cores in the cluster              |
-| nomad.billable.cores.total                | Active client CPU cores in the cluster                    |
-| plugin.csi.unique.count                   | Unique CSI plugins                                        |
-| policy.sentinel.count                     | Sentinel policies                                         |
-| sentinel.enforcement.advisory.count       | Sentinel policies with "advisory" enforcement level       |
-| sentinel.enforcement.hard-mandatory.count | Sentinel policies with "hard-mandatory" enforcement level |
-| sentinel.enforcement.soft-mandatory.count | Sentinel policies with "soft-mandatory" enforcement level |
-| sentinel.scope.submit-csi-volume.count    | Sentinel policies with "submit-csi-volume" scope          |
-| sentinel.scope.submit-host-volume.count   | Sentinel policies with "submit-host-volume" scope         |
-| sentinel.scope.submit-job.count           | Sentinel policies with "submit-job" scope                 |
-| task.driver.docker.count                  | Tasks with the "docker" driver                            |
-| task.driver.exec.count                    | Tasks with the "exec" driver                              |
-| task.driver.exec2.count                   | Tasks with the "exec2" driver                             |
-| task.driver.java.count                    | Tasks with the "java" driver                              |
-| task.driver.nomad-driver-virt.count       | Tasks with the "nomad-driver-virt" driver                 |
-| task.driver.other.count                   | Tasks with some other driver                              |
-| task.driver.pledge.count                  | Tasks with the "pledge" driver                            |
-| task.driver.podman.count                  | Tasks with the "podman" driver                            |
-| task.driver.qemu.count                    | Tasks with the "qemu" driver                              |
-| task.driver.raw_exec.count                | Tasks with the "raw_exec" driver                          |
-| variable.count                            | Nomad Variables                                           |
-| variable.lock.count                       | Nomad Variable Locks                                      |
-| volume.csi.capacity                       | Capacity of all CSI volumes in MB                         |
-| volume.csi.count                          | Number of "csi" volumes                                   |
-| volume.dhv.capacity                       | Capacity of all dynamic host volumes in MB                |
-| volume.dhv.plugin.other.count             | Dynamic host volumes with non-standard plugins            |
-| volume.dynamic.count                      | Number of "dynamic" volumes                               |
-| volume.static.count                       | Number of "static" volumes                                |
+| Key                                       | Description                                             |
+|-------------------------------------------|---------------------------------------------------------|
+| acl.auth.method.count                    | ACL Auth Methods                                         |
+| acl.auth.method.jwt.count                | ACL Auth Methods of type JWT                             |
+| acl.auth.method.oidc.count               | ACL Auth Methods of type OIDC                            |
+| acl.policy.count                         | ACL policies                                             |
+| acl.role.count                           | ACL roles                                                |
+| acl.token.count                          | ACL tokens                                               |
+| alloc.count                              | All allocations                                          |
+| alloc.status.complete.count              | Allocations with client status "complete"                |
+| alloc.status.failed.count                | Allocations with client status "failed"                  |
+| alloc.status.lost.count                  | Allocations with client status "lost"                    |
+| alloc.status.pending.count               | Allocations with client status "pending"                 |
+| alloc.status.running.count               | Allocations with client status "running"                 |
+| alloc.status.unknown.count               | Allocations with client status "unknown"                 |
+| alloc.task.count                         | All tasks in allocations                                 |
+| alloc.task.running.count                 | Running tasks in allocations                             |
+| client.count                             | Client nodes in the cluster                              |
+| client.device.gpu.amd.count              | Clients with the "amd" gpu device driver                 |
+| client.device.gpu.nvidia.count           | Clients with the "nvidia" gpu device driver              |
+| client.device.gpu.other.count            | Clients with a gpu device driver of unknown vendor       |
+| client.device.other.other.count          | Clients with some other device driver                    |
+| client.device.usb.other.count            | Clients with a usb device driver of unknown vendor       |
+| client.driver.docker.count               | Clients with the docker driver                           |
+| client.driver.exec.count                 | Clients with the exec driver                             |
+| client.driver.exec2.count                | Clients with the exec2 driver                            |
+| client.driver.java.count                 | Clients with the java driver                             |
+| client.driver.nomad-driver-virt.count    | Clients with the nomad-driver-virt driver                |
+| client.driver.other.count                | Clients with the other driver                            |
+| client.driver.pledge.count               | Clients with the pledge driver                           |
+| client.driver.podman.count               | Clients with the podman driver                           |
+| client.driver.qemu.count                 | Clients with the qemu driver                             |
+| client.driver.raw_exec.count             | Clients with the raw_exec driver                         |
+| client.plugin.cni.unique.count           | Unique CNI plugins on client nodes                       |
+| client.plugin.driver.unique.count        | Unique task drivers on client nodes                      |
+| client.plugin.host_volume.unique.count   | Unique host volume plugins on client nodes               |
+| client.plugin.secret.unique.count        | Unique secret plugins on client nodes                    |
+| client.resources.compute                 | Total client compute                                     |
+| client.resources.core.count              | Total client CPU cores                                   |
+| client.resources.memory                  | Total client memory in MB                                |
+| client.vault.enabled.count               | Clients with Vault enabled                               |
+| job.count                                | All jobs                                                 |
+| job.device.gpu.amd.count                 | Jobs with the "amd" gpu device driver                    |
+| job.device.gpu.nvidia.count              | Jobs with the "nvidia" gpu device driver                 |
+| job.device.gpu.other.count               | Jobs with a gpu device driver of unknown vendor          |
+| job.device.other.other.count             | Jobs with some other device driver                       |
+| job.device.usb.other.count               | Jobs with a usb device driver of unknown vendor          |
+| job.driver.docker.count                  | Tasks defined with the docker driver                     |
+| job.driver.exec.count                    | Tasks defined with the exec driver                       |
+| job.driver.exec2.count                   | Tasks defined with the exec2 driver                      |
+| job.driver.java.count                    | Tasks defined with the java driver                       |
+| job.driver.nomad-driver-virt.count       | Tasks defined with the nomad-driver-virt driver          |
+| job.driver.other.count                   | Tasks defined with the other driver                      |
+| job.driver.pledge.count                  | Tasks defined with the pledge driver                     |
+| job.driver.podman.count                  | Tasks defined with the podman driver                     |
+| job.driver.qemu.count                    | Tasks defined with the qemu driver                       |
+| job.driver.raw_exec.count                | Tasks defined with the raw_exec driver                   |
+| job.group.count                          | Task groups in jobs                                      |
+| job.network.cni.args.count               | Networks in jobs with custom CNI args                    |
+| job.network.mode.bridge.count            | Networks in jobs with mode "bridge"                      |
+| job.network.mode.cni.count               | Networks in jobs with mode "cni"                         |
+| job.network.mode.host.count              | Networks in jobs with mode "host"                        |
+| job.network.mode.other.count             | Networks in jobs with some other mode                    |
+| job.parameterized.count                  | Parameterized jobs                                       |
+| job.parameterized.dispatched.count       | Dispatched parameterized jobs                            |
+| job.periodic.count                       | Periodic jobs                                            |
+| job.periodic.dispatched.count            | Dispatched periodic jobs                                 |
+| job.service.consul.connect.count         | Connect services in jobs                                 |
+| job.service.consul.count                 | Consul services in jobs                                  |
+| job.service.nomad.count                  | Nomad provider services in jobs                          |
+| job.task.identity.count                  | Tasks in jobs with identity enabled                      |
+| job.task.template.count                  | Tasks in jobs with templates                             |
+| job.task.vault.count                     | Tasks in jobs with Vault enabled                         |
+| job.type.batch.count                     | Jobs of type "batch"                                     |
+| job.type.service.count                   | Jobs of type "service"                                   |
+| job.type.sysbatch.count                  | Jobs of type "sysbatch"                                  |
+| job.type.system.count                    | Jobs of type "system"                                    |
+| job.volume.csi.count                     | CSI volumes in jobs                                      |
+| job.volume.host.count                    | Host volumes in jobs                                     |
+| job.volume.sticky.count                  | Sticky volumes in jobs                                   |
+| namespace.count                          | Namespaces                                               |
+| namespace.quotas.count                   | Quotas                                                   |
+| node.cpu.arch.amd64.count                | Clients with "amd64" CPU architecture                    |
+| node.cpu.arch.arm64.count                | Clients with "arm64" CPU architecture                    |
+| node.cpu.arch.other.count                | Clients with some other CPU architecture                 |
+| node.cpu.arch.s390x.count                | Clients with "s390x" CPU architecture                    |
+| node.cpu.arch.unique.count               | Unique CPU architectures on client nodes                 |
+| node.kernel.name.aix.count               | Clients with "aix" kernel                                |
+| node.kernel.name.darwin.count            | Clients with "darwin" kernel                             |
+| node.kernel.name.freebsd.count           | Clients with "freebsd" kernel                            |
+| node.kernel.name.linux.count             | Clients with "linux" kernel                              |
+| node.kernel.name.other.count             | Clients with some other kernel                           |
+| node.kernel.name.plan9.count             | Clients with "plan9" kernel                              |
+| node.kernel.name.solaris.count           | Clients with "solaris" kernel                            |
+| node.kernel.name.unique.count            | Unique kernels on client nodes                           |
+| node.os.name.alpine.count                | Clients with "alpine" operating system                   |
+| node.os.name.amazon.count                | Clients with "amazon" operating system                   |
+| node.os.name.arch.count                  | Clients with "arch" operating system                     |
+| node.os.name.centos.count                | Clients with "centos" operating system                   |
+| node.os.name.cloudlinux.count            | Clients with "cloudlinux" operating system               |
+| node.os.name.coreos.count                | Clients with "coreos" operating system                   |
+| node.os.name.darwin.count                | Clients with "darwin" operating system                   |
+| node.os.name.debian.count                | Clients with "debian" operating system                   |
+| node.os.name.fedora.count                | Clients with "fedora" operating system                   |
+| node.os.name.gentoo.count                | Clients with "gentoo" operating system                   |
+| node.os.name.opensuse.count              | Clients with "opensuse" operating system                 |
+| node.os.name.oracle.count                | Clients with "oracle" operating system                   |
+| node.os.name.other.count                 | Clients with some other operating system                 |
+| node.os.name.raspbian.count              | Clients with "raspbian" operating system                 |
+| node.os.name.redhat.count                | Clients with "redhat" operating system                   |
+| node.os.name.suse.count                  | Clients with "suse" operating system                     |
+| node.os.name.ubuntu.count                | Clients with "ubuntu" operating system                   |
+| node.os.name.unique.count                | Unique operating systems on client nodes                 |
+| node.os.name.windows.count               | Clients with "windows" operating system                  |
+| node.pool.count                          | Node pools                                               |
+| node.status.disconnected.count           | Clients with status "disconnected"                       |
+| node.status.down.count                   | Clients with status "down"                               |
+| node.status.initializing.count           | Clients with status "initializing"                       |
+| node.status.ready.count                  | Clients with status "ready"                              |
+| node.status.unknown.count                | Clients with status "unknown"                            |
+| nomad.billable.clients                   | Number of client nodes in the cluster                    |
+| nomad.billable.cores.s390x               | Active client s390x CPU cores in the cluster             |
+| nomad.billable.cores.total               | Active client CPU cores in the cluster                   |
+| plugin.csi.unique.count                  | Unique CSI plugins                                       |
+| policy.sentinel.count                    | Sentinel policies                                        |
+| sentinel.enforcement.advisory.count      | Sentinel policies with "advisory" enforcement level      |
+| sentinel.enforcement.hard-mandatory.count| Sentinel policies with "hard-mandatory" enforcement level|
+| sentinel.enforcement.soft-mandatory.count| Sentinel policies with "soft-mandatory" enforcement level|
+| sentinel.scope.submit-csi-volume.count   | Sentinel policies with "submit-csi-volume" scope         |
+| sentinel.scope.submit-host-volume.count  | Sentinel policies with "submit-host-volume" scope        |
+| sentinel.scope.submit-job.count          | Sentinel policies with "submit-job" scope                |
+| task.device.gpu.amd.count                | Tasks with the "amd" gpu device driver                   |
+| task.device.gpu.nvidia.count             | Tasks with the "nvidia" gpu device driver                |
+| task.device.gpu.other.count              | Tasks with a gpu device driver of unknown vendor         |
+| task.device.other.other.count            | Tasks with some other device driver                      |
+| task.device.usb.other.count              | Tasks with a usb device driver of unknown vendor         |
+| task.driver.docker.count                 | Allocated tasks running with the docker driver           |
+| task.driver.exec.count                   | Allocated tasks running with the exec driver             |
+| task.driver.exec2.count                  | Allocated tasks running with the exec2 driver            |
+| task.driver.java.count                   | Allocated tasks running with the java driver             |
+| task.driver.nomad-driver-virt.count      | Allocated tasks running with the nomad-driver-virt driver|
+| task.driver.other.count                  | Allocated tasks running with the other driver            |
+| task.driver.pledge.count                 | Allocated tasks running with the pledge driver           |
+| task.driver.podman.count                 | Allocated tasks running with the podman driver           |
+| task.driver.qemu.count                   | Allocated tasks running with the qemu driver             |
+| task.driver.raw_exec.count               | Allocated tasks running with the raw_exec driver         |
+| variable.count                           | Nomad Variables                                          |
+| variable.lock.count                      | Nomad Variable Locks                                     |
+| volume.csi.capacity                      | Capacity of all CSI volumes in MB                        |
+| volume.csi.count                         | Number of "csi" volumes                                  |
+| volume.dhv.capacity                      | Capacity of all dynamic host volumes in MB               |
+| volume.dhv.plugin.other.count            | Dynamic host volumes with non-standard plugins           |
+| volume.dynamic.count                     | Number of "dynamic" volumes                              |
+| volume.static.count                      | Number of "static" volumes                               |
 
 
 ## Example payload

--- a/content/nomad/v1.8.x/content/docs/enterprise/license/utilization-reporting.mdx
+++ b/content/nomad/v1.8.x/content/docs/enterprise/license/utilization-reporting.mdx
@@ -166,158 +166,159 @@ that might identify proprietary information.
 
 | Key                                       | Description                                             |
 |-------------------------------------------|---------------------------------------------------------|
-| acl.auth.method.count                    | ACL Auth Methods                                         |
-| acl.auth.method.jwt.count                | ACL Auth Methods of type JWT                             |
-| acl.auth.method.oidc.count               | ACL Auth Methods of type OIDC                            |
-| acl.policy.count                         | ACL policies                                             |
-| acl.role.count                           | ACL roles                                                |
-| acl.token.count                          | ACL tokens                                               |
-| alloc.count                              | All allocations                                          |
-| alloc.status.complete.count              | Allocations with client status "complete"                |
-| alloc.status.failed.count                | Allocations with client status "failed"                  |
-| alloc.status.lost.count                  | Allocations with client status "lost"                    |
-| alloc.status.pending.count               | Allocations with client status "pending"                 |
-| alloc.status.running.count               | Allocations with client status "running"                 |
-| alloc.status.unknown.count               | Allocations with client status "unknown"                 |
-| alloc.task.count                         | All tasks in allocations                                 |
-| alloc.task.running.count                 | Running tasks in allocations                             |
-| client.count                             | Client nodes in the cluster                              |
-| client.device.gpu.amd.count              | Clients with the "amd" gpu device driver                 |
-| client.device.gpu.nvidia.count           | Clients with the "nvidia" gpu device driver              |
-| client.device.gpu.other.count            | Clients with a gpu device driver of unknown vendor       |
-| client.device.other.other.count          | Clients with some other device driver                    |
-| client.device.usb.other.count            | Clients with a usb device driver of unknown vendor       |
-| client.driver.docker.count               | Clients with the docker driver                           |
-| client.driver.exec.count                 | Clients with the exec driver                             |
-| client.driver.exec2.count                | Clients with the exec2 driver                            |
-| client.driver.java.count                 | Clients with the java driver                             |
-| client.driver.nomad-driver-virt.count    | Clients with the nomad-driver-virt driver                |
-| client.driver.other.count                | Clients with the other driver                            |
-| client.driver.pledge.count               | Clients with the pledge driver                           |
-| client.driver.podman.count               | Clients with the podman driver                           |
-| client.driver.qemu.count                 | Clients with the qemu driver                             |
-| client.driver.raw_exec.count             | Clients with the raw_exec driver                         |
-| client.plugin.cni.unique.count           | Unique CNI plugins on client nodes                       |
-| client.plugin.driver.unique.count        | Unique task drivers on client nodes                      |
-| client.plugin.host_volume.unique.count   | Unique host volume plugins on client nodes               |
-| client.plugin.secret.unique.count        | Unique secret plugins on client nodes                    |
-| client.resources.compute                 | Total client compute                                     |
-| client.resources.core.count              | Total client CPU cores                                   |
-| client.resources.memory                  | Total client memory in MB                                |
-| client.vault.enabled.count               | Clients with Vault enabled                               |
-| job.count                                | All jobs                                                 |
-| job.device.gpu.amd.count                 | Jobs with the "amd" gpu device driver                    |
-| job.device.gpu.nvidia.count              | Jobs with the "nvidia" gpu device driver                 |
-| job.device.gpu.other.count               | Jobs with a gpu device driver of unknown vendor          |
-| job.device.other.other.count             | Jobs with some other device driver                       |
-| job.device.usb.other.count               | Jobs with a usb device driver of unknown vendor          |
-| job.driver.docker.count                  | Tasks defined with the docker driver                     |
-| job.driver.exec.count                    | Tasks defined with the exec driver                       |
-| job.driver.exec2.count                   | Tasks defined with the exec2 driver                      |
-| job.driver.java.count                    | Tasks defined with the java driver                       |
-| job.driver.nomad-driver-virt.count       | Tasks defined with the nomad-driver-virt driver          |
-| job.driver.other.count                   | Tasks defined with the other driver                      |
-| job.driver.pledge.count                  | Tasks defined with the pledge driver                     |
-| job.driver.podman.count                  | Tasks defined with the podman driver                     |
-| job.driver.qemu.count                    | Tasks defined with the qemu driver                       |
-| job.driver.raw_exec.count                | Tasks defined with the raw_exec driver                   |
-| job.group.count                          | Task groups in jobs                                      |
-| job.network.cni.args.count               | Networks in jobs with custom CNI args                    |
-| job.network.mode.bridge.count            | Networks in jobs with mode "bridge"                      |
-| job.network.mode.cni.count               | Networks in jobs with mode "cni"                         |
-| job.network.mode.host.count              | Networks in jobs with mode "host"                        |
-| job.network.mode.other.count             | Networks in jobs with some other mode                    |
-| job.parameterized.count                  | Parameterized jobs                                       |
-| job.parameterized.dispatched.count       | Dispatched parameterized jobs                            |
-| job.periodic.count                       | Periodic jobs                                            |
-| job.periodic.dispatched.count            | Dispatched periodic jobs                                 |
-| job.service.consul.connect.count         | Connect services in jobs                                 |
-| job.service.consul.count                 | Consul services in jobs                                  |
-| job.service.nomad.count                  | Nomad provider services in jobs                          |
-| job.task.identity.count                  | Tasks in jobs with identity enabled                      |
-| job.task.template.count                  | Tasks in jobs with templates                             |
-| job.task.vault.count                     | Tasks in jobs with Vault enabled                         |
-| job.type.batch.count                     | Jobs of type "batch"                                     |
-| job.type.service.count                   | Jobs of type "service"                                   |
-| job.type.sysbatch.count                  | Jobs of type "sysbatch"                                  |
-| job.type.system.count                    | Jobs of type "system"                                    |
-| job.volume.csi.count                     | CSI volumes in jobs                                      |
-| job.volume.host.count                    | Host volumes in jobs                                     |
-| job.volume.sticky.count                  | Sticky volumes in jobs                                   |
-| namespace.count                          | Namespaces                                               |
-| namespace.quotas.count                   | Quotas                                                   |
-| node.cpu.arch.amd64.count                | Clients with "amd64" CPU architecture                    |
-| node.cpu.arch.arm64.count                | Clients with "arm64" CPU architecture                    |
-| node.cpu.arch.other.count                | Clients with some other CPU architecture                 |
-| node.cpu.arch.s390x.count                | Clients with "s390x" CPU architecture                    |
-| node.cpu.arch.unique.count               | Unique CPU architectures on client nodes                 |
-| node.kernel.name.aix.count               | Clients with "aix" kernel                                |
-| node.kernel.name.darwin.count            | Clients with "darwin" kernel                             |
-| node.kernel.name.freebsd.count           | Clients with "freebsd" kernel                            |
-| node.kernel.name.linux.count             | Clients with "linux" kernel                              |
-| node.kernel.name.other.count             | Clients with some other kernel                           |
-| node.kernel.name.plan9.count             | Clients with "plan9" kernel                              |
-| node.kernel.name.solaris.count           | Clients with "solaris" kernel                            |
-| node.kernel.name.unique.count            | Unique kernels on client nodes                           |
-| node.os.name.alpine.count                | Clients with "alpine" operating system                   |
-| node.os.name.amazon.count                | Clients with "amazon" operating system                   |
-| node.os.name.arch.count                  | Clients with "arch" operating system                     |
-| node.os.name.centos.count                | Clients with "centos" operating system                   |
-| node.os.name.cloudlinux.count            | Clients with "cloudlinux" operating system               |
-| node.os.name.coreos.count                | Clients with "coreos" operating system                   |
-| node.os.name.darwin.count                | Clients with "darwin" operating system                   |
-| node.os.name.debian.count                | Clients with "debian" operating system                   |
-| node.os.name.fedora.count                | Clients with "fedora" operating system                   |
-| node.os.name.gentoo.count                | Clients with "gentoo" operating system                   |
-| node.os.name.opensuse.count              | Clients with "opensuse" operating system                 |
-| node.os.name.oracle.count                | Clients with "oracle" operating system                   |
-| node.os.name.other.count                 | Clients with some other operating system                 |
-| node.os.name.raspbian.count              | Clients with "raspbian" operating system                 |
-| node.os.name.redhat.count                | Clients with "redhat" operating system                   |
-| node.os.name.suse.count                  | Clients with "suse" operating system                     |
-| node.os.name.ubuntu.count                | Clients with "ubuntu" operating system                   |
-| node.os.name.unique.count                | Unique operating systems on client nodes                 |
-| node.os.name.windows.count               | Clients with "windows" operating system                  |
-| node.pool.count                          | Node pools                                               |
-| node.status.disconnected.count           | Clients with status "disconnected"                       |
-| node.status.down.count                   | Clients with status "down"                               |
-| node.status.initializing.count           | Clients with status "initializing"                       |
-| node.status.ready.count                  | Clients with status "ready"                              |
-| node.status.unknown.count                | Clients with status "unknown"                            |
-| nomad.billable.clients                   | Number of client nodes in the cluster                    |
-| nomad.billable.cores.s390x               | Active client s390x CPU cores in the cluster             |
-| nomad.billable.cores.total               | Active client CPU cores in the cluster                   |
-| plugin.csi.unique.count                  | Unique CSI plugins                                       |
-| policy.sentinel.count                    | Sentinel policies                                        |
-| sentinel.enforcement.advisory.count      | Sentinel policies with "advisory" enforcement level      |
-| sentinel.enforcement.hard-mandatory.count| Sentinel policies with "hard-mandatory" enforcement level|
-| sentinel.enforcement.soft-mandatory.count| Sentinel policies with "soft-mandatory" enforcement level|
-| sentinel.scope.submit-csi-volume.count   | Sentinel policies with "submit-csi-volume" scope         |
-| sentinel.scope.submit-host-volume.count  | Sentinel policies with "submit-host-volume" scope        |
-| sentinel.scope.submit-job.count          | Sentinel policies with "submit-job" scope                |
-| task.device.gpu.amd.count                | Tasks with the "amd" gpu device driver                   |
-| task.device.gpu.nvidia.count             | Tasks with the "nvidia" gpu device driver                |
-| task.device.gpu.other.count              | Tasks with a gpu device driver of unknown vendor         |
-| task.device.other.other.count            | Tasks with some other device driver                      |
-| task.device.usb.other.count              | Tasks with a usb device driver of unknown vendor         |
-| task.driver.docker.count                 | Allocated tasks running with the docker driver           |
-| task.driver.exec.count                   | Allocated tasks running with the exec driver             |
-| task.driver.exec2.count                  | Allocated tasks running with the exec2 driver            |
-| task.driver.java.count                   | Allocated tasks running with the java driver             |
-| task.driver.nomad-driver-virt.count      | Allocated tasks running with the nomad-driver-virt driver|
-| task.driver.other.count                  | Allocated tasks running with the other driver            |
-| task.driver.pledge.count                 | Allocated tasks running with the pledge driver           |
-| task.driver.podman.count                 | Allocated tasks running with the podman driver           |
-| task.driver.qemu.count                   | Allocated tasks running with the qemu driver             |
-| task.driver.raw_exec.count               | Allocated tasks running with the raw_exec driver         |
-| variable.count                           | Nomad Variables                                          |
-| variable.lock.count                      | Nomad Variable Locks                                     |
-| volume.csi.capacity                      | Capacity of all CSI volumes in MB                        |
-| volume.csi.count                         | Number of "csi" volumes                                  |
-| volume.dhv.capacity                      | Capacity of all dynamic host volumes in MB               |
-| volume.dhv.plugin.other.count            | Dynamic host volumes with non-standard plugins           |
-| volume.dynamic.count                     | Number of "dynamic" volumes                              |
-| volume.static.count                      | Number of "static" volumes                               |
+| acl.auth.method.count                    | ACL Auth Methods                                           |
+| acl.auth.method.jwt.count                | ACL Auth Methods of type JWT                               |
+| acl.auth.method.oidc.count               | ACL Auth Methods of type OIDC                              |
+| acl.policy.count                         | ACL policies                                               |
+| acl.role.count                           | ACL roles                                                  |
+| acl.token.count                          | ACL tokens                                                 |
+| alloc.count                              | All allocations                                            |
+| alloc.status.complete.count              | Allocations with client status "complete"                  |
+| alloc.status.failed.count                | Allocations with client status "failed"                    |
+| alloc.status.lost.count                  | Allocations with client status "lost"                      |
+| alloc.status.pending.count               | Allocations with client status "pending"                   |
+| alloc.status.running.count               | Allocations with client status "running"                   |
+| alloc.status.unknown.count               | Allocations with client status "unknown"                   |
+| alloc.task.count                         | All tasks in allocations                                   |
+| alloc.task.running.count                 | Running tasks in allocations                               |
+| client.count                             | Client nodes in the cluster                                |
+| client.device.gpu.amd.count              | Clients with the "amd" gpu device driver                   |
+| client.device.gpu.nvidia.count           | Clients with the "nvidia" gpu device driver                |
+| client.device.gpu.other.count            | Clients with a gpu device driver of unknown vendor         |
+| client.device.other.other.count          | Clients with some other device driver                      |
+| client.device.usb.other.count            | Clients with a usb device driver of unknown vendor         |
+| client.driver.docker.count               | Clients with the "docker" driver                           |
+| client.driver.exec.count                 | Clients with the "exec" driver                             |
+| client.driver.exec2.count                | Clients with the "exec2" driver                            |
+| client.driver.java.count                 | Clients with the "java" driver                             |
+| client.driver.nomad-driver-virt.count    | Clients with the "nomad-driver-virt" driver                |
+| client.driver.other.count                | Clients with the "other" driver                            |
+| client.driver.pledge.count               | Clients with the "pledge" driver                           |
+| client.driver.podman.count               | Clients with the "podman" driver                           |
+| client.driver.qemu.count                 | Clients with the "qemu" driver                             |
+| client.driver.raw_exec.count             | Clients with the "raw_exec" driver                         |
+| client.plugin.cni.unique.count           | Unique CNI plugins on client nodes                         |
+| client.plugin.driver.unique.count        | Unique task drivers on client nodes                        |
+| client.plugin.host_volume.unique.count   | Unique host volume plugins on client nodes                 |
+| client.plugin.secret.unique.count        | Unique secret plugins on client nodes                      |
+| client.resources.compute                 | Total client compute                                       |
+| client.resources.core.count              | Total client CPU cores                                     |
+| client.resources.memory                  | Total client memory in MB                                  |
+| client.vault.enabled.count               | Clients with Vault enabled                                 |
+| job.count                                | All jobs                                                   |
+| job.device.gpu.amd.count                 | Jobs with the "amd" gpu device driver                      |
+| job.device.gpu.nvidia.count              | Jobs with the "nvidia" gpu device driver                   |
+| job.device.gpu.other.count               | Jobs with a gpu device driver of unknown vendor            |
+| job.device.other.other.count             | Jobs with some other device driver                         |
+| job.device.usb.other.count               | Jobs with a usb device driver of unknown vendor            |
+| job.driver.docker.count                  | Tasks defined with the "docker" driver                     |
+| job.driver.exec.count                    | Tasks defined with the "exec" driver                       |
+| job.driver.exec2.count                   | Tasks defined with the "exec2" driver                      |
+| job.driver.java.count                    | Tasks defined with the "java" driver                       |
+| job.driver.nomad-driver-virt.count       | Tasks defined with the "nomad-driver-virt" driver          |
+| job.driver.other.count                   | Jobs with the "other" driver                               |
+| job.driver.pledge.count                  | Tasks defined with the "pledge" driver                     |
+| job.driver.podman.count                  | Tasks defined with the "podman" driver                     |
+| job.driver.qemu.count                    | Tasks defined with the "qemu" driver                       |
+| job.driver.raw_exec.count                | Tasks defined with the "raw_exec" driver                   |
+| job.group.count                          | Task groups in jobs                                        |
+| job.network.cni.args.count               | Networks in jobs with custom CNI args                      |
+| job.network.mode.bridge.count            | Networks in jobs with mode "bridge"                        |
+| job.network.mode.cni.count               | Networks in jobs with mode "cni"                           |
+| job.network.mode.host.count              | Networks in jobs with mode "host"                          |
+| job.network.mode.other.count             | Networks in jobs with some other mode                      |
+| job.parameterized.count                  | Parameterized jobs                                         |
+| job.parameterized.dispatched.count       | Dispatched parameterized jobs                              |
+| job.periodic.count                       | Periodic jobs                                              |
+| job.periodic.dispatched.count            | Dispatched periodic jobs                                   |
+| job.service.consul.connect.count         | Connect services in jobs                                   |
+| job.service.consul.count                 | Consul services in jobs                                    |
+| job.service.nomad.count                  | Nomad provider services in jobs                            |
+| job.task.identity.count                  | Tasks in jobs with identity enabled                        |
+| job.task.template.count                  | Tasks in jobs with templates                               |
+| job.task.vault.count                     | Tasks in jobs with Vault enabled                           |
+| job.type.batch.count                     | Jobs of type "batch"                                       |
+| job.type.service.count                   | Jobs of type "service"                                     |
+| job.type.sysbatch.count                  | Jobs of type "sysbatch"                                    |
+| job.type.system.count                    | Jobs of type "system"                                      |
+| job.volume.csi.count                     | CSI volumes in jobs                                        |
+| job.volume.host.count                    | Host volumes in jobs                                       |
+| job.volume.sticky.count                  | Sticky volumes in jobs                                     |
+| namespace.count                          | Namespaces                                                 |
+| namespace.quotas.count                   | Quotas                                                     |
+| node.cpu.arch.amd64.count                | Clients with "amd64" CPU architecture                      |
+| node.cpu.arch.arm64.count                | Clients with "arm64" CPU architecture                      |
+| node.cpu.arch.other.count                | Clients with some other CPU architecture                   |
+| node.cpu.arch.s390x.count                | Clients with "s390x" CPU architecture                      |
+| node.cpu.arch.unique.count               | Unique CPU architectures on client nodes                   |
+| node.kernel.name.aix.count               | Clients with "aix" kernel                                  |
+| node.kernel.name.darwin.count            | Clients with "darwin" kernel                               |
+| node.kernel.name.freebsd.count           | Clients with "freebsd" kernel                              |
+| node.kernel.name.linux.count             | Clients with "linux" kernel                                |
+| node.kernel.name.other.count             | Clients with some other kernel                             |
+| node.kernel.name.plan9.count             | Clients with "plan9" kernel                                |
+| node.kernel.name.solaris.count           | Clients with "solaris" kernel                              |
+| node.kernel.name.unique.count            | Unique kernels on client nodes                             |
+| node.os.name.alpine.count                | Clients with "alpine" operating system                     |
+| node.os.name.amazon.count                | Clients with "amazon" operating system                     |
+| node.os.name.arch.count                  | Clients with "arch" operating system                       |
+| node.os.name.centos.count                | Clients with "centos" operating system                     |
+| node.os.name.cloudlinux.count            | Clients with "cloudlinux" operating system                 |
+| node.os.name.coreos.count                | Clients with "coreos" operating system                     |
+| node.os.name.darwin.count                | Clients with "darwin" operating system                     |
+| node.os.name.debian.count                | Clients with "debian" operating system                     |
+| node.os.name.fedora.count                | Clients with "fedora" operating system                     |
+| node.os.name.gentoo.count                | Clients with "gentoo" operating system                     |
+| node.os.name.opensuse.count              | Clients with "opensuse" operating system                   |
+| node.os.name.oracle.count                | Clients with "oracle" operating system                     |
+| node.os.name.other.count                 | Clients with some other operating system                   |
+| node.os.name.raspbian.count              | Clients with "raspbian" operating system                   |
+| node.os.name.redhat.count                | Clients with "redhat" operating system                     |
+| node.os.name.suse.count                  | Clients with "suse" operating system                       |
+| node.os.name.ubuntu.count                | Clients with "ubuntu" operating system                     |
+| node.os.name.unique.count                | Unique operating systems on client nodes                   |
+| node.os.name.windows.count               | Clients with "windows" operating system                    |
+| node.pool.count                          | Node pools                                                 |
+| node.status.disconnected.count           | Clients with status "disconnected"                         |
+| node.status.down.count                   | Clients with status "down"                                 |
+| node.status.initializing.count           | Clients with status "initializing"                         |
+| node.status.ready.count                  | Clients with status "ready"                                |
+| node.status.unknown.count                | Clients with status "unknown"                              |
+| nomad.billable.clients                   | Number of client nodes in the cluster                      |
+| nomad.billable.cores.s390x               | Active client s390x CPU cores in the cluster               |
+| nomad.billable.cores.total               | Active client CPU cores in the cluster                     |
+| plugin.csi.unique.count                  | Unique CSI plugins                                         |
+| policy.sentinel.count                    | Sentinel policies                                          |
+| sentinel.enforcement.advisory.count      | Sentinel policies with "advisory" enforcement level        |
+| sentinel.enforcement.hard-mandatory.count| Sentinel policies with "hard-mandatory" enforcement level  |
+| sentinel.enforcement.soft-mandatory.count| Sentinel policies with "soft-mandatory" enforcement level  |
+| sentinel.scope.submit-csi-volume.count   | Sentinel policies with "submit-csi-volume" scope           |
+| sentinel.scope.submit-host-volume.count  | Sentinel policies with "submit-host-volume" scope          |
+| sentinel.scope.submit-job.count          | Sentinel policies with "submit-job" scope                  |
+| task.device.gpu.amd.count                | Tasks with the "amd" gpu device driver                     |
+| task.device.gpu.nvidia.count             | Tasks with the "nvidia" gpu device driver                  |
+| task.device.gpu.other.count              | Tasks with a gpu device driver of unknown vendor           |
+| task.device.other.other.count            | Tasks with some other device driver                        |
+| task.device.usb.other.count              | Tasks with a usb device driver of unknown vendor           |
+| task.driver.docker.count                 | Allocated tasks running with the "docker" driver           |
+| task.driver.exec.count                   | Allocated tasks running with the "exec" driver             |
+| task.driver.exec2.count                  | Allocated tasks running with the "exec2" driver            |
+| task.driver.java.count                   | Allocated tasks running with the "java" driver             |
+| task.driver.nomad-driver-virt.count      | Allocated tasks running with the "nomad-driver-virt" driver|
+| task.driver.other.count                  | Tasks with the "other" driver                              |
+| task.driver.pledge.count                 | Allocated tasks running with the "pledge" driver           |
+| task.driver.podman.count                 | Allocated tasks running with the "podman" driver           |
+| task.driver.qemu.count                   | Allocated tasks running with the "qemu" driver             |
+| task.driver.raw_exec.count               | Allocated tasks running with the "raw_exec" driver         |
+| variable.count                           | Nomad Variables                                            |
+| variable.lock.count                      | Nomad Variable Locks                                       |
+| volume.csi.capacity                      | Capacity of all CSI volumes in MB                          |
+| volume.csi.count                         | Number of "csi" volumes                                    |
+| volume.dhv.capacity                      | Capacity of all dynamic host volumes in MB                 |
+| volume.dhv.plugin.other.count            | Dynamic host volumes with non-standard plugins             |
+| volume.dynamic.count                     | Number of "dynamic" volumes                                |
+| volume.static.count                      | Number of "static" volumes                                 |
+
 
 
 ## Example payload

--- a/content/nomad/v2.0.x/content/docs/enterprise/license/utilization-reporting.mdx
+++ b/content/nomad/v2.0.x/content/docs/enterprise/license/utilization-reporting.mdx
@@ -161,148 +161,169 @@ The values are all integers for pre-determined values. We do not collect any str
 that might identify proprietary information.
 
 <!-- NOTE to maintainers: Generate this table with a CLI tool in the registry repo
-     https://github.com/hashicorp/hashicorp-census-registry/tree/main/nomad/v2/cmd
+     https://github.com/hashicorp/hashicorp-census-registry/tree/main/nomad/v3/cmd
 -->
+|Metadata|  ||
+|:---|:---:|:---:|
+| Key                 | Use Cases| Description                                       |
+| nomad.nonprod_server| licensing| Annotates snapshot as coming from a nonprod server|
 
-| Key                                       | Description                                               |
-|-------------------------------------------|-----------------------------------------------------------|
-| acl.auth.method.count                     | ACL Auth Methods                                          |
-| acl.auth.method.jwt.count                 | ACL Auth Methods of type JWT                              |
-| acl.auth.method.oidc.count                | ACL Auth Methods of type OIDC                             |
-| acl.policy.count                          | ACL policies                                              |
-| acl.role.count                            | ACL roles                                                 |
-| acl.token.count                           | ACL tokens                                                |
-| alloc.count                               | All allocations                                           |
-| alloc.status.complete.count               | Allocations with client status "complete"                 |
-| alloc.status.failed.count                 | Allocations with client status "failed"                   |
-| alloc.status.lost.count                   | Allocations with client status "lost"                     |
-| alloc.status.pending.count                | Allocations with client status "pending"                  |
-| alloc.status.running.count                | Allocations with client status "running"                  |
-| alloc.status.unknown.count                | Allocations with client status "unknown"                  |
-| alloc.task.count                          | All tasks in allocations                                  |
-| alloc.task.running.count                  | Running tasks in allocations                              |
-| client.count                              | Client nodes in the cluster                               |
-| client.driver.docker.count                | Clients with the "docker" driver                          |
-| client.driver.exec.count                  | Clients with the "exec" driver                            |
-| client.driver.exec2.count                 | Clients with the "exec2" driver                           |
-| client.driver.java.count                  | Clients with the "java" driver                            |
-| client.driver.nomad-driver-virt.count     | Clients with the "nomad-driver-virt" driver               |
-| client.driver.other.count                 | Clients with some other driver                            |
-| client.driver.pledge.count                | Clients with the "pledge" driver                          |
-| client.driver.podman.count                | Clients with the "podman" driver                          |
-| client.driver.qemu.count                  | Clients with the "qemu" driver                            |
-| client.driver.raw_exec.count              | Clients with the "raw_exec" driver                        |
-| client.plugin.cni.unique.count            | Unique CNI plugins on client nodes                        |
-| client.plugin.driver.unique.count         | Unique task drivers on client nodes                       |
-| client.plugin.host_volume.unique.count    | Unique host volume plugins on client nodes                |
-| client.plugin.secret.unique.count         | Unique secret plugins on client nodes                     |
-| client.resources.compute                  | Total client compute                                      |
-| client.resources.core.count               | Total client CPU cores                                    |
-| client.resources.memory                   | Total client memory in MB                                 |
-| client.vault.enabled.count                | Clients with Vault enabled                                |
-| job.count                                 | All jobs                                                  |
-| job.driver.docker.count                   | Jobs with the "docker" driver                             |
-| job.driver.exec.count                     | Jobs with the "exec" driver                               |
-| job.driver.exec2.count                    | Jobs with the "exec2" driver                              |
-| job.driver.java.count                     | Jobs with the "java" driver                               |
-| job.driver.nomad-driver-virt.count        | Jobs with the "nomad-driver-virt" driver                  |
-| job.driver.other.count                    | Jobs with some other driver                               |
-| job.driver.pledge.count                   | Jobs with the "pledge" driver                             |
-| job.driver.podman.count                   | Jobs with the "podman" driver                             |
-| job.driver.qemu.count                     | Jobs with the "qemu" driver                               |
-| job.driver.raw_exec.count                 | Jobs with the "raw_exec" driver                           |
-| job.group.count                           | Task groups in jobs                                       |
-| job.network.cni.args.count                | Networks in jobs with custom CNI args                     |
-| job.network.mode.bridge.count             | Networks in jobs with mode "bridge"                       |
-| job.network.mode.cni.count                | Networks in jobs with mode "cni"                          |
-| job.network.mode.host.count               | Networks in jobs with mode "host"                         |
-| job.network.mode.other.count              | Networks in jobs with some other mode                     |
-| job.parameterized.count                   | Parameterized jobs                                        |
-| job.parameterized.dispatched.count        | Dispatched parameterized jobs                             |
-| job.periodic.count                        | Periodic jobs                                             |
-| job.periodic.dispatched.count             | Dispatched periodic jobs                                  |
-| job.service.consul.connect.count          | Connect services in jobs                                  |
-| job.service.consul.count                  | Consul services in jobs                                   |
-| job.service.nomad.count                   | Nomad provider services in jobs                           |
-| job.task.identity.count                   | Tasks in jobs with identity enabled                       |
-| job.task.template.count                   | Tasks in jobs with templates                              |
-| job.task.vault.count                      | Tasks in jobs with Vault enabled                          |
-| job.type.batch.count                      | Jobs of type "batch"                                      |
-| job.type.service.count                    | Jobs of type "service"                                    |
-| job.type.sysbatch.count                   | Jobs of type "sysbatch"                                   |
-| job.type.system.count                     | Jobs of type "system"                                     |
-| job.volume.csi.count                      | CSI volumes in jobs                                       |
-| job.volume.host.count                     | Host volumes in jobs                                      |
-| job.volume.sticky.count                   | Sticky volumes in jobs                                    |
-| namespace.count                           | Namespaces                                                |
-| namespace.quotas.count                    | Quotas                                                    |
-| node.cpu.arch.amd64.count                 | Clients with "amd64" CPU architecture                     |
-| node.cpu.arch.arm64.count                 | Clients with "arm64" CPU architecture                     |
-| node.cpu.arch.other.count                 | Clients with some other CPU architecture                  |
-| node.cpu.arch.s390x.count                 | Clients with "s390x" CPU architecture                     |
-| node.cpu.arch.unique.count                | Unique CPU architectures on client nodes                  |
-| node.kernel.name.aix.count                | Clients with "aix" kernel                                 |
-| node.kernel.name.darwin.count             | Clients with "darwin" kernel                              |
-| node.kernel.name.freebsd.count            | Clients with "freebsd" kernel                             |
-| node.kernel.name.linux.count              | Clients with "linux" kernel                               |
-| node.kernel.name.other.count              | Clients with some other kernel                            |
-| node.kernel.name.plan9.count              | Clients with "plan9" kernel                               |
-| node.kernel.name.solaris.count            | Clients with "solaris" kernel                             |
-| node.kernel.name.unique.count             | Unique kernels on client nodes                            |
-| node.os.name.alpine.count                 | Clients with "alpine" operating system                    |
-| node.os.name.amazon.count                 | Clients with "amazon" operating system                    |
-| node.os.name.arch.count                   | Clients with "arch" operating system                      |
-| node.os.name.centos.count                 | Clients with "centos" operating system                    |
-| node.os.name.cloudlinux.count             | Clients with "cloudlinux" operating system                |
-| node.os.name.coreos.count                 | Clients with "coreos" operating system                    |
-| node.os.name.darwin.count                 | Clients with "darwin" operating system                    |
-| node.os.name.debian.count                 | Clients with "debian" operating system                    |
-| node.os.name.fedora.count                 | Clients with "fedora" operating system                    |
-| node.os.name.gentoo.count                 | Clients with "gentoo" operating system                    |
-| node.os.name.opensuse.count               | Clients with "opensuse" operating system                  |
-| node.os.name.oracle.count                 | Clients with "oracle" operating system                    |
-| node.os.name.other.count                  | Clients with some other operating system                  |
-| node.os.name.raspbian.count               | Clients with "raspbian" operating system                  |
-| node.os.name.redhat.count                 | Clients with "redhat" operating system                    |
-| node.os.name.suse.count                   | Clients with "suse" operating system                      |
-| node.os.name.ubuntu.count                 | Clients with "ubuntu" operating system                    |
-| node.os.name.unique.count                 | Unique operating systems on client nodes                  |
-| node.os.name.windows.count                | Clients with "windows" operating system                   |
-| node.pool.count                           | Node pools                                                |
-| node.status.disconnected.count            | Clients with status "disconnected"                        |
-| node.status.down.count                    | Clients with status "down"                                |
-| node.status.initializing.count            | Clients with status "initializing"                        |
-| node.status.ready.count                   | Clients with status "ready"                               |
-| node.status.unknown.count                 | Clients with status "unknown"                             |
-| nomad.billable.clients                    | Number of client nodes in the cluster                     |
-| nomad.billable.cores.s390x                | Active client s390x CPU cores in the cluster              |
-| nomad.billable.cores.total                | Active client CPU cores in the cluster                    |
-| plugin.csi.unique.count                   | Unique CSI plugins                                        |
-| policy.sentinel.count                     | Sentinel policies                                         |
-| sentinel.enforcement.advisory.count       | Sentinel policies with "advisory" enforcement level       |
-| sentinel.enforcement.hard-mandatory.count | Sentinel policies with "hard-mandatory" enforcement level |
-| sentinel.enforcement.soft-mandatory.count | Sentinel policies with "soft-mandatory" enforcement level |
-| sentinel.scope.submit-csi-volume.count    | Sentinel policies with "submit-csi-volume" scope          |
-| sentinel.scope.submit-host-volume.count   | Sentinel policies with "submit-host-volume" scope         |
-| sentinel.scope.submit-job.count           | Sentinel policies with "submit-job" scope                 |
-| task.driver.docker.count                  | Tasks with the "docker" driver                            |
-| task.driver.exec.count                    | Tasks with the "exec" driver                              |
-| task.driver.exec2.count                   | Tasks with the "exec2" driver                             |
-| task.driver.java.count                    | Tasks with the "java" driver                              |
-| task.driver.nomad-driver-virt.count       | Tasks with the "nomad-driver-virt" driver                 |
-| task.driver.other.count                   | Tasks with some other driver                              |
-| task.driver.pledge.count                  | Tasks with the "pledge" driver                            |
-| task.driver.podman.count                  | Tasks with the "podman" driver                            |
-| task.driver.qemu.count                    | Tasks with the "qemu" driver                              |
-| task.driver.raw_exec.count                | Tasks with the "raw_exec" driver                          |
-| variable.count                            | Nomad Variables                                           |
-| variable.lock.count                       | Nomad Variable Locks                                      |
-| volume.csi.capacity                       | Capacity of all CSI volumes in MB                         |
-| volume.csi.count                          | Number of "csi" volumes                                   |
-| volume.dhv.capacity                       | Capacity of all dynamic host volumes in MB                |
-| volume.dhv.plugin.other.count             | Dynamic host volumes with non-standard plugins            |
-| volume.dynamic.count                      | Number of "dynamic" volumes                               |
-| volume.static.count                       | Number of "static" volumes                                |
+
+| Metrics||
+|:---|:---|
+| Key                                      | Description                                              |
+| acl.auth.method.count                    | ACL Auth Methods                                         |
+| acl.auth.method.jwt.count                | ACL Auth Methods of type JWT                             |
+| acl.auth.method.oidc.count               | ACL Auth Methods of type OIDC                            |
+| acl.policy.count                         | ACL policies                                             |
+| acl.role.count                           | ACL roles                                                |
+| acl.token.count                          | ACL tokens                                               |
+| alloc.count                              | All allocations                                          |
+| alloc.status.complete.count              | Allocations with client status "complete"                |
+| alloc.status.failed.count                | Allocations with client status "failed"                  |
+| alloc.status.lost.count                  | Allocations with client status "lost"                    |
+| alloc.status.pending.count               | Allocations with client status "pending"                 |
+| alloc.status.running.count               | Allocations with client status "running"                 |
+| alloc.status.unknown.count               | Allocations with client status "unknown"                 |
+| alloc.task.count                         | All tasks in allocations                                 |
+| alloc.task.running.count                 | Running tasks in allocations                             |
+| client.count                             | Client nodes in the cluster                              |
+| client.device.gpu.amd.count              | Clients with the "amd" gpu device driver                 |
+| client.device.gpu.nvidia.count           | Clients with the "nvidia" gpu device driver              |
+| client.device.gpu.other.count            | Clients with a gpu device driver of unknown vendor       |
+| client.device.other.other.count          | Clients with some other device driver                    |
+| client.device.usb.other.count            | Clients with a usb device driver of unknown vendor       |
+| client.driver.docker.count               | Clients with the docker driver                           |
+| client.driver.exec.count                 | Clients with the exec driver                             |
+| client.driver.exec2.count                | Clients with the exec2 driver                            |
+| client.driver.java.count                 | Clients with the java driver                             |
+| client.driver.nomad-driver-virt.count    | Clients with the nomad-driver-virt driver                |
+| client.driver.other.count                | Clients with the other driver                            |
+| client.driver.pledge.count               | Clients with the pledge driver                           |
+| client.driver.podman.count               | Clients with the podman driver                           |
+| client.driver.qemu.count                 | Clients with the qemu driver                             |
+| client.driver.raw_exec.count             | Clients with the raw_exec driver                         |
+| client.plugin.cni.unique.count           | Unique CNI plugins on client nodes                       |
+| client.plugin.driver.unique.count        | Unique task drivers on client nodes                      |
+| client.plugin.host_volume.unique.count   | Unique host volume plugins on client nodes               |
+| client.plugin.secret.unique.count        | Unique secret plugins on client nodes                    |
+| client.resources.compute                 | Total client compute                                     |
+| client.resources.core.count              | Total client CPU cores                                   |
+| client.resources.memory                  | Total client memory in MB                                |
+| client.vault.enabled.count               | Clients with Vault enabled                               |
+| job.count                                | All jobs                                                 |
+| job.device.gpu.amd.count                 | Jobs with the "amd" gpu device driver                    |
+| job.device.gpu.nvidia.count              | Jobs with the "nvidia" gpu device driver                 |
+| job.device.gpu.other.count               | Jobs with a gpu device driver of unknown vendor          |
+| job.device.other.other.count             | Jobs with some other device driver                       |
+| job.device.usb.other.count               | Jobs with a usb device driver of unknown vendor          |
+| job.driver.docker.count                  | Tasks defined with the docker driver                     |
+| job.driver.exec.count                    | Tasks defined with the exec driver                       |
+| job.driver.exec2.count                   | Tasks defined with the exec2 driver                      |
+| job.driver.java.count                    | Tasks defined with the java driver                       |
+| job.driver.nomad-driver-virt.count       | Tasks defined with the nomad-driver-virt driver          |
+| job.driver.other.count                   | Tasks defined with the other driver                      |
+| job.driver.pledge.count                  | Tasks defined with the pledge driver                     |
+| job.driver.podman.count                  | Tasks defined with the podman driver                     |
+| job.driver.qemu.count                    | Tasks defined with the qemu driver                       |
+| job.driver.raw_exec.count                | Tasks defined with the raw_exec driver                   |
+| job.group.count                          | Task groups in jobs                                      |
+| job.network.cni.args.count               | Networks in jobs with custom CNI args                    |
+| job.network.mode.bridge.count            | Networks in jobs with mode "bridge"                      |
+| job.network.mode.cni.count               | Networks in jobs with mode "cni"                         |
+| job.network.mode.host.count              | Networks in jobs with mode "host"                        |
+| job.network.mode.other.count             | Networks in jobs with some other mode                    |
+| job.parameterized.count                  | Parameterized jobs                                       |
+| job.parameterized.dispatched.count       | Dispatched parameterized jobs                            |
+| job.periodic.count                       | Periodic jobs                                            |
+| job.periodic.dispatched.count            | Dispatched periodic jobs                                 |
+| job.service.consul.connect.count         | Connect services in jobs                                 |
+| job.service.consul.count                 | Consul services in jobs                                  |
+| job.service.nomad.count                  | Nomad provider services in jobs                          |
+| job.task.identity.count                  | Tasks in jobs with identity enabled                      |
+| job.task.template.count                  | Tasks in jobs with templates                             |
+| job.task.vault.count                     | Tasks in jobs with Vault enabled                         |
+| job.type.batch.count                     | Jobs of type "batch"                                     |
+| job.type.service.count                   | Jobs of type "service"                                   |
+| job.type.sysbatch.count                  | Jobs of type "sysbatch"                                  |
+| job.type.system.count                    | Jobs of type "system"                                    |
+| job.volume.csi.count                     | CSI volumes in jobs                                      |
+| job.volume.host.count                    | Host volumes in jobs                                     |
+| job.volume.sticky.count                  | Sticky volumes in jobs                                   |
+| namespace.count                          | Namespaces                                               |
+| namespace.quotas.count                   | Quotas                                                   |
+| node.cpu.arch.amd64.count                | Clients with "amd64" CPU architecture                    |
+| node.cpu.arch.arm64.count                | Clients with "arm64" CPU architecture                    |
+| node.cpu.arch.other.count                | Clients with some other CPU architecture                 |
+| node.cpu.arch.s390x.count                | Clients with "s390x" CPU architecture                    |
+| node.cpu.arch.unique.count               | Unique CPU architectures on client nodes                 |
+| node.kernel.name.aix.count               | Clients with "aix" kernel                                |
+| node.kernel.name.darwin.count            | Clients with "darwin" kernel                             |
+| node.kernel.name.freebsd.count           | Clients with "freebsd" kernel                            |
+| node.kernel.name.linux.count             | Clients with "linux" kernel                              |
+| node.kernel.name.other.count             | Clients with some other kernel                           |
+| node.kernel.name.plan9.count             | Clients with "plan9" kernel                              |
+| node.kernel.name.solaris.count           | Clients with "solaris" kernel                            |
+| node.kernel.name.unique.count            | Unique kernels on client nodes                           |
+| node.os.name.alpine.count                | Clients with "alpine" operating system                   |
+| node.os.name.amazon.count                | Clients with "amazon" operating system                   |
+| node.os.name.arch.count                  | Clients with "arch" operating system                     |
+| node.os.name.centos.count                | Clients with "centos" operating system                   |
+| node.os.name.cloudlinux.count            | Clients with "cloudlinux" operating system               |
+| node.os.name.coreos.count                | Clients with "coreos" operating system                   |
+| node.os.name.darwin.count                | Clients with "darwin" operating system                   |
+| node.os.name.debian.count                | Clients with "debian" operating system                   |
+| node.os.name.fedora.count                | Clients with "fedora" operating system                   |
+| node.os.name.gentoo.count                | Clients with "gentoo" operating system                   |
+| node.os.name.opensuse.count              | Clients with "opensuse" operating system                 |
+| node.os.name.oracle.count                | Clients with "oracle" operating system                   |
+| node.os.name.other.count                 | Clients with some other operating system                 |
+| node.os.name.raspbian.count              | Clients with "raspbian" operating system                 |
+| node.os.name.redhat.count                | Clients with "redhat" operating system                   |
+| node.os.name.suse.count                  | Clients with "suse" operating system                     |
+| node.os.name.ubuntu.count                | Clients with "ubuntu" operating system                   |
+| node.os.name.unique.count                | Unique operating systems on client nodes                 |
+| node.os.name.windows.count               | Clients with "windows" operating system                  |
+| node.pool.count                          | Node pools                                               |
+| node.status.disconnected.count           | Clients with status "disconnected"                       |
+| node.status.down.count                   | Clients with status "down"                               |
+| node.status.initializing.count           | Clients with status "initializing"                       |
+| node.status.ready.count                  | Clients with status "ready"                              |
+| node.status.unknown.count                | Clients with status "unknown"                            |
+| nomad.billable.clients                   | Number of client nodes in the cluster                    |
+| nomad.billable.cores.s390x               | Active client s390x CPU cores in the cluster             |
+| nomad.billable.cores.total               | Active client CPU cores in the cluster                   |
+| plugin.csi.unique.count                  | Unique CSI plugins                                       |
+| policy.sentinel.count                    | Sentinel policies                                        |
+| sentinel.enforcement.advisory.count      | Sentinel policies with "advisory" enforcement level      |
+| sentinel.enforcement.hard-mandatory.count| Sentinel policies with "hard-mandatory" enforcement level|
+| sentinel.enforcement.soft-mandatory.count| Sentinel policies with "soft-mandatory" enforcement level|
+| sentinel.scope.submit-csi-volume.count   | Sentinel policies with "submit-csi-volume" scope         |
+| sentinel.scope.submit-host-volume.count  | Sentinel policies with "submit-host-volume" scope        |
+| sentinel.scope.submit-job.count          | Sentinel policies with "submit-job" scope                |
+| task.device.gpu.amd.count                | Tasks with the "amd" gpu device driver                   |
+| task.device.gpu.nvidia.count             | Tasks with the "nvidia" gpu device driver                |
+| task.device.gpu.other.count              | Tasks with a gpu device driver of unknown vendor         |
+| task.device.other.other.count            | Tasks with some other device driver                      |
+| task.device.usb.other.count              | Tasks with a usb device driver of unknown vendor         |
+| task.driver.docker.count                 | Allocated tasks running with the docker driver           |
+| task.driver.exec.count                   | Allocated tasks running with the exec driver             |
+| task.driver.exec2.count                  | Allocated tasks running with the exec2 driver            |
+| task.driver.java.count                   | Allocated tasks running with the java driver             |
+| task.driver.nomad-driver-virt.count      | Allocated tasks running with the nomad-driver-virt driver|
+| task.driver.other.count                  | Allocated tasks running with the other driver            |
+| task.driver.pledge.count                 | Allocated tasks running with the pledge driver           |
+| task.driver.podman.count                 | Allocated tasks running with the podman driver           |
+| task.driver.qemu.count                   | Allocated tasks running with the qemu driver             |
+| task.driver.raw_exec.count               | Allocated tasks running with the raw_exec driver         |
+| variable.count                           | Nomad Variables                                          |
+| variable.lock.count                      | Nomad Variable Locks                                     |
+| volume.csi.capacity                      | Capacity of all CSI volumes in MB                        |
+| volume.csi.count                         | Number of "csi" volumes                                  |
+| volume.dhv.capacity                      | Capacity of all dynamic host volumes in MB               |
+| volume.dhv.plugin.other.count            | Dynamic host volumes with non-standard plugins           |
+| volume.dynamic.count                     | Number of "dynamic" volumes                              |
+| volume.static.count                      | Number of "static" volumes                               |
 
 
 ## Example payload

--- a/content/nomad/v2.0.x/content/docs/enterprise/license/utilization-reporting.mdx
+++ b/content/nomad/v2.0.x/content/docs/enterprise/license/utilization-reporting.mdx
@@ -171,159 +171,159 @@ that might identify proprietary information.
 
 | Metrics||
 |:---|:---|
-| Key                                      | Description                                              |
-| acl.auth.method.count                    | ACL Auth Methods                                         |
-| acl.auth.method.jwt.count                | ACL Auth Methods of type JWT                             |
-| acl.auth.method.oidc.count               | ACL Auth Methods of type OIDC                            |
-| acl.policy.count                         | ACL policies                                             |
-| acl.role.count                           | ACL roles                                                |
-| acl.token.count                          | ACL tokens                                               |
-| alloc.count                              | All allocations                                          |
-| alloc.status.complete.count              | Allocations with client status "complete"                |
-| alloc.status.failed.count                | Allocations with client status "failed"                  |
-| alloc.status.lost.count                  | Allocations with client status "lost"                    |
-| alloc.status.pending.count               | Allocations with client status "pending"                 |
-| alloc.status.running.count               | Allocations with client status "running"                 |
-| alloc.status.unknown.count               | Allocations with client status "unknown"                 |
-| alloc.task.count                         | All tasks in allocations                                 |
-| alloc.task.running.count                 | Running tasks in allocations                             |
-| client.count                             | Client nodes in the cluster                              |
-| client.device.gpu.amd.count              | Clients with the "amd" gpu device driver                 |
-| client.device.gpu.nvidia.count           | Clients with the "nvidia" gpu device driver              |
-| client.device.gpu.other.count            | Clients with a gpu device driver of unknown vendor       |
-| client.device.other.other.count          | Clients with some other device driver                    |
-| client.device.usb.other.count            | Clients with a usb device driver of unknown vendor       |
-| client.driver.docker.count               | Clients with the docker driver                           |
-| client.driver.exec.count                 | Clients with the exec driver                             |
-| client.driver.exec2.count                | Clients with the exec2 driver                            |
-| client.driver.java.count                 | Clients with the java driver                             |
-| client.driver.nomad-driver-virt.count    | Clients with the nomad-driver-virt driver                |
-| client.driver.other.count                | Clients with the other driver                            |
-| client.driver.pledge.count               | Clients with the pledge driver                           |
-| client.driver.podman.count               | Clients with the podman driver                           |
-| client.driver.qemu.count                 | Clients with the qemu driver                             |
-| client.driver.raw_exec.count             | Clients with the raw_exec driver                         |
-| client.plugin.cni.unique.count           | Unique CNI plugins on client nodes                       |
-| client.plugin.driver.unique.count        | Unique task drivers on client nodes                      |
-| client.plugin.host_volume.unique.count   | Unique host volume plugins on client nodes               |
-| client.plugin.secret.unique.count        | Unique secret plugins on client nodes                    |
-| client.resources.compute                 | Total client compute                                     |
-| client.resources.core.count              | Total client CPU cores                                   |
-| client.resources.memory                  | Total client memory in MB                                |
-| client.vault.enabled.count               | Clients with Vault enabled                               |
-| job.count                                | All jobs                                                 |
-| job.device.gpu.amd.count                 | Jobs with the "amd" gpu device driver                    |
-| job.device.gpu.nvidia.count              | Jobs with the "nvidia" gpu device driver                 |
-| job.device.gpu.other.count               | Jobs with a gpu device driver of unknown vendor          |
-| job.device.other.other.count             | Jobs with some other device driver                       |
-| job.device.usb.other.count               | Jobs with a usb device driver of unknown vendor          |
-| job.driver.docker.count                  | Tasks defined with the docker driver                     |
-| job.driver.exec.count                    | Tasks defined with the exec driver                       |
-| job.driver.exec2.count                   | Tasks defined with the exec2 driver                      |
-| job.driver.java.count                    | Tasks defined with the java driver                       |
-| job.driver.nomad-driver-virt.count       | Tasks defined with the nomad-driver-virt driver          |
-| job.driver.other.count                   | Tasks defined with the other driver                      |
-| job.driver.pledge.count                  | Tasks defined with the pledge driver                     |
-| job.driver.podman.count                  | Tasks defined with the podman driver                     |
-| job.driver.qemu.count                    | Tasks defined with the qemu driver                       |
-| job.driver.raw_exec.count                | Tasks defined with the raw_exec driver                   |
-| job.group.count                          | Task groups in jobs                                      |
-| job.network.cni.args.count               | Networks in jobs with custom CNI args                    |
-| job.network.mode.bridge.count            | Networks in jobs with mode "bridge"                      |
-| job.network.mode.cni.count               | Networks in jobs with mode "cni"                         |
-| job.network.mode.host.count              | Networks in jobs with mode "host"                        |
-| job.network.mode.other.count             | Networks in jobs with some other mode                    |
-| job.parameterized.count                  | Parameterized jobs                                       |
-| job.parameterized.dispatched.count       | Dispatched parameterized jobs                            |
-| job.periodic.count                       | Periodic jobs                                            |
-| job.periodic.dispatched.count            | Dispatched periodic jobs                                 |
-| job.service.consul.connect.count         | Connect services in jobs                                 |
-| job.service.consul.count                 | Consul services in jobs                                  |
-| job.service.nomad.count                  | Nomad provider services in jobs                          |
-| job.task.identity.count                  | Tasks in jobs with identity enabled                      |
-| job.task.template.count                  | Tasks in jobs with templates                             |
-| job.task.vault.count                     | Tasks in jobs with Vault enabled                         |
-| job.type.batch.count                     | Jobs of type "batch"                                     |
-| job.type.service.count                   | Jobs of type "service"                                   |
-| job.type.sysbatch.count                  | Jobs of type "sysbatch"                                  |
-| job.type.system.count                    | Jobs of type "system"                                    |
-| job.volume.csi.count                     | CSI volumes in jobs                                      |
-| job.volume.host.count                    | Host volumes in jobs                                     |
-| job.volume.sticky.count                  | Sticky volumes in jobs                                   |
-| namespace.count                          | Namespaces                                               |
-| namespace.quotas.count                   | Quotas                                                   |
-| node.cpu.arch.amd64.count                | Clients with "amd64" CPU architecture                    |
-| node.cpu.arch.arm64.count                | Clients with "arm64" CPU architecture                    |
-| node.cpu.arch.other.count                | Clients with some other CPU architecture                 |
-| node.cpu.arch.s390x.count                | Clients with "s390x" CPU architecture                    |
-| node.cpu.arch.unique.count               | Unique CPU architectures on client nodes                 |
-| node.kernel.name.aix.count               | Clients with "aix" kernel                                |
-| node.kernel.name.darwin.count            | Clients with "darwin" kernel                             |
-| node.kernel.name.freebsd.count           | Clients with "freebsd" kernel                            |
-| node.kernel.name.linux.count             | Clients with "linux" kernel                              |
-| node.kernel.name.other.count             | Clients with some other kernel                           |
-| node.kernel.name.plan9.count             | Clients with "plan9" kernel                              |
-| node.kernel.name.solaris.count           | Clients with "solaris" kernel                            |
-| node.kernel.name.unique.count            | Unique kernels on client nodes                           |
-| node.os.name.alpine.count                | Clients with "alpine" operating system                   |
-| node.os.name.amazon.count                | Clients with "amazon" operating system                   |
-| node.os.name.arch.count                  | Clients with "arch" operating system                     |
-| node.os.name.centos.count                | Clients with "centos" operating system                   |
-| node.os.name.cloudlinux.count            | Clients with "cloudlinux" operating system               |
-| node.os.name.coreos.count                | Clients with "coreos" operating system                   |
-| node.os.name.darwin.count                | Clients with "darwin" operating system                   |
-| node.os.name.debian.count                | Clients with "debian" operating system                   |
-| node.os.name.fedora.count                | Clients with "fedora" operating system                   |
-| node.os.name.gentoo.count                | Clients with "gentoo" operating system                   |
-| node.os.name.opensuse.count              | Clients with "opensuse" operating system                 |
-| node.os.name.oracle.count                | Clients with "oracle" operating system                   |
-| node.os.name.other.count                 | Clients with some other operating system                 |
-| node.os.name.raspbian.count              | Clients with "raspbian" operating system                 |
-| node.os.name.redhat.count                | Clients with "redhat" operating system                   |
-| node.os.name.suse.count                  | Clients with "suse" operating system                     |
-| node.os.name.ubuntu.count                | Clients with "ubuntu" operating system                   |
-| node.os.name.unique.count                | Unique operating systems on client nodes                 |
-| node.os.name.windows.count               | Clients with "windows" operating system                  |
-| node.pool.count                          | Node pools                                               |
-| node.status.disconnected.count           | Clients with status "disconnected"                       |
-| node.status.down.count                   | Clients with status "down"                               |
-| node.status.initializing.count           | Clients with status "initializing"                       |
-| node.status.ready.count                  | Clients with status "ready"                              |
-| node.status.unknown.count                | Clients with status "unknown"                            |
-| nomad.billable.clients                   | Number of client nodes in the cluster                    |
-| nomad.billable.cores.s390x               | Active client s390x CPU cores in the cluster             |
-| nomad.billable.cores.total               | Active client CPU cores in the cluster                   |
-| plugin.csi.unique.count                  | Unique CSI plugins                                       |
-| policy.sentinel.count                    | Sentinel policies                                        |
-| sentinel.enforcement.advisory.count      | Sentinel policies with "advisory" enforcement level      |
-| sentinel.enforcement.hard-mandatory.count| Sentinel policies with "hard-mandatory" enforcement level|
-| sentinel.enforcement.soft-mandatory.count| Sentinel policies with "soft-mandatory" enforcement level|
-| sentinel.scope.submit-csi-volume.count   | Sentinel policies with "submit-csi-volume" scope         |
-| sentinel.scope.submit-host-volume.count  | Sentinel policies with "submit-host-volume" scope        |
-| sentinel.scope.submit-job.count          | Sentinel policies with "submit-job" scope                |
-| task.device.gpu.amd.count                | Tasks with the "amd" gpu device driver                   |
-| task.device.gpu.nvidia.count             | Tasks with the "nvidia" gpu device driver                |
-| task.device.gpu.other.count              | Tasks with a gpu device driver of unknown vendor         |
-| task.device.other.other.count            | Tasks with some other device driver                      |
-| task.device.usb.other.count              | Tasks with a usb device driver of unknown vendor         |
-| task.driver.docker.count                 | Allocated tasks running with the docker driver           |
-| task.driver.exec.count                   | Allocated tasks running with the exec driver             |
-| task.driver.exec2.count                  | Allocated tasks running with the exec2 driver            |
-| task.driver.java.count                   | Allocated tasks running with the java driver             |
-| task.driver.nomad-driver-virt.count      | Allocated tasks running with the nomad-driver-virt driver|
-| task.driver.other.count                  | Allocated tasks running with the other driver            |
-| task.driver.pledge.count                 | Allocated tasks running with the pledge driver           |
-| task.driver.podman.count                 | Allocated tasks running with the podman driver           |
-| task.driver.qemu.count                   | Allocated tasks running with the qemu driver             |
-| task.driver.raw_exec.count               | Allocated tasks running with the raw_exec driver         |
-| variable.count                           | Nomad Variables                                          |
-| variable.lock.count                      | Nomad Variable Locks                                     |
-| volume.csi.capacity                      | Capacity of all CSI volumes in MB                        |
-| volume.csi.count                         | Number of "csi" volumes                                  |
-| volume.dhv.capacity                      | Capacity of all dynamic host volumes in MB               |
-| volume.dhv.plugin.other.count            | Dynamic host volumes with non-standard plugins           |
-| volume.dynamic.count                     | Number of "dynamic" volumes                              |
-| volume.static.count                      | Number of "static" volumes                               |
+| Key                                      | Description                                                |
+| acl.auth.method.count                    | ACL Auth Methods                                           |
+| acl.auth.method.jwt.count                | ACL Auth Methods of type JWT                               |
+| acl.auth.method.oidc.count               | ACL Auth Methods of type OIDC                              |
+| acl.policy.count                         | ACL policies                                               |
+| acl.role.count                           | ACL roles                                                  |
+| acl.token.count                          | ACL tokens                                                 |
+| alloc.count                              | All allocations                                            |
+| alloc.status.complete.count              | Allocations with client status "complete"                  |
+| alloc.status.failed.count                | Allocations with client status "failed"                    |
+| alloc.status.lost.count                  | Allocations with client status "lost"                      |
+| alloc.status.pending.count               | Allocations with client status "pending"                   |
+| alloc.status.running.count               | Allocations with client status "running"                   |
+| alloc.status.unknown.count               | Allocations with client status "unknown"                   |
+| alloc.task.count                         | All tasks in allocations                                   |
+| alloc.task.running.count                 | Running tasks in allocations                               |
+| client.count                             | Client nodes in the cluster                                |
+| client.device.gpu.amd.count              | Clients with the "amd" gpu device driver                   |
+| client.device.gpu.nvidia.count           | Clients with the "nvidia" gpu device driver                |
+| client.device.gpu.other.count            | Clients with a gpu device driver of unknown vendor         |
+| client.device.other.other.count          | Clients with some other device driver                      |
+| client.device.usb.other.count            | Clients with a usb device driver of unknown vendor         |
+| client.driver.docker.count               | Clients with the "docker" driver                           |
+| client.driver.exec.count                 | Clients with the "exec" driver                             |
+| client.driver.exec2.count                | Clients with the "exec2" driver                            |
+| client.driver.java.count                 | Clients with the "java" driver                             |
+| client.driver.nomad-driver-virt.count    | Clients with the "nomad-driver-virt" driver                |
+| client.driver.other.count                | Clients with the "other" driver                            |
+| client.driver.pledge.count               | Clients with the "pledge" driver                           |
+| client.driver.podman.count               | Clients with the "podman" driver                           |
+| client.driver.qemu.count                 | Clients with the "qemu" driver                             |
+| client.driver.raw_exec.count             | Clients with the "raw_exec" driver                         |
+| client.plugin.cni.unique.count           | Unique CNI plugins on client nodes                         |
+| client.plugin.driver.unique.count        | Unique task drivers on client nodes                        |
+| client.plugin.host_volume.unique.count   | Unique host volume plugins on client nodes                 |
+| client.plugin.secret.unique.count        | Unique secret plugins on client nodes                      |
+| client.resources.compute                 | Total client compute                                       |
+| client.resources.core.count              | Total client CPU cores                                     |
+| client.resources.memory                  | Total client memory in MB                                  |
+| client.vault.enabled.count               | Clients with Vault enabled                                 |
+| job.count                                | All jobs                                                   |
+| job.device.gpu.amd.count                 | Jobs with the "amd" gpu device driver                      |
+| job.device.gpu.nvidia.count              | Jobs with the "nvidia" gpu device driver                   |
+| job.device.gpu.other.count               | Jobs with a gpu device driver of unknown vendor            |
+| job.device.other.other.count             | Jobs with some other device driver                         |
+| job.device.usb.other.count               | Jobs with a usb device driver of unknown vendor            |
+| job.driver.docker.count                  | Tasks defined with the "docker" driver                     |
+| job.driver.exec.count                    | Tasks defined with the "exec" driver                       |
+| job.driver.exec2.count                   | Tasks defined with the "exec2" driver                      |
+| job.driver.java.count                    | Tasks defined with the "java" driver                       |
+| job.driver.nomad-driver-virt.count       | Tasks defined with the "nomad-driver-virt" driver          |
+| job.driver.other.count                   | Jobs with the "other" driver                               |
+| job.driver.pledge.count                  | Tasks defined with the "pledge" driver                     |
+| job.driver.podman.count                  | Tasks defined with the "podman" driver                     |
+| job.driver.qemu.count                    | Tasks defined with the "qemu" driver                       |
+| job.driver.raw_exec.count                | Tasks defined with the "raw_exec" driver                   |
+| job.group.count                          | Task groups in jobs                                        |
+| job.network.cni.args.count               | Networks in jobs with custom CNI args                      |
+| job.network.mode.bridge.count            | Networks in jobs with mode "bridge"                        |
+| job.network.mode.cni.count               | Networks in jobs with mode "cni"                           |
+| job.network.mode.host.count              | Networks in jobs with mode "host"                          |
+| job.network.mode.other.count             | Networks in jobs with some other mode                      |
+| job.parameterized.count                  | Parameterized jobs                                         |
+| job.parameterized.dispatched.count       | Dispatched parameterized jobs                              |
+| job.periodic.count                       | Periodic jobs                                              |
+| job.periodic.dispatched.count            | Dispatched periodic jobs                                   |
+| job.service.consul.connect.count         | Connect services in jobs                                   |
+| job.service.consul.count                 | Consul services in jobs                                    |
+| job.service.nomad.count                  | Nomad provider services in jobs                            |
+| job.task.identity.count                  | Tasks in jobs with identity enabled                        |
+| job.task.template.count                  | Tasks in jobs with templates                               |
+| job.task.vault.count                     | Tasks in jobs with Vault enabled                           |
+| job.type.batch.count                     | Jobs of type "batch"                                       |
+| job.type.service.count                   | Jobs of type "service"                                     |
+| job.type.sysbatch.count                  | Jobs of type "sysbatch"                                    |
+| job.type.system.count                    | Jobs of type "system"                                      |
+| job.volume.csi.count                     | CSI volumes in jobs                                        |
+| job.volume.host.count                    | Host volumes in jobs                                       |
+| job.volume.sticky.count                  | Sticky volumes in jobs                                     |
+| namespace.count                          | Namespaces                                                 |
+| namespace.quotas.count                   | Quotas                                                     |
+| node.cpu.arch.amd64.count                | Clients with "amd64" CPU architecture                      |
+| node.cpu.arch.arm64.count                | Clients with "arm64" CPU architecture                      |
+| node.cpu.arch.other.count                | Clients with some other CPU architecture                   |
+| node.cpu.arch.s390x.count                | Clients with "s390x" CPU architecture                      |
+| node.cpu.arch.unique.count               | Unique CPU architectures on client nodes                   |
+| node.kernel.name.aix.count               | Clients with "aix" kernel                                  |
+| node.kernel.name.darwin.count            | Clients with "darwin" kernel                               |
+| node.kernel.name.freebsd.count           | Clients with "freebsd" kernel                              |
+| node.kernel.name.linux.count             | Clients with "linux" kernel                                |
+| node.kernel.name.other.count             | Clients with some other kernel                             |
+| node.kernel.name.plan9.count             | Clients with "plan9" kernel                                |
+| node.kernel.name.solaris.count           | Clients with "solaris" kernel                              |
+| node.kernel.name.unique.count            | Unique kernels on client nodes                             |
+| node.os.name.alpine.count                | Clients with "alpine" operating system                     |
+| node.os.name.amazon.count                | Clients with "amazon" operating system                     |
+| node.os.name.arch.count                  | Clients with "arch" operating system                       |
+| node.os.name.centos.count                | Clients with "centos" operating system                     |
+| node.os.name.cloudlinux.count            | Clients with "cloudlinux" operating system                 |
+| node.os.name.coreos.count                | Clients with "coreos" operating system                     |
+| node.os.name.darwin.count                | Clients with "darwin" operating system                     |
+| node.os.name.debian.count                | Clients with "debian" operating system                     |
+| node.os.name.fedora.count                | Clients with "fedora" operating system                     |
+| node.os.name.gentoo.count                | Clients with "gentoo" operating system                     |
+| node.os.name.opensuse.count              | Clients with "opensuse" operating system                   |
+| node.os.name.oracle.count                | Clients with "oracle" operating system                     |
+| node.os.name.other.count                 | Clients with some other operating system                   |
+| node.os.name.raspbian.count              | Clients with "raspbian" operating system                   |
+| node.os.name.redhat.count                | Clients with "redhat" operating system                     |
+| node.os.name.suse.count                  | Clients with "suse" operating system                       |
+| node.os.name.ubuntu.count                | Clients with "ubuntu" operating system                     |
+| node.os.name.unique.count                | Unique operating systems on client nodes                   |
+| node.os.name.windows.count               | Clients with "windows" operating system                    |
+| node.pool.count                          | Node pools                                                 |
+| node.status.disconnected.count           | Clients with status "disconnected"                         |
+| node.status.down.count                   | Clients with status "down"                                 |
+| node.status.initializing.count           | Clients with status "initializing"                         |
+| node.status.ready.count                  | Clients with status "ready"                                |
+| node.status.unknown.count                | Clients with status "unknown"                              |
+| nomad.billable.clients                   | Number of client nodes in the cluster                      |
+| nomad.billable.cores.s390x               | Active client s390x CPU cores in the cluster               |
+| nomad.billable.cores.total               | Active client CPU cores in the cluster                     |
+| plugin.csi.unique.count                  | Unique CSI plugins                                         |
+| policy.sentinel.count                    | Sentinel policies                                          |
+| sentinel.enforcement.advisory.count      | Sentinel policies with "advisory" enforcement level        |
+| sentinel.enforcement.hard-mandatory.count| Sentinel policies with "hard-mandatory" enforcement level  |
+| sentinel.enforcement.soft-mandatory.count| Sentinel policies with "soft-mandatory" enforcement level  |
+| sentinel.scope.submit-csi-volume.count   | Sentinel policies with "submit-csi-volume" scope           |
+| sentinel.scope.submit-host-volume.count  | Sentinel policies with "submit-host-volume" scope          |
+| sentinel.scope.submit-job.count          | Sentinel policies with "submit-job" scope                  |
+| task.device.gpu.amd.count                | Tasks with the "amd" gpu device driver                     |
+| task.device.gpu.nvidia.count             | Tasks with the "nvidia" gpu device driver                  |
+| task.device.gpu.other.count              | Tasks with a gpu device driver of unknown vendor           |
+| task.device.other.other.count            | Tasks with some other device driver                        |
+| task.device.usb.other.count              | Tasks with a usb device driver of unknown vendor           |
+| task.driver.docker.count                 | Allocated tasks running with the "docker" driver           |
+| task.driver.exec.count                   | Allocated tasks running with the "exec" driver             |
+| task.driver.exec2.count                  | Allocated tasks running with the "exec2" driver            |
+| task.driver.java.count                   | Allocated tasks running with the "java" driver             |
+| task.driver.nomad-driver-virt.count      | Allocated tasks running with the "nomad-driver-virt" driver|
+| task.driver.other.count                  | Tasks with the "other" driver                              |
+| task.driver.pledge.count                 | Allocated tasks running with the "pledge" driver           |
+| task.driver.podman.count                 | Allocated tasks running with the "podman" driver           |
+| task.driver.qemu.count                   | Allocated tasks running with the "qemu" driver             |
+| task.driver.raw_exec.count               | Allocated tasks running with the "raw_exec" driver         |
+| variable.count                           | Nomad Variables                                            |
+| variable.lock.count                      | Nomad Variable Locks                                       |
+| volume.csi.capacity                      | Capacity of all CSI volumes in MB                          |
+| volume.csi.count                         | Number of "csi" volumes                                    |
+| volume.dhv.capacity                      | Capacity of all dynamic host volumes in MB                 |
+| volume.dhv.plugin.other.count            | Dynamic host volumes with non-standard plugins             |
+| volume.dynamic.count                     | Number of "dynamic" volumes                                |
+| volume.static.count                      | Number of "static" volumes                                 |
 
 
 ## Example payload


### PR DESCRIPTION
This PR updates nomad's census metrics tables:
- the 1.x.x pages get updated with improved metric descriptions to go with [hashicorp-census-registry #121](https://github.com/hashicorp/hashicorp-census-registry/pull/121)
- the 2.x.x pages get that update as well as the addition of the metadata table with the non-prod label. I thought I added that as part of the PAO work but it appears I left that out.

the template picker also appears to be broken 🤷 

@aimeeu do you think we have enough time to get this into the next release?
