### PR TITLE
VAULT-45716: address follow-up docs comments

### DIFF
--- a/content/vault/v2.x/content/docs/configuration/listener/tcp/index.mdx
+++ b/content/vault/v2.x/content/docs/configuration/listener/tcp/index.mdx
@@ -165,7 +165,8 @@ default value in the `"/sys/config/ui"` [API endpoint](/vault/api-docs/system/co
 - `max_token_header_size` `(int: 8192)` – Specifies the maximum allowed size, in
   bytes, for authentication token header values passed with `X-Vault-Token` or
   `Authorization: Bearer`. A value of `0` uses the default limit. A negative
-  value disables the limit.
+  value disables the limit. Requests that exceed the configured limit return a
+  `431 Request Header Fields Too Large` error.
 
 - `max_request_duration` `(string: "90s")` – Specifies the maximum
   request duration allowed before Vault cancels the request. This overrides

--- a/content/vault/v2.x/content/docs/configuration/listener/tcp/index.mdx
+++ b/content/vault/v2.x/content/docs/configuration/listener/tcp/index.mdx
@@ -166,7 +166,7 @@ default value in the `"/sys/config/ui"` [API endpoint](/vault/api-docs/system/co
   bytes, for authentication token header values passed with `X-Vault-Token` or
   `Authorization: Bearer`. A value of `0` uses the default limit. A negative
   value disables the limit. Requests that exceed the configured limit return a
-  `431 Request Header Fields Too Large` error.
+  `431` status code, with an error message including `authentication token exceeds maximum allowed header size`.
 
 - `max_request_duration` `(string: "90s")` – Specifies the maximum
   request duration allowed before Vault cancels the request. This overrides

--- a/content/vault/v2.x/content/docs/updates/release-notes.mdx
+++ b/content/vault/v2.x/content/docs/updates/release-notes.mdx
@@ -202,6 +202,9 @@ which will include all missing artifacts.
   use exponential backoff and orphan handling so Vault can retry failed root and
   static credential rotations without overloading the system. Vault 2.0.0 supports
   LDAP static roles in addition to the engines that already support root rotation.
+- **TCP listener**: Added the `max_token_header_size` option to limit the
+  size of authentication token header values passed with `X-Vault-Token` or
+  `Authorization: Bearer`.
 
 ## Feature deprecations and EOL
 

--- a/content/vault/v2.x/content/docs/updates/release-notes.mdx
+++ b/content/vault/v2.x/content/docs/updates/release-notes.mdx
@@ -202,9 +202,6 @@ which will include all missing artifacts.
   use exponential backoff and orphan handling so Vault can retry failed root and
   static credential rotations without overloading the system. Vault 2.0.0 supports
   LDAP static roles in addition to the engines that already support root rotation.
-- **TCP listener**: Added the `max_token_header_size` option to limit the
-  size of authentication token header values passed with `X-Vault-Token` or
-  `Authorization: Bearer`.
 
 ## Feature deprecations and EOL
 


### PR DESCRIPTION
## Summary

- Adds the `431 Request Header Fields Too Large` response text to the `max_token_header_size` TCP listener docs.
- Removes the Vault 2.0.0 release-note entry for `max_token_header_size`.