### PR TITLE
Vault 45588 rar toggle census metrics

### DIFF
--- a/content/vault/v1.20.x/content/docs/license/product-usage-reporting.mdx
+++ b/content/vault/v1.20.x/content/docs/license/product-usage-reporting.mdx
@@ -230,7 +230,6 @@ All of these metrics are numerical, and contain no sensitive values or additiona
 | `vault.ui.custom_banners.authenticated`                             | How many authenticated custom banners have been enabled across all namespaces.                             |
 | `vault.ui.custom_banners.unauthenticated`                           | How many unauthenticated custom banners have been enabled across all namespaces.                           |
 | `vault.storage.max_entry_size`                                      | The value of `max_entry_size` parameter for the storage stanza in the config.                              |
-| `vault.oauth.resource.server.config.count`                          | The total number of OAauth resource server configurations across all namespaces.                           |
 | `vault.storage.max_mount_and_namespace_table_entry_size`            | The value of `max_mount_and_namespace_table_entry_size` parameter for the storage stanza in the config.    |
 | `vault.operator.import.kv.version2.secrets.source.vault.count`      | The total number of secrets imported from Vault using operator import command.                             |
 | `vault.operator.import.kv.version2.secrets.source.aws.count`        | The total number of secrets imported from AWS using operator import command.                               |

--- a/content/vault/v2.x/content/docs/license/product-usage-reporting.mdx
+++ b/content/vault/v2.x/content/docs/license/product-usage-reporting.mdx
@@ -80,6 +80,9 @@ IBM collects the following product usage metrics as numerical data. Vault does n
 | Metric Name | Description |
 | --- | --- |
 | `vault.adaptive_overload_protection_enabled` | Whether Adaptive Overload Protection is enabled on Enterprise clusters. |
+| `vault.agentregistry.agent.registrations.count` | Total number of agent registrations across all namespaces. |
+| `vault.agentregistry.agent.registrations.with_rar_off.count` | Total number of agent registrations with RAR toggled off across all namespaces. |
+| `vault.agentregistry.agent.registrations.with_rar_on.count` | Total number of agent registrations with RAR toggled on across all namespaces. |
 | `vault.audit.device.file.count` | The total number of audit devices of type file configured for this cluster. |
 | `vault.audit.device.socket.tcp.count` | The total number of audit devices of type TCP socket configured for this cluster. |
 | `vault.audit.device.socket.udp.count` | The total number of audit devices of type UDP socket configured for this cluster. |
@@ -153,6 +156,9 @@ IBM collects the following product usage metrics as numerical data. Vault does n
 | `vault.mfa.stepup.pingid.count` | The count of MFA configurations using the PingID method enforced as step-up authentication. |
 | `vault.mfa.stepup.totp.count` | The count of MFA configurations using the TOTP method enforced as step-up authentication. |
 | `vault.namespaces.count` | Total number of namespaces. |
+| `vault.oauth.resource.server.config.count` | Total number of OAuth resource server configurations across all namespaces. |
+| `vault.oauth.resource.server.config.with_rar_on.count` | Total number of OAuth resource server configurations with RAR toggled on across all namespaces. |
+| `vault.oauth.resource.server.config.with_rar_off.count` | Total number of OAuth resource server configurations with RAR toggled off across all namespaces. |
 | `vault.operator.import.kv.version2.secrets.count` | Total number of secrets imported from using operator import command. |
 | `vault.operator.import.kv.version2.secrets.source.aws.count` | Total number of secrets imported from AWS using operator import command. |
 | `vault.operator.import.kv.version2.secrets.source.azure.count` | Total number of secrets imported from Azure using operator import command. |

--- a/content/vault/v2.x/content/docs/updates/release-notes.mdx
+++ b/content/vault/v2.x/content/docs/updates/release-notes.mdx
@@ -87,6 +87,11 @@ which will include all missing artifacts.
 - **Product usage metrics**: 
   - Added a count of local account static roles managed by mounts of OS secrets engine across all namespaces (`secret.engine.os.local.account.static.role.count`).
   - Added a count of agent registrations across all namespaces (`vault.agentregistry.agent.registrations.count`).
+  - Added a count of agent registrations with RAR toggled off across all namespaces (vault.agentregistry.agent.registrations.with_rar_off.count).
+  - Added a count of agent registrations with RAR toggled on across all namespaces (vault.agentregistry.agent.registrations.with_rar_on.count).
+  - Added a count of OAuth resource server configurations across all namespaces (vault.oauth.resource.server.config.count).
+  - Added a count of OAuth resource server configurations with RAR toggled on across all namespaces (vault.oauth.resource.server.config.with_rar_on.count).
+  - Added a count of OAuth resource server configurations with RAR toggled off across all namespaces (vault.oauth.resource.server.config.with_rar_off.count).
 
 - **JWT/OIDC auth plugin - Added multi-JWKS key ID cache:**
   JWT authentication with multiple JWKS URLs (`jwks_pairs`) now uses a


### PR DESCRIPTION
- Add vault metrics for the count of OAuth resource server and agent registrations with RAR toggled on and toggled off.
   - `vault.agentregistry.agent.registrations.with_rar_off.count`
   - `vault.agentregistry.agent.registrations.with_rar_on.count`
   - `vault.oauth.resource.server.config.with_rar_on.count`
   - `vault.oauth.resource.server.config.with_rar_off.count`
   
- Move `vault.oauth.resource.server.config.count` from `1.20.x `to `2.x`. It was incorrectly placed in `1.20` in a previous PR.

Jira: https://hashicorp.atlassian.net/browse/VAULT-45588
Vault PR: https://github.com/hashicorp/vault-enterprise/pull/15265