### PR TITLE
Docs: s3 backend: fix ListBucket prefix examples

### DIFF
--- a/content/terraform/v1.15.x/docs/language/backend/s3.mdx
+++ b/content/terraform/v1.15.x/docs/language/backend/s3.mdx
@@ -90,7 +90,7 @@ This is seen in the following AWS IAM Statement:
       "Resource": "arn:aws:s3:::mybucket",
       "Condition": {
         "StringEquals": {
-          "s3:prefix": "mybucket/path/to/my/key"
+          "s3:prefix": "path/to/my/key"
         }
       }
     },
@@ -569,7 +569,7 @@ to only a single state object within an S3 bucket is shown below:
       "Resource": "arn:aws:s3:::example-bucket",
       "Condition": {
         "StringEquals": {
-          "s3:prefix": "path/to/state"
+          "s3:prefix": "myapp/production/tfstate"
         }
       }
     },


### PR DESCRIPTION
### What
Fixed the S3 backend's `ListBucket` prefixes' documentation/examples.  
Page: `Developer / Terraform / Configuration Language / Backends / s3`

### Why
- One example was objectively wrong.
- The other example could be improved by making it more aligned with itself.

----------

### Merge Checklist

#### Pull Request
- [x] (N/A) Description links to related pull requests or issues, if any.

#### Content
- [x] (N/A) You added redirects to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages **across all affected versions**. Refer to [Redirects](https://github.com/hashicorp/web-unified-docs/blob/main/docs/content-guide/redirects.md#example-redirects) for examples and guidance. 
- [x] (N/A) Links to related content where appropriate (e.g., CLI, language, API endpoints, permissions, etc.).
- [x] (N/A) Pages with related content are updated and link to this content when appropriate.
- [x] (N/A) Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] (N/A) New pages have metadata (page name and description) at the top.
- [x] (N/A) New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] (N/A) New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] (N/A) UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
