### PR TITLE
Update description of source_module_id [TF-38184]

### DIFF
--- a/content/terraform-docs-common/docs/cloud-docs/api-docs/explorer.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/api-docs/explorer.mdx
@@ -125,7 +125,7 @@ fields available for each view type are detailed below:
 | `providers`                       | `string`   | A comma separated list of providers used in this workspace. |
 | `resources_drifted`               | `number`   | The count of resources that drift was detected for. |
 | `resources_undrifted`             | `number`   | The count of resources that drift was not detected for. |
-| `source_module_id`                | `string`   | The workspace's source module identifier. |
+| `source_module_id`                | `string`   | For workspaces using no-code modules, the identifier of the module. |
 | `state_version_terraform_version` | `string`   | The Terraform version used to create the current run's state file. |
 | `tags`                            | `string`   | A comma separated list of tags (keys and key:value pairs) applied to this workspace. |
 | `vcs_repo_identifier`             | `string`   | The name of the repository configured for this workspace, if available. |

--- a/content/terraform-docs-common/docs/cloud-docs/api-docs/explorer.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/api-docs/explorer.mdx
@@ -125,7 +125,7 @@ fields available for each view type are detailed below:
 | `providers`                       | `string`   | A comma separated list of providers used in this workspace. |
 | `resources_drifted`               | `number`   | The count of resources that drift was detected for. |
 | `resources_undrifted`             | `number`   | The count of resources that drift was not detected for. |
-| `source_module_id`                | `string`   | For workspaces using no-code modules, the identifier of the module. |
+| `source_module_id`                | `string`   | The source module identifier. Only available for workspaces created from a no-code module. |
 | `state_version_terraform_version` | `string`   | The Terraform version used to create the current run's state file. |
 | `tags`                            | `string`   | A comma separated list of tags (keys and key:value pairs) applied to this workspace. |
 | `vcs_repo_identifier`             | `string`   | The name of the repository configured for this workspace, if available. |

--- a/content/terraform-enterprise/2.0.x/docs/enterprise/api-docs/explorer.mdx
+++ b/content/terraform-enterprise/2.0.x/docs/enterprise/api-docs/explorer.mdx
@@ -128,7 +128,7 @@ fields available for each view type are detailed below:
 | `providers`                       | `string`   | A comma separated list of providers used in this workspace.                                                                              |
 | `resources_drifted`               | `number`   | The count of resources that drift was detected for.                                                                                      |
 | `resources_undrifted`             | `number`   | The count of resources that drift was not detected for.                                                                                  |
-| `source_module_id`                | `string`   | The workspace's source module identifier. |
+| `source_module_id`                | `string`   | For workspaces using no-code modules, the identifier of the module.                                                                      |
 | `state_version_terraform_version` | `string`   | The Terraform version used to create the current run's state file.                                                                       |
 | `tags`                            | `string`   | A comma separated list of tags (keys and key:value pairs) applied to this workspace.                                                     |
 | `vcs_repo_identifier`             | `string`   | The name of the repository configured for this workspace, if available.                                                                  |

--- a/content/terraform-enterprise/2.0.x/docs/enterprise/api-docs/explorer.mdx
+++ b/content/terraform-enterprise/2.0.x/docs/enterprise/api-docs/explorer.mdx
@@ -128,7 +128,7 @@ fields available for each view type are detailed below:
 | `providers`                       | `string`   | A comma separated list of providers used in this workspace.                                                                              |
 | `resources_drifted`               | `number`   | The count of resources that drift was detected for.                                                                                      |
 | `resources_undrifted`             | `number`   | The count of resources that drift was not detected for.                                                                                  |
-| `source_module_id`                | `string`   | For workspaces using no-code modules, the identifier of the module.                                                                      |
+| `source_module_id`                | `string`   | FThe source module identifier. Only available for workspaces created from a no-code module.                                                                      |
 | `state_version_terraform_version` | `string`   | The Terraform version used to create the current run's state file.                                                                       |
 | `tags`                            | `string`   | A comma separated list of tags (keys and key:value pairs) applied to this workspace.                                                     |
 | `vcs_repo_identifier`             | `string`   | The name of the repository configured for this workspace, if available.                                                                  |


### PR DESCRIPTION
### What

In Explorer workspace view, "Source module ID" has been re-titled as "No-code module". Note that the database column name is not changed and remains `source_module_id` in the API and CSV tables. This updates the documentation to emphasize that this field is used for the no-code module.

### Why

By customer request, see [JRIA FRB](https://hashicorp.atlassian.net/browse/FRB-7350) and [JIRA work item](https://hashicorp.atlassian.net/browse/TF-38184), to clarify that this field shows the no-code module.


----------

### Merge Checklist

#### Pull Request
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] N/A You added redirects to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages **across all affected versions**. Refer to [Redirects](https://github.com/hashicorp/web-unified-docs/blob/main/docs/content-guide/redirects.md#example-redirects) for examples and guidance. 
- [x] N/A Links to related content where appropriate (e.g., CLI, language, API endpoints, permissions, etc.).
- [x] N/A Pages with related content are updated and link to this content when appropriate.
- [x] N/A Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] N/A New pages have metadata (page name and description) at the top.
- [x] N/A New images are 2048 px wide. 
- [x] N/A New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] N/A UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
