### PR TITLE
Add tutorial link for Terraform MCP server integration

### DIFF
--- a/content/terraform-mcp-server/v1.0.x/docs/mcp-server/deploy/index.mdx
+++ b/content/terraform-mcp-server/v1.0.x/docs/mcp-server/deploy/index.mdx
@@ -12,6 +12,8 @@ last_modified: 2026-02-23T18:38:01.000Z
 
 This topic provides an overview of how to deploy the Terraform Model Context Protocol (MCP) server. The Terraform MCP server enables AI models to generate Terraform configuration using up-to-date information from the Terraform Registry. You can also connect the server to HCP Terraform or your Terraform Enterprise deployment. This lets you generate Terraform configuration using artifacts from your organizations. 
 
+> **Hands-on**: Try the [Integrate your private module registry with the Terraform MCP server tutorial](https://developer.hashicorp.com/terraform/tutorials/cloud/mcp). 
+
 ## Workflows 
 
 You can install the Terraform MCP server either on your local machine or in a remote environment. Local deployments are best for helping you get started or for one-off projects. Refer to [Local deployments](/terraform/mcp-server/deploy/local) for instructions. 


### PR DESCRIPTION
Added a hands-on tutorial link for integrating private module registry with the Terraform MCP server.

