### PR TITLE
Add force_new_client param to CF auth config API docs

### DIFF
--- a/content/vault/v1.19.x/content/api-docs/auth/cf.mdx
+++ b/content/vault/v1.19.x/content/api-docs/auth/cf.mdx
@@ -52,6 +52,8 @@ documentation](/vault/docs/auth/cf).
   the lower the risk of replay attacks.
 - `cf_timeout` `(duration: 0s)`: The timeout for the CF API. If not set, the default
   timeout is 0, which means no timeout.
+- `force_new_client` `(bool: false)`: When set to true, forces creation of a new CF
+  client for every login request instead of using a cached shared client.
 
 ### Sample payload
 

--- a/content/vault/v1.20.x/content/api-docs/auth/cf.mdx
+++ b/content/vault/v1.20.x/content/api-docs/auth/cf.mdx
@@ -52,6 +52,8 @@ documentation](/vault/docs/auth/cf).
   the lower the risk of replay attacks.
 - `cf_timeout` `(duration: 0s)`: The timeout for the CF API. If not set, the default
   timeout is 0, which means no timeout.
+- `force_new_client` `(bool: false)`: When set to true, forces creation of a new CF
+  client for every login request instead of using a cached shared client.
 
 ### Sample payload
 

--- a/content/vault/v1.21.x/content/api-docs/auth/cf.mdx
+++ b/content/vault/v1.21.x/content/api-docs/auth/cf.mdx
@@ -52,6 +52,8 @@ documentation](/vault/docs/auth/cf).
   the lower the risk of replay attacks.
 - `cf_timeout` `(duration: 0s)`: The timeout for the CF API. If not set, the default
   timeout is 0, which means no timeout.
+- `force_new_client` `(bool: false)`: When set to true, forces creation of a new CF
+  client for every login request instead of using a cached shared client.
 
 ### Sample payload
 

--- a/content/vault/v2.x/content/api-docs/auth/cf.mdx
+++ b/content/vault/v2.x/content/api-docs/auth/cf.mdx
@@ -52,6 +52,8 @@ documentation](/vault/docs/auth/cf).
   the lower the risk of replay attacks.
 - `cf_timeout` `(duration: 0s)`: The timeout for the CF API. If not set, the default
   timeout is 0, which means no timeout.
+- `force_new_client` `(bool: false)`: When set to true, forces creation of a new CF
+  client for every login request instead of using a cached shared client.
 
 ### Sample payload
 


### PR DESCRIPTION
Please go to the `Preview` tab and select the appropriate template:

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
