### PR TITLE
docs: Update entity list key_info examples

### DIFF
--- a/content/vault/v2.x/content/api-docs/secret/identity/entity.mdx
+++ b/content/vault/v2.x/content/api-docs/secret/identity/entity.mdx
@@ -248,15 +248,26 @@ $ curl \
 ```json
 {
   "data": {
-    "keys": [
-      "02fe5a88-912b-6794-62ed-db873ef86a95",
-      "3bf81bc9-44df-8138-57f9-724a9ae36d04",
-      "627fba68-98c9-c012-71ba-bfb349585ce1",
-      "6c4c805b-b384-3d0e-4d51-44d349887b96",
-      "70a72feb-35d1-c775-0813-8efaa8b4b9b5",
-      "f1092a67-ce34-48fd-161d-c13a367bc1cd",
-      "faedd89a-0d82-c197-c8f9-93a3e6cf0cd0"
-    ]
+    "key_info": {
+      "02fe5a88-912b-6794-62ed-db873ef86a95": {
+        "name": "entity-a",
+        "creation_time": "2024-01-01T12:00:00.000000000Z",
+        "last_update_time": "2024-01-01T12:30:00.000000000Z",
+        "disabled": false,
+        "aliases": [
+          {
+            "id": "35405f3c-884a-a3ff-4176-bac57f220811",
+            "name": "app-alias-1",
+            "mount_accessor": "auth_jwt_e47c5220",
+            "creation_time": "2024-01-01T12:05:00.000000000Z",
+            "last_update_time": "2024-01-01T12:35:00.000000000Z",
+            "mount_type": "jwt",
+            "mount_path": "auth/tfc_jwt/"
+          }
+        ]
+      }
+    },
+    "keys": ["02fe5a88-912b-6794-62ed-db873ef86a95"]
   }
 }
 ```
@@ -402,7 +413,26 @@ $ curl \
 ```json
 {
   "data": {
-    "keys": ["testentityname"]
+    "key_info": {
+      "02fe5a88-912b-6794-62ed-db873ef86a95": {
+        "name": "entity-a",
+        "creation_time": "2024-01-01T12:00:00.000000000Z",
+        "last_update_time": "2024-01-01T12:30:00.000000000Z",
+        "disabled": false,
+        "aliases": [
+          {
+            "id": "35405f3c-884a-a3ff-4176-bac57f220811",
+            "name": "app-alias-1",
+            "mount_accessor": "auth_jwt_e47c5220",
+            "creation_time": "2024-01-01T12:05:00.000000000Z",
+            "last_update_time": "2024-01-01T12:35:00.000000000Z",
+            "mount_type": "jwt",
+            "mount_path": "auth/tfc_jwt/"
+          }
+        ]
+      }
+    },
+    "keys": ["entity-a"]
   }
 }
 ```


### PR DESCRIPTION
## Summary

Updates the Vault identity entity API docs to show the full `key_info` response body returned by the list entity endpoints.

Changes include:

- Adds `key_info` to the `List entities by ID` sample response.
- Adds `key_info` to the `List entities by name` sample response.
- Shows entity metadata fields returned in `key_info`: `name`, `creation_time`, `last_update_time`, and `disabled`.
- Shows nested alias fields returned in entity `key_info`: `id`, `name`, `mount_accessor`, `creation_time`, `last_update_time`, `mount_type`, and `mount_path`.

Note : The List entities by name example keeps key_info keyed by entity ID because the shared entity list handler builds key_info with entity IDs for both list-by-ID and list-by-name responses.

Docs Ticket: https://hashicorp.atlassian.net/browse/VAULT-45872

Code Ticket: https://hashicorp.atlassian.net/browse/VAULT-45584

