### PR TITLE
[TF-38261] Add changelog entry for Dedicated Actions experience

### DIFF
--- a/content/terraform-docs-common/docs/cloud-docs/changelog.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/changelog.mdx
@@ -16,7 +16,7 @@ Keep track of changes to HCP Terraform.
 
 ## 2026-06-10
 
-* Dedicated Actions Experience. HCP Terraform now provides a dedicated Actions experience in the workspace where you can discover the actions declared in your Terraform configuration, inspect invocation history and statuses, and invoke or re-invoke actions directly from the UI. Refer to [Terraform Actions documentation](https://developer.hashicorp.com/terraform/cloud-docs/actions) for more information.
+- HCP Terraform now provides a dedicated **Actions** page that shows actions declared in your Terraform configuration. You can view action invocation history and statuses and invoke or re-invoke actions directly from the UI. Refer to [Manage Terraform actions](/terraform/cloud-docs/actions) for more information.
 
 ## 2026-06-08
 

--- a/content/terraform-docs-common/docs/cloud-docs/changelog.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/changelog.mdx
@@ -16,7 +16,7 @@ Keep track of changes to HCP Terraform.
 
 ## 2026-06-10
 
-* Dedicated Actions Experience. HCP Terraform now provides a dedicated Actions experience in the workspace where you can discover the actions declared in your Terraform configuration, inspect invocation history and statuses, and invoke or re-invoke actions directly from the UI. This experience is available for Standard and Premium tiers and requires Terraform 1.14 or newer. Refer to [Terraform Actions documentation](https://developer.hashicorp.com/terraform/cloud-docs/workspaces/actions) for more information.
+* Dedicated Actions Experience. HCP Terraform now provides a dedicated Actions experience in the workspace where you can discover the actions declared in your Terraform configuration, inspect invocation history and statuses, and invoke or re-invoke actions directly from the UI. This experience is available for Standard and Premium tiers and requires Terraform 1.14 or newer. Refer to [Terraform Actions documentation](https://developer.hashicorp.com/terraform/cloud-docs/actions) for more information.
 
 ## 2026-06-08
 

--- a/content/terraform-docs-common/docs/cloud-docs/changelog.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/changelog.mdx
@@ -16,7 +16,7 @@ Keep track of changes to HCP Terraform.
 
 ## 2026-06-10
 
-* Dedicated Actions Experience. HCP Terraform now provides a dedicated Actions experience in the workspace where you can discover the actions declared in your Terraform configuration, inspect invocation history and statuses, and invoke or re-invoke actions directly from the UI. This experience is available for Standard and Premium tiers and requires Terraform 1.14 or newer. Refer to [Terraform Actions documentation](https://developer.hashicorp.com/terraform/cloud-docs/actions) for more information.
+* Dedicated Actions Experience. HCP Terraform now provides a dedicated Actions experience in the workspace where you can discover the actions declared in your Terraform configuration, inspect invocation history and statuses, and invoke or re-invoke actions directly from the UI. Refer to [Terraform Actions documentation](https://developer.hashicorp.com/terraform/cloud-docs/actions) for more information.
 
 ## 2026-06-08
 

--- a/content/terraform-docs-common/docs/cloud-docs/changelog.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/changelog.mdx
@@ -14,6 +14,10 @@ last_modified: 2026-04-14T20:50:21.000Z
 
 Keep track of changes to HCP Terraform.
 
+## 2026-06-10
+
+* Dedicated Actions Experience. HCP Terraform now provides a dedicated Actions experience in the workspace where you can discover the actions declared in your Terraform configuration, inspect invocation history and statuses, and invoke or re-invoke actions directly from the UI. This experience is available for Standard and Premium tiers and requires Terraform 1.14 or newer. Refer to [Terraform Actions documentation](https://developer.hashicorp.com/terraform/cloud-docs/workspaces/actions) for more information.
+
 ## 2026-06-08
 
 * Project-level run tasks. HCP Terraform now supports project-level run tasks, enabling organizations to apply security, compliance, and operational guardrails consistently across groups of workspaces while reducing manual overhead. Refer to [HCP Terraform run tasks](https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings/run-tasks) for more information.


### PR DESCRIPTION
## Summary

- Adds a `2026-06-10` HCP Terraform changelog entry for the **Dedicated Actions experience** in `content/terraform-docs-common/docs/cloud-docs/changelog.mdx`.

## Entry

> **2026-06-10**
> Dedicated Actions Experience. HCP Terraform now provides a dedicated Actions experience in the workspace where you can discover the actions declared in your Terraform configuration, inspect invocation history and statuses, and invoke or re-invoke actions directly from the UI or API. This experience is available for Standard and Premium tiers and requires Terraform 1.14 or newer.