### PR TITLE
Clarify workspace recovery requirements

### DIFF
--- a/content/terraform-docs-common/docs/cloud-docs/workspaces/create.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/workspaces/create.mdx
@@ -103,7 +103,9 @@ Choose one of the following actions:
 @include 'beta.mdx'
  
 You have 30 days to recover a deleted workspace. While a discarded workspace is recoverable, HCP Terraform and Terraform Enterprise continue to record new configuration versions committed through VCS webhooks, but commits don’t trigger new runs. You can’t recover a workspace that has the same name as an existing workspace. To proceed, you must either delete or rename the existing workspace. 
- 
+
+You must be on a paid subscription to recover a workspace. Refer to [Workspace recovery requirements](#workspace-recovery-requirements) for more information.
+  
 Complete the following steps to recover a discarded workspace: 
  
 1. Sign in to [HCP Terraform](https://app.terraform.io/) or Terraform Enterprise and choose your organization. 

--- a/content/terraform-docs-common/docs/cloud-docs/workspaces/create.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/workspaces/create.mdx
@@ -104,8 +104,9 @@ Choose one of the following actions:
  
 You have 30 days to recover a deleted workspace. While a discarded workspace is recoverable, HCP Terraform and Terraform Enterprise continue to record new configuration versions committed through VCS webhooks, but commits don’t trigger new runs. You can’t recover a workspace that has the same name as an existing workspace. To proceed, you must either delete or rename the existing workspace. 
 
-You must have a paid subscription to recover a workspace. Refer to [Workspace recovery requirements](#workspace-recovery-requirements) for more information.
-  
+<!-- BEGIN: TFC:only name:pnp-callout -->
+You must have a paid subscription to recover a workspace. Refer to [Workspace recovery requirements](#workspace-recovery-requirements) for more information.<!-- END: TFC:only name:pnp-callout -->
+
 Complete the following steps to recover a discarded workspace: 
  
 1. Sign in to [HCP Terraform](https://app.terraform.io/) or Terraform Enterprise and choose your organization. 

--- a/content/terraform-docs-common/docs/cloud-docs/workspaces/create.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/workspaces/create.mdx
@@ -104,7 +104,7 @@ Choose one of the following actions:
  
 You have 30 days to recover a deleted workspace. While a discarded workspace is recoverable, HCP Terraform and Terraform Enterprise continue to record new configuration versions committed through VCS webhooks, but commits don’t trigger new runs. You can’t recover a workspace that has the same name as an existing workspace. To proceed, you must either delete or rename the existing workspace. 
 
-You must be on a paid subscription to recover a workspace. Refer to [Workspace recovery requirements](#workspace-recovery-requirements) for more information.
+You must have a paid subscription to recover a workspace. Refer to [Workspace recovery requirements](#workspace-recovery-requirements) for more information.
   
 Complete the following steps to recover a discarded workspace: 
  


### PR DESCRIPTION
This PR reiterates that you must have a paid subscription to restore a workspace