### PR TITLE
Nomad Docs - New task driver functions

### DIFF
--- a/content/nomad/v1.10.x/content/plugins/author/task-driver.mdx
+++ b/content/nomad/v1.10.x/content/plugins/author/task-driver.mdx
@@ -248,6 +248,30 @@ The `ExecTask` function is used by the Nomad client to execute commands inside
 the task execution context. For example, the Docker driver executes commands
 inside the running container. `ExecTask` is called for Consul script checks.
 
+### `Init(context.Context) error`
+
+> Optional
+
+The `Init` function initializes the driver prior to use. Nomad calls this function after
+`SetConfig`. Use `Init` to perform any required setup prior to receiving other requests. 
+
+### `Shutdown(context.Context) error`
+
+> Optional 
+
+The `Shutdown` function signals that the driver will be shutdown. Use this function 
+to perform any desired cleanup before the driver process is terminated. 
+When the Nomad client makes this request, a timeout is applied for the request 
+to complete, after which the context is canceled. The timeout for the 
+request is two seconds. Once the timeout is reached, the Nomad client
+proceeds with shutting down the driver and allows an additional two seconds 
+before killing the process.
+
+There is no guarantee that Nomad calls the `Shutdown` function prior
+to the driver process being terminated. Because there are a variety of ways in
+which a driver process may terminated (the driver crashing, process being killed
+outside of Nomad, etc.), calling `Shutdown` is considered best effort.
+
 @include 'plugins/hcl-specifications.mdx'
 
 [exec2 driver]: https://github.com/hashicorp/nomad-driver-exec2

--- a/content/nomad/v1.11.x/content/plugins/author/task-driver.mdx
+++ b/content/nomad/v1.11.x/content/plugins/author/task-driver.mdx
@@ -248,6 +248,30 @@ The `ExecTask` function is used by the Nomad client to execute commands inside
 the task execution context. For example, the Docker driver executes commands
 inside the running container. `ExecTask` is called for Consul script checks.
 
+### `Init(context.Context) error`
+
+> Optional
+
+The `Init` function initializes the driver prior to use. Nomad calls this function after
+`SetConfig`. Use `Init` to perform any required setup prior to receiving other requests. 
+
+### `Shutdown(context.Context) error`
+
+> Optional 
+
+The `Shutdown` function signals that the driver will be shutdown. Use this function 
+to perform any desired cleanup before the driver process is terminated. 
+When the Nomad client makes this request, a timeout is applied for the request 
+to complete, after which the context is canceled. The timeout for the 
+request is two seconds. Once the timeout is reached, the Nomad client
+proceeds with shutting down the driver and allows an additional two seconds 
+before killing the process.
+
+There is no guarantee that Nomad calls the `Shutdown` function prior
+to the driver process being terminated. Because there are a variety of ways in
+which a driver process may terminated (the driver crashing, process being killed
+outside of Nomad, etc.), calling `Shutdown` is considered best effort.
+
 @include 'plugins/hcl-specifications.mdx'
 
 [exec2 driver]: https://github.com/hashicorp/nomad-driver-exec2

--- a/content/nomad/v2.0.x/content/plugins/author/task-driver.mdx
+++ b/content/nomad/v2.0.x/content/plugins/author/task-driver.mdx
@@ -248,6 +248,30 @@ The `ExecTask` function is used by the Nomad client to execute commands inside
 the task execution context. For example, the Docker driver executes commands
 inside the running container. `ExecTask` is called for Consul script checks.
 
+### `Init(context.Context) error`
+
+> Optional
+
+The `Init` function initializes the driver prior to use. Nomad calls this function after
+`SetConfig`. Use `Init` to perform any required setup prior to receiving other requests. 
+
+### `Shutdown(context.Context) error`
+
+> Optional 
+
+The `Shutdown` function signals that the driver will be shutdown. Use this function 
+to perform any desired cleanup before the driver process is terminated. 
+When the Nomad client makes this request, a timeout is applied for the request 
+to complete, after which the context is canceled. The timeout for the 
+request is two seconds. Once the timeout is reached, the Nomad client
+proceeds with shutting down the driver and allows an additional two seconds 
+before killing the process.
+
+There is no guarantee that Nomad calls the `Shutdown` function prior
+to the driver process being terminated. Because there are a variety of ways in
+which a driver process may terminated (the driver crashing, process being killed
+outside of Nomad, etc.), calling `Shutdown` is considered best effort.
+
 @include 'plugins/hcl-specifications.mdx'
 
 [exec2 driver]: https://github.com/hashicorp/nomad-driver-exec2


### PR DESCRIPTION
## Description

Add documentation for optional `Init` and `Shutdown` task driver plugin function.

## Links

Nomad Code PR: hashicorp/nomad#28104 and hashicorp/nomad#28102

## Contributor checklists

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [x] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [ ] Verify that all status checks passed
- [ ] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [ ] I added redirects for any moved or removed pages
- [ ] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [ ] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [ ] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.
