### PR TITLE
Nomad Docs - Update task driver lifecycle

### DIFF
--- a/content/nomad/v1.10.x/content/plugins/author/task-driver.mdx
+++ b/content/nomad/v1.10.x/content/plugins/author/task-driver.mdx
@@ -29,11 +29,11 @@ boilerplate necessary for a task driver plugin, along with detailed comments.
 
 ### Lifecycle and state
 
-A task driver plugin is long-lived and its lifetime is not bound to the Nomad
-client. This means that the Nomad client can restart without restarting the
-driver. Nomad ensures that one instance of the task driver is running. If
-the task driver crashes or otherwise terminates, Nomad launches another instance
-of it.
+A task driver plugin is responsible for managing long-lived tasks. The lifetime of
+those tasks is not bound to the Nomad client. This means that the Nomad client,
+and the driver plugin, can restart without affecting running tasks. Nomad ensures
+that one instance of the task driver is running. If the task driver crashes or
+otherwise terminates, Nomad launches another instance of it.
 
 Task drivers should maintain as little state as possible. State for a task is
 stored by the Nomad client on task creation. This enables a pattern where the

--- a/content/nomad/v1.11.x/content/plugins/author/task-driver.mdx
+++ b/content/nomad/v1.11.x/content/plugins/author/task-driver.mdx
@@ -29,11 +29,11 @@ boilerplate necessary for a task driver plugin, along with detailed comments.
 
 ### Lifecycle and state
 
-A task driver plugin is long-lived and its lifetime is not bound to the Nomad
-client. This means that the Nomad client can restart without restarting the
-driver. Nomad ensures that one instance of the task driver is running. If
-the task driver crashes or otherwise terminates, Nomad launches another instance
-of it.
+A task driver plugin is responsible for managing long-lived tasks. The lifetime of
+those tasks is not bound to the Nomad client. This means that the Nomad client,
+and the driver plugin, can restart without affecting running tasks. Nomad ensures
+that one instance of the task driver is running. If the task driver crashes or
+otherwise terminates, Nomad launches another instance of it.
 
 Task drivers should maintain as little state as possible. State for a task is
 stored by the Nomad client on task creation. This enables a pattern where the

--- a/content/nomad/v2.0.x/content/plugins/author/task-driver.mdx
+++ b/content/nomad/v2.0.x/content/plugins/author/task-driver.mdx
@@ -29,11 +29,11 @@ boilerplate necessary for a task driver plugin, along with detailed comments.
 
 ### Lifecycle and state
 
-A task driver plugin is long-lived and its lifetime is not bound to the Nomad
-client. This means that the Nomad client can restart without restarting the
-driver. Nomad ensures that one instance of the task driver is running. If
-the task driver crashes or otherwise terminates, Nomad launches another instance
-of it.
+A task driver plugin is responsible for managing long-lived tasks. The lifetime of
+those tasks is not bound to the Nomad client. This means that the Nomad client,
+and the driver plugin, can restart without affecting running tasks. Nomad ensures
+that one instance of the task driver is running. If the task driver crashes or
+otherwise terminates, Nomad launches another instance of it.
 
 Task drivers should maintain as little state as possible. State for a task is
 stored by the Nomad client on task creation. This enables a pattern where the


### PR DESCRIPTION
## Description

Clarifies the description of the Nomad task driver plugin lifecycle.

## Contributor checklists

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [x] 1 week: Default expectation
- [x] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [ ] Verify that all status checks passed
- [ ] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [ ] I added redirects for any moved or removed pages
- [ ] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [ ] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [ ] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.
