### PR TITLE
HCP TF: Provide detailed metrics (run amount) for Run Tasks

### DIFF
--- a/content/terraform-docs-common/docs/cloud-docs/api-docs/run-tasks/run-task-stages-and-results.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/api-docs/run-tasks/run-task-stages-and-results.mdx
@@ -110,6 +110,7 @@ curl \
           "passed-at": "2022-06-08T20:32:12+08:00",
           "running-at": "2022-06-08T20:32:11+08:00"
         },
+        "duration": 1000,
         "created-at": "2022-06-08T12:31:56.94Z",
         "updated-at": "2022-06-08T12:32:12.315Z"
       },
@@ -183,6 +184,7 @@ curl \
         "passed-at": "2022-06-08T20:32:12+08:00",
         "running-at": "2022-06-08T20:32:11+08:00"
       },
+      "duration": 1000,
       "created-at": "2022-06-08T12:31:56.94Z",
       "updated-at": "2022-06-08T12:32:12.315Z"
     },
@@ -255,6 +257,7 @@ curl \
         "passed-at": "2022-06-08T20:32:12+08:00",
         "running-at": "2022-06-08T20:32:11+08:00"
       },
+      "duration": 1000,
       "url": "https://external.service/project/task-123abc",
       "created-at": "2022-06-08T12:31:56.954Z",
       "updated-at": "2022-06-08T12:32:12.27Z",
@@ -326,6 +329,7 @@ curl \
             "running-at":"2022-09-21T06:36:54+00:00",
             "awaiting-override-at":"2022-09-21T06:31:50+00:00"
          },
+         "duration": 304000,
          "created-at":"2022-09-21T06:29:44.632Z",
          "updated-at":"2022-09-21T06:36:54.952Z",
          "permissions":{


### PR DESCRIPTION
Add duration field (in milliseconds) to JSON response examples, calculated from status timestamps.
Jira: [FRB-6741](https://hashicorp.atlassian.net/browse/FRB-6741)
### What
Updated the Run Task Stages and Results API documentation to include the duration field in all JSON response examples. The duration field represents the elapsed time in milliseconds between the running-at timestamp and the final status timestamp.

**Changed pages:**
- `content/terraform-docs-common/docs/cloud-docs/api-docs/run-tasks/run-task-stages-and-results.mdx`

**Updated JSON responses:**
- List the Run Task Stages in a Run (GET `/runs/:run_id/task-stages`)
- Show a Run Task Stage (GET `/task-stages/:task_stage_id`)
- Show a Run Task Result (GET `/task-results/:task_result_id`)
- Override a Task Stage (POST `/task-stages/:task_stage_id/actions/override`)

### Why
The HCP Terraform API currently provides only start and end timestamps for run tasks, requiring users to manually calculate durations. This change adds the `duration` field to standardize performance metrics reporting across the API, consistent with other metrics like Sentinel policies, plan, and apply timings which are already provided in milliseconds.

This enhancement benefits users who track run task performance by eliminating the need for manual duration calculations and providing consistency with other API performance metrics.

### Screenshots
<img width="689" height="769" alt="image" src="https://github.com/user-attachments/assets/5855673d-7a27-49e1-9944-3679eb88cb9d" />
<img width="663" height="595" alt="image" src="https://github.com/user-attachments/assets/a19f81f5-c3d2-480a-b590-eeaf71edf565" />

----------

### Merge Checklist

#### Pull Request
- [x] Description links to related pull requests or issues, if any.(N/A - no related PRs/issues)

#### Content
- [x] Redirects have been added to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages.(N/A - no pages moved, renamed, or deleted)
- [x] API documentation and the API Changelog have been updated.
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).(N/A - existing links maintained)
- [x] Pages with related content are updated and link to this content when appropriate.(N/A - no related pages require updates)
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.(N/A - no navigation changes)
- [x] New pages have metadata (page name and description) at the top.(N/A - existing page updated)
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.(N/A - no images added)
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.(N/A - updated existing JSON examples)
- [x] UI elements (button names, page names, etc.) are bolded.(N/A - no UI elements added)
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.


[FRB-6741]: https://hashicorp.atlassian.net/browse/FRB-6741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ