### PR TITLE
[TF-38261] Add changelog entry for action invocations in stacks SRO feature

### DIFF
--- a/content/terraform-docs-common/docs/cloud-docs/changelog.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/changelog.mdx
@@ -14,13 +14,11 @@ last_modified: 2026-04-14T20:50:21.000Z
 
 Keep track of changes to HCP Terraform.
 
-## 2026-06-12
-
-- Stack deployment runs now display action invocations in the structured run output. You can view direct and lifecycle action invocations alongside standard run steps, including their status, timing, and resource association. Refer to [Review deployment runs](/terraform/cloud-docs/stacks/deploy/runs) for more information.
-
 ## 2026-06-10
 
 - HCP Terraform now provides a dedicated **Actions** page that shows actions declared in your Terraform configuration. You can view action invocation history and statuses and invoke or re-invoke actions directly from the UI. Refer to [Manage Terraform actions](/terraform/cloud-docs/actions) for more information.
+
+- Stack deployment runs now display action invocations in the structured run output. You can view lifecycle action invocations alongside standard run steps, including their status, timing, and resource association. Refer to [Review deployment runs](/terraform/cloud-docs/stacks/deploy/runs) for more information.
 
 ## 2026-06-08
 

--- a/content/terraform-docs-common/docs/cloud-docs/changelog.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/changelog.mdx
@@ -14,6 +14,10 @@ last_modified: 2026-04-14T20:50:21.000Z
 
 Keep track of changes to HCP Terraform.
 
+## 2026-06-12
+
+- Stack deployment runs now display action invocations in the structured run output. You can view direct and lifecycle action invocations alongside standard run steps, including their status, timing, and resource association. Refer to [Review deployment runs](/terraform/cloud-docs/stacks/deploy/runs) for more information.
+
 ## 2026-06-10
 
 - HCP Terraform now provides a dedicated **Actions** page that shows actions declared in your Terraform configuration. You can view action invocation history and statuses and invoke or re-invoke actions directly from the UI. Refer to [Manage Terraform actions](/terraform/cloud-docs/actions) for more information.


### PR DESCRIPTION
## Summary

- Adds a `2026-06-12` HCP Terraform changelog entry for the **Action invocations in stacks SRO** feature in `content/terraform-docs-common/docs/cloud-docs/changelog.mdx`.