### PR TITLE
Nomad: document fallback behavior for Consul tokens

### DIFF
--- a/content/nomad/v1.10.x/content/docs/configuration/client.mdx
+++ b/content/nomad/v1.10.x/content/docs/configuration/client.mdx
@@ -604,6 +604,12 @@ refer to the [drivers documentation](/nomad/docs/job-declare/task-driver).
   }
   ```
 
+- `use_client_consul_token` `bool: false` - Allow task templates to use the
+  Nomad client agent's Consul token if workload identity is not configured. The
+  Nomad client agent's token must have a policy that allows any Consul reads
+  required by workload templates. This may include reading from the service
+  catalog and reading from Consul KV from any Consul namespace.
+
 - `vault_retry` `(map: { attempts = 12 backoff = "250ms" max_backoff = "1m" })` -
   This controls the retry behavior when an error is returned from Vault. Consul
   Template is highly fault tolerant, meaning it does not exit in the face of failure.

--- a/content/nomad/v1.10.x/content/docs/configuration/consul.mdx
+++ b/content/nomad/v1.10.x/content/docs/configuration/consul.mdx
@@ -240,8 +240,8 @@ agents with [`server.enabled`] set to `true`.
 The `service_identity` and `task_identity` blocks accept all the same values as
 the job specification's [`identity`][identity_block] (except that the
 `service_identity` ignores the `env` and `file` fields). By ensuring these
-blocks are set on the Nomad servers, you'll automatically migrate workloads to
-use Workload Identity as the next version is submitted to the cluster.
+blocks are set on the Nomad servers, you automatically migrate workloads to
+use workload identity as the next version is submitted to the cluster.
 
 The recommended configuration for `service_identity` and `task_identity` is as
 follows. Refer to [Migrating to Using Workload Identity with Consul][] for

--- a/content/nomad/v1.10.x/content/docs/configuration/consul.mdx
+++ b/content/nomad/v1.10.x/content/docs/configuration/consul.mdx
@@ -240,9 +240,8 @@ agents with [`server.enabled`] set to `true`.
 The `service_identity` and `task_identity` blocks accept all the same values as
 the job specification's [`identity`][identity_block] (except that the
 `service_identity` ignores the `env` and `file` fields). By ensuring these
-blocks are set on the Nomad servers, you can automatically migrate your existing
-jobs to use Workload Identity without modifying the job specification and
-resubmitting them.
+blocks are set on the Nomad servers, you'll automatically migrate workloads to
+use Workload Identity as the next version is submitted to the cluster.
 
 The recommended configuration for `service_identity` and `task_identity` is as
 follows. Refer to [Migrating to Using Workload Identity with Consul][] for

--- a/content/nomad/v1.10.x/content/docs/secure/acl/consul.mdx
+++ b/content/nomad/v1.10.x/content/docs/secure/acl/consul.mdx
@@ -80,18 +80,18 @@ service_prefix "" {
 
 ## Nomad Workload Identities
 
-Nomad clients can use a task or service's [Workload Identity][nomad_wid] to
+Nomad clients can use a task or service's [workload identity][nomad_wid] to
 authenticate to Consul and obtain an ACL token specific to the service or
 task. When using Nomad workload identities, every allocation gets its own Consul
 ACL token(s).
 
-Without workload identity, allocations fallback to using the Nomad client
+Without workload identity, allocations fall back to using the Nomad client
 agent's own Consul token. This is a simpler approach but allows all workloads on
 the same node access to the same data from Consul. If this is suitable for your
 environment, refer to [Consul Without Workload Identity][].
 
 By default, Nomad does not generate workload identities for services, and tasks
-only receive an identity that can be used to access data from Nomad itself, such
+only receive an identity that they can use to access data from Nomad itself, such
 as for reading [Variables][] from a [`template`][] block. To access Consul using
 workload identity, jobs must have additional workload identities defined as
 [`identity`][] blocks.
@@ -429,10 +429,10 @@ Consul service mesh.
 
 For service registration and Consul service mesh, the client automatically falls
 back to use its own Consul token for any workload that doesn't have a workload
-identity for Consul from the server. This will include any allocation that was
+identity for Consul from the server. This includes any allocation that was
 created before the servers were configured to use workload identity.
 
-For `template` blocks you'll need additional configuration to allow job template
+For `template` blocks you need additional configuration to allow job template
 blocks to use the Nomad client's token, which may have broader capabilities than
 a task strictly needs. Set [`client.template.use_client_consul_token =
 true`][use-client-consul-token] in the Nomad client's agent configuration to
@@ -449,9 +449,9 @@ key_prefix "" {
 ## Migrating to Using Workload Identity with Consul
 
 Nomad version 1.7.0 introduced Workload Identity authentication, and deprecated
-authenticating via a token passed to the `job run` command. Token authentication
-was then removed in Nomad 1.10.0. Migrating from the legacy (pre-1.7) workflow
-where workload use the agent's Consul token requires configuation on your Consul
+authenticating with a token passed to the `job run` command. We then removed token authentication
+in Nomad 1.10.0. Migrating from the legacy (pre-1.7) workflow
+where workloads use the agent's Consul token requires configuation on your Consul
 cluster and your Nomad server agents. It does not require updating your running
 Nomad jobs. To migrate:
 

--- a/content/nomad/v1.10.x/content/docs/secure/acl/consul.mdx
+++ b/content/nomad/v1.10.x/content/docs/secure/acl/consul.mdx
@@ -80,16 +80,21 @@ service_prefix "" {
 
 ## Nomad Workload Identities
 
-Starting in Nomad 1.7, Nomad clients can use a task or service's [Workload
-Identity][nomad_wid] to authenticate to Consul and obtain an ACL token specific
-to the service or task. When using Nomad workload identities, you no longer
-need to pass in a Consul ACL token to submit a job.
+Nomad clients can use a task or service's [Workload Identity][nomad_wid] to
+authenticate to Consul and obtain an ACL token specific to the service or
+task. When using Nomad workload identities, every allocation gets its own Consul
+ACL token(s).
+
+Without workload identity, allocations fallback to using the Nomad client
+agent's own Consul token. This is a simpler approach but allows all workloads on
+the same node access to the same data from Consul. If this is suitable for your
+environment, refer to [Consul Without Workload Identity][].
 
 By default, Nomad does not generate workload identities for services, and tasks
-only receive an identity that can be used to access data from Nomad itself,
-such as for reading [Variables][] from a [`template`][] block. To access
-Consul, jobs must have additional workload identities defined as [`identity`][]
-blocks.
+only receive an identity that can be used to access data from Nomad itself, such
+as for reading [Variables][] from a [`template`][] block. To access Consul using
+workload identity, jobs must have additional workload identities defined as
+[`identity`][] blocks.
 
 To avoid having to add these additional identities to every job, you can
 configure Nomad servers with the [`consul.service_identity`][] and
@@ -416,23 +421,52 @@ The [`nomad setup consul`][nomad_cli_setup_consul] command and the
 module can help you automate the process of applying configuration to a Consul
 cluster.
 
+## Consul Without Workload Identity
+
+Without workload identity, Nomad clients use their own Consul ACL token to
+register services, read services and KV for `template` blocks, and configure
+Consul service mesh.
+
+For service registration and Consul service mesh, the client automatically falls
+back to use its own Consul token for any workload that doesn't have a workload
+identity for Consul from the server. This will include any allocation that was
+created before the servers were configured to use workload identity.
+
+For `template` blocks you'll need additional configuration to allow job template
+blocks to use the Nomad client's token, which may have broader capabilities than
+a task strictly needs. Set [`client.template.use_client_consul_token =
+true`][use-client-consul-token] in the Nomad client's agent configuration to
+allow the template runner access to the token. Add the following block to the
+Consul policy used by the Nomad client to allow the client to read Consul KV
+data in `template` blocks.
+
+```hcl
+key_prefix "" {
+  policy = "read"
+}
+```
+
 ## Migrating to Using Workload Identity with Consul
 
 Nomad version 1.7.0 introduced Workload Identity authentication, and deprecated
-token authentication.  Token authentication was then removed in Nomad 1.10.0.
-Migrating from the legacy (pre-1.7) workflow where workload use the agent's
-Consul token requires configuation on your Consul cluster and your Nomad server
-agents. It does not require updating your running Nomad jobs. To migrate:
+authenticating via a token passed to the `job run` command. Token authentication
+was then removed in Nomad 1.10.0. Migrating from the legacy (pre-1.7) workflow
+where workload use the agent's Consul token requires configuation on your Consul
+cluster and your Nomad server agents. It does not require updating your running
+Nomad jobs. To migrate:
 
 * Create the Consul auth method and binding rules on your Consul cluster.
 * Enable [`consul.service_identity`][] blocks in your Nomad server agent configurations.
 * Enable [`consul.task_identity`][] blocks in your Nomad server agent configurations.
+* Enable [`client.template.use_client_consul_token =
+  true`][use-client-consul-token] in your Nomad client agent configurations.
 * (Optionally) add [`identity`][] blocks to your jobs if you want to use a
   different identity because of how your auth method and binding rules are
   configured.
 
-Note that when using Workload Identity you will no longer need to pass in a
-Consul token to submit a job.
+You can remove `client.template.use_client_consul_token = true` from client
+agents once all jobs have been redeployed at least once with workload identity
+and all their allocations replaced.
 
 [Variables]: /nomad/docs/concepts/variables
 [`-bind-name`]: /consul/commands/acl/binding-rule/create#bind-name
@@ -473,3 +507,4 @@ Consul token to submit a job.
 [nomad_wid_claims]: /nomad/docs/concepts/workload-identity#workload-identity-claims
 [tf_nomad_setup_consul]: https://registry.terraform.io/modules/hashicorp-modules/nomad-setup/consul/
 [tutorial_mtls]: /nomad/docs/secure/traffic/tls
+[use-client-consul-token]: /nomad/docs/configuration/client#use_client_consul_token

--- a/content/nomad/v1.11.x/content/docs/configuration/client.mdx
+++ b/content/nomad/v1.11.x/content/docs/configuration/client.mdx
@@ -100,7 +100,7 @@ client {
   constraints set on the attribute `unique.storage.bytestotal`. The actual total
   disk space can be determined via the [Read Stats
   API](/nomad/api-docs/client#read-stats)
-  
+
 - `disk_free_mb` `(int:0)` - Previously specified the disk space free for
   scheduling allocations. If set, it would override any detected free disk
   space. This value has been deprecated and is now ignored by Nomad clients. Use
@@ -256,7 +256,7 @@ client {
 
 - `host_network` <code>([host_network](#host_network-block): nil)</code> - Registers
   additional host networks with the node that can be selected when port mapping.
-  Although this parameter defaults to nil, Nomad creates a host network named "default" 
+  Although this parameter defaults to nil, Nomad creates a host network named "default"
   using the [`network_interface`](#network_interface) field.
 
 - `drain_on_shutdown` <code>([drain_on_shutdown](#drain_on_shutdown-block):
@@ -551,7 +551,7 @@ refer to the [drivers documentation](/nomad/docs/job-declare/task-driver).
 
 - `exit_on_failure` `(bool: false)` - Specifies whether the client should exit
   if fingerprinter fails to probe the envrionment endpoint service.
-  
+
   Nomad tries to identify if its running within the named environment on startup
   by probing the environment's metadata endpoint. If the endpoint is
   unreachable, Nomad by default skips fingerprinting for that environment
@@ -652,6 +652,12 @@ fingerprinter "env_aws" {
     max_backoff = "1m"
   }
   ```
+
+- `use_client_consul_token` `bool: false` - Allow task templates to use the
+  Nomad client agent's Consul token if workload identity is not configured. The
+  Nomad client agent's token must have a policy that allows any Consul reads
+  required by workload templates. This may include reading from the service
+  catalog and reading from Consul KV from any Consul namespace.
 
 - `vault_retry` `(map: { attempts = 12 backoff = "250ms" max_backoff = "1m" })` -
   This controls the retry behavior when an error is returned from Vault. Consul

--- a/content/nomad/v1.11.x/content/docs/configuration/consul.mdx
+++ b/content/nomad/v1.11.x/content/docs/configuration/consul.mdx
@@ -244,9 +244,8 @@ agents with [`server.enabled`] set to `true`.
 The `service_identity` and `task_identity` blocks accept all the same values as
 the job specification's [`identity`][identity_block] (except that the
 `service_identity` ignores the `env` and `file` fields). By ensuring these
-blocks are set on the Nomad servers, you can automatically migrate your existing
-jobs to use Workload Identity without modifying the job specification and
-resubmitting them.
+blocks are set on the Nomad servers, you'll automatically migrate workloads to
+use Workload Identity as the next version is submitted to the cluster.
 
 The recommended configuration for `service_identity` and `task_identity` is as
 follows. Refer to [Migrating to Using Workload Identity with Consul][] for

--- a/content/nomad/v1.11.x/content/docs/configuration/consul.mdx
+++ b/content/nomad/v1.11.x/content/docs/configuration/consul.mdx
@@ -244,8 +244,8 @@ agents with [`server.enabled`] set to `true`.
 The `service_identity` and `task_identity` blocks accept all the same values as
 the job specification's [`identity`][identity_block] (except that the
 `service_identity` ignores the `env` and `file` fields). By ensuring these
-blocks are set on the Nomad servers, you'll automatically migrate workloads to
-use Workload Identity as the next version is submitted to the cluster.
+blocks are set on the Nomad servers, you automatically migrate workloads to
+use workload identity as the next version is submitted to the cluster.
 
 The recommended configuration for `service_identity` and `task_identity` is as
 follows. Refer to [Migrating to Using Workload Identity with Consul][] for

--- a/content/nomad/v1.11.x/content/docs/secure/acl/consul.mdx
+++ b/content/nomad/v1.11.x/content/docs/secure/acl/consul.mdx
@@ -80,16 +80,21 @@ service_prefix "" {
 
 ## Nomad Workload Identities
 
-Starting in Nomad 1.7, Nomad clients can use a task or service's [Workload
-Identity][nomad_wid] to authenticate to Consul and obtain an ACL token specific
-to the service or task. When using Nomad workload identities, you no longer
-need to pass in a Consul ACL token to submit a job.
+Nomad clients can use a task or service's [Workload Identity][nomad_wid] to
+authenticate to Consul and obtain an ACL token specific to the service or
+task. When using Nomad workload identities, every allocation gets its own Consul
+ACL token(s).
+
+Without workload identity, allocations fallback to using the Nomad client
+agent's own Consul token. This is a simpler approach but allows all workloads on
+the same node access to the same data from Consul. If this is suitable for your
+environment, refer to [Consul Without Workload Identity][].
 
 By default, Nomad does not generate workload identities for services, and tasks
-only receive an identity that can be used to access data from Nomad itself,
-such as for reading [Variables][] from a [`template`][] block. To access
-Consul, jobs must have additional workload identities defined as [`identity`][]
-blocks.
+only receive an identity that can be used to access data from Nomad itself, such
+as for reading [Variables][] from a [`template`][] block. To access Consul using
+workload identity, jobs must have additional workload identities defined as
+[`identity`][] blocks.
 
 To avoid having to add these additional identities to every job, you can
 configure Nomad servers with the [`consul.service_identity`][] and
@@ -416,23 +421,52 @@ The [`nomad setup consul`][nomad_cli_setup_consul] command and the
 module can help you automate the process of applying configuration to a Consul
 cluster.
 
+## Consul Without Workload Identity
+
+Without workload identity, Nomad clients use their own Consul ACL token to
+register services, read services and KV for `template` blocks, and configure
+Consul service mesh.
+
+For service registration and Consul service mesh, the client automatically falls
+back to use its own Consul token for any workload that doesn't have a workload
+identity for Consul from the server. This will include any allocation that was
+created before the servers were configured to use workload identity.
+
+For `template` blocks you'll need additional configuration to allow job template
+blocks to use the Nomad client's token, which may have broader capabilities than
+a task strictly needs. Set [`client.template.use_client_consul_token =
+true`][use-client-consul-token] in the Nomad client's agent configuration to
+allow the template runner access to the token. Add the following block to the
+Consul policy used by the Nomad client to allow the client to read Consul KV
+data in `template` blocks.
+
+```hcl
+key_prefix "" {
+  policy = "read"
+}
+```
+
 ## Migrating to Using Workload Identity with Consul
 
 Nomad version 1.7.0 introduced Workload Identity authentication, and deprecated
-token authentication.  Token authentication was then removed in Nomad 1.10.0.
-Migrating from the legacy (pre-1.7) workflow where workload use the agent's
-Consul token requires configuation on your Consul cluster and your Nomad server
-agents. It does not require updating your running Nomad jobs. To migrate:
+authenticating via a token passed to the `job run` command. Token authentication
+was then removed in Nomad 1.10.0. Migrating from the legacy (pre-1.7) workflow
+where workload use the agent's Consul token requires configuation on your Consul
+cluster and your Nomad server agents. It does not require updating your running
+Nomad jobs. To migrate:
 
 * Create the Consul auth method and binding rules on your Consul cluster.
 * Enable [`consul.service_identity`][] blocks in your Nomad server agent configurations.
 * Enable [`consul.task_identity`][] blocks in your Nomad server agent configurations.
+* Enable [`client.template.use_client_consul_token =
+  true`][use-client-consul-token] in your Nomad client agent configurations.
 * (Optionally) add [`identity`][] blocks to your jobs if you want to use a
   different identity because of how your auth method and binding rules are
   configured.
 
-Note that when using Workload Identity you will no longer need to pass in a
-Consul token to submit a job.
+You can remove `client.template.use_client_consul_token = true` from client
+agents once all jobs have been redeployed at least once with workload identity
+and all their allocations replaced.
 
 [Variables]: /nomad/docs/concepts/variables
 [`-bind-name`]: /consul/commands/acl/binding-rule/create#bind-name
@@ -473,3 +507,4 @@ Consul token to submit a job.
 [nomad_wid_claims]: /nomad/docs/concepts/workload-identity#workload-identity-claims
 [tf_nomad_setup_consul]: https://registry.terraform.io/modules/hashicorp-modules/nomad-setup/consul/
 [tutorial_mtls]: /nomad/docs/secure/traffic/tls
+[use-client-consul-token]: /nomad/docs/configuration/client#use_client_consul_token

--- a/content/nomad/v1.11.x/content/docs/secure/acl/consul.mdx
+++ b/content/nomad/v1.11.x/content/docs/secure/acl/consul.mdx
@@ -80,18 +80,18 @@ service_prefix "" {
 
 ## Nomad Workload Identities
 
-Nomad clients can use a task or service's [Workload Identity][nomad_wid] to
+Nomad clients can use a task or service's [workload identity][nomad_wid] to
 authenticate to Consul and obtain an ACL token specific to the service or
 task. When using Nomad workload identities, every allocation gets its own Consul
 ACL token(s).
 
-Without workload identity, allocations fallback to using the Nomad client
+Without workload identity, allocations fall back to using the Nomad client
 agent's own Consul token. This is a simpler approach but allows all workloads on
 the same node access to the same data from Consul. If this is suitable for your
 environment, refer to [Consul Without Workload Identity][].
 
 By default, Nomad does not generate workload identities for services, and tasks
-only receive an identity that can be used to access data from Nomad itself, such
+only receive an identity they can use to access data from Nomad itself, such
 as for reading [Variables][] from a [`template`][] block. To access Consul using
 workload identity, jobs must have additional workload identities defined as
 [`identity`][] blocks.
@@ -429,10 +429,10 @@ Consul service mesh.
 
 For service registration and Consul service mesh, the client automatically falls
 back to use its own Consul token for any workload that doesn't have a workload
-identity for Consul from the server. This will include any allocation that was
+identity for Consul from the server. This includes any allocation that was
 created before the servers were configured to use workload identity.
 
-For `template` blocks you'll need additional configuration to allow job template
+For `template` blocks you need additional configuration to allow job template
 blocks to use the Nomad client's token, which may have broader capabilities than
 a task strictly needs. Set [`client.template.use_client_consul_token =
 true`][use-client-consul-token] in the Nomad client's agent configuration to
@@ -449,11 +449,11 @@ key_prefix "" {
 ## Migrating to Using Workload Identity with Consul
 
 Nomad version 1.7.0 introduced Workload Identity authentication, and deprecated
-authenticating via a token passed to the `job run` command. Token authentication
-was then removed in Nomad 1.10.0. Migrating from the legacy (pre-1.7) workflow
-where workload use the agent's Consul token requires configuation on your Consul
-cluster and your Nomad server agents. It does not require updating your running
-Nomad jobs. To migrate:
+authenticating with a token passed to the `job run` command. We then removed
+token authentication in Nomad 1.10.0. Migrating from the legacy (pre-1.7)
+workflow where workloads use the agent's Consul token requires configuation on
+your Consul cluster and your Nomad server agents. It does not require updating
+your running Nomad jobs. To migrate:
 
 * Create the Consul auth method and binding rules on your Consul cluster.
 * Enable [`consul.service_identity`][] blocks in your Nomad server agent configurations.

--- a/content/nomad/v2.0.x/content/docs/configuration/client.mdx
+++ b/content/nomad/v2.0.x/content/docs/configuration/client.mdx
@@ -656,11 +656,11 @@ fingerprinter "env_aws" {
   }
   ```
 
-- `use_client_consul_token` `bool: false` - If set, templates for tasks
-  without workload identity configured for Consul are configured with the Nomad
-  client agent's Consul token (if any). The Nomad client agent's token must have
-  a policy that includes reading the service catalog and reading from Consul KV
-  from any Consul namespace that might appear in a workload's templates.
+- `use_client_consul_token` `bool: false` - Allow task templates to use the
+  Nomad client agent's Consul token if workload identity is not configured. The
+  Nomad client agent's token must have a policy that allows any Consul reads
+  required by workload templates. This may include reading from the service
+  catalog and reading from Consul KV from any Consul namespace.
 
 - `vault_retry` `(map: { attempts = 12 backoff = "250ms" max_backoff = "1m" })` -
   This controls the retry behavior when an error is returned from Vault. Consul

--- a/content/nomad/v2.0.x/content/docs/configuration/client.mdx
+++ b/content/nomad/v2.0.x/content/docs/configuration/client.mdx
@@ -100,7 +100,7 @@ client {
   constraints set on the attribute `unique.storage.bytestotal`. The actual total
   disk space can be determined via the [Read Stats
   API](/nomad/api-docs/client#read-stats)
-  
+
 - `disk_free_mb` `(int:0)` - Previously specified the disk space free for
   scheduling allocations. If set, it would override any detected free disk
   space. This value has been deprecated and is now ignored by Nomad clients. Use
@@ -256,7 +256,7 @@ client {
 
 - `host_network` <code>([host_network](#host_network-block): nil)</code> - Registers
   additional host networks with the node that can be selected when port mapping.
-  Although this parameter defaults to nil, Nomad creates a host network named "default" 
+  Although this parameter defaults to nil, Nomad creates a host network named "default"
   using the [`network_interface`](#network_interface) field.
 
 - `drain_on_shutdown` <code>([drain_on_shutdown](#drain_on_shutdown-block):
@@ -554,7 +554,7 @@ refer to the [drivers documentation](/nomad/docs/job-declare/task-driver).
 
 - `exit_on_failure` `(bool: false)` - Specifies whether the client should exit
   if fingerprinter fails to probe the envrionment endpoint service.
-  
+
   Nomad tries to identify if its running within the named environment on startup
   by probing the environment's metadata endpoint. If the endpoint is
   unreachable, Nomad by default skips fingerprinting for that environment
@@ -655,6 +655,12 @@ fingerprinter "env_aws" {
     max_backoff = "1m"
   }
   ```
+
+- `use_client_consul_token` `bool: false` - If set, templates for tasks
+  without workload identity configured for Consul are configured with the Nomad
+  client agent's Consul token (if any). The Nomad client agent's token must have
+  a policy that includes reading the service catalog and reading from Consul KV
+  from any Consul namespace that might appear in a workload's templates.
 
 - `vault_retry` `(map: { attempts = 12 backoff = "250ms" max_backoff = "1m" })` -
   This controls the retry behavior when an error is returned from Vault. Consul

--- a/content/nomad/v2.0.x/content/docs/configuration/consul.mdx
+++ b/content/nomad/v2.0.x/content/docs/configuration/consul.mdx
@@ -244,9 +244,8 @@ agents with [`server.enabled`] set to `true`.
 The `service_identity` and `task_identity` blocks accept all the same values as
 the job specification's [`identity`][identity_block] (except that the
 `service_identity` ignores the `env` and `file` fields). By ensuring these
-blocks are set on the Nomad servers, you can automatically migrate your existing
-jobs to use Workload Identity without modifying the job specification and
-resubmitting them.
+blocks are set on the Nomad servers, you'll automatically migrate workloads to
+use Workload Identity as the next version is submitted to the cluster.
 
 The recommended configuration for `service_identity` and `task_identity` is as
 follows. Refer to [Migrating to Using Workload Identity with Consul][] for

--- a/content/nomad/v2.0.x/content/docs/configuration/consul.mdx
+++ b/content/nomad/v2.0.x/content/docs/configuration/consul.mdx
@@ -244,8 +244,8 @@ agents with [`server.enabled`] set to `true`.
 The `service_identity` and `task_identity` blocks accept all the same values as
 the job specification's [`identity`][identity_block] (except that the
 `service_identity` ignores the `env` and `file` fields). By ensuring these
-blocks are set on the Nomad servers, you'll automatically migrate workloads to
-use Workload Identity as the next version is submitted to the cluster.
+blocks are set on the Nomad servers, you automatically migrate workloads to
+use workload identity as the next version is submitted to the cluster.
 
 The recommended configuration for `service_identity` and `task_identity` is as
 follows. Refer to [Migrating to Using Workload Identity with Consul][] for

--- a/content/nomad/v2.0.x/content/docs/secure/acl/consul.mdx
+++ b/content/nomad/v2.0.x/content/docs/secure/acl/consul.mdx
@@ -432,9 +432,11 @@ back to use its own Consul token for any workload that doesn't have a workload
 identity for Consul from the server. This will include any allocation that was
 created before the servers were configured to use workload identity.
 
-For `template` blocks you'll need additional configuration. Set
-[`client.template.use_client_consul_token = true`][use-client-consul-token] in
-the Nomad client's agent configuration. And add the following block to the
+For `template` blocks you'll need additional configuration to allow job template
+blocks to use the Nomad client's token, which may have broader capabilities than
+a task strictly needs. Set [`client.template.use_client_consul_token =
+true`][use-client-consul-token] in the Nomad client's agent configuration to
+allow the template runner access to the token. Add the following block to the
 Consul policy used by the Nomad client to allow the client to read Consul KV
 data in `template` blocks.
 

--- a/content/nomad/v2.0.x/content/docs/secure/acl/consul.mdx
+++ b/content/nomad/v2.0.x/content/docs/secure/acl/consul.mdx
@@ -80,16 +80,21 @@ service_prefix "" {
 
 ## Nomad Workload Identities
 
-Starting in Nomad 1.7, Nomad clients can use a task or service's [Workload
-Identity][nomad_wid] to authenticate to Consul and obtain an ACL token specific
-to the service or task. When using Nomad workload identities, you no longer
-need to pass in a Consul ACL token to submit a job.
+Nomad clients can use a task or service's [Workload Identity][nomad_wid] to
+authenticate to Consul and obtain an ACL token specific to the service or
+task. When using Nomad workload identities, every allocation gets its own Consul
+ACL token(s).
+
+Without workload identity, allocations fallback to using the Nomad client
+agent's own Consul token. This is a simpler approach but allows all workloads on
+the same node access to the same data from Consul. If this is suitable for your
+environment, refer to [Consul Without Workload Identity][].
 
 By default, Nomad does not generate workload identities for services, and tasks
-only receive an identity that can be used to access data from Nomad itself,
-such as for reading [Variables][] from a [`template`][] block. To access
-Consul, jobs must have additional workload identities defined as [`identity`][]
-blocks.
+only receive an identity that can be used to access data from Nomad itself, such
+as for reading [Variables][] from a [`template`][] block. To access Consul using
+workload identity, jobs must have additional workload identities defined as
+[`identity`][] blocks.
 
 To avoid having to add these additional identities to every job, you can
 configure Nomad servers with the [`consul.service_identity`][] and
@@ -416,23 +421,50 @@ The [`nomad setup consul`][nomad_cli_setup_consul] command and the
 module can help you automate the process of applying configuration to a Consul
 cluster.
 
+## Consul Without Workload Identity
+
+Without workload identity, Nomad clients use their own Consul ACL token to
+register services, read services and KV for `template` blocks, and configure
+Consul service mesh.
+
+For service registration and Consul service mesh, the client automatically falls
+back to use its own Consul token for any workload that doesn't have a workload
+identity for Consul from the server. This will include any allocation that was
+created before the servers were configured to use workload identity.
+
+For `template` blocks you'll need additional configuration. Set
+[`client.template.use_client_consul_token = true`][use-client-consul-token] in
+the Nomad client's agent configuration. And add the following block to the
+Consul policy used by the Nomad client to allow the client to read Consul KV
+data in `template` blocks.
+
+```hcl
+key_prefix "" {
+  policy = "read"
+}
+```
+
 ## Migrating to Using Workload Identity with Consul
 
 Nomad version 1.7.0 introduced Workload Identity authentication, and deprecated
-token authentication.  Token authentication was then removed in Nomad 1.10.0.
-Migrating from the legacy (pre-1.7) workflow where workload use the agent's
-Consul token requires configuation on your Consul cluster and your Nomad server
-agents. It does not require updating your running Nomad jobs. To migrate:
+authenticating via a token passed to the `job run` command. Token authentication
+was then removed in Nomad 1.10.0. Migrating from the legacy (pre-1.7) workflow
+where workload use the agent's Consul token requires configuation on your Consul
+cluster and your Nomad server agents. It does not require updating your running
+Nomad jobs. To migrate:
 
 * Create the Consul auth method and binding rules on your Consul cluster.
 * Enable [`consul.service_identity`][] blocks in your Nomad server agent configurations.
 * Enable [`consul.task_identity`][] blocks in your Nomad server agent configurations.
+* Enable [`client.template.use_client_consul_token =
+  true`][use-client-consul-token] in your Nomad client agent configurations.
 * (Optionally) add [`identity`][] blocks to your jobs if you want to use a
   different identity because of how your auth method and binding rules are
   configured.
 
-Note that when using Workload Identity you will no longer need to pass in a
-Consul token to submit a job.
+You can remove `client.template.use_client_consul_token = true` from client
+agents once all jobs have been redeployed at least once with workload identity
+and all their allocations replaced.
 
 [Variables]: /nomad/docs/concepts/variables
 [`-bind-name`]: /consul/commands/acl/binding-rule/create#bind-name
@@ -473,3 +505,4 @@ Consul token to submit a job.
 [nomad_wid_claims]: /nomad/docs/concepts/workload-identity#workload-identity-claims
 [tf_nomad_setup_consul]: https://registry.terraform.io/modules/hashicorp-modules/nomad-setup/consul/
 [tutorial_mtls]: /nomad/docs/secure/traffic/tls
+[use-client-consul-token]: /nomad/docs/configuration/client#use_client_consul_token

--- a/content/nomad/v2.0.x/content/docs/secure/acl/consul.mdx
+++ b/content/nomad/v2.0.x/content/docs/secure/acl/consul.mdx
@@ -80,18 +80,18 @@ service_prefix "" {
 
 ## Nomad Workload Identities
 
-Nomad clients can use a task or service's [Workload Identity][nomad_wid] to
+Nomad clients can use a task or service's [workload identity][nomad_wid] to
 authenticate to Consul and obtain an ACL token specific to the service or
 task. When using Nomad workload identities, every allocation gets its own Consul
 ACL token(s).
 
-Without workload identity, allocations fallback to using the Nomad client
+Without workload identity, allocations fall back to using the Nomad client
 agent's own Consul token. This is a simpler approach but allows all workloads on
 the same node access to the same data from Consul. If this is suitable for your
 environment, refer to [Consul Without Workload Identity][].
 
 By default, Nomad does not generate workload identities for services, and tasks
-only receive an identity that can be used to access data from Nomad itself, such
+only receive an identity they can use to access data from Nomad itself, such
 as for reading [Variables][] from a [`template`][] block. To access Consul using
 workload identity, jobs must have additional workload identities defined as
 [`identity`][] blocks.
@@ -429,10 +429,10 @@ Consul service mesh.
 
 For service registration and Consul service mesh, the client automatically falls
 back to use its own Consul token for any workload that doesn't have a workload
-identity for Consul from the server. This will include any allocation that was
+identity for Consul from the server. This includes any allocation that was
 created before the servers were configured to use workload identity.
 
-For `template` blocks you'll need additional configuration to allow job template
+For `template` blocks you need additional configuration to allow job template
 blocks to use the Nomad client's token, which may have broader capabilities than
 a task strictly needs. Set [`client.template.use_client_consul_token =
 true`][use-client-consul-token] in the Nomad client's agent configuration to
@@ -449,11 +449,11 @@ key_prefix "" {
 ## Migrating to Using Workload Identity with Consul
 
 Nomad version 1.7.0 introduced Workload Identity authentication, and deprecated
-authenticating via a token passed to the `job run` command. Token authentication
-was then removed in Nomad 1.10.0. Migrating from the legacy (pre-1.7) workflow
-where workload use the agent's Consul token requires configuation on your Consul
-cluster and your Nomad server agents. It does not require updating your running
-Nomad jobs. To migrate:
+authenticating with a token passed to the `job run` command. We then removed
+token authentication in Nomad 1.10.0. Migrating from the legacy (pre-1.7)
+workflow where workloads use the agent's Consul token requires configuation on
+your Consul cluster and your Nomad server agents. It does not require updating
+your running Nomad jobs. To migrate:
 
 * Create the Consul auth method and binding rules on your Consul cluster.
 * Enable [`consul.service_identity`][] blocks in your Nomad server agent configurations.


### PR DESCRIPTION
In Nomad 1.10.0 we intended to require Workload Identity (WI) if you want to use the Consul integration with workloads for `service` blocks, `template` blocks, or `connect` blocks. We're partially winding back that decision and will allow workloads without WI configured to fallback to the Nomad client agent's own token.

Ref: https://github.com/hashicorp/nomad/pull/28106
Ref: https://hashicorp.atlassian.net/browse/NMD-1338

## Contributor checklists

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [x] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [x] Verify that all status checks passed
- [x] Verify that the preview environment deployed successfully
- [x] Add additional reviewers if they are not part of assigned groups

Content:

- [x] I added redirects for any moved or removed pages
- [x] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [x] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [x] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.
