### PR TITLE
Consul: Using Vault as a backend with external CA

### DIFF
--- a/content/consul/v1.21.x/content/docs/secure-mesh/certificate/vault.mdx
+++ b/content/consul/v1.21.x/content/docs/secure-mesh/certificate/vault.mdx
@@ -41,6 +41,7 @@ This page describes how configure the Vault CA provider.
 
 You can enable Vault as the CA by configuring Consul to use `"vault"` as the CA provider
 and including the required provider configuration options.
+Vault can be utilised either as an [intermediate CA](/vault/docs/secrets/pki/quick-start-intermediate-ca) signed by an existing root CA, or as a [root CA](/vault/docs/secrets/pki/quick-start-root-ca).
 You can provide the CA configuration in the server agents' configuration file
 or in the body of a `PUT` request to the
 [`/connect/ca/configuration`](/consul/api-docs/connect/ca#update-ca-configuration) API endpoint.
@@ -61,6 +62,10 @@ connect {
     address = "http://localhost:8200"
     token = "<vault-token-with-necessary-policy>"
     root_pki_path = "connect-root"
+    leaf_cert_ttl = "72h"
+    private_key_bits = 4096
+    private_key_type = "rsa"
+    intermediate_cert_ttl = "8760h"
     intermediate_pki_path = "connect-dc1-intermediate"
   }
 }
@@ -77,6 +82,10 @@ connect {
     "Address": "http://localhost:8200",
     "Token": "<vault-token-with-necessary-policy>",
     "RootPKIPath": "connect-root",
+    "LeafCertTTL": "72h",
+    "PrivateKeyBits": 4096,
+    "PrivateKeyType": "rsa",
+    "IntermediateCertTTL": "8760h",
     "IntermediatePKIPath": "connect-dc1-intermediate"
   }
 }

--- a/content/consul/v1.22.x/content/docs/secure-mesh/certificate/vault.mdx
+++ b/content/consul/v1.22.x/content/docs/secure-mesh/certificate/vault.mdx
@@ -41,6 +41,7 @@ This page describes how configure the Vault CA provider.
 
 You can enable Vault as the CA by configuring Consul to use `"vault"` as the CA provider
 and including the required provider configuration options.
+Vault can be utilised either as an [intermediate CA](/vault/docs/secrets/pki/quick-start-intermediate-ca) signed by an existing root CA, or as a [root CA](/vault/docs/secrets/pki/quick-start-root-ca).
 You can provide the CA configuration in the server agents' configuration file
 or in the body of a `PUT` request to the
 [`/connect/ca/configuration`](/consul/api-docs/connect/ca#update-ca-configuration) API endpoint.
@@ -61,6 +62,10 @@ connect {
     address = "http://localhost:8200"
     token = "<vault-token-with-necessary-policy>"
     root_pki_path = "connect-root"
+    leaf_cert_ttl = "72h"
+    private_key_bits = 4096
+    private_key_type = "rsa"
+    intermediate_cert_ttl = "8760h"
     intermediate_pki_path = "connect-dc1-intermediate"
   }
 }
@@ -77,6 +82,10 @@ connect {
     "Address": "http://localhost:8200",
     "Token": "<vault-token-with-necessary-policy>",
     "RootPKIPath": "connect-root",
+    "LeafCertTTL": "72h",
+    "PrivateKeyBits": 4096,
+    "PrivateKeyType": "rsa",
+    "IntermediateCertTTL": "8760h",
     "IntermediatePKIPath": "connect-dc1-intermediate"
   }
 }

--- a/content/consul/v2.0.x/content/docs/secure-mesh/certificate/vault.mdx
+++ b/content/consul/v2.0.x/content/docs/secure-mesh/certificate/vault.mdx
@@ -41,6 +41,7 @@ This page describes how configure the Vault CA provider.
 
 You can enable Vault as the CA by configuring Consul to use `"vault"` as the CA provider
 and including the required provider configuration options.
+Vault can be utilised either as an [intermediate CA](/vault/docs/secrets/pki/quick-start-intermediate-ca) signed by an existing root CA, or as a [root CA](/vault/docs/secrets/pki/quick-start-root-ca).
 You can provide the CA configuration in the server agents' configuration file
 or in the body of a `PUT` request to the
 [`/connect/ca/configuration`](/consul/api-docs/connect/ca#update-ca-configuration) API endpoint.
@@ -61,6 +62,10 @@ connect {
     address = "http://localhost:8200"
     token = "<vault-token-with-necessary-policy>"
     root_pki_path = "connect-root"
+    leaf_cert_ttl = "72h"
+    private_key_bits = 4096
+    private_key_type = "rsa"
+    intermediate_cert_ttl = "8760h"
     intermediate_pki_path = "connect-dc1-intermediate"
   }
 }
@@ -77,6 +82,10 @@ connect {
     "Address": "http://localhost:8200",
     "Token": "<vault-token-with-necessary-policy>",
     "RootPKIPath": "connect-root",
+    "LeafCertTTL": "72h",
+    "PrivateKeyBits": 4096,
+    "PrivateKeyType": "rsa",
+    "IntermediateCertTTL": "8760h",
     "IntermediatePKIPath": "connect-dc1-intermediate"
   }
 }


### PR DESCRIPTION
## Description
Adding a clarification that Vault can be both used as an intermediary CA, as well as a root CA.

## Links
[Slack](https://ibm-hashicorp.slack.com/archives/C09L3C2PG5A/p1780652380624049)


## Contributor checklists

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [x] 3 days: Small changes, easy reviews
- [ ] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [ ] Verify that all status checks passed
- [ ] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [x] I added redirects for any moved or removed pages
- [x] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [ ] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [x] This PR is set to merge into the correct base branch.
- [x] The content does not contain technical inaccuracies.
- [x] The content follows the Education content and style guides.
- [x] I have verified and tested changes to instructions for end users.
