### PR TITLE
VAULT-45105: Updates documentation for config-oauth-resource-server

### DIFF
--- a/content/vault/v2.x/content/api-docs/secret/agent-registry.mdx
+++ b/content/vault/v2.x/content/api-docs/secret/agent-registry.mdx
@@ -6,13 +6,14 @@ description: This is the API documentation for managing Agent Registry records i
 
 # Agent Registry
 
-@include 'alerts/private-preview.mdx'
+@include 'alerts/beta.mdx'
 
 @include 'alerts/enterprise-only.mdx'
 
 The `/agent-registry` endpoint registers agent identities with a set of ceiling policies
 that constrain the maximum permissions available to the agent. An entity must
-have an Agent Registry record before it can authenticate using OAuth credentials.
+have an Agent Registry record before it can authenticate using OAuth credentials,
+which Vault validates through an [OAuth Resource Server profile](/vault/api-docs/system/config-oauth-resource-server).
 
 Once you create an Agent Registry record using the `/agent-registry/register` endpoint, you can reference it for read, update, and delete operations in two ways:
 

--- a/content/vault/v2.x/content/api-docs/secret/agent-registry.mdx
+++ b/content/vault/v2.x/content/api-docs/secret/agent-registry.mdx
@@ -12,8 +12,8 @@ description: This is the API documentation for managing Agent Registry records i
 
 The `/agent-registry` endpoint registers agent identities with a set of ceiling policies
 that constrain the maximum permissions available to the agent. An entity must
-have an Agent Registry record before it can authenticate using OAuth credentials,
-which Vault validates through an [OAuth Resource Server profile](/vault/api-docs/system/config-oauth-resource-server).
+have an Agent Registry record before it can authenticate using OAuth credentials.
+Vault validates those OAuth credentials through an [OAuth Resource Server profile](/vault/api-docs/system/config-oauth-resource-server).
 
 Once you create an Agent Registry record using the `/agent-registry/register` endpoint, you can reference it for read, update, and delete operations in two ways:
 

--- a/content/vault/v2.x/content/api-docs/system/config-oauth-resource-server.mdx
+++ b/content/vault/v2.x/content/api-docs/system/config-oauth-resource-server.mdx
@@ -26,7 +26,7 @@ have an active registration in the
 [Agent Registry](/vault/api-docs/secret/agent-registry). Vault rejects OAuth
 credentials for entities without an Agent Registry record.
 
-By default, each OAuth Resource Server configuration profile requires Rich
+By default, each OAuth Resource Server configuration profile requires OAuth 2.0 Rich
 Authorization Requests (RAR) in the JWTs it validates. Clients provide RAR in
 the `authorization_details` claim of the JWT. To allow JWTs that omit
 `authorization_details`, set `optional_authorization_details=true` on the

--- a/content/vault/v2.x/content/api-docs/system/config-oauth-resource-server.mdx
+++ b/content/vault/v2.x/content/api-docs/system/config-oauth-resource-server.mdx
@@ -8,7 +8,7 @@ description: >-
 
 # `/sys/config/oauth-resource-server`
 
-@include 'alerts/private-preview.mdx'
+@include 'alerts/beta.mdx'
 
 @include 'alerts/enterprise-only.mdx'
 
@@ -25,6 +25,12 @@ JWT authentication through OAuth workflows requires the presenting entity to
 have an active registration in the
 [Agent Registry](/vault/api-docs/secret/agent-registry). Vault rejects OAuth
 credentials for entities without an Agent Registry record.
+
+By default, each OAuth Resource Server configuration profile requires Rich
+Authorization Requests (RAR) for the JWTs it validates. Clients provide RAR in
+the `authorization_details` claim of the JWT. To allow JWTs that omit
+`authorization_details`, set `optional_authorization_details=true` on the
+profile.
 
 ## List profiles
 

--- a/content/vault/v2.x/content/api-docs/system/config-oauth-resource-server.mdx
+++ b/content/vault/v2.x/content/api-docs/system/config-oauth-resource-server.mdx
@@ -27,7 +27,7 @@ have an active registration in the
 credentials for entities without an Agent Registry record.
 
 By default, each OAuth Resource Server configuration profile requires Rich
-Authorization Requests (RAR) for the JWTs it validates. Clients provide RAR in
+Authorization Requests (RAR) in the JWTs it validates. Clients provide RAR in
 the `authorization_details` claim of the JWT. To allow JWTs that omit
 `authorization_details`, set `optional_authorization_details=true` on the
 profile.


### PR DESCRIPTION
Updates documentation for config-oauth-resource-server and agent registry to cross reference and also update warning to beta (from private preview)

Please go to the `Preview` tab and select the appropriate template:

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
