### PR TITLE
tfctl: add beta CLI developer docs

### DIFF
--- a/content/tfctl/v0.2.x/data/tfctl-nav-data.json
+++ b/content/tfctl/v0.2.x/data/tfctl-nav-data.json
@@ -1,0 +1,79 @@
+[
+	{
+		"heading": "tfctl"
+	},
+	{
+		"title": "Overview",
+		"path": "",
+		"badge": {
+			"text": "BETA",
+			"type": "outlined",
+			"color": "neutral"
+		}
+	},
+	{
+		"title": "Install",
+		"path": "install"
+	},
+	{
+		"title": "Configuration",
+		"path": "configuration"
+	},
+	{
+		"title": "Use tfctl with AI agents",
+		"path": "agents"
+	},
+	{
+		"title": "Telemetry",
+		"path": "telemetry"
+	},
+	{
+		"title": "Errors",
+		"path": "errors"
+	},
+	{
+		"title": "CLI reference",
+		"routes": [
+			{
+				"title": "Overview",
+				"path": "reference/cli"
+			},
+			{
+				"title": "Global flags",
+				"path": "reference/cli/global-flags"
+			},
+			{
+				"title": "tfctl api",
+				"path": "reference/cli/api"
+			},
+			{
+				"title": "tfctl auth",
+				"path": "reference/cli/auth"
+			},
+			{
+				"title": "tfctl get",
+				"path": "reference/cli/get"
+			},
+			{
+				"title": "tfctl create",
+				"path": "reference/cli/create"
+			},
+			{
+				"title": "tfctl run",
+				"path": "reference/cli/run"
+			},
+			{
+				"title": "tfctl variable",
+				"path": "reference/cli/variable"
+			},
+			{
+				"title": "tfctl profile",
+				"path": "reference/cli/profile"
+			},
+			{
+				"title": "tfctl harness",
+				"path": "reference/cli/harness"
+			}
+		]
+	}
+]

--- a/content/tfctl/v0.2.x/docs/tfctl/agents.mdx
+++ b/content/tfctl/v0.2.x/docs/tfctl/agents.mdx
@@ -1,0 +1,103 @@
+---
+page_title: Use tfctl with AI agents
+description: |-
+  Install the tfctl agent skill so AI coding agents can run HCP Terraform
+  workflows, with delete operations deferred to a human.
+---
+
+# Use tfctl with AI agents
+
+`tfctl` ships with an agent skill that teaches supported AI coding agents how to use the
+`tfctl` command. The skill instructs agents to defer all delete operations to you rather
+than run them directly.
+
+After you install the skill, you can ask an agent to do work that maps to `tfctl`
+commands — for example, "check the latest run on `payments-api` and start a new run if it
+failed." The agent runs the commands and reports back.
+
+Two things make this work:
+
+- `--json` and `--markdown` give agents structured output to parse. See
+  [global flags](/terraform/tfctl/reference/cli#global-flags).
+- `--dry-run` lets an agent preview a change before making it.
+- [`tfctl api`](/terraform/tfctl/reference/cli/api) and
+  [`tfctl api schema`](/terraform/tfctl/reference/cli/api#tfctl-api-schema-search) let an agent call any
+  platform operation, not only the high-level commands.
+
+## How the skill handles deletes
+
+The skill tells agents never to issue a delete (`-X DELETE`) themselves. When you ask an
+agent to delete something, it prints the exact `tfctl` command and asks you to run it.
+Deletes always require a human in the loop.
+
+<Warning>
+
+This safeguard is a behavioral instruction to the agent, not a restriction in the
+`tfctl` binary. `tfctl` does not block delete requests on its own: a command such as
+`tfctl api ... -X DELETE` still deletes the resource if you or an agent runs it. Use
+`--dry-run` to preview a mutation before sending it.
+
+</Warning>
+
+## Agents with one-command skill install
+
+The [`tfctl harness install`](/terraform/tfctl/reference/cli/harness) command installs the skill directly
+into the following agents' skill directories:
+
+- `antigravity`
+- `bob`
+- `claude`
+- `codex`
+- `copilot`
+- `opencode`
+- `pi`
+
+Any other agent that reads an `AGENTS.md` file can still use `tfctl`. Add the context
+document to `AGENTS.md` instead. Refer to [Add tfctl context to AGENTS.md](#add-tfctl-context-to-agentsmd).
+
+## Install the agent skill
+
+Install the skill with the [`tfctl harness install`](/terraform/tfctl/reference/cli/harness) command.
+Replace `<agent>` with one of the supported agents.
+
+Install for use across all projects (recommended):
+
+```shell-session
+$ tfctl harness install <agent> --global
+```
+
+Install for the current project only:
+
+```shell-session
+$ tfctl harness install <agent>
+```
+
+Alternatively, install the skill with npx:
+
+```shell-session
+$ npx skills add hashicorp/tfctl-cli --skill 'tfctl'
+```
+
+This adds the skill to your user profile so compatible agents can run `tfctl` commands
+on your behalf.
+
+## Add tfctl context to AGENTS.md
+
+Any agent that reads an `AGENTS.md` file can use `tfctl`, including agents that
+`tfctl harness install` does not support directly. Print the `tfctl` context document and
+add it to your project's `AGENTS.md`:
+
+```shell-session
+$ tfctl harness context
+```
+
+## Prerequisites
+
+Configure `tfctl` with a hostname, token, and organization before an agent uses it. See
+[Configure tfctl](/terraform/tfctl/configuration).
+
+## Next steps
+
+- [`tfctl harness` reference](/terraform/tfctl/reference/cli/harness)
+- [Command reference and global flags](/terraform/tfctl/reference/cli)
+- [Configure tfctl](/terraform/tfctl/configuration)

--- a/content/tfctl/v0.2.x/docs/tfctl/configuration.mdx
+++ b/content/tfctl/v0.2.x/docs/tfctl/configuration.mdx
@@ -1,0 +1,163 @@
+---
+page_title: Configure tfctl
+description: |-
+  Configure tfctl with profiles, environment variables, and Terraform config.
+  Set the hostname, token, and organization.
+---
+
+# Configure tfctl
+
+`tfctl` reads each setting from the first source that has it, in this order:
+
+1. The active **profile**.
+2. **Environment variables**.
+3. Local **Terraform configuration**.
+
+So you can keep persistent settings in a profile, override them per-shell with an
+environment variable, or fall back to credentials you already have from Terraform.
+
+## Quick start
+
+Configure the three settings most commands need — hostname, token, and organization:
+
+```shell-session
+# 1. Point tfctl at an instance (defaults to app.terraform.io)
+$ tfctl profile set hostname app.terraform.io
+
+# 2. Authenticate (opens a browser to create a token)
+$ tfctl auth login
+
+# 3. Set your default organization
+$ tfctl profile set organization my-org-name
+```
+
+## Set the hostname
+
+The default hostname is the HCP Terraform instance at `app.terraform.io`. To use a
+different HCP Terraform region or your organization's Terraform Enterprise instance, set
+the `hostname` property:
+
+```shell-session
+$ tfctl profile set hostname <host>
+```
+
+For EU regions, use `app.eu.terraform.io`.
+
+## Set the authentication token
+
+Run `tfctl auth login` to create and install a token that `tfctl` uses to authenticate
+with HCP Terraform or Terraform Enterprise:
+
+```shell-session
+$ tfctl auth login
+```
+
+The command opens HCP Terraform or your Terraform Enterprise instance in a browser
+window. Select **Create an API token**, give the token a description, and set its
+expiration. Select **Generate token**, then copy the token and paste it into your
+terminal. The CLI does not print the pasted token to the screen.
+
+<Warning>
+
+Verify that login succeeds **before** you close the token page in your browser. HCP
+Terraform does not show the token again once the page is closed. If an issue occurs or
+you close the dialog before copying the token, you must create a new one.
+
+</Warning>
+
+If you already have a token, set it directly:
+
+```shell-session
+$ tfctl profile set token $TOKEN
+```
+
+As with Terraform, `tfctl` stores tokens in plain text. If no token is configured for
+the active profile, `tfctl` falls back to your Terraform configuration. See
+[Terraform tokens](#terraform-tokens).
+
+## Set the organization
+
+Set the default organization for commands that require one:
+
+```shell-session
+$ tfctl profile set organization <name>
+```
+
+## Manage profiles
+
+Use the [`tfctl profile profiles`](/terraform/tfctl/reference/cli/profile) command group to create and
+manage profiles. Use a separate profile for each HCP Terraform organization and for each
+HCP Terraform or Terraform Enterprise instance.
+
+Create a profile (it is activated automatically):
+
+```shell-session
+$ tfctl profile profiles create <name>
+```
+
+### Example: two instances side by side
+
+```shell-session
+# Configure a US organization
+$ tfctl profile profiles create us --hostname=app.terraform.io
+$ tfctl profile set organization my-us-org-name
+$ tfctl auth login
+
+# Configure an EU organization
+$ tfctl profile profiles create eu --hostname=app.eu.terraform.io
+$ tfctl profile set organization my-eu-org-name
+$ tfctl auth login
+
+# Switch between them
+$ tfctl profile profiles activate us
+```
+
+## Configuration reference
+
+`tfctl` stores its configuration in the following directory, depending on your operating
+system:
+
+- **Linux / macOS:** `~/.config/tfctl`
+- **Windows:** `%AppData%/tfctl`
+
+Per-profile configuration lives in the `profiles` subdirectory. For example,
+`profiles/default.hcl` stores the configuration for your default profile.
+
+### Profile properties
+
+Set these properties with [`tfctl profile set <property> <value>`](/terraform/tfctl/reference/cli/profile#tfctl-profile-set):
+
+| Property               | Description                                                                                                                                                  |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `default_organization` | The HCP Terraform or Terraform Enterprise organization to operate on by default.                                                                            |
+| `hostname`             | Default API hostname, if different from HCP Terraform (`app.terraform.io`). Controls which regional endpoints are used. For EU regions, use `app.eu.terraform.io`. |
+| `token`                | The API token to use for all requests.                                                                                                                     |
+| `no_color`             | If `true`, the CLI does not use color when printing messages to the terminal.                                                                              |
+| `telemetry`            | Controls telemetry behavior. See [Telemetry](/terraform/tfctl/telemetry).                                                                                                |
+
+### Terraform tokens
+
+If you have not configured a token for the active profile with `tfctl auth login`,
+`tfctl` checks your Terraform configuration for a matching token. These tokens may be in:
+
+- Your Terraform credentials file, for example `~/.terraform.d/credentials.tfrc.json`.
+- A Terraform environment variable, such as `TF_TOKEN_app_terraform_io`.
+
+### Environment variables
+
+If a setting is not configured for the active profile, `tfctl` checks the following
+environment variables:
+
+| Variable                | Description                                                                                                                                             |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `TFCTL_ORGANIZATION`    | The organization to use for commands that require one.                                                                                                 |
+| `TFCTL_HOSTNAME`        | The Terraform Enterprise or HCP Terraform hostname to use. Defaults to `app.terraform.io`.                                                             |
+| `TFCTL_TOKEN`           | An HCP Terraform API token to use with the default profile.                                                                                            |
+| `TFCTL_TOKEN_<profile>` | An HCP Terraform API token to use with the named profile.                                                                                              |
+| `TF_TOKEN_<hostname>`   | An HCP Terraform API token presented during authentication, with the hostname in Punycode (for example, `TF_TOKEN_app_terraform_io`). Used only if no token is configured another way. |
+
+## Next steps
+
+- Run your first [commands](/terraform/tfctl/reference/cli).
+- [Use tfctl with AI agents](/terraform/tfctl/agents).
+- Review [telemetry settings](/terraform/tfctl/telemetry).

--- a/content/tfctl/v0.2.x/docs/tfctl/errors.mdx
+++ b/content/tfctl/v0.2.x/docs/tfctl/errors.mdx
@@ -1,0 +1,51 @@
+---
+page_title: Exit codes and troubleshooting
+description: |-
+  Reference for tfctl exit codes and how to resolve common errors.
+---
+
+# Exit codes and troubleshooting
+
+`tfctl` returns a specific exit code for each class of outcome. Use these codes to
+interpret results in scripts and automation.
+
+## Exit codes
+
+| Exit code | Meaning                            | Solution                                |
+| --------- | ---------------------------------- | --------------------------------------- |
+| `0`       | OK                                 | —                                       |
+| `1`       | Usage error                        | Read `tfctl <command> --help`.          |
+| `2`       | Not found or authorization error   | Verify the URL or resource ID.          |
+| `3`       | Authentication error               | Run `tfctl auth login`.                 |
+| `4`       | Network error                      | Check your connectivity.                |
+| `5`       | API server error persists          | Try again later.                        |
+| `6`       | Underlying error detected          | Varies depending on the error condition. |
+| `130`     | Canceled (Ctrl-C)                  | —                                       |
+
+## Troubleshooting tips
+
+- **Usage errors (`1`).** Run the command with `--help` to review the expected arguments
+  and flags.
+- **Authorization vs. authentication.** Exit code `2` means the resource was not found or
+  your token lacks access — verify the ID and your permissions. Exit code `3` means your
+  token is missing or invalid — re-authenticate with `tfctl auth login`. Check your token
+  with `tfctl auth status`.
+- **Get more detail.** Add the global `--debug` flag to any command to print debug output
+  about what `tfctl` is doing.
+- **Preview changes.** Use the global `--dry-run` flag to see what a mutating command
+  would do without making any changes.
+
+## Get help
+
+Use `--help` on any command for detailed usage:
+
+```shell-session
+$ tfctl --help
+$ tfctl run --help
+```
+
+## Related
+
+- [`tfctl auth`](/terraform/tfctl/reference/cli/auth)
+- [Global flags](/terraform/tfctl/reference/cli#global-flags)
+- [Configure tfctl](/terraform/tfctl/configuration)

--- a/content/tfctl/v0.2.x/docs/tfctl/index.mdx
+++ b/content/tfctl/v0.2.x/docs/tfctl/index.mdx
@@ -1,0 +1,84 @@
+---
+page_title: tfctl overview
+description: |-
+  Learn what tfctl is: the official CLI for HCP Terraform and Terraform
+  Enterprise, for people and AI coding agents.
+---
+
+# tfctl: the HCP Terraform CLI
+
+`tfctl` is the official command-line interface for HCP Terraform and Terraform
+Enterprise. Use it to manage runs, variables, and workspaces, and to call any HCP
+Terraform API v2 operation directly.
+
+<Note>
+
+`tfctl` is in beta. Do not use beta features in production environments.
+
+</Note>
+
+You can drive `tfctl` yourself or let an AI coding agent drive it for you. The
+[agent skill](/terraform/tfctl/agents) defers delete operations to you when an agent is at the
+keyboard.
+
+## Commands
+
+- [`tfctl run`](/terraform/tfctl/reference/cli/run) — start runs and check status by run ID, workspace ID,
+  or workspace name.
+- [`tfctl variable`](/terraform/tfctl/reference/cli/variable) — import Terraform and environment variables
+  into workspaces or variable sets. Variables that look sensitive are marked sensitive.
+- [`tfctl api`](/terraform/tfctl/reference/cli/api) — make any HCP Terraform API v2 request. `tfctl`
+  resolves `{path}` parameters and paginates for you.
+- [`tfctl api schema`](/terraform/tfctl/reference/cli/api#tfctl-api-schema-search) — search API operations
+  and fetch their OpenAPI schemas.
+- [`tfctl profile`](/terraform/tfctl/reference/cli/profile) — switch between organizations and instances
+  using named profiles.
+- [`tfctl harness`](/terraform/tfctl/reference/cli/harness) — install the AI agent skill.
+
+## Syntax
+
+```text
+tfctl <command> [subcommand] [flags] [arguments]
+```
+
+Every command accepts the same [global flags](/terraform/tfctl/reference/cli#global-flags). Use
+`--json` or `--markdown` for machine-readable output, and `--dry-run` to preview a change
+without making it.
+
+Settings resolve from your active **profile**, then **environment variables**, then your
+local **Terraform configuration**. See [Configure tfctl](/terraform/tfctl/configuration).
+
+## Get started
+
+1. [Install tfctl](/terraform/tfctl/install).
+2. [Configure a profile](/terraform/tfctl/configuration) with a hostname, token, and organization.
+3. Check a workspace:
+
+   ```shell-session
+   $ tfctl run status my-workspace
+   ```
+
+## A quick tour
+
+```shell-session
+# Check the status of the latest run on a workspace
+$ tfctl run status example-app-workspace
+
+# Start a run with a message
+$ tfctl run start example-app-workspace --message="Run started with tfctl."
+
+# Get detailed run status as JSON for scripting
+$ tfctl run status example-app-workspace --json
+
+# Make a raw API request
+$ tfctl api /organizations/{organization}/workspaces/example-app-workspace
+```
+
+## Where to go next
+
+- [Install](/terraform/tfctl/install) — the CLI, shell completion, and agent skill.
+- [Configure tfctl](/terraform/tfctl/configuration) — profiles, authentication, hostnames, and
+  environment variables.
+- [Commands](/terraform/tfctl/reference/cli) — the command reference and global flags.
+- [Use with AI agents](/terraform/tfctl/agents).
+- [Exit codes & troubleshooting](/terraform/tfctl/errors).

--- a/content/tfctl/v0.2.x/docs/tfctl/install.mdx
+++ b/content/tfctl/v0.2.x/docs/tfctl/install.mdx
@@ -1,0 +1,134 @@
+---
+page_title: Install tfctl
+description: |-
+  Install the tfctl CLI with Homebrew, a precompiled binary, or from source,
+  plus shell completion and the agent skill.
+---
+
+# Install tfctl
+
+You can install the `tfctl` CLI, its shell completion utility, and its AI agent skill
+separately. Choose the installation method that fits your environment.
+
+## Install the CLI
+
+### Homebrew
+
+macOS and Linux users can install `tfctl` from the HashiCorp Homebrew tap:
+
+```shell-session
+$ brew install hashicorp/tap/tfctl
+```
+
+### Precompiled binaries
+
+Download official release binaries from
+[releases.hashicorp.com](https://releases.hashicorp.com/tfctl/). After downloading,
+unzip the archive and move the `tfctl` binary onto your `PATH`.
+
+### Build from source
+
+To compile the binary yourself, refer to [Build from source](#build-from-source-1).
+
+### Verify the installation
+
+```shell-session
+$ tfctl --version
+```
+
+## Install shell completion
+
+We recommend installing the shell completion module for command, argument, and API path
+completion:
+
+```shell-session
+$ tfctl --autocomplete-install
+```
+
+To remove shell completion later:
+
+```shell-session
+$ tfctl --autocomplete-uninstall
+```
+
+## Install the AI agent skill
+
+`tfctl` ships with an agent skill that gives AI coding agents access to HCP Terraform
+through the `tfctl` command, while discouraging non-human delete operations. For full
+details, see [Use tfctl with AI agents](/terraform/tfctl/agents).
+
+Install the skill with the `tfctl harness install` command, replacing `<agent>` with a
+supported agent (`antigravity`, `bob`, `claude`, `codex`, `copilot`, `opencode`, or
+`pi`):
+
+```shell-session
+$ tfctl harness install <agent> --global
+```
+
+Alternatively, install the skill with npx:
+
+```shell-session
+$ npx skills add hashicorp/tfctl-cli --skill 'tfctl'
+```
+
+This adds the skill to your user profile so compatible agents can run `tfctl` commands
+on your behalf.
+
+For an agent that `tfctl harness install` does not support, add the context document to
+your project's `AGENTS.md` instead. Refer to [Use tfctl with AI agents](/terraform/tfctl/agents).
+
+## Run tfctl in Docker
+
+If you have a `TFCTL_TOKEN` environment variable set, you can invoke `tfctl` using
+Docker. The following command runs `tfctl` in a container and passes the local
+`TFCTL_TOKEN` value into it:
+
+```shell-session
+$ docker run -e TFCTL_TOKEN hashicorp/tfctl
+```
+
+For other configuration environment variables, see
+[Environment variables](/terraform/tfctl/configuration#environment-variables).
+
+## Build from source
+
+### Prerequisites
+
+- Go v1.26.4 or later
+- `git`
+- `make`
+
+### Steps
+
+1. Clone the repository:
+
+   ```shell-session
+   # SSH
+   $ git clone git@github.com:hashicorp/tfctl-cli.git
+
+   # HTTPS
+   $ git clone https://github.com/hashicorp/tfctl-cli.git
+   ```
+
+2. Change into the new directory:
+
+   ```shell-session
+   $ cd tfctl-cli
+   ```
+
+3. Build and install:
+
+   ```shell-session
+   $ make go/install
+   ```
+
+4. Verify the installation:
+
+   ```shell-session
+   $ tfctl --version
+   ```
+
+## Next steps
+
+- [Configure tfctl](/terraform/tfctl/configuration) with a profile, hostname, and token.
+- Explore the [command reference](/terraform/tfctl/reference/cli).

--- a/content/tfctl/v0.2.x/docs/tfctl/reference/cli/api.mdx
+++ b/content/tfctl/v0.2.x/docs/tfctl/reference/cli/api.mdx
@@ -1,0 +1,108 @@
+---
+page_title: tfctl api
+description: |-
+  Make any HCP Terraform API v2 request from the command line and explore the
+  API schema with tfctl api schema.
+---
+
+# `tfctl api`
+
+The `tfctl api` command provides direct access to the HCP Terraform API v2. Use it for
+advanced automation and for operations not covered by the high-level commands. The
+`tfctl api schema` subcommands help you discover available operations and their schemas.
+
+## `tfctl api`
+
+**Usage:** `tfctl api <path> [options]`
+
+Perform any HCP Terraform API v2 request with the given path or URL.
+
+The HCP Terraform API typically requires a resource ID as part of the path for
+resource-specific requests. To support this, `tfctl` interpolates parameter values in the
+`<path>` argument, denoted by `{name}`. Whenever possible, `tfctl` infers these values from
+the path, the active profile, or local Terraform configuration. You can also provide
+values explicitly with `--pathparam`.
+
+### Arguments
+
+- `<path>` (required): API path relative to the configured host, or a full URL.
+
+### Options
+
+| Flag                     | Description                                                                                         |
+| ------------------------ | ------------------------------------------------------------------------------------------------- |
+| `--all`                  | Fetch all records across multiple pages (up to 2000) and combine them into one page.              |
+| `--attribute`, `-a`      | Set an attribute in the request body. Sets `--method` to `POST`. Repeatable. Format: `<name>=<value>`. |
+| `--field`, `-f`          | Add a query parameter to the request URL. Repeatable. Format: `<name>=<value>`.                   |
+| `--header`, `-H`         | Add an HTTP header to the request. Repeatable. Format: `<name>=<value>`.                           |
+| `--input`, `-i`          | Specify the entire JSON request body. Repeatable. Format as a JSON:API data envelope, or `-` to read from stdin. |
+| `--method`, `-X`         | HTTP method to use (`GET`, `POST`, and so on).                                                     |
+| `--page-number`, `-n`    | Page number to return. Ignored if `--all` is set. Default: `1`.                                   |
+| `--page-size`, `-s`      | Limit the number of records to return. Ignored if `--all` is set. Default varies by resource.     |
+| `--pathparam`, `-p`      | Provide a hint for path-parameter resolution. Repeatable. Format: `<name>=<value>`.               |
+| `--type`, `-t`           | Resource type for `--attribute` JSON:API request bodies. Inferred from the path when possible.    |
+
+### Examples
+
+Get a workspace by name (the `{organization}` parameter is inferred from your profile):
+
+```shell-session
+$ tfctl api /organizations/{organization}/workspaces/example-app-workspace
+```
+
+Resolve a path parameter explicitly — useful when a unique resource name must be resolved
+to an ID:
+
+```shell-session
+$ tfctl api /projects/{name} -p 'name=Default Project'
+```
+
+Create a resource by setting attributes (implies `POST`):
+
+```shell-session
+$ tfctl api /organizations/{organization}/workspaces -a name=my-new-workspace
+```
+
+Fetch every page of a paginated collection:
+
+```shell-session
+$ tfctl api /organizations/{organization}/workspaces --all
+```
+
+## `tfctl api schema search`
+
+**Usage:** `tfctl api schema search <query>`
+
+Search all platform operations that you can invoke with `tfctl api`.
+
+### Arguments
+
+- `<query>` (required): Any phrase.
+
+### Example
+
+```shell-session
+$ tfctl api schema search 'run tasks'
+```
+
+## `tfctl api schema get`
+
+**Usage:** `tfctl api schema get <operation-id>`
+
+Get the OpenAPI specification for a single operation, including any schema components it
+uses.
+
+### Arguments
+
+- `<operation-id>` (required): The operation ID from any search result.
+
+### Example
+
+```shell-session
+$ tfctl api schema get getTask
+```
+
+## Related
+
+- [`tfctl get`](/terraform/tfctl/reference/cli/get) and [`tfctl create`](/terraform/tfctl/reference/cli/create) — simplified shortcuts over `tfctl api`.
+- [Global flags reference](/terraform/tfctl/reference/cli/global-flags)

--- a/content/tfctl/v0.2.x/docs/tfctl/reference/cli/auth.mdx
+++ b/content/tfctl/v0.2.x/docs/tfctl/reference/cli/auth.mdx
@@ -1,0 +1,66 @@
+---
+page_title: tfctl auth
+description: |-
+  Authenticate tfctl with HCP Terraform or Terraform Enterprise and check token
+  status.
+---
+
+# `tfctl auth`
+
+The `tfctl auth` commands manage authentication with HCP Terraform and Terraform
+Enterprise.
+
+## `tfctl auth login`
+
+**Usage:** `tfctl auth login [options]`
+
+Authenticate the `tfctl` CLI with HCP Terraform or Terraform Enterprise. The command
+opens a browser to the token creation page for the configured hostname and prompts you to
+paste the generated token.
+
+<Warning>
+
+Verify that login succeeds before you close the token page in your browser. HCP Terraform
+does not show the token again once the page is closed.
+
+</Warning>
+
+### Examples
+
+Log in interactively:
+
+```shell-session
+$ tfctl auth login
+```
+
+Log in with a token from stdin. Replace `abcd.atlasv1.1234` with a valid HCP Terraform or
+Terraform Enterprise token:
+
+```shell-session
+$ echo "abcd.atlasv1.1234" | tfctl auth login --token
+```
+
+### Related
+
+- [Configure tfctl](/terraform/tfctl/configuration)
+- [Global flags reference](/terraform/tfctl/reference/cli/global-flags)
+
+## `tfctl auth status`
+
+**Usage:** `tfctl auth status [options]`
+
+Check the status of the currently configured authentication token, including its
+expiration date if available.
+
+### Examples
+
+Check the status of the token for the configured host:
+
+```shell-session
+$ tfctl auth status
+```
+
+### Related
+
+- [Configure tfctl](/terraform/tfctl/configuration)
+- [Global flags reference](/terraform/tfctl/reference/cli/global-flags)

--- a/content/tfctl/v0.2.x/docs/tfctl/reference/cli/create.mdx
+++ b/content/tfctl/v0.2.x/docs/tfctl/reference/cli/create.mdx
@@ -1,0 +1,47 @@
+---
+page_title: tfctl create
+description: |-
+  Create HCP Terraform resources from the command line, a shortcut over tfctl
+  api.
+---
+
+# `tfctl create`
+
+**Usage:** `tfctl create <type>`
+
+Create a resource. `tfctl create` is a simplified shortcut over [`tfctl api`](/terraform/tfctl/reference/cli/api)
+for create operations.
+
+## Arguments
+
+- `<type>` (required): A resource type name to create, like `projects`, `organizations`, or
+  `agent-pools`.
+
+## Flags
+
+| Flag                   | Description                                                                                        |
+| ---------------------- | ------------------------------------------------------------------------------------------------ |
+| `--attribute`, `-a`    | Attribute for the JSON:API request body. Repeatable. Format: `<name>=<value>`.                   |
+| `--input`, `-i`        | Specify the entire JSON request body. Repeatable. Format as a JSON:API data envelope, or `-` to read from stdin. |
+| `--organization`, `-o` | Organization name. Defaults to the profile `default_organization` or your Terraform configuration context. |
+
+## Examples
+
+Create a project by setting an attribute:
+
+```shell-session
+$ tfctl create projects -a name=my-new-project
+```
+
+Create a resource from a JSON:API request body on stdin:
+
+```shell-session
+$ echo '{"data":{"type":"projects","attributes":{"name":"my-new-project"}}}' \
+  | tfctl create projects -i -
+```
+
+## Related
+
+- [`tfctl api`](/terraform/tfctl/reference/cli/api) — the underlying low-level command.
+- [`tfctl get`](/terraform/tfctl/reference/cli/get) — get or list resources.
+- [Global flags reference](/terraform/tfctl/reference/cli/global-flags)

--- a/content/tfctl/v0.2.x/docs/tfctl/reference/cli/get.mdx
+++ b/content/tfctl/v0.2.x/docs/tfctl/reference/cli/get.mdx
@@ -1,0 +1,46 @@
+---
+page_title: tfctl get
+description: |-
+  Get or list HCP Terraform resources by ID, type prefix, or type name, a
+  shortcut over tfctl api.
+---
+
+# `tfctl get`
+
+**Usage:** `tfctl get <id>`
+
+Get or list a resource. `tfctl get` is a simplified shortcut over [`tfctl api`](/terraform/tfctl/reference/cli/api)
+for read operations.
+
+## Arguments
+
+- `<id>` (required): A flexible string argument that can be one of:
+  - A **resource ID**, like `proj-9arLMbi8daoo3hhG` or `ws-sRMALNbEeg1aT93F`.
+  - A **resource type prefix**, like `proj`, `ws`, or `varset`.
+  - A **resource type name**, like `projects`, `organizations`, or `agent-pools`.
+
+## Examples
+
+Get a single workspace by ID:
+
+```shell-session
+$ tfctl get ws-sRMALNbEeg1aT93F
+```
+
+List all projects by type name:
+
+```shell-session
+$ tfctl get projects
+```
+
+List resources by type prefix:
+
+```shell-session
+$ tfctl get varset
+```
+
+## Related
+
+- [`tfctl api`](/terraform/tfctl/reference/cli/api) — the underlying low-level command.
+- [`tfctl create`](/terraform/tfctl/reference/cli/create) — create resources.
+- [Global flags reference](/terraform/tfctl/reference/cli/global-flags)

--- a/content/tfctl/v0.2.x/docs/tfctl/reference/cli/global-flags.mdx
+++ b/content/tfctl/v0.2.x/docs/tfctl/reference/cli/global-flags.mdx
@@ -1,0 +1,73 @@
+---
+page_title: tfctl global flags
+description: |-
+  Reference for the global flags that tfctl accepts on every command, including
+  output format, profile selection, and dry-run flags.
+---
+
+# `tfctl` global flags
+
+This topic provides reference information about the flags that `tfctl` accepts on every
+command.
+
+## Flags
+
+- `--debug`: Enable debug output.
+    - This flag is optional.
+    - Boolean.
+    - Default: `false`.
+- `--dry-run`: Create a preview of the proposed changes without making them.
+    - This flag is optional.
+    - Boolean.
+    - Default: `false`.
+- `--json`: Set the output format to JSON.
+    - This flag is optional.
+    - Boolean.
+    - Default: `false`.
+- `--jq`: Apply a jq filter expression to JSON output. Implies `--json`.
+    - This flag is optional.
+    - String.
+    - Default: none.
+- `--markdown`: Set the output format to Markdown.
+    - This flag is optional.
+    - Boolean.
+    - Default: `false`.
+- `--no-color`: Disable color output.
+    - This flag is optional.
+    - Boolean.
+    - Default: `false`.
+- `--profile`: The profile to use. If you omit this flag, `tfctl` uses the current
+  profile.
+    - This flag is optional.
+    - String.
+    - Default: the current profile.
+- `--quiet`: Minimize output and disable interactive prompting.
+    - This flag is optional.
+    - Boolean.
+    - Default: `false`.
+- `--version`: Print the version of the `tfctl` CLI.
+    - This flag is optional.
+    - Boolean.
+    - Default: `false`.
+
+## Output formats
+
+By default, `tfctl` prints human-readable output. Use `--json` or `--markdown` for
+machine-readable output. Use `--jq` to filter JSON inline:
+
+```shell-session
+$ tfctl run status my-workspace --jq='.data.attributes.status'
+```
+
+The `--json` and `--markdown` flags change stdout only. Diagnostic and progress messages
+go to stderr and keep their original format.
+
+## Dry-run mode
+
+The `--dry-run` flag previews a mutating command without making changes. `tfctl` writes
+what it would have done to stderr.
+
+## Related
+
+- [tfctl commands](/terraform/tfctl/reference/cli)
+- [Configure tfctl](/terraform/tfctl/configuration)

--- a/content/tfctl/v0.2.x/docs/tfctl/reference/cli/harness.mdx
+++ b/content/tfctl/v0.2.x/docs/tfctl/reference/cli/harness.mdx
@@ -1,0 +1,75 @@
+---
+page_title: tfctl harness
+description: |-
+  Install AI coding agent skills for tfctl or print the tfctl agent context
+  document for use in AGENTS.md.
+---
+
+# `tfctl harness`
+
+The `tfctl harness` commands install AI coding agent skills and print agent context for
+`tfctl`. For a conceptual overview, see [Use tfctl with AI agents](/terraform/tfctl/agents).
+
+## Subcommands
+
+- [`context`](#tfctl-harness-context): Print coding agent context for `tfctl`, suitable
+  for `AGENTS.md`.
+- [`install`](#tfctl-harness-install): Install coding agent skills for `tfctl`.
+
+## `tfctl harness install` agents
+
+The `install` subcommand supports the following agents. The `context` subcommand works
+with any agent that reads an `AGENTS.md` file.
+
+- `antigravity`
+- `bob`
+- `claude`
+- `codex`
+- `copilot`
+- `opencode`
+- `pi`
+
+## `tfctl harness install`
+
+**Usage:** `tfctl harness install <agent> [options]`
+
+Install coding agent skills for `tfctl`. By default, the skill is installed in the
+current project directory. For an agent that `install` does not support, use
+[`tfctl harness context`](#tfctl-harness-context) with an `AGENTS.md` file instead.
+
+### Flags
+
+| Flag        | Description                                                                |
+| ----------- | ------------------------------------------------------------------------- |
+| `--global`  | Install skills in the global user directory instead of the current project. |
+
+### Examples
+
+Install the skill for Bob in the current project directory:
+
+```shell-session
+$ tfctl harness install bob
+```
+
+Install the skill for Claude in your user directory, for use across all projects:
+
+```shell-session
+$ tfctl harness install --global claude
+```
+
+## `tfctl harness context`
+
+**Usage:** `tfctl harness context`
+
+Print the coding agent context for `tfctl`, suitable for adding to an `AGENTS.md` file.
+
+### Examples
+
+```shell-session
+$ tfctl harness context
+```
+
+## Related
+
+- [Use tfctl with AI agents](/terraform/tfctl/agents)
+- [Global flags reference](/terraform/tfctl/reference/cli/global-flags)

--- a/content/tfctl/v0.2.x/docs/tfctl/reference/cli/index.mdx
+++ b/content/tfctl/v0.2.x/docs/tfctl/reference/cli/index.mdx
@@ -1,0 +1,49 @@
+---
+page_title: tfctl commands
+description: |-
+  Reference for tfctl command syntax, global flags, and the commands for
+  managing HCP Terraform and Terraform Enterprise.
+---
+
+# `tfctl commands`
+
+`tfctl` manages HCP Terraform and Terraform Enterprise from the command line. Use the
+high-level commands for common tasks, or [`tfctl api`](/terraform/tfctl/reference/cli/api) to reach the platform API
+directly.
+
+## Command syntax
+
+```text
+tfctl <command> [subcommand] [flags] [arguments]
+```
+
+Use the `--help` flag to print detailed usage for any command. For example:
+
+```shell-session
+$ tfctl --help        # help for the tfctl CLI
+$ tfctl run --help    # help for the run command
+```
+
+## Commands
+
+| Command                  | Description                                                             |
+| ------------------------ | --------------------------------------------------------------------- |
+| [`auth`](/terraform/tfctl/reference/cli/auth)         | Authenticate the CLI and check token status.                          |
+| [`api`](/terraform/tfctl/reference/cli/api)           | Make any HCP Terraform API v2 request and explore the API schema.     |
+| [`get`](/terraform/tfctl/reference/cli/get)           | Get or list a resource — a shortcut over `tfctl api`.                  |
+| [`create`](/terraform/tfctl/reference/cli/create)     | Create a resource — a shortcut over `tfctl api`.                       |
+| [`run`](/terraform/tfctl/reference/cli/run)           | Start runs and check run status.                                      |
+| [`variable`](/terraform/tfctl/reference/cli/variable) | Import Terraform and environment variables into workspaces or sets.   |
+| [`profile`](/terraform/tfctl/reference/cli/profile)   | Manage configuration profiles and properties.                         |
+| [`harness`](/terraform/tfctl/reference/cli/harness)   | Install AI agent skills or print agent context.                       |
+
+## Global flags
+
+`tfctl` accepts a set of global flags, such as `--json`, `--dry-run`, and `--profile`, on
+every command. Refer to [Global flags reference](/terraform/tfctl/reference/cli/global-flags) for the full list and
+descriptions.
+
+## Next steps
+
+- Start with [`tfctl auth`](/terraform/tfctl/reference/cli/auth) to authenticate.
+- See [Exit codes & troubleshooting](/terraform/tfctl/errors) for how to interpret command results.

--- a/content/tfctl/v0.2.x/docs/tfctl/reference/cli/profile.mdx
+++ b/content/tfctl/v0.2.x/docs/tfctl/reference/cli/profile.mdx
@@ -1,0 +1,204 @@
+---
+page_title: tfctl profile
+description: |-
+  Manage tfctl configuration profiles and properties for connecting to multiple
+  HCP Terraform and Terraform Enterprise instances.
+---
+
+# `tfctl profile`
+
+The `tfctl profile` commands manage configuration profiles and their properties. Use a
+separate profile for each HCP Terraform organization and for each HCP Terraform or
+Terraform Enterprise instance. For an overview of the layered configuration system, see
+[Configure tfctl](/terraform/tfctl/configuration).
+
+`tfctl profile` has two groups of commands:
+
+- **Property commands** (`display`, `get`, `set`, `unset`) operate on the properties of a
+  profile.
+- **Profile commands** (`profile profiles ...`) create and manage profiles themselves.
+
+## `tfctl profile display`
+
+**Usage:** `tfctl profile display [options]`
+
+Print the configuration for a profile.
+
+### Examples
+
+Print information about the active profile:
+
+```shell-session
+$ tfctl profile display
+```
+
+Print information about a named profile:
+
+```shell-session
+$ tfctl profile display --profile="my-profile"
+```
+
+## `tfctl profile get`
+
+**Usage:** `tfctl profile get <property> [options]`
+
+Get the value of a configuration property for a profile.
+
+### Arguments
+
+- `<property>` (required, string): The configuration property name to retrieve.
+
+### Examples
+
+Get the organization for the active profile:
+
+```shell-session
+$ tfctl profile get organization
+```
+
+## `tfctl profile set`
+
+**Usage:** `tfctl profile set <property> <value> [options]`
+
+Set the value of a configuration property for a profile. For the full list of
+configurable properties, see [Profile properties](/terraform/tfctl/configuration#profile-properties).
+
+### Arguments
+
+- `<property>` (required, string): The configuration property name to set.
+- `<value>` (required, string): The value to set for the property.
+
+### Examples
+
+Set the organization for the active profile:
+
+```shell-session
+$ tfctl profile set organization my-organization
+```
+
+## `tfctl profile unset`
+
+**Usage:** `tfctl profile unset <property> [options]`
+
+Unset the value of a configuration property for a profile.
+
+### Arguments
+
+- `<property>` (required, string): The configuration property name to unset.
+
+### Examples
+
+Unset the organization for the active profile:
+
+```shell-session
+$ tfctl profile unset organization
+```
+
+## Manage profiles
+
+The `tfctl profile profiles` command group creates and manages profiles.
+
+### `tfctl profile profiles create`
+
+**Usage:** `tfctl profile profiles create <name> [options]`
+
+Create a new profile. The CLI activates it automatically unless you pass `--no-activate`.
+
+#### Arguments
+
+- `<name>` (required, string): The profile name to create.
+
+#### Flags
+
+| Flag             | Type    | Default | Description                                  |
+| ---------------- | ------- | ------- | ------------------------------------------- |
+| `--no-activate`  | boolean | `false` | Don't automatically activate the new profile. |
+| `--hostname`     | string  | —       | Set the hostname for the new profile.        |
+
+#### Examples
+
+Create and switch to a new profile configured for a Terraform Enterprise instance:
+
+```shell-session
+$ tfctl profile profiles create my-profile --hostname="my-tfe-instance.example.com"
+```
+
+### `tfctl profile profiles activate`
+
+**Usage:** `tfctl profile profiles activate <name> [options]`
+
+Activate an existing named profile.
+
+#### Arguments
+
+- `<name>` (required, string): The profile name to activate.
+
+#### Examples
+
+Switch to a named profile:
+
+```shell-session
+$ tfctl profile profiles activate my-profile
+```
+
+Switch back to the default profile:
+
+```shell-session
+$ tfctl profile profiles activate default
+```
+
+### `tfctl profile profiles list`
+
+**Usage:** `tfctl profile profiles list [options]`
+
+List existing profiles.
+
+#### Examples
+
+List all profiles in JSON format:
+
+```shell-session
+$ tfctl profile profiles list --json
+```
+
+### `tfctl profile profiles delete`
+
+**Usage:** `tfctl profile profiles delete <name> [<name> ...] [options]`
+
+Delete one or more existing named profiles.
+
+#### Arguments
+
+- `<name>` (required, string, repeatable): One or more profile names to delete.
+
+#### Examples
+
+Delete a profile named `old-profile`:
+
+```shell-session
+$ tfctl profile profiles delete old-profile
+```
+
+### `tfctl profile profiles rename`
+
+**Usage:** `tfctl profile profiles rename <name> --new_name=<new-name> [options]`
+
+Rename an existing named profile.
+
+#### Arguments
+
+- `<name>` (required, string): The current profile name.
+- `--new_name` (required, string): The new profile name.
+
+#### Examples
+
+Rename a profile:
+
+```shell-session
+$ tfctl profile profiles rename old-name --new_name="new-name"
+```
+
+## Related
+
+- [Configure tfctl](/terraform/tfctl/configuration)
+- [Global flags reference](/terraform/tfctl/reference/cli/global-flags)

--- a/content/tfctl/v0.2.x/docs/tfctl/reference/cli/run.mdx
+++ b/content/tfctl/v0.2.x/docs/tfctl/reference/cli/run.mdx
@@ -1,0 +1,100 @@
+---
+page_title: tfctl run
+description: |-
+  Start runs and check run status on HCP Terraform and Terraform Enterprise
+  workspaces by run ID, workspace ID, or workspace name.
+---
+
+# `tfctl run`
+
+The `tfctl run` commands manage runs on HCP Terraform and Terraform Enterprise
+workspaces.
+
+## `tfctl run start`
+
+**Usage:** `tfctl run start <name-or-id> [options]`
+
+Start a new run on the workspace specified by ID or name.
+
+### Arguments
+
+- `<name-or-id>` (required): Workspace ID or name.
+
+### Flags
+
+| Flag                   | Type    | Default | Description                                                                              |
+| ---------------------- | ------- | ------- | --------------------------------------------------------------------------------------- |
+| `--allow-empty-apply`  | boolean | `false` | Allow the run to proceed even if the plan has no changes.                                |
+| `--debugging-mode`     | boolean | `false` | Enable trace logging for this run by setting `TF_LOG=trace` in the run's environment.    |
+| `--message`            | string  | —       | Attach a message to the run.                                                            |
+| `--organization`       | string  | profile | Organization name. Overrides the organization configured for the profile.               |
+
+### Examples
+
+Start a new run on an existing workspace named `my-workspace`:
+
+```shell-session
+$ tfctl run start my-workspace
+```
+
+Start a run with a message:
+
+```shell-session
+$ tfctl run start my-workspace --message="Run started with tfctl."
+```
+
+### Related
+
+- [Configure tfctl](/terraform/tfctl/configuration)
+- [Global flags reference](/terraform/tfctl/reference/cli/global-flags)
+
+## `tfctl run status`
+
+**Usage:** `tfctl run status <id> [options]`
+
+Print the status of a run. You can pass a run ID, workspace ID, or workspace name:
+
+- **Run ID** (prefixed with `run-`): Gets that specific run.
+- **Workspace ID** (prefixed with `ws-`): Gets the latest run on the workspace.
+- **Workspace name**: Gets the most recent run on the named workspace.
+
+### Arguments
+
+- `<id>` (required): Run ID, workspace ID, or workspace name.
+
+### Flags
+
+| Flag             | Type   | Default | Description                                                                       |
+| ---------------- | ------ | ------- | -------------------------------------------------------------------------------- |
+| `--organization` | string | profile | Organization name. Defaults to the profile organization or Terraform context.    |
+
+### Examples
+
+Print the status of a specific run by ID:
+
+```shell-session
+$ tfctl run status run-1234abcd
+```
+
+Print the status of the latest run on a workspace by name:
+
+```shell-session
+$ tfctl run status my-workspace
+```
+
+Print the status of the latest run on a workspace by ID:
+
+```shell-session
+$ tfctl run status ws-abc123xyz
+```
+
+Get detailed run status as JSON for scripting:
+
+```shell-session
+$ tfctl run status my-workspace --json
+```
+
+### Related
+
+- [Configure tfctl](/terraform/tfctl/configuration)
+- [Global flags reference](/terraform/tfctl/reference/cli/global-flags)

--- a/content/tfctl/v0.2.x/docs/tfctl/reference/cli/variable.mdx
+++ b/content/tfctl/v0.2.x/docs/tfctl/reference/cli/variable.mdx
@@ -1,0 +1,59 @@
+---
+page_title: tfctl variable
+description: |-
+  Import Terraform variables from .tfvars files and environment variables into
+  HCP Terraform workspaces or variable sets.
+---
+
+# `tfctl variable`
+
+The `tfctl variable` commands import variables into HCP Terraform and Terraform
+Enterprise.
+
+## `tfctl variable import`
+
+**Usage:** `tfctl variable import [<tfvars-file>] [options]`
+
+Import Terraform variables from `.tfvars` files, or environment variables from the
+`tfctl` process environment, into a workspace or variable set.
+
+You must provide either a variable set or a workspace by name. Otherwise, `tfctl` scans
+the current working directory for Terraform configuration to determine the workspace
+name.
+
+### Arguments
+
+- `<tfvars-file>` (optional): The `.tfvars` file to import variables from. You can specify a
+  path if the file is in another directory. The CLI automatically marks variables whose
+  names suggest they may be sensitive — such as those containing `secret`, `token`, or
+  `private` — as `sensitive`.
+
+### Options
+
+| Flag                   | Type    | Default | Description                                                                                       |
+| ---------------------- | ------- | ------- | ------------------------------------------------------------------------------------------------ |
+| `--env`, `-e`          | string  | —       | Environment variable to import. Repeatable. All imported environment variables are marked sensitive. |
+| `--organization`       | string  | profile | Organization name. Defaults to the profile configuration or Terraform context.                   |
+| `--overwrite`          | boolean | `false` | Update existing variables to match the imported values. Otherwise the CLI errors when imported variables don't match existing ones. |
+| `--variable-set-name`  | string  | —       | Target variable set by name. If omitted, the CLI sets workspace variables.                       |
+| `--workspace`          | string  | context | Workspace name override. Defaults to the HCP Terraform or Terraform Enterprise configuration context. |
+
+### Examples
+
+Import Terraform variables from a `terraform.tfvars` file into a workspace:
+
+```shell-session
+$ tfctl variable import terraform.tfvars --workspace="my-workspace"
+```
+
+Import multiple environment variables into a variable set and overwrite existing values:
+
+```shell-session
+$ tfctl variable import --overwrite --variable-set-name="my-varset" \
+  --env="AWS_ACCESS_KEY_ID" --env="AWS_SECRET_ACCESS_KEY"
+```
+
+## Related
+
+- [Configure tfctl](/terraform/tfctl/configuration)
+- [Global flags reference](/terraform/tfctl/reference/cli/global-flags)

--- a/content/tfctl/v0.2.x/docs/tfctl/telemetry.mdx
+++ b/content/tfctl/v0.2.x/docs/tfctl/telemetry.mdx
@@ -1,0 +1,52 @@
+---
+page_title: Telemetry
+description: |-
+  Learn what anonymous telemetry tfctl collects and how to inspect or disable
+  it.
+---
+
+# Telemetry
+
+By default, HashiCorp collects anonymous trace telemetry for each `tfctl` command
+invocation. This telemetry includes:
+
+- The command name.
+- The exit status.
+- Network metrics.
+- Basic process information.
+
+## Disable telemetry
+
+You can disable telemetry using any of the following methods:
+
+- Set the `TFCTL_TELEMETRY` environment variable to `disabled`.
+- Set the `DO_NOT_TRACK` environment variable to `true`.
+- Disable telemetry in your profile:
+
+  ```shell-session
+  $ tfctl profile set telemetry disabled
+  ```
+
+## Inspect telemetry
+
+To see the telemetry that `tfctl` transmits, set the profile `telemetry` property to
+`log`. This outputs span data to stderr instead of exporting it:
+
+```shell-session
+$ tfctl profile set telemetry log
+```
+
+## Telemetry property values
+
+The `telemetry` profile property accepts the following values:
+
+| Value                  | Behavior                                              |
+| ---------------------- | ---------------------------------------------------- |
+| `false` or `disabled`  | Disable telemetry.                                   |
+| `log`                  | Output span data to stderr instead of exporting it.  |
+| _any other value_      | Enable OTLP export.                                  |
+
+## Related
+
+- [Configure tfctl](/terraform/tfctl/configuration)
+- [Profile properties](/terraform/tfctl/configuration#profile-properties)

--- a/productConfig.mjs
+++ b/productConfig.mjs
@@ -265,6 +265,17 @@ export const PRODUCT_CONFIG = {
 		versionedDocs: true,
 		websiteDir: 'website',
 	},
+	tfctl: {
+		assetDir: '',
+		basePaths: ['tfctl'],
+		contentDir: 'docs',
+		dataDir: 'data',
+		navDataPath: 'tfctl',
+		productSlug: 'terraform',
+		semverCoerce: semver.coerce,
+		versionedDocs: true,
+		websiteDir: 'website',
+	},
 	'terraform-migrate': {
 		assetDir: '',
 		basePaths: ['migrate'],


### PR DESCRIPTION
## Summary

Adds **beta** developer documentation for the `tfctl` CLI (HCP Terraform / Terraform Enterprise) to the unified docs, served under `/terraform/tfctl/...`.

This is a content handoff for the tfctl docs port (Education: IPE-1459). Opening as **draft** for review by the docs team before it goes live.

### What's included
- `content/tfctl/v0.2.x/docs/tfctl/**` — 16 pages: Overview, Install, Configuration, Use tfctl with AI agents, Telemetry, Errors, and a CLI reference (`reference/cli/*`) for `api`, `auth`, `get`, `create`, `run`, `variable`, `profile`, `harness`, plus global flags.
- `content/tfctl/v0.2.x/data/tfctl-nav-data.json` — sidebar nav (Overview badged `BETA`).
- `productConfig.mjs` — `tfctl` product entry (`productSlug: terraform`, `basePaths: ['tfctl']`, versioned).

### Notes
- Source of truth is the README in `hashicorp/tfctl-cli`; content follows the Education style guide + CLI reference content type.
- Companion change in `hashicorp/dev-portal` registers `tfctl` in `unified_docs_migrated_repos` and adds the `rootDocsPaths` entry.
- Release status: **Beta** (pre-GA).

🤖 Generated with [opencode](https://opencode.ai)