### PR TITLE
Add Vault UI patch release notes for June 2026 (2.0.3, 1.21.8, 1.20.13, 1.19.19)

### DIFF
--- a/content/vault/v1.19.x/content/docs/updates/release-notes.mdx
+++ b/content/vault/v1.19.x/content/docs/updates/release-notes.mdx
@@ -16,6 +16,19 @@ last_modified: 2025-08-15T22:50:12-07:00
 
 @include 'release-notes/intro.mdx'
 
+## Vault 1.19.19
+
+**Released**: 2026-06-17
+
+### Bug fixes and security patches
+
+- **Fix**: Fixed stuck dropdowns in the Transit secrets engine Vault GUI.
+
+### Improvements and behavior changes
+
+- **Charts**: Migrated charts from Lineal to Carbon Charts, including tooltip
+  enhancements for better clarity and usability.
+
 ## Known issues and important changes
 
 @include '../../../global/partials/important-changes/summary-tables/1_19.mdx'

--- a/content/vault/v1.20.x/content/docs/updates/release-notes.mdx
+++ b/content/vault/v1.20.x/content/docs/updates/release-notes.mdx
@@ -18,6 +18,26 @@ last_modified: 2025-08-15T22:50:12-07:00
 
 @include 'tips/change-tracker.mdx'
 
+## Vault 1.20.13
+
+**Released**: 2026-06-17
+
+### Bug fixes and security patches
+
+- **Fix**: Fixed stuck dropdowns in the Transit secrets engine Vault GUI.
+
+### Improvements and behavior changes
+
+- **Charts**: Migrated charts from Lineal to Carbon Charts in the Client usage
+  overview and Vault usage dashboards for a more polished and consistent visual
+  experience.
+- **Donut chart tooltips**: Refined tooltip styling and functionality on donut
+  charts for better clarity and consistency.
+- **Vault Reporting Dashboard** <EnterpriseAlert inline="true" />: Migrated
+  the Vault Reporting Dashboard from a shared package into Vault Enterprise.
+- **Babel preset**: Reinstalled `@babel/preset-env` at `~7.29.5` to stay
+  current with the JavaScript build ecosystem.
+
 ## Executive summary
 
 Vault Enterprise 1.20.0 streamlines the user experience, and improves visibility

--- a/content/vault/v1.21.x/content/docs/updates/release-notes.mdx
+++ b/content/vault/v1.21.x/content/docs/updates/release-notes.mdx
@@ -20,6 +20,24 @@ Release | RC date    | GA date
 @include 'tips/change-tracker.mdx'
 
 
+## Vault 1.21.8
+
+**Released**: 2026-06-17
+
+### Bug fixes and security patches
+
+- **Fix**: Fixed stuck dropdowns in the Transit secrets engine Vault GUI.
+
+### Improvements and behavior changes
+
+- **Charts**: Migrated charts from Lineal to Carbon Charts in the Client usage
+  overview and Vault usage dashboards for a more polished and consistent visual
+  experience.
+- **Vault Reporting Dashboard** <EnterpriseAlert inline="true" />: Migrated
+  the Vault Reporting Dashboard from a shared package into Vault Enterprise.
+- **Babel preset**: Reinstalled `@babel/preset-env` at `~7.29.5` to stay
+  current with the JavaScript build ecosystem.
+
 ## Executive summary
 
 Vault Enterprise 1.21 minimizes operational burden, improves pricing visibility,

--- a/content/vault/v2.x/content/docs/updates/release-notes.mdx
+++ b/content/vault/v2.x/content/docs/updates/release-notes.mdx
@@ -41,7 +41,7 @@ create policies, and discover Vault capabilities.
 
 ### Bug fixes and security patches
 
-- None
+- **Fix**: Fixed stuck dropdowns in the Transit secrets engine Vault GUI.
 
 ### Improvements and behavior changes
 
@@ -53,8 +53,17 @@ create policies, and discover Vault capabilities.
     [`force_new_client`](/vault/api-docs/auth/cf#force_new_client) configuration
     flag. When enabled, the plugin creates a new CF client for every login
     request instead of using the shared cached client.
-
-
+- **Charts**: Migrated charts from Lineal to Carbon Charts in the Client usage
+  overview and Vault usage dashboards for a more polished and consistent visual
+  experience.
+- **Donut chart tooltips**: Refined tooltip styling and functionality on donut
+  charts for better clarity and consistency.
+- **`ember-basic-dropdown`**: Bumped to `~8.9.0` to satisfy a peer dependency
+  requirement with `@hashicorp/design-system-components`.
+- **Babel preset**: Reinstalled `@babel/preset-env` at `~7.29.5` to stay
+  current with the JavaScript build ecosystem.
+- **Dependency overrides**: Removed stale dependency overrides from
+  `ui/package.json` to reduce unnecessary version constraints.
 
 ## Vault 2.0.2
 


### PR DESCRIPTION
## Summary

Adds patch-level release note sections to four Vault version files for the June 2026 UI patch releases. Follows the v2.x patch format (`## Vault X.Y.Z` → `### Bug fixes and security patches` / `### Improvements and behavior changes`).

## Changes by version

### Vault 2.0.3 (`v2.x`)
- **Fix**: Transit secrets engine dropdown fix in the Vault GUI
- **Improvement**: Charts migrated from Lineal to Carbon Charts (Client usage overview + Vault usage dashboards)
- **Improvement**: Donut chart tooltip styling and functionality refined
- **Maintenance**: `ember-basic-dropdown` bumped to `~8.9.0` for peer dependency compatibility
- **Maintenance**: `@babel/preset-env` reinstalled at `~7.29.5`
- **Maintenance**: Stale dependency overrides removed from `ui/package.json`

### Vault 1.21.8 (`v1.21.x`)
- **Fix**: Transit secrets engine dropdown fix in the Vault GUI
- **Improvement**: Charts migrated from Lineal to Carbon Charts (Client usage overview + Vault usage dashboards)
- **Improvement**: Vault Reporting Dashboard migrated from shared package into Vault Enterprise _(Enterprise only)_
- **Maintenance**: `@babel/preset-env` reinstalled at `~7.29.5`

### Vault 1.20.13 (`v1.20.x`)
- **Fix**: Transit secrets engine dropdown fix in the Vault GUI
- **Improvement**: Charts migrated from Lineal to Carbon Charts (Client usage overview + Vault usage dashboards)
- **Improvement**: Donut chart tooltip styling and functionality refined
- **Improvement**: Vault Reporting Dashboard migrated from shared package into Vault Enterprise _(Enterprise only)_
- **Maintenance**: `@babel/preset-env` reinstalled at `~7.29.5`

### Vault 1.19.19 (`v1.19.x`)
- **Fix**: Transit secrets engine dropdown fix in the Vault GUI
- **Improvement**: Charts migrated from Lineal to Carbon Charts, including tooltip enhancements

## Notes

- Security vulnerability fixes (fast-uri, Rollup, tmp, scarf) are intentionally excluded per team decision
- Babel item for **1.19.19 is omitted** — the `@babel/preset-env` version on `release/1.19.x+ent` shows `~7.26.9` rather than the expected `~7.29.5`; pending confirmation from the committer before adding
- The Vault Reporting Dashboard migration was a no-op in the CE `release/2.x.x` branch and is omitted from 2.0.3 notes