### PR TITLE
Terraform Docs

### DIFF
--- a/content/terraform/v1.15.x/docs/language/functions/index.mdx
+++ b/content/terraform/v1.15.x/docs/language/functions/index.mdx
@@ -127,7 +127,6 @@ tables describe function support across Terraform configuration types.
 | [index](/terraform/language/functions/index)             | .hcl | finds the first element for a given value in a list |
 | [keys](/terraform/language/functions/keys)                       | .hcl,<br/>.tfcomponent.hcl,<br/>.tfdeploy.hcl | takes a map and returns a list containing the keys from that map |
 | [length](/terraform/language/functions/length)                       | .hcl | returns the length of a given list, map, or string |
-| [length](/terraform/language/functions/length)                       | .hcl | returns the length of a given list, map, or string |
 | [list](/terraform/language/functions/list)                       | &nbsp; | deprecated after Terraform 0.12. Use [`tolist`](/terraform/language/functions/tolist) instead |
 | [lookup](/terraform/language/functions/lookup)                       | .hcl | retrieves the value of a single element from a map, given its key |
 | [map](/terraform/language/functions/map)                       | &nbsp; | deprecated after Terraform 0.12. Use [`tomap`](/terraform/language/functions/tomap) instead |


### PR DESCRIPTION
### What
<!-- Explain what you changed and provide a list of changed page names. -->

Function `length` appears twice in docs. Remove one of them.

### Why
<!-- Explain why this change is necessary and how it benefits users. -->

Redundancy does not help in this case.

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

<img width="846" height="274" alt="Screenshot 2026-06-18 at 16 02 18" src="https://github.com/user-attachments/assets/fa924275-a97d-465c-9222-42bdf5d1be44" />

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] You added redirects to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages **across all affected versions**. Refer to [Redirects](https://github.com/hashicorp/web-unified-docs/blob/main/docs/content-guide/redirects.md#example-redirects) for examples and guidance. 
- [ ] Links to related content where appropriate (e.g., CLI, language, API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
