### PR TITLE
VAULT-45870: Added documentation for changes in list agent registration behavior

### DIFF
--- a/content/vault/v2.x/content/api-docs/secret/agent-registry.mdx
+++ b/content/vault/v2.x/content/api-docs/secret/agent-registry.mdx
@@ -254,10 +254,12 @@ $ curl \
     ],
     "key_info": {
       "a3b04076-e7d9-251f-4a7d-8c4f0a7b59c6": {
-        "display_name": "my-agent"
+        "display_name": "my-agent",
+        "entity_id": "fe2a8568-91cc-7580-40a4-6bed9a5867fa"
       },
       "b7c19832-44ad-6fa1-9e23-1a5d0c8e47b3": {
-        "display_name": "other-agent"
+        "display_name": "other-agent",
+        "entity_id": "19d91f5b-0f31-4af7-a39d-c5a8f9bd2be1"
       }
     }
   }
@@ -415,10 +417,12 @@ $ curl \
     ],
     "key_info": {
       "my-agent": {
-        "display_name": "my-agent"
+        "display_name": "my-agent",
+        "entity_id": "fe2a8568-91cc-7580-40a4-6bed9a5867fa"
       },
       "other-agent": {
-        "display_name": "other-agent"
+        "display_name": "other-agent",
+        "entity_id": "19d91f5b-0f31-4af7-a39d-c5a8f9bd2be1"
       }
     }
   }

--- a/content/vault/v2.x/content/docs/updates/release-notes.mdx
+++ b/content/vault/v2.x/content/docs/updates/release-notes.mdx
@@ -40,12 +40,16 @@ create policies, and discover Vault capabilities.
 
 ### Bug fixes and security patches
 
-- None
+- **Fix**: Fixed `key_info` output when querying the list of agent registrations
+  by name with the API endpoint
+  [`/agent-registry/registration/display-name`](/vault/api-docs/secret/agent-registry#list-registrations-by-name).
 
 ### Improvements and behavior changes
 
-- None
-
+- **Agent registry**: Added the `entity_id` field to `key_info` in the output of
+  [`/agent-registry/registration/id`](/vault/api-docs/secret/agent-registry#list-registrations-by-id)
+  and
+  [`/agent-registry/registration/display-name`](/vault/api-docs/secret/agent-registry#list-registrations-by-name).
 
 ## Vault 2.0.3
 


### PR DESCRIPTION
Please go to the `Preview` tab and select the appropriate template:

This PR is supposed to reflect changes made to Vault's source code in this PR: 
https://github.com/hashicorp/vault-enterprise/pull/15410

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
