### PR TITLE
Add tfctl CLI entry to HCP Terraform changelog

### DIFF
--- a/content/terraform-docs-common/docs/cloud-docs/changelog.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/changelog.mdx
@@ -14,6 +14,10 @@ last_modified: 2026-04-14T20:50:21.000Z
 
 Keep track of changes to HCP Terraform.
 
+## 2026-06-17
+
+* tfctl CLI. The official CLI for HCP Terraform and Terraform Enterprise is now available, giving teams a first-party way to manage platform operations, common workflows, and API-driven automation from the command line. Refer to the [tfctl CLI repository](https://github.com/hashicorp/tfctl-cli) for more information.
+
 ## 2026-06-10
 
 - HCP Terraform now provides a dedicated **Actions** page that shows actions declared in your Terraform configuration. You can view action invocation history and statuses and invoke or re-invoke actions directly from the UI. Refer to [Manage Terraform actions](/terraform/cloud-docs/actions) for more information.
@@ -173,4 +177,3 @@ Keep track of changes to HCP Terraform.
 ## 2025-05-02
 
 * HCP Waypoint – GitHub Actions Support. Enables triggering Waypoint Actions directly from GitHub Actions to bridge CI/CD with internal developer platform workflows. Refer to [Waypoint Actions documentation](https://developer.hashicorp.com/hcp/docs/waypoint/concepts/actions) for more information.
-


### PR DESCRIPTION
## Summary

Adds an HCP Terraform changelog entry announcing the tfctl CLI.

## Changes

- adds a new `2026-06-17` changelog entry
- links to the `hashicorp/tfctl-cli` repository for more information
