### PR TITLE
Remove local accounts secrets engine entry from HCP Vault changelog

### DIFF
--- a/content/hcp-docs/content/docs/vault/changelog.mdx
+++ b/content/hcp-docs/content/docs/vault/changelog.mdx
@@ -22,7 +22,6 @@ The following Vault 2.0 features are now available in HCP Vault:
 - [Envelope encryption](/vault/docs/secrets/transit/envelope-encryption) - Use Transit for in-place encryption workflows where Vault protects data encryption keys and your applications encrypt and decrypt local data.
 - [Visual policy generator](/vault/docs/ui/visual-policy-editor) - Create policies faster and reduce manual policy authoring by generating ACL policy snippets from the Vault GUI.
 - [Public CA integration](/vault/docs/secrets/pki-external-ca) - Use Vault to interface to public CAs in order to issue certificates.
-- [Local accounts secrets engine](/vault/docs/secrets/os) - Use Vault to automatically rotate Linux local account credentials.
 - [Namespace onboarding workflow](/vault/docs/enterprise/namespaces) - Answer a few key questions in the Vault GUI to create new namespaces then continue in the GUI, CLI, or Terraform.
 - [AWS KMS multi-region keys](/vault/docs/secrets/key-management/awskms#multi-region-keys) - Create and replicate managed keys across AWS regions so you can support multi-region encryption and disaster recovery workflows.
 - [SPIFFE JWT-SVID support](/vault/docs/secrets/spiffe) - Let authenticated workloads request JWT-SVIDs from Vault so they can participate in SPIFFE-based identity workflows.


### PR DESCRIPTION
## Summary
- remove the local accounts secrets engine bullet from the HCP Vault Dedicated changelog
