### PR TITLE
Update Azure Vault Sizing

### DIFF
--- a/content/vault/v2.x/content/docs/concepts/integrated-storage/migration-checklist.mdx
+++ b/content/vault/v2.x/content/docs/concepts/integrated-storage/migration-checklist.mdx
@@ -97,25 +97,25 @@ which impacts the host's RAM.
 
 It is recommended to avoid hosting Consul on an instance with burstable CPU.
 
-| Size  | CPU      | Memory       | Disk  | Typical Cloud Instance Types              |
-| ----- | -------- | ------------ | ----- | ----------------------------------------- |
-| Small | 2 core   | 4-8 GB RAM   | 25 GB | **AWS:** m5.large                         |
-|       |          |              |       | **Azure:** Standard_D2_v3                 |
-|       |          |              |       | **GCE:** n1-standard-2, n1-standard-4     |
-| Large | 4-8 core | 16-32 GB RAM | 50 GB | **AWS:** m5.xlarge, m5.2xlarge            |
-|       |          |              |       | **Azure:** Standard_D4_v3, Standard_D8_v3 |
-|       |          |              |       | **GCE:** n1-standard-8, n1-standard-16    |
+| Size  | CPU      | Memory       | Disk  | Typical Cloud Instance Types                |
+| ----- | -------- | ------------ | ----- | ------------------------------------------- |
+| Small | 2 core   | 4-8 GB RAM   | 25 GB | **AWS:** m5.large                           |
+|       |          |              |       | **Azure:** Standard_D2s_v7                  |
+|       |          |              |       | **GCE:** n1-standard-2, n1-standard-4       |
+| Large | 4-8 core | 16-32 GB RAM | 50 GB | **AWS:** m5.xlarge, m5.2xlarge              |
+|       |          |              |       | **Azure:** Standard_D4s_v7, Standard_D8s_v7 |
+|       |          |              |       | **GCE:** n1-standard-8, n1-standard-16      |
 
 #### Machine sizes for Vault with Integrated Storage
 
-| Size  | CPU      | Memory       | Disk   | Typical Cloud Instance Types               |
-| ----- | -------- | ------------ | ------ | ------------------------------------------ |
-| Small | 2 core   | 8-16 GB RAM  | 100 GB | **AWS:** m5.large, m5.xlarge               |
-|       |          |              |        | **Azure:** Standard_D2_v3, Standard_D4_v3  |
-|       |          |              |        | **GCE:** n2-standard-2, n2-standard-4      |
-| Large | 4-8 core | 32-64 GB RAM | 200 GB | **AWS:** m5.2xlarge, m5.4xlarge            |
-|       |          |              |        | **Azure:** Standard_D8_v3, Standard_D16_v3 |
-|       |          |              |        | **GCE:** n2-standard-8, n2-standard-16     |
+| Size  | CPU      | Memory       | Disk   | Typical Cloud Instance Types                 |
+| ----- | -------- | ------------ | ------ | -------------------------------------------- |
+| Small | 2 core   | 8-16 GB RAM  | 100 GB | **AWS:** m5.large, m5.xlarge                 |
+|       |          |              |        | **Azure:** Standard_D2s_v7, Standard_D4s_v7  |
+|       |          |              |        | **GCE:** n2-standard-2, n2-standard-4        |
+| Large | 4-8 core | 32-64 GB RAM | 200 GB | **AWS:** m5.2xlarge, m5.4xlarge              |
+|       |          |              |        | **Azure:** Standard_D8s_v7, Standard_D16s_v7 |
+|       |          |              |        | **GCE:** n2-standard-8, n2-standard-16       |
 
 If many secrets are being generated or rotated frequently, this information will
 need to be flushed to the disk often. Therefore, the infrastructure should have


### PR DESCRIPTION
Note there's no Vault Template listed so just reused the consul one.

## Description
Azure now mark the Dv3 series as 'legacy' https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/general-purpose/dv3-series?tabs=sizebasic . This updates them to equivalent sizes on a modern instance type. 

## Links
N/A

## Contributor checklists

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [x] 3 days: Small changes, easy reviews
- [ ] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [x] Verify that all status checks passed
- [ ] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [x] I added redirects for any moved or removed pages
- [x] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [ ] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [ ] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.
