### PR TITLE
updates docs to include free org quota details

### DIFF
--- a/content/terraform-docs-common/docs/cloud-docs/overview/index.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/overview/index.mdx
@@ -48,6 +48,8 @@ Refer to [Terraform pricing](https://www.hashicorp.com/products/terraform/pricin
 
 Small teams can use most of HCP Terraform's features for free, including remote Terraform execution, VCS integration, the private module registry, single-sign-on, policy enforcement, run tasks, and more.
 
+Each user has a quota of two free organizations. If you would like to create a new free organization after your first two, you must upgrade an existing organization to a paid plan.
+
 Free organizations are limited to 500 managed resources. Refer to [What is a managed resource](/terraform/cloud-docs/overview/estimate-hcp-terraform-cost#what-is-a-managed-resource) for more details.
 
 ### Paid features


### PR DESCRIPTION

Updated section : `/terraform/cloud-docs/overview#free-organizations`

Please go to the `Preview` tab and select the appropriate template:

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)



### Example Output
<img width="647" height="343" alt="image" src="https://github.com/user-attachments/assets/aa2218c0-9ee6-4be5-9ae0-bad4f1eabc46" />
