### PR TITLE
VAULT-43958: Adding new fields to Vault Secrets Sync destination APIs 

### DIFF
--- a/content/vault/v2.x/content/api-docs/system/secrets-sync.mdx
+++ b/content/vault/v2.x/content/api-docs/system/secrets-sync.mdx
@@ -276,7 +276,7 @@ role ARN. We recommend using a different random UUID per destination.
 - `region` `(string: "")` - Region where to manage the secrets manager entries. If omitted, configuration fallbacks on
 the AWS credentials provider chain and tries to infer region from the environment.
 
-- `kms_key_id` `(string: "")` - The KMS key arn to be used for encrypting the secrets at rest in AWS Secrets Manager. 
+- `kms_key_id` `(string: "")` - The KMS key ARN Vault should use to encrypt secrets at rest in AWS Secrets Manager. 
 
 - `regional_kms_keys` `(map<string|string>: nil)` - A map of region names to KMS key names to leverage customer-managed encryption keys for
   encryption at rest. Each pair follows the format `region_name=encryption_key_arn`. 
@@ -461,10 +461,10 @@ This endpoint creates a destination to synchronize secrets with the GCP Secret M
   encryption at rest. Each pair follows the format `location_name=encryption_key_resource_name`. Refer to the
   [sample payloads](#sample-payloads) for more details. This field is deprecated. Use `regional_kms_keys` instead.
 
-- `global_kms_key` `(string: "")` - The KMS key id to be used for encrypting the secrets at rest in GCP Secrets Manager. This field is deprecated. 
-   Use `kms_key_id` instead.
+- `global_kms_key` `(string: "")` - **DEPRECATED** Use `kms_key_id` instead.
+   The KMS key ID Vault should use to encrypt secrets at rest in GCP Secrets Manager.
 
-- `kms_key_id` `(string: "")` - The KMS key id to be used for encrypting the secrets at rest in GCP Secrets Manager. 
+- `kms_key_id` `(string: "")` - The KMS key ID Vault should use for encrypting secrets at rest in GCP Secrets Manager. 
 
 - `regional_kms_keys` `(map<string|string>: nil)` - A map of location names to KMS key names to leverage customer-managed encryption keys for
   encryption at rest. Each pair follows the format `location_name=encryption_key_resource_name`. 

--- a/content/vault/v2.x/content/api-docs/system/secrets-sync.mdx
+++ b/content/vault/v2.x/content/api-docs/system/secrets-sync.mdx
@@ -3,8 +3,8 @@ layout: api
 page_title: /sys/sync - HTTP API
 description: The `/sys/sync` endpoints are used to configure destinations and associate secrets to sync with these destinations.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2026-04-15T00:14:10.000Z
-last_modified: 2026-04-15T00:14:10.000Z
+created_at: 2026-04-14T17:13:42-07:00
+last_modified: 2026-06-23T16:49:42.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -276,6 +276,11 @@ role ARN. We recommend using a different random UUID per destination.
 - `region` `(string: "")` - Region where to manage the secrets manager entries. If omitted, configuration fallbacks on
 the AWS credentials provider chain and tries to infer region from the environment.
 
+- `kms_key_id` `(string: "")` - The KMS key arn to be used for encrypting the secrets at rest in AWS Secrets Manager. 
+
+- `regional_kms_keys` `(map<string|string>: nil)` - A map of region names to KMS key names to leverage customer-managed encryption keys for
+  encryption at rest. Each pair follows the format `region_name=encryption_key_arn`. 
+
 - `secret_name_template` `(string: "")` - Template to use when generating the secret names on the external system.
 The default template yields names like `vault/kv_1234/my-secret`. See [this documentation](/vault/docs/sync#name-template) for more details.
 
@@ -454,7 +459,15 @@ This endpoint creates a destination to synchronize secrets with the GCP Secret M
 
 - `locational_kms_keys` `(map<string|string>: nil)` - A map of location names to KMS key names to leverage customer-managed encryption keys for
   encryption at rest. Each pair follows the format `location_name=encryption_key_resource_name`. Refer to the
-  [sample payloads](#sample-payloads) for more details.
+  [sample payloads](#sample-payloads) for more details. This field is deprecated. Use `regional_kms_keys` instead.
+
+- `global_kms_key` `(string: "")` - The KMS key id to be used for encrypting the secrets at rest in GCP Secrets Manager. This field is deprecated. 
+   Use `kms_key_id` instead.
+
+- `kms_key_id` `(string: "")` - The KMS key id to be used for encrypting the secrets at rest in GCP Secrets Manager. 
+
+- `regional_kms_keys` `(map<string|string>: nil)` - A map of location names to KMS key names to leverage customer-managed encryption keys for
+  encryption at rest. Each pair follows the format `location_name=encryption_key_resource_name`. 
 
 - `secret_name_template` `(string: "")` - Template to use when generating the secret names on the external system.
 The default template yields names like `vault/kv_1234/my-secret`. See [this documentation](/vault/docs/sync#name-template) for more details.


### PR DESCRIPTION

The PR introduces 2 new fields - kms_key_id and regional_kms_keys on the secrets sync destination API for AWS and GCP providers. Jira - [VAULT-43958](https://hashicorp.atlassian.net/browse/VAULT-43958)
Please go to the `Preview` tab and select the appropriate template:

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)


[VAULT-43958]: https://hashicorp.atlassian.net/browse/VAULT-43958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ