### PR TITLE
Remove beta flag from recoverable items feature

### DIFF
--- a/content/terraform-docs-common/docs/cloud-docs/stacks/destroy.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/stacks/destroy.mdx
@@ -65,8 +65,6 @@ By following the steps above, you can forcefully delete a Stack without removing
 
 ## Recover a Stack 
 
-@include 'beta.mdx'
-
 You have 30 days to recover a discarded Stack. During the recovery window, HCP Terraform and Terraform Enterprise continue to record new configuration versions committed through VCS webhooks, but commits don’t trigger new runs. You can’t recover a Stack that has the same name as an existing Stack.  
 
 Complete the following steps to recover a discarded workspace:  

--- a/content/terraform-docs-common/docs/cloud-docs/users-teams-organizations/organizations/settings.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/users-teams-organizations/organizations/settings.mdx
@@ -63,8 +63,6 @@ Enable the **Show Terraform pre-releases** option to allow teams to use features
 
 ### Allow deleted workspaces and stacks to be recoverable
 
-@include 'beta.mdx'
-
 Enable the **Allow deleted workspaces and stacks to be recoverable** option to let team members recover workspaces and stacks for 30 days from date of deletion. Deleted workspaces and Stacks appear in the [**Recoverable items** page](#recoverable-items). 
 
 After 30 days, HCP Terraform permanently removes them. You are not billed for recoverable workspaces and stacks that contain managed resources. 
@@ -250,8 +248,6 @@ The **Runs** page shows all Terraform runs with that are currently in progress, 
 To learn how to view Stack deployment runs, refer to [Review deployment runs](/terraform/cloud-docs/stacks/deploy/runs).
 
 ## Recoverable items 
-
-@include 'beta.mdx'
 
 If you delete platform resources, such as workspaces and Stacks, you can find and restore them in the **Recoverable items** page if the [**Allow deleted workspaces and stacks to be recoverable**](#allow-deleted-workspaces-and-stacks-to-be-recoverable) option is enabled for the organization. You can restore resources listed on the **Recoverable items** page within 30 days from when they were discarded. Refer to the following topics for instructions: 
  

--- a/content/terraform-docs-common/docs/cloud-docs/workspaces/create.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/workspaces/create.mdx
@@ -100,8 +100,6 @@ Choose one of the following actions:
 
 ## Recover a workspace 
 
-@include 'beta.mdx'
- 
 You have 30 days to recover a deleted workspace. While a discarded workspace is recoverable, HCP Terraform and Terraform Enterprise continue to record new configuration versions committed through VCS webhooks, but commits don’t trigger new runs. You can’t recover a workspace that has the same name as an existing workspace. To proceed, you must either delete or rename the existing workspace. 
 
 <!-- BEGIN: TFC:only name:pnp-callout -->


### PR DESCRIPTION
This PR removes the beta callout from the recoverable items feature, which is now GA.

Removes `@include 'beta.mdx'` from:
- Organization settings — "Allow deleted workspaces and stacks to be recoverable" setting
- Organization settings — "Recoverable items" page section
- Workspaces — "Recover a workspace"
- Stacks — "Recover a Stack"

Closes TF-37711