### PR TITLE
VAULT-45511: Add bounded event queue configuration documentation

### DIFF
--- a/content/vault/v1.21.x/content/docs/concepts/events.mdx
+++ b/content/vault/v1.21.x/content/docs/concepts/events.mdx
@@ -250,7 +250,7 @@ The event notification system supports configurable bounded queues for event sub
 
 To enable bounded event queues, set the `VAULT_EVENT_NOTIFICATIONS_BOUNDED_QUEUE_SIZE` environment variable to a positive integer (e.g., 16) on your Vault server. This configures buffered channels of that size (maximum 1000) for each subscriber:
 
-```shell
+```shell-session
 $ export VAULT_EVENT_NOTIFICATIONS_BOUNDED_QUEUE_SIZE=16
 ```
 

--- a/content/vault/v1.21.x/content/docs/concepts/events.mdx
+++ b/content/vault/v1.21.x/content/docs/concepts/events.mdx
@@ -251,7 +251,7 @@ The event notification system supports configurable bounded queues for event sub
 To enable bounded event queues, set the `VAULT_EVENT_NOTIFICATIONS_BOUNDED_QUEUE_SIZE` environment variable to a positive integer (e.g., 16) on your Vault server. This configures buffered channels of that size (maximum 1000) for each subscriber:
 
 ```shell
-VAULT_EVENT_NOTIFICATIONS_BOUNDED_QUEUE_SIZE=16
+$ export VAULT_EVENT_NOTIFICATIONS_BOUNDED_QUEUE_SIZE=16
 ```
 
 When bounded queues are enabled, subscribers may miss events if the queue fills up faster than events can be consumed. The default value is 0 (unbounded) for backward compatibility.

--- a/content/vault/v1.21.x/content/docs/concepts/events.mdx
+++ b/content/vault/v1.21.x/content/docs/concepts/events.mdx
@@ -254,7 +254,7 @@ To enable bounded event queues, set the `VAULT_EVENT_NOTIFICATIONS_BOUNDED_QUEUE
 $ export VAULT_EVENT_NOTIFICATIONS_BOUNDED_QUEUE_SIZE=16
 ```
 
-When bounded queues are enabled, subscribers may miss events if the queue fills up faster than events can be consumed. The default value is 0 (unbounded) for backward compatibility.
+When you enable bounded queues, subscribers may miss events if the queue fills up faster than Vault can process them. The default value is 0 (unbounded) for backward compatibility.
 
 ## Supported versions
 

--- a/content/vault/v1.21.x/content/docs/concepts/events.mdx
+++ b/content/vault/v1.21.x/content/docs/concepts/events.mdx
@@ -244,6 +244,18 @@ caches the results for a short period of time to improve performance.
 As a result, event notifications **may** still be sent for a few minutes after a token is
 revoked or a policy is deleted.
 
+## Bounded event queues
+
+The event notification system supports configurable bounded queues for event subscribers to prevent resource exhaustion in deployments with high subscriber counts.
+
+To enable bounded event queues, set the `VAULT_EVENT_NOTIFICATIONS_BOUNDED_QUEUE_SIZE` environment variable to a positive integer (e.g., 16) on your Vault server. This configures buffered channels of that size (maximum 1000) for each subscriber:
+
+```shell
+VAULT_EVENT_NOTIFICATIONS_BOUNDED_QUEUE_SIZE=16
+```
+
+When bounded queues are enabled, subscribers may miss events if the queue fills up faster than events can be consumed. The default value is 0 (unbounded) for backward compatibility.
+
 ## Supported versions
 
 | Version | Support                                     |


### PR DESCRIPTION
Adds documentation for the `VAULT_EVENT_NOTIFICATIONS_BOUNDED_QUEUE_SIZE` environment variable introduced to configure bounded event queues for event notification subscribers.

Original PR: https://github.com/hashicorp/vault-enterprise/pull/15549
