### PR TITLE
fix: adjust repo-sync permissions

### DIFF
--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -20,6 +20,9 @@ concurrency:
 
 jobs:
   repo-sync:
+    permissions:
+      contents: write
+      pull-requests: write
     if: github.repository == 'hashicorp/web-unified-docs-internal' || github.repository == 'hashicorp/web-unified-docs'
     name: Repo Sync
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description

This PR adds the permissions for the repo-sync action on the jobs. This is to fix an issue we are seeing where this action is not working properly