### PR TITLE
Nomad: server join deprecations

### DIFF
--- a/content/nomad/v2.0.x/content/commands/server/join.mdx
+++ b/content/nomad/v2.0.x/content/commands/server/join.mdx
@@ -33,7 +33,7 @@ region.
 
 Joining servers in different regions will [federate][] the regions. This assumes
 that ACLs have been bootstrapped in the authoritative region. You should always
-run `server join` against the authoritative region. See [Configure for multiple
+run `server join` against the authoritative region. Refer to [Configure for multiple
 regions][] in the ACLs tutorial.
 
 ## Examples

--- a/content/nomad/v2.0.x/content/commands/server/join.mdx
+++ b/content/nomad/v2.0.x/content/commands/server/join.mdx
@@ -28,9 +28,13 @@ specified, then an attempt will be made to join each one. If one or more nodes
 are joined successfully, the exit code will be 0. Otherwise, the exit code will
 be 1.
 
+When joining servers to a region, run `server join` against the leader of a
+region.
+
 Joining servers in different regions will [federate][] the regions. This assumes
-that ACLs have been bootstrapped in the authoritative region. See [Configure for
-multiple regions][] in the ACLs tutorial.
+that ACLs have been bootstrapped in the authoritative region. You should always
+run `server join` against the authoritative region. See [Configure for multiple
+regions][] in the ACLs tutorial.
 
 ## Examples
 

--- a/content/nomad/v2.0.x/content/docs/deploy/clusters/connect-nodes.mdx
+++ b/content/nomad/v2.0.x/content/docs/deploy/clusters/connect-nodes.mdx
@@ -55,9 +55,10 @@ server {
 ```
 
 Alternatively, you can supply a server's address after the servers have all been
-started by running the [`server join` command] on the servers individually to
-cluster the servers. All servers can join one other server, and then rely on the
-gossip protocol to discover the rest.
+started by running the [`server join` command][] on the servers individually to
+cluster the servers. You should always run the `server join` command against the
+leader. All servers can join one other server, and then rely on the gossip
+protocol to discover the rest.
 
 ```shell-session
 $ nomad server join <known-address>
@@ -246,7 +247,7 @@ instructions.
 
 Follow these steps to use client node introduction tokens:
 
-1. Configure your Nomad server's `server.client_introduction` block. 
+1. Configure your Nomad server's `server.client_introduction` block.
 
    This example sets strict enforcement, which means the server rejects any
    client without a valid token. Refer to the [`server.client_introduction`
@@ -289,13 +290,13 @@ Follow these steps to use client node introduction tokens:
    tokens. The policy must include `node` scope with `write` permission, which
    is the least amount of privilege that you need for a client introduction
    token.
-   
+
    <Tabs>
       <Tab heading="CLI" group="cli">
 
       Create a node policy for the cluster. Save the file as
-      `client-introduction.hcl`.      
-     
+      `client-introduction.hcl`.
+
       ```hcl
       node {
         policy = "write"
@@ -304,7 +305,7 @@ Follow these steps to use client node introduction tokens:
 
       Use the [`nomad acl policy apply`
       command](/nomad/commands/acl/policy/apply) to create a policy called
-      `client-introduction` from the `client-introduction.hcl` file.  
+      `client-introduction` from the `client-introduction.hcl` file.
 
      ```shell-session
      $ nomad acl policy apply client-introduction client-introduction.hcl
@@ -313,8 +314,8 @@ Follow these steps to use client node introduction tokens:
       </Tab>
       <Tab heading="API" group="api">
 
-      Create a node policy for the cluster. Save the file as `client-introduction.json`.      
-        
+      Create a node policy for the cluster. Save the file as `client-introduction.json`.
+
       ```json
       {
         "Name": "client-introduction",
@@ -322,7 +323,7 @@ Follow these steps to use client node introduction tokens:
           "node": {
             "*": {
               "policy": "write"
-            } 
+            }
           }
         }
       }
@@ -331,14 +332,14 @@ Follow these steps to use client node introduction tokens:
       Use the [`/v1/acl/policy/:policy_name` API endpoint](/nomad/api-docs/acl/policies#create-or-update-policy) to create the policy in your cluster.
 
       Replace the `<MANAGEMENT_TOKEN>` and `<NOMAD_IP>` placeholders with your management token's value and your Nomad IP address.
-      
+
       ```shell-script
       $ curl \
           --request POST \
           --data @client-introduction.json \
           --header "X-Nomad-Token: <MANAGEMENT_TOKEN>" \
           https://<NOMAD_IP>:4646/v1/acl/policy/client-introduction
-      ```        
+      ```
 
       </Tab>
    </Tabs>
@@ -357,7 +358,7 @@ Follow these steps to use client node introduction tokens:
    $ nomad acl role create --tls-skip-verify -name="client-introduction" \
       -policy="client-introduction"
    ```
-  
+
    The output describes the ACL role, including its attached policies and the
    Raft index at its creation.
 
@@ -432,7 +433,7 @@ Follow these steps to use client node introduction tokens:
    command](/nomad/commands/node/intro/create) to generate the client
    introduction token.  This example writes the result to a file called
    `intro_token.jwt`.
-   
+
    ```shell-session
    $ nomad node intro create -node-pool=staging  > intro_token.jwt
    ```
@@ -452,7 +453,7 @@ Follow these steps to use client node introduction tokens:
 
    This example scopes the token to a node pool named `staging`. Scoping to a
    node pool is optional.
-   
+
    Create a `client-introduction-token.json` file to define the node pool.
 
    ```json
@@ -464,7 +465,7 @@ Follow these steps to use client node introduction tokens:
    Create the client introduction token. Replace the `<MANAGEMENT_TOKEN>` and
    `<NOMAD_IP>` placeholders with your management token's value and your Nomad
    IP address.
-   
+
    ```shell-session
    $ curl \
       --request POST \
@@ -485,7 +486,7 @@ Follow these steps to use client node introduction tokens:
    </Tabs>
 
 1. Start the Nomad client with the client introduction token.
-   
+
    Provide the client introduction token to the Nomad client using one
    of these options:
 

--- a/content/nomad/v2.0.x/content/docs/deploy/clusters/federate-regions.mdx
+++ b/content/nomad/v2.0.x/content/docs/deploy/clusters/federate-regions.mdx
@@ -98,7 +98,7 @@ ip-172-31-29-34.west  172.31.29.34  4648  alive   true    2         0.10.1  dc1 
 ## Federate the regions
 
 Run the [`nomad server join`][server-join] command from a server in one cluster
-and supply it the IP address of the server in your other cluster while
+and supply it the IP address of the leader in your authoritative region while
 specifying port 4648.
 
 Below is an example of running the `nomad server join` command from the server

--- a/content/nomad/v2.0.x/content/docs/upgrade/upgrade-specific.mdx
+++ b/content/nomad/v2.0.x/content/docs/upgrade/upgrade-specific.mdx
@@ -16,6 +16,27 @@ upgrade. However, specific versions of Nomad may have more details provided for
 their upgrades as a result of new features or changed behavior. This page is
 used to document those details separately from the standard upgrade flow.
 
+## Nomad 2.0.4
+
+#### Unauthenticated server join is deprecated
+
+Using the `server join` command or the [Join
+Agent](/nomad/api-docs/agent#join-agent) API without authentication is
+deprecated. Nomad 2.1.0 will require using a token with the `agent:write`
+permission. Note this requires that the `server join` command is used against
+the leader of a region for joining a new node to a cluster, or against the
+authoritative region to federate a region. For creating new clusters, you should
+use the [`server_join`](/nomad/docs/configuration/server#server_join) agent
+configuration with gossip encryption and mTLS enabled.
+
+#### Deprecated server configurations will be removed
+
+The [deprecated server configuration
+parameters](/nomad/docs/configuration/server#deprecated-parameters)
+`server.retry_join`, `server.retry_interval`, `server.retry_max`, and
+`server.start_join` will be removed in Nomad 2.1.0. Use the
+[`server.server_join`](/nomad/docs/configuration/server#server_join) instead.
+
 ## Nomad 2.0.0
 
 #### Server configuration's raft_boltdb parameter deprecation


### PR DESCRIPTION
As part of an effort to harden Nomad server join, we're deprecating the unauthenticated server join API and requiring authentication as of Nomad 2.1.0. In the process, we'll also be removing long-deprecated server configuration fields related to server join. This changeset also updates documentation for the join process to steer users into the right direction for the future deprecation.

(Note: no backports on this.)

Ref: https://github.com/hashicorp/nomad/pull/28176
Ref: https://hashicorp.atlassian.net/browse/NMD-1506
Ref: https://hashicorp.atlassian.net/browse/NMD-1508
Ref: https://hashicorp.atlassian.net/browse/SECVULN-44064

## Contributor checklists

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [x] 3 days: Small changes, easy reviews
- [ ] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [x] Verify that all status checks passed
- [x] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [x] I added redirects for any moved or removed pages
- [x] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [x] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [ ] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.
