### PR TITLE
fix: update stefanbuck/github-issue-parser to node 24

### DIFF
--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Parse issue form
-        uses: stefanbuck/github-issue-parser@2ea9b35a8c584529ed00891a8f7e41dc46d0441e # v3.2.1
+        uses: stefanbuck/github-issue-parser@0d9ce93802360bd2925bc2cc4be1d807ed1d1233 # v3.2.4
         id: issue-parser
         with:
           template-path: .github/ISSUE_TEMPLATE/${{ matrix.template }}


### PR DESCRIPTION
### Description

This PR updates the stefanbuck/github-issue-parser action to node 24. 
[Monday task](https://ibm.monday.com/boards/18402251594/pulses/11538707592)