### PR TITLE
Deprecated duplicate hcl attributes and updated documentation to proper versions››

### DIFF
--- a/content/vault/v1.21.x/content/partials/deprecation/duplicate-hcl-attributes.mdx
+++ b/content/vault/v1.21.x/content/partials/deprecation/duplicate-hcl-attributes.mdx
@@ -2,16 +2,20 @@
 
 | Announced | Expected end of support | Expected removal |
 | :-------: | :---------------------: | :--------------: |
-| JUN 2025  | OCT 2025                | N/A
+| JUN 2025  | OCT 2025                | v2.1.0
 
-The ability to duplicate attributes in HCL configuration files and policy definitions is deprecated.
+The ability to duplicate attributes in HCL configuration files and policy
+definitions is deprecated. Vault now returns an error, rather than a warning,
+when it encounters duplicate attributes while parsing HCL configuration files or
+policy definitions.
 
-To find affected policies, look for "policy contains duplicate attributes"
-warnings in the server logs. Once we remove support for duplicate attributes,
-you cannot interact with affected policies. For example, Vault will return an
-error if you try to create a token referencing an affected policy or use an
-existing token that references the policy.
+To find affected files and policies, look for "already set" argument errors when
+Vault parses a file, or "policy contains duplicate attributes" errors in the
+server logs. You cannot interact with affected policies. For example, Vault
+returns an error if you try to create a token referencing an affected policy or
+use an existing token that references the policy.
 
-The Vault CLI now checks provided configuration files to determine if the file
-is subject to the duplicate parameter deprecation and returns a warning about
-the issue.
+During the deprecation period, the environment variable
+`VAULT_ALLOW_PENDING_REMOVAL_DUPLICATE_HCL_ATTRIBUTES` can be set to revert to
+the legacy behavior, where Vault allows duplicate attributes and only logs a
+warning.

--- a/content/vault/v1.21.x/content/partials/deprecation/duplicate-hcl-attributes.mdx
+++ b/content/vault/v1.21.x/content/partials/deprecation/duplicate-hcl-attributes.mdx
@@ -15,7 +15,7 @@ server logs. You cannot interact with affected policies. For example, Vault
 returns an error if you try to create a token referencing an affected policy or
 use an existing token that references the policy.
 
-During the deprecation period, the environment variable
-`VAULT_ALLOW_PENDING_REMOVAL_DUPLICATE_HCL_ATTRIBUTES` can be set to revert to
-the legacy behavior, where Vault allows duplicate attributes and only logs a
-warning.
+During the deprecation period, you can revert to legacy behavior by setting the
+environment variable `VAULT_ALLOW_PENDING_REMOVAL_DUPLICATE_HCL_ATTRIBUTES`.
+When you enable legacy behavior, Vault allows duplicate attributes and logs a
+warning about the pending deprecation instead of returning an error.

--- a/content/vault/v1.21.x/content/partials/deprecation/duplicate-hcl-attributes.mdx
+++ b/content/vault/v1.21.x/content/partials/deprecation/duplicate-hcl-attributes.mdx
@@ -2,7 +2,7 @@
 
 | Announced | Expected end of support | Expected removal |
 | :-------: | :---------------------: | :--------------: |
-| JUN 2025  | OCT 2025                | v2.1.0
+| JUN 2025  | OCT 2025                | N/A
 
 The ability to duplicate attributes in HCL configuration files and policy
 definitions is deprecated. Vault now returns an error, rather than a warning,

--- a/content/vault/v2.x/content/docs/updates/deprecation.mdx
+++ b/content/vault/v2.x/content/docs/updates/deprecation.mdx
@@ -46,11 +46,11 @@ or raise a ticket with your support team.
 
 @include 'deprecation/vault-agent-api-proxy.mdx'
 
-@include 'deprecation/duplicate-hcl-attributes.mdx'
-
 @include 'deprecation/list-allowed-parameters.mdx'
 
 ## Removed 
+
+@include 'deprecation/duplicate-hcl-attributes.mdx'
 
 @include 'deprecation/aws-field-change.mdx'
 

--- a/content/vault/v2.x/content/docs/updates/important-changes.mdx
+++ b/content/vault/v2.x/content/docs/updates/important-changes.mdx
@@ -41,18 +41,15 @@ to your preferred behavior.
 | Breaking     | 2.1.0+           | All
 
 Vault no longer supports duplicate attributes in HCL configuration files or
-policy definitions. Parsing a configuration file or policy that defines the same
-argument more than once now always returns an error. The
+policy definitions. As a result, Vault now returns an error when it detects the
+same argument more than once and ignores the
 `VAULT_ALLOW_PENDING_REMOVAL_DUPLICATE_HCL_ATTRIBUTES` environment variable that
-previously reverted to the legacy behavior in 1.21 is removed and no longer has
-any effect.
+previously enabled the legacy behavior.
 
 #### Recommendation
 
 Remove duplicate attributes from your Vault configuration files and policy
-definitions before upgrading. In 1.21, you can set
-`VAULT_ALLOW_PENDING_REMOVAL_DUPLICATE_HCL_ATTRIBUTES` to revert to the legacy
-warning behavior while you identify and fix affected files.
+definitions before upgrading.
 
 
 

--- a/content/vault/v2.x/content/docs/updates/important-changes.mdx
+++ b/content/vault/v2.x/content/docs/updates/important-changes.mdx
@@ -34,7 +34,27 @@ Review any deployments where you rely on environment variables to confirm whethe
 they currently override stored configuration and update the plugin configuration
 to your preferred behavior.
 
-### Previously unauthenticated endpoints require authentication ((#sys-endpoint-auth)) <EnterpriseAlert inline="true" />
+### Duplicate HCL attributes always fail ((#duplicate-hcl-attributes))
+
+| Change       | Affected version | Vault edition
+| ------------ | ---------------- | -------------
+| Breaking     | 2.1.0+           | All
+
+Vault no longer supports duplicate attributes in HCL configuration files or
+policy definitions. Parsing a configuration file or policy that defines the same
+argument more than once now always returns an error. The
+`VAULT_ALLOW_PENDING_REMOVAL_DUPLICATE_HCL_ATTRIBUTES` environment variable that
+previously reverted to the legacy behavior in 1.21 is removed and no longer has
+any effect.
+
+#### Recommendation
+
+Remove duplicate attributes from your Vault configuration files and policy
+definitions before upgrading. In 1.21, you can set
+`VAULT_ALLOW_PENDING_REMOVAL_DUPLICATE_HCL_ATTRIBUTES` to revert to the legacy
+warning behavior while you identify and fix affected files.
+
+
 
 | Change       | Affected version | Vault edition
 | ------------ | ---------------- | -------------

--- a/content/vault/v2.x/content/partials/deprecation/duplicate-hcl-attributes.mdx
+++ b/content/vault/v2.x/content/partials/deprecation/duplicate-hcl-attributes.mdx
@@ -2,7 +2,7 @@
 
 | Announced | Expected end of support | Expected removal |
 | :-------: | :---------------------: | :--------------: |
-| JUN 2025  | OCT 2025                | v2.1.0
+| JUN 2025  | OCT 2025                | OCT 2026
 
 Support for duplicate attributes in HCL configuration files and policy
 definitions is removed. Vault always returns an error when it encounters

--- a/content/vault/v2.x/content/partials/deprecation/duplicate-hcl-attributes.mdx
+++ b/content/vault/v2.x/content/partials/deprecation/duplicate-hcl-attributes.mdx
@@ -2,16 +2,16 @@
 
 | Announced | Expected end of support | Expected removal |
 | :-------: | :---------------------: | :--------------: |
-| JUN 2025  | OCT 2025                | N/A
+| JUN 2025  | OCT 2025                | v2.1.0
 
-The ability to duplicate attributes in HCL configuration files and policy definitions is deprecated.
+Support for duplicate attributes in HCL configuration files and policy
+definitions is removed. Vault always returns an error when it encounters
+duplicate attributes while parsing HCL configuration files or policy
+definitions, and the `VAULT_ALLOW_PENDING_REMOVAL_DUPLICATE_HCL_ATTRIBUTES`
+environment variable that previously reverted to the legacy behavior no longer
+has any effect.
 
-To find affected policies, look for "policy contains duplicate attributes"
-warnings in the server logs. Once we remove support for duplicate attributes,
-you cannot interact with affected policies. For example, Vault will return an
-error if you try to create a token referencing an affected policy or use an
-existing token that references the policy.
-
-The Vault CLI now checks provided configuration files to determine if the file
-is subject to the duplicate parameter deprecation and returns a warning about
-the issue.
+To find affected files and policies, look for "already set" argument errors when
+Vault parses a file, or "policy contains duplicate attributes" errors in the
+server logs. Remove the duplicate attributes from your configuration files and
+policy definitions to resolve the error.


### PR DESCRIPTION
Docs companion to Vault PR [#15924](https://github.com/hashicorp/vault-enterprise/pull/15924) ([VAULT-35839](https://hashicorp.atlassian.net/browse/VAULT-35839)), which removes support for duplicate HCL attributes in config files and policies.

[VAULT-35839]: https://hashicorp.atlassian.net/browse/VAULT-35839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ