### PR TITLE
VAULT-45468: add page for RAR

### DIFF
--- a/content/vault/v2.x/content/api-docs/secret/agent-registry.mdx
+++ b/content/vault/v2.x/content/api-docs/secret/agent-registry.mdx
@@ -66,7 +66,7 @@ Create or update an Agent Registry record. When you provide an `id`, Vault updat
 
 - `optional_authorization_details` `(bool: false)` – When set to `true`, allows
   the agent to authenticate without providing `authorization_details` in the JWT.
-  By default, Vault requires RAR (rich authorization requests) for the agent registry and rejects non-RAR requests.
+  By default, Vault requires RAR (rich authorization requests) for the agent registry and rejects non-RAR requests. For more information about RAR constraints, refer to [Rich Authorization Requests](/vault/docs/concepts/native-ai-agent-support/rich-authorization-requests).
 
 ### Sample payload
 

--- a/content/vault/v2.x/content/api-docs/secret/agent-registry.mdx
+++ b/content/vault/v2.x/content/api-docs/secret/agent-registry.mdx
@@ -62,7 +62,7 @@ Create or update an Agent Registry record. When you provide an `id`, Vault updat
 
 - `no_default_ceiling_policy` `(bool: false)` – When set to `true`, opts out
   of automatically adding the `default` and `default-ceiling` policies to the
-  Agent Registry record.
+  Agent Registry record. For more information about default ceiling policies, refer to [Default ceiling policies](/vault/docs/concepts/native-ai-agent-support/overview#default-ceiling-policies).
 
 - `optional_authorization_details` `(bool: false)` – When set to `true`, allows
   the agent to authenticate without providing `authorization_details` in the JWT.
@@ -166,10 +166,11 @@ Update the Agent Registry record whose `id` matches the value you provide.
   as ceiling policies to this Agent Registry record. Cannot contain `root`.
 
 - `no_default_ceiling_policy` `(bool: false)` – When set to `true`, opts out
-  of automatically adding default ceiling policies.
+  of automatically adding default ceiling policies. For more information about default ceiling policies, refer to [Default ceiling policies](/vault/docs/concepts/native-ai-agent-support/overview#default-ceiling-policies).
 
 - `optional_authorization_details` `(bool: false)` – When set to `true`, allows
   the agent to authenticate without `authorization_details` in the JWT.
+  By default, Vault requires RAR (rich authorization requests) for the agent registry and rejects non-RAR requests. For more information about RAR constraints, refer to [Rich Authorization Requests](/vault/docs/concepts/native-ai-agent-support/rich-authorization-requests).
 
 ### Sample payload
 
@@ -327,10 +328,11 @@ Update the Agent Registry record whose `display_name` matches the value you prov
   this Agent Registry record. Cannot contain `root`.
 
 - `no_default_ceiling_policy` `(bool: false)` – When set to `true`, opts out
-  of automatically adding default ceiling policies.
+  of automatically adding default ceiling policies. For more information about default ceiling policies, refer to [Default ceiling policies](/vault/docs/concepts/native-ai-agent-support/overview#default-ceiling-policies).
 
 - `optional_authorization_details` `(bool: false)` – When set to `true`, allows
   the agent to authenticate without `authorization_details` in the JWT.
+  By default, Vault requires RAR (rich authorization requests) for the agent registry and rejects non-RAR requests. For more information about RAR constraints, refer to [Rich Authorization Requests](/vault/docs/concepts/native-ai-agent-support/rich-authorization-requests).
 
 ### Sample payload
 

--- a/content/vault/v2.x/content/api-docs/system/config-oauth-resource-server.mdx
+++ b/content/vault/v2.x/content/api-docs/system/config-oauth-resource-server.mdx
@@ -32,7 +32,7 @@ By default, each OAuth Resource Server configuration profile requires OAuth 2.0 
 Authorization Requests (RAR) in the JWTs it validates. Clients provide RAR in
 the `authorization_details` claim of the JWT. To allow JWTs that omit
 `authorization_details`, set `optional_authorization_details=true` on the
-profile.
+profile. For more information about RAR constraints, refer to [Rich Authorization Requests](/vault/docs/concepts/native-ai-agent-support/rich-authorization-requests).
 
 ## Activate the OAuth Resource Server feature
 
@@ -211,7 +211,7 @@ Create a new OAuth Resource Server configuration profile.
 
 - `no_default_policy` `(bool: false)` – When set to `true`, tokens
   authenticated through the profile omit the `default` policy unless it is
-  applied through another mechanism.
+  applied through another mechanism. For more information about the default policy, refer to [Default policy](/vault/docs/concepts/policies#default-policy).
 
 - `optional_authorization_details` `(bool: false)` – When set to `true`, allows
   authentication without `authorization_details` in the JWT for all agents using

--- a/content/vault/v2.x/content/api-docs/system/config-oauth-resource-server.mdx
+++ b/content/vault/v2.x/content/api-docs/system/config-oauth-resource-server.mdx
@@ -215,7 +215,7 @@ Create a new OAuth Resource Server configuration profile.
 
 - `optional_authorization_details` `(bool: false)` – When set to `true`, allows
   authentication without `authorization_details` in the JWT for all agents using
-  the configured profile. By default, Vault requires RAR (rich authorization requests) for the agent registry and rejects non-RAR requests.
+  the configured profile. By default, Vault requires RAR (rich authorization requests) for the agent registry and rejects non-RAR requests. For more information about RAR constraints, refer to [Rich Authorization Requests](/vault/docs/concepts/native-ai-agent-support/rich-authorization-requests).
 
 - `user_claim` `(string: "sub")` – The JWT claim to use as the user
   identifier.

--- a/content/vault/v2.x/content/docs/concepts/native-ai-agent-support/overview.mdx
+++ b/content/vault/v2.x/content/docs/concepts/native-ai-agent-support/overview.mdx
@@ -46,10 +46,10 @@ Native AI agent support combines identity, credential validation, and governance
 
 1. Vault validates an OAuth JWT using an OAuth resource server configuration
    profile.
-2. Vault resolves the authenticated client to a Vault Identity
+1. Vault resolves the authenticated client to a Vault Identity
    [entity](/vault/docs/concepts/identity).
-3. Vault checks whether the relevant entity has an Agent Registry record.
-4. Vault evaluates the entity's baseline policies and, for delegated
+1. Vault checks whether the relevant entity has an Agent Registry record.
+1. Vault evaluates the entity's baseline policies and, for delegated
    on-behalf-of workflows, the agent's authorization ceiling.
 
 Vault Identity answers the question "who is this client?" The Agent Registry
@@ -127,7 +127,7 @@ An agent's authorization ceiling cannot expand what an agent is allowed to do.
 In a delegated workflow, Vault evaluates two policy sets independently:
 
 1. The subject's baseline policies must allow the request.
-2. The agent's ceiling policies must also allow the request.
+1. The agent's ceiling policies must also allow the request.
 
 If either policy set denies the operation, Vault denies the request. The ceiling
 can only further restrict operations that the subject's baseline would otherwise
@@ -183,7 +183,7 @@ While not recommended, making RAR optional can be useful when your identity prov
 You can configure RAR constraint settings in two ways:
 
 1. Set `optional_authorization_details` to `true` in the OAuth resource server configuration.
-2. Set `optional_authorization_details` to `true` in the agent registration.
+1. Set `optional_authorization_details` to `true` in the agent registration.
 
 Setting `optional_authorization_details` to `true` at the OAuth resource server configuration level applies to all AI agents authorized by the OAuth resource server. Setting it at the agent configuration level only affects the specific agent, provided that  the corresponding OAuth server configurations setting is set to `false`.
 
@@ -255,8 +255,8 @@ A JWT can include multiple authorization detail objects in the `authorization_de
 RAR constraints narrow the access granted by ACL policies. For a request to succeed all of the following must be true:
 
 1. The request path and operation must match at least one `path` and `capabilities` constraint in the RAR.
-2. The ACL policy associated with the entity must permit the operation.
-3. When a matching RAR constraint includes `allowed_parameters`, the request parameters must satisfy those constraints.
+1. The ACL policy associated with the entity must permit the operation.
+1. When a matching RAR constraint includes `allowed_parameters`, the request parameters must satisfy those constraints.
 
 RAR constraints only restrict access and cannot expand permissions beyond what ACL policies allow.
 

--- a/content/vault/v2.x/content/docs/concepts/native-ai-agent-support/overview.mdx
+++ b/content/vault/v2.x/content/docs/concepts/native-ai-agent-support/overview.mdx
@@ -180,10 +180,18 @@ We recommend using RAR for all agentic workflows to enable fine-grained authoriz
 
 While not recommended, making RAR optional can be useful when your identity provider does not support RAR or during a migration period.
 
-You can make RAR optional in one of two ways:
+You can configure RAR constraint settings in two ways:
 
-1. Set `optional_authorization_details` to `true` on the OAuth resource server.
-2. Set `optional_authorization_details` to `true` for the agent registration.
+1. Set `optional_authorization_details` to `true` in the OAuth resource server configuration.
+2. Set `optional_authorization_details` to `true` in the agent registration.
+
+Setting `optional_authorization_details` to `true` at the OAuth resource server configuration level applies to all AI agents authorized by the OAuth resource server. Setting it at the agent configuration level only affects the specific agent, provided that  the corresponding OAuth server configurations setting is set to `false`.
+
+<Note>
+
+The settings can be modified at any time and will take effect during the requests.
+
+</Note>
 
 When you make RAR optional, Vault permits authentication without the `authorization_details` claim.
 
@@ -223,7 +231,7 @@ The following constraint:
 
 #### Rich authorization request example with multiple constraints
 
-A JWT can include multiple authorization detail objects in the `authorization_details` array. Vault evaluates each constraint independently. Requests that include multiple constraints succeed if it matches at least one constraint that permits the operation.
+A JWT can include multiple authorization detail objects in the `authorization_details` array. Vault evaluates each constraint independently. The JWT request succeeds if the authorization detail object matches at least one constraint that permits the operation and no matching constraint denies it.
 
 ```json
 {

--- a/content/vault/v2.x/content/docs/concepts/native-ai-agent-support/overview.mdx
+++ b/content/vault/v2.x/content/docs/concepts/native-ai-agent-support/overview.mdx
@@ -166,6 +166,8 @@ Rich Authorization Requests (RAR) allow OAuth tokens to include fine-grained aut
 `authorization_details` claim. Vault uses the provided constraints to enforce
 path-level and parameter-level access control beyond what standard ACL policies provide.
 
+For more information about RAR constraints, refer to [Rich Authorization Requests](/vault/docs/concepts/native-ai-agent-support/rich-authorization-requests).
+
 ### Default behavior
 
 Vault enables RAR by default, and OAuth 2.0 tokens with `authorization_details` always honor the RAR authentication details.
@@ -181,7 +183,7 @@ While not recommended, making RAR optional can be useful when your identity prov
 You can make RAR optional in one of two ways:
 
 1. Set `optional_authorization_details` to `true` on the OAuth resource server.
-1. Set `optional_authorization_details` to `true` for the agent registration.
+2. Set `optional_authorization_details` to `true` for the agent registration.
 
 When you make RAR optional, Vault permits authentication without the `authorization_details` claim.
 
@@ -219,7 +221,6 @@ The following constraint:
 }
 ```
 
-
 #### Rich authorization request example with multiple constraints
 
 A JWT can include multiple authorization detail objects in the `authorization_details` array. Vault evaluates each constraint independently. Requests that include multiple constraints succeed if it matches at least one constraint that permits the operation.
@@ -246,8 +247,8 @@ A JWT can include multiple authorization detail objects in the `authorization_de
 RAR constraints narrow the access granted by ACL policies. For a request to succeed all of the following must be true:
 
 1. The request path and operation must match at least one `path` and `capabilities` constraint in the RAR.
-1. The ACL policy associated with the entity must permit the operation.
-1. When a matching RAR constraint includes `allowed_parameters`, the request parameters must satisfy those constraints.
+2. The ACL policy associated with the entity must permit the operation.
+3. When a matching RAR constraint includes `allowed_parameters`, the request parameters must satisfy those constraints.
 
 RAR constraints only restrict access and cannot expand permissions beyond what ACL policies allow.
 

--- a/content/vault/v2.x/content/docs/concepts/native-ai-agent-support/rich-authorization-requests.mdx
+++ b/content/vault/v2.x/content/docs/concepts/native-ai-agent-support/rich-authorization-requests.mdx
@@ -29,8 +29,8 @@ When a client presents an OAuth JWT containing RAR constraints in the
 and the RAR constraints. For a request to succeed:
 
 1. The request path and operation must match at least one RAR constraint
-2. The entity's ACL policies must permit the operation
-3. Any parameter-level constraints in the RAR must be satisfied
+1. The entity's ACL policies must permit the operation
+1. Any parameter-level constraints in the RAR must be satisfied
 
 RAR constraints can only restrict access, never granting permissions beyond
 what ACL policies allow.
@@ -152,7 +152,7 @@ with the Agent Registry. Operators can make RAR optional in two ways:
 
 1. **Per OAuth resource server profile**: Set `optional_authorization_details` to `true` on the
    [OAuth resource server configuration](/vault/api-docs/system/config-oauth-resource-server)
-2. **Per agent registration**: Set `optional_authorization_details` to `true` on the
+1. **Per agent registration**: Set `optional_authorization_details` to `true` on the
    [Agent Registry record](/vault/api-docs/secret/agent-registry)
 
 When RAR is optional, Vault permits authentication without the

--- a/content/vault/v2.x/content/docs/concepts/native-ai-agent-support/rich-authorization-requests.mdx
+++ b/content/vault/v2.x/content/docs/concepts/native-ai-agent-support/rich-authorization-requests.mdx
@@ -1,0 +1,171 @@
+---
+layout: docs
+page_title: Rich Authorization Requests (RAR)
+description: >-
+  Learn about Rich Authorization Requests (RAR) in Vault, including path access constraints, capabilities, and parameter-level controls using allowed_parameters, denied_parameters, and required_parameters.
+---
+
+# Rich authorization requests (RAR)
+
+@include 'alerts/private-preview.mdx'
+
+@include 'alerts/enterprise-only.mdx'
+
+Rich Authorization Requests (RAR) provide fine-grained authorization constraints
+for OAuth 2.0 tokens used with Vault's [AI agent support](/vault/docs/concepts/native-ai-agent-support/overview).
+RAR embeds detailed access control rules directly in JWT tokens,
+enabling path-level and parameter-level restrictions beyond what standard ACL
+policies provide.
+
+[RFC 9396](https://datatracker.ietf.org/doc/html/rfc9396) defines RAR and
+extends OAuth 2.0 to support complex authorization scenarios. In Vault, RAR
+constraints work alongside ACL policies to narrow permissions without ever expanding
+them.
+
+## How RAR works with Vault
+
+When a client presents an OAuth JWT containing RAR constraints in the
+`authorization_details` claim, Vault evaluates both the entity's ACL policies
+and the RAR constraints. For a request to succeed:
+
+1. The request path and operation must match at least one RAR constraint
+2. The entity's ACL policies must permit the operation
+3. Any parameter-level constraints in the RAR must be satisfied
+
+RAR constraints can only restrict access, never granting permissions beyond
+what ACL policies allow.
+
+## RAR type: `vault:path_access`
+
+Vault supports the `vault:path_access` RAR type for fine-grained path and
+parameter authorization. Each authorization detail object in the
+`authorization_details` claim must conform to the following structure.
+
+### Required fields
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `type` | string | Must be `vault:path_access` to indicate a Vault path access constraint. |
+| `path` | string | The Vault path the constraint applies to. Supports exact path matching only. |
+| `capabilities` | array of strings | List of capabilities permitted for the path. |
+
+The `capabilities` field uses the same capability values as [Vault ACL policies](/vault/docs/concepts/policies#capabilities), including `create`, `read`, `update`, `delete`, `list`, `sudo`, and `deny`. RAR capabilities work in conjunction with policy-level capabilities to determine final access permissions.
+
+### Optional fields
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `allowed_parameters` | object | Map of parameter names to arrays of allowed values. Restricts which request parameters and values Vault permits. When specified, Vault allows only the listed parameters. |
+| `denied_parameters` | object | Map of parameter names to arrays of denied values. Blocks specific parameter values. Takes precedence over `allowed_parameters`. |
+| `required_parameters` | array of strings | List of parameter names that must be present in the request. Vault rejects requests missing any required parameter. |
+
+These parameter control fields work similarly to the parameter controls available in [Vault ACL policies](/vault/docs/concepts/policies#fine-grained-control). RAR parameter controls provide an additional layer of restriction on top of policy-level controls, enabling fine-grained authorization directly within OAuth tokens.
+
+## Interaction with ACL policies
+
+RAR constraints work alongside Vault ACL policies, not as a replacement. Both
+ACL policies and RAR constraints must permit an operation for the operation to succeed.
+
+### Policy-level parameter controls
+
+Vault ACL policies also support `allowed_parameters`, `denied_parameters`, and
+`required_parameters`. When both policy-level and RAR-level controls are present:
+
+- **RAR constraints narrow policy permissions**: RAR can only further restrict what policies allow
+- **Denied parameters take precedence**: When either policy or RAR denies a parameter, Vault denies the parameter
+- **Allowed parameters are intersected**: A parameter must be allowed by both policy and RAR
+- **Required parameters are combined**: All required parameters from both sources must be present
+
+**Example:**
+
+Policy:
+```hcl
+path "secret/data/*" {
+  capabilities = ["create", "update"]
+  allowed_parameters = {
+    "data" = []
+    "metadata" = []
+  }
+}
+```
+
+RAR constraint:
+```json
+{
+  "type": "vault:path_access",
+  "path": "secret/data/app-config",
+  "capabilities": ["create", "update"],
+  "allowed_parameters": {
+    "data": []
+  }
+}
+```
+
+**Result**: Vault allows only the `data` parameter (intersection of policy and RAR).
+The RAR constraint blocks the `metadata` parameter even though the policy
+allows the parameter.
+
+## Multiple RAR constraints
+
+A JWT can include multiple authorization detail objects in the
+`authorization_details` array. Vault evaluates each constraint independently and
+allows the request when the request matches at least one constraint that permits the
+operation.
+
+**Example with multiple constraints:**
+
+```json
+{
+  "authorization_details": [
+    {
+      "type": "vault:path_access",
+      "path": "database/creds/readonly-role",
+      "capabilities": ["read"]
+    },
+    {
+      "type": "vault:path_access",
+      "path": "pki/issue/my-role",
+      "capabilities": ["create", "update"],
+      "required_parameters": ["common_name"]
+    },
+    {
+      "type": "vault:path_access",
+      "path": "secret/data/app-*",
+      "capabilities": ["read", "list"],
+      "denied_parameters": {
+        "version": ["1"]
+      }
+    }
+  ]
+}
+```
+
+The JWT above allows:
+- Reading from `database/creds/readonly-role`
+- Creating or updating at `pki/issue/my-role` (with `common_name` required)
+- Reading or listing from `secret/data/app-*` paths (except version 1)
+
+## Making RAR optional
+
+By default, Vault requires the `authorization_details` claim in OAuth JWTs used
+with the Agent Registry. Operators can make RAR optional in two ways:
+
+1. **Per OAuth resource server profile**: Set `optional_authorization_details` to `true` on the
+   [OAuth resource server configuration](/vault/api-docs/system/config-oauth-resource-server)
+2. **Per agent registration**: Set `optional_authorization_details` to `true` on the
+   [Agent Registry record](/vault/api-docs/secret/agent-registry)
+
+When RAR is optional, Vault permits authentication without the
+`authorization_details` claim and uses only the entity's ACL policies for
+authorization.
+
+For more information about RAR enforcement modes and configuration options, see
+[RAR enforcement](/vault/docs/concepts/native-ai-agent-support/overview#rar-enforcement)
+in the AI agent support overview.
+
+## Related resources
+
+- [AI agent support](/vault/docs/concepts/native-ai-agent-support/overview)
+- [Agent Registry API](/vault/api-docs/secret/agent-registry)
+- [OAuth Resource Server API](/vault/api-docs/system/config-oauth-resource-server)
+- [RFC 9396: OAuth 2.0 Rich Authorization Requests](https://datatracker.ietf.org/doc/html/rfc9396)

--- a/content/vault/v2.x/content/docs/concepts/native-ai-agent-support/rich-authorization-requests.mdx
+++ b/content/vault/v2.x/content/docs/concepts/native-ai-agent-support/rich-authorization-requests.mdx
@@ -2,14 +2,14 @@
 layout: docs
 page_title: Rich Authorization Requests (RAR)
 description: >-
-  Learn about Rich Authorization Requests (RAR) in Vault, including path access constraints, capabilities, and parameter-level controls using allowed_parameters, denied_parameters, and required_parameters.
+  Learn about Rich Authorization Requests (RAR) in Vault, including path access constraints, capabilities, and parameter-level controls using allowed, denied, and required parameters.
 ---
 
 # Rich authorization requests (RAR)
 
-@include 'alerts/private-preview.mdx'
-
 @include 'alerts/enterprise-only.mdx'
+
+@include 'alerts/beta.mdx'
 
 Rich Authorization Requests (RAR) provide fine-grained authorization constraints
 for OAuth 2.0 tokens used with Vault's [AI agent support](/vault/docs/concepts/native-ai-agent-support/overview).

--- a/content/vault/v2.x/data/docs-nav-data.json
+++ b/content/vault/v2.x/data/docs-nav-data.json
@@ -111,12 +111,21 @@
       },
       {
         "title": "AI Agent Support",
-        "path": "concepts/native-ai-agent-support",
         "badge": {
           "text": "ENT",
           "type": "filled",
           "color": "neutral"
-        }
+        },
+        "routes": [
+          {
+            "title": "Overview",
+            "path": "concepts/native-ai-agent-support/overview"
+          },
+          {
+            "title": "Rich Authorization Requests",
+            "path": "concepts/native-ai-agent-support/rich-authorization-requests"
+          }
+        ]
       },
       {
         "title": "Response Wrapping",

--- a/content/vault/v2.x/redirects.jsonc
+++ b/content/vault/v2.x/redirects.jsonc
@@ -533,16 +533,6 @@
     "destination": "/vault/docs/concepts/billing/start-date",
     "permanent": true
   },
-  {
-    "source": "/vault/docs/concepts/agent-registry",
-    "destination": "/vault/docs/concepts/native-ai-agent-support",
-    "permanent": true
-  },
-  {
-    "source": "/vault/docs/concepts/oauth-resource-server-configuration",
-    "destination": "/vault/docs/concepts/native-ai-agent-support",
-    "permanent": true
-  },
 
   /**
     Backfacing redirects:
@@ -571,6 +561,26 @@
   {
     "source": "/vault/docs/enterprise/lts",
     "destination": "/vault/docs/enterprise/support",
+    "permanent": true
+  },
+
+  /*****************************************************************************
+    2026 | AI Agent Support
+   *****************************************************************************/
+
+  {
+    "source": "/vault/docs/concepts/agent-registry",
+    "destination": "/vault/docs/concepts/native-ai-agent-support/overview",
+    "permanent": true
+  },
+  {
+    "source": "/vault/docs/concepts/oauth-resource-server-configuration",
+    "destination": "/vault/docs/concepts/native-ai-agent-support/overview",
+    "permanent": true
+  },
+  {
+    "source": "/vault/docs/concepts/native-ai-agent-support",
+    "destination": "/vault/docs/concepts/native-ai-agent-support/overview",
     "permanent": true
   },
   


### PR DESCRIPTION
- Move `native-ai-agent-support` page to `native-ai-agent-support/overview.mdx `to create a sibling page for RAR.
- Add content to RAR page.
- Add links to RAR page in `overview`, `OAuth resource server` and `agent-registrations` pages.
- Add redirects for `native-ai-agent-support/overview`

Background: We wanted to add more details about RAR to the users, including `allowed_parameters`, `denied_parameters` and `required_parameters`, but didn't want to overload any existing pages.

Ticket: https://hashicorp.atlassian.net/browse/VAULT-45468
