### PR TITLE
Address some issues with responses in PKI External CA api-docs

### DIFF
--- a/content/vault/v2.x/content/api-docs/secret/pki-external-ca.mdx
+++ b/content/vault/v2.x/content/api-docs/secret/pki-external-ca.mdx
@@ -201,13 +201,22 @@ $ curl                                        \
 ```json
 {
   "data": {
-    "name": "letsencrypt-prod",
-    "directory_url": "https://acme-v02.api.letsencrypt.org/directory",
-    "email_contacts": ["admin@example.com", "security@example.com"],
-    "acme_account_key_id": "https://acme-v02.api.letsencrypt.org/acme/acct/123456789",
+    "account_keys": {
+      "0": {
+        "key_creation_date": "2026-06-29T12:28:24Z",
+        "key_type": "ec-256",
+        "key_version": 0
+      }
+    },
     "active_key_version": 0,
-    "creation_date": "2026-02-24T20:00:00Z",
-    "last_updated_date": "2026-02-24T20:00:00Z"
+    "creation_date": "2026-06-29T12:28:24Z",
+    "directory_url": "https://acme-v02.api.letsencrypt.org/directory",
+    "email_contacts": [
+      "test@example.com"
+    ],
+    "last_updated_date": "2026-06-29T12:28:24Z",
+    "name": "letsencrypt-prod",
+    "trusted_ca": ""
   }
 }
 ```
@@ -250,13 +259,22 @@ $ curl                                        \
 ```json
 {
   "data": {
-    "name": "letsencrypt-prod",
-    "directory_url": "https://acme-v02.api.letsencrypt.org/directory",
-    "email_contacts": ["admin@example.com", "security@example.com"],
-    "acme_account_key_id": "https://acme-v02.api.letsencrypt.org/acme/acct/123456789",
+    "account_keys": {
+      "0": {
+        "key_creation_date": "2026-06-29T12:28:24Z",
+        "key_type": "ec-256",
+        "key_version": 0
+      }
+    },
     "active_key_version": 0,
-    "creation_date": "2026-02-24T20:00:00Z",
-    "last_updated_date": "2026-02-24T20:30:00Z"
+    "creation_date": "2026-06-29T12:28:24Z",
+    "directory_url": "https://acme-v02.api.letsencrypt.org/directory",
+    "email_contacts": [
+      "test@example.com"
+    ],
+    "last_updated_date": "2026-06-29T12:48:24Z",
+    "name": "letsencrypt-prod",
+    "trusted_ca": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----"
   }
 }
 ```
@@ -597,13 +615,7 @@ $ curl                                        \
 ```json
 {
   "data": {
-    "order_id": "01936d8e-7c3a-7890-b123-456789abcdef",
-    "order_status": "new",
-    "identifiers": ["example.com", "www.example.com"],
-    "workflow_type": "identifiers",
-    "creation_date": "2026-02-24T20:00:00Z",
-    "next_work_date": "2026-02-24T20:00:01Z",
-    "expires": "2026-02-24T20:30:00Z"
+    "order_id": "01936d8e-7c3a-7890-b123-456789abcdef"
   }
 }
 ```
@@ -634,34 +646,38 @@ $ curl                                        \
 
 ```json
 {
-  "data": {
-    "order_id": "01936d8e-7c3a-7890-b123-456789abcdef",
-    "order_status": "awaiting_challenge_fulfillment",
-    "identifiers": ["example.com", "www.example.com"],
-    "workflow_type": "identifiers",
-    "authorizations": [
-      {
-        "identifier": "example.com",
-        "challenges": [
-          {
-            "type": "http-01",
-            "url": "https://acme-v02.api.letsencrypt.org/acme/chall/...",
-            "token": "LoqXcYV8q5ONbJQxbmR7SCTNo3tiAXDfowyjxAjEuX0",
-            "ready": false
-          },
-          {
-            "type": "dns-01",
-            "url": "https://acme-v02.api.letsencrypt.org/acme/chall/...",
-            "token": "LoqXcYV8q5ONbJQxbmR7SCTNo3tiAXDfowyjxAjEuX0",
-            "ready": false
-          }
-        ]
-      }
+ "data": {
+    "challenges": {
+      "test.example.com": [
+        {
+          "challenge_status": "pending",
+          "challenge_type": "tls-alpn-01",
+          "expires": "2026-07-06T12:45:23Z"
+        },
+        {
+          "challenge_status": "pending",
+          "challenge_type": "dns-01",
+          "expires": "2026-07-06T12:45:23Z"
+        },
+        {
+          "challenge_status": "pending",
+          "challenge_type": "http-01",
+          "expires": "2026-07-06T12:45:23Z"
+        }
+      ]
+    },
+    "creation_date": "2026-06-29T08:45:22-04:00",
+    "csr": "",
+    "expires": "2026-07-06T12:45:23Z",
+    "identifiers": [
+      "test.example.com"
     ],
-    "creation_date": "2026-02-24T20:00:00Z",
-    "last_update": "2026-02-24T20:00:05Z",
-    "next_work_date": "2026-02-24T21:00:05Z",
-    "expires": "2026-02-24T20:30:00Z"
+    "last_error": "",
+    "last_update": "2026-06-29T08:45:24-04:00",
+    "next_work_date": "2026-06-29T09:45:24-04:00",
+    "order_status": "awaiting-challenge-fulfillment",
+    "role_name": "web-server",
+    "serial_number": ""
   }
 }
 ```
@@ -690,21 +706,13 @@ requirements.
   - `dns-01` - DNS-01 challenge
   - `tls-alpn-01` - TLS-ALPN-01 challenge
 
-#### Sample payload
-
-```json
-{
-  "identifier": "example.com",
-  "challenge_type": "http-01"
-}
-```
-
 #### Sample request
 
 ```shell-session
 $ curl                                        \
     --header "X-Vault-Token: ${VAULT_TOKEN}"  \
-    --data @payload.json                      \
+    --url-query "identifier=example.com" \
+    --url-query "challenge_type=http-01" \
     ${VAULT_ADDR}/v1/pki-external-ca/role/web-server/order/01936d8e-7c3a-7890-b123-456789abcdef/challenge
 ```
 
@@ -713,27 +721,10 @@ $ curl                                        \
 ```json
 {
   "data": {
-    "order_id": "01936d8e-7c3a-7890-b123-456789abcdef",
-    "authorizations": [
-      {
-        "identifier": "example.com",
-        "challenges": [
-          {
-            "type": "http-01",
-            "token": "LoqXcYV8q5ONbJQxbmR7SCTNo3tiAXDfowyjxAjEuX0",
-            "key_authorization": "LoqXcYV8q5ONbJQxbmR7SCTNo3tiAXDfowyjxAjEuX0.9jg46WB3rR_AHD-EBXdN7cBkH1WOu0tA3M9fm21mqTI",
-            "validation_url": "http://example.com/.well-known/acme-challenge/LoqXcYV8q5ONbJQxbmR7SCTNo3tiAXDfowyjxAjEuX0"
-          },
-          {
-            "type": "dns-01",
-            "token": "LoqXcYV8q5ONbJQxbmR7SCTNo3tiAXDfowyjxAjEuX0",
-            "key_authorization": "LoqXcYV8q5ONbJQxbmR7SCTNo3tiAXDfowyjxAjEuX0.9jg46WB3rR_AHD-EBXdN7cBkH1WOu0tA3M9fm21mqTI",
-            "dns_record_name": "_acme-challenge.example.com",
-            "dns_record_value": "gfj9Xq...Rg85nM"
-          }
-        ]
-      }
-    ]
+    "challenge_auth": "b483Q4ouEAg-xDJ-VmpSXIDMck9_SMtYXlHz3ilLgR0.zSp7WXxIJEAVN6IMDTWgUJVfnuCmvxlUTGbKiADGQJE",
+    "challenge_status": "pending",
+    "challenge_token": "b483Q4ouEAg-xDJ-VmpSXIDMck9_SMtYXlHz3ilLgR0",
+    "expires": "2026-07-06T12:45:23Z"
   }
 }
 ```
@@ -782,16 +773,7 @@ $ curl                                        \
 
 #### Sample response
 
-```json
-{
-  "data": {
-    "order_id": "01936d8e-7c3a-7890-b123-456789abcdef",
-    "identifier": "example.com",
-    "challenge_type": "http-01",
-    "marked_ready": true
-  }
-}
-```
+Empty response on success.
 
 ### Fetch certificate
 
@@ -825,11 +807,14 @@ $ curl                                        \
 ```json
 {
   "data": {
-    "certificate": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----",
-    "issuing_ca": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----",
+    "authority_key_id": "b3:cc:83:6c:...:64:a5:e6:f5",
     "ca_chain": ["-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----"],
+    "certificate": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----",
+    "certificate_format": "pem",
+    "not_after": "2026-09-27T12:43:03Z",
+    "not_before": "2026-06-29T12:43:04Z",
     "private_key": "-----BEGIN EC PRIVATE KEY-----\n...\n-----END EC PRIVATE KEY-----",
-    "private_key_type": "ec",
+    "private_key_type": "EC",
     "serial_number": "03:e7:1f:...:a2:3d"
   }
 }
@@ -881,15 +866,7 @@ $ curl                                        \
 
 #### Sample response
 
-```json
-{
-  "data": {
-    "order_id": "01936d8e-7c3a-7890-b123-456789abcdef",
-    "revoked": true,
-    "revocation_time": "2026-02-24T21:00:00Z"
-  }
-}
-```
+Empty response on success.
 
 ### List active orders
 
@@ -927,7 +904,7 @@ $ curl                                        \
 
 ### Get cached certificate
 
-Retrieve the most recently issued (cached) certificate certificate for a role
+Retrieve the most recently issued (cached) certificate for a role
 without going through the order workflow.
 
 | Method | Path                                     |
@@ -953,21 +930,13 @@ without going through the order workflow.
   - `der` - DER format
   - `pem_bundle` - PEM format with full certificate chain
 
-#### Sample payload
-
-```json
-{
-  "identifiers": ["example.com", "www.example.com"],
-  "min_validity_percentage": 75
-}
-```
-
 #### Sample request
 
 ```shell-session
 $ curl                                        \
     --header "X-Vault-Token: ${VAULT_TOKEN}"  \
-    --data @payload.json                      \
+    --url-query "identifiers=example.com" \
+    --url-query "min_validity_percentage=75" \
     ${VAULT_ADDR}/v1/pki-external-ca/role/web-server/cached
 ```
 
@@ -976,11 +945,15 @@ $ curl                                        \
 ```json
 {
   "data": {
-    "certificate": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----",
-    "issuing_ca": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----",
+    "authority_key_id": "b3:cc:83:6c:...:64:a5:e6:f5",
     "ca_chain": ["-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----"],
-    "serial_number": "03:e7:1f:...:a2:3d",
-    "order_id": "01936d8e-7c3a-7890-b123-456789abcdef"
+    "certificate": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----",
+    "certificate_format": "pem",
+    "not_after": "2026-09-27T12:43:03Z",
+    "not_before": "2026-06-29T12:43:04Z",
+    "private_key": "-----BEGIN EC PRIVATE KEY-----\n...\n-----END EC PRIVATE KEY-----",
+    "private_key_type": "EC",
+    "serial_number": "03:e7:1f:...:a2:3d"
   }
 }
 ```
@@ -1050,14 +1023,30 @@ $ curl                                        \
 ```json
 {
   "data": {
-    "order_id": "01936d8e-7c3a-7890-b123-456789abcdef",
+    "challenges": {
+      "example.com": [
+        {
+          "challenge_status": "valid",
+          "challenge_type": "dns-01",
+          "expires": "2026-07-06T13:39:32Z"
+        },
+        {
+          "challenge_status": "pending",
+          "challenge_type": "http-01",
+          "expires": "2026-07-06T13:39:32Z"
+        }
+      ]
+    },
+    "creation_date": "2026-06-29T09:39:31-04:00",
+    "csr": "",
+    "expires": "2026-07-06T13:39:32Z",
+    "identifiers": ["example.com"],
+    "last_error": "",
+    "last_update": "2026-06-29T09:41:37-04:00",
+    "next_work_date": "0001-01-01T00:00:00Z",
     "order_status": "completed",
     "role_name": "web-server",
-    "identifiers": ["example.com", "www.example.com"],
-    "workflow_type": "identifiers",
-    "creation_date": "2026-02-24T20:00:00Z",
-    "last_update": "2026-02-24T20:15:00Z",
-    "expires": "2026-02-24T20:30:00Z"
+    "serial_number": "2c:7f:bd:fd:e3:64:cd:5d:bf:bf:1c:50:80:79:5b:40:96:94"
   }
 }
 ```

--- a/content/vault/v2.x/content/docs/secrets/pki-external-ca/index.mdx
+++ b/content/vault/v2.x/content/docs/secrets/pki-external-ca/index.mdx
@@ -423,10 +423,10 @@ $ vault read pki-external-ca/role/web-servers/order/01936d8e-7c3a-7890-b123-4567
 Order statuses:
 - `new` - Order created, not yet submitted to ACME server
 - `submitted` - Submitted to ACME server
-- `awaiting_challenge_fulfillment` - Waiting for client to fulfill challenges
-- `notify_acme_server_challenges_completed` - Ready to notify ACME server
-- `processing_challenge` - ACME server is validating challenges
-- `fetching_certificate` - Retrieving issued certificate
+- `awaiting-challenge-fulfillment` - Waiting for client to fulfill challenges
+- `notify-acme-server-challenges-completed` - Ready to notify ACME server
+- `processing-challenge` - ACME server is validating challenges
+- `fetching-certificate` - Retrieving issued certificate
 - `completed` - Certificate issued successfully
 - `expired` - Order expired before completion
 - `revoked` - Vault revoked the certificate


### PR DESCRIPTION
Address some curl commands that weren't working as expected within the PKI External CA api-docs, correct some of the sample responses that were incorrect or missing items. 

Also address the order status, the docs were using underscores, but they are hyphen separated in reality.  
