### PR TITLE
fix typo in TFE nav

### DIFF
--- a/content/terraform-enterprise/2.0.x/data/enterprise-nav-data.json
+++ b/content/terraform-enterprise/2.0.x/data/enterprise-nav-data.json
@@ -972,7 +972,7 @@
             "title": "AWS Configuration",
             "routes": [
               {
-                "tite": "Overview",
+                "title": "Overview",
                 "path": "dynamic-provider-credentials/aws-configuration"
               },
               {


### PR DESCRIPTION
This PR fixes a typo in the nav json file for TFE that prevented the label from rendering