### PR TITLE
IPE-1541: document tag-based policy set scope (Phase 2)

### DIFF
--- a/content/terraform-docs-common/docs/cloud-docs/workspaces/policy-enforcement/manage-policy-sets/configure.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/workspaces/policy-enforcement/manage-policy-sets/configure.mdx
@@ -42,12 +42,7 @@ This page contains all of the policy sets available in the organization, includi
 1. Click **Next**, then choose either **Sentinel** or **Open policy agent (OPA)** as the policy framework. A policy set can only contain policies that use the same framework. You cannot change a policy set's framework type after creation.
 1. Specify a unique and descriptive name for the policy set. You can use any combination of letters, numbers, `-`, and `_`. A name is required.
 1. It is optional, but you can add a description. We recommend adding a description so that the purpose of the policy set is clear to team members.
-1. Choose a policy set scope:
-   - Enable the **Policies enforced globally** option to automatically enforce this policy set on all of the organization's existing and future workspaces. You can optionally click **Add exclusions** and choose projects, workspaces, or tags to exempt from the policy set.
-   - Enable the **Policies enforced on selected projects and workspaces** option to enforce the policy set on specific workspaces or all workspaces in a project. This affects all current and future workspaces for any projects you choose.
-   - Enable the **Policies applied to tags (Beta)** option to enforce the policy set on all workspaces that match the selected tags. You must select at least one tag.
-1. If you choose **Policies applied to tags (Beta)**, use **Add tags** to select one or more tags from your organization. HCP Terraform and Terraform Enterprise display workspaces that match the selected tags.
-1. Optional: Click **Add exclusions** to exclude projects, workspaces, or tags (Beta) from the selected scope. When you use tag-based scope, you cannot exclude a tag that is already selected for inclusion.
+1. Configure the scope for the policy set. Refer to [Policy set scope](#policy-set-scope) for details.
 1. For Sentinel policy sets, choose a policy execution mode. Refer to [Policy set execution modes](#policy-set-execution-modes) for details about each option. For OPA policy sets, configure the following settings:
    - Choose an OPA version from the **Runtime version** drop-down menu.
    - Enable the **This policy set can be overridden in the event of mandatory failures** option to let users with override policy permissions apply plans, even when a mandatory policy fails. Refer to [Policy enforcement levels](/terraform/cloud-docs/workspaces/policy-enforcement/manage-policy-sets#policy-enforcement-levels) for more information.
@@ -66,6 +61,16 @@ This page contains all of the policy sets available in the organization, includi
 1. Click **Create policy set** to finish.
 
 Depending on the type of policy set you choose to create, you can then add policies to the set using the UI, connected VCS repository, the API, or the `tfe` provider. If you are creating an OPA policy set or a Sentinel policy set using agents, we recommend choosing a specific runtime version for your policy set to ensure consistent behavior.
+
+### Policy set scope
+
+HCP Terraform and Terraform Enterprise provide several options for fine tuning the scope of your policy sets. You can enable one of the following scope settings when configuring your policy set connection:  
+
+- **Policies enforced globally**: Automatically enforces the policy set on all of the organization's existing and future workspaces. It is optional, but you can also specify workspaces to exlude from the policy set when this scope is enabled. Enable one of the following settings to configure exclusions:
+   - **Names of projects and workspaces**: Choose one or more projects or one or more workspaces to exclude. Selecting a project exempts all workspaces in the project from the policies. You can also choose specific workspaces to exempt from the policy set. Note that the **Projects** and **Workspaces** selectors function independently so that you can exclude entire projects as well as specific workspaces in other projects. 
+   - **Tabs attached to workspaces (Beta)**: Choose tags within the organization. Workspaces with matching tags are exempt from the policies. Refer to [Create workspace tags](/terraform/cloud-docs/workspaces/tags) for more information about tags.   
+- **Policies enforced on selected projects and workspaces**: Enforces the policy set on specific workspaces or all workspaces in a project. This affects all current and future workspaces for any projects you choose. Note that the **Projects** and **Workspaces** selectors function independently so that you can enforce the policies on entire projects as well as specific workspaces in other projects. 
+- **Policies applied to tags (Beta)**: Enforces the policy set on all workspaces that match the selected tags. You must select at least one tag. You can click the **View matched workspaces** link to preview which workspaces HCP Terraform and Terraform Enterprise enforces the policies on. Refer to [Create workspace tags](/terraform/cloud-docs/workspaces/tags) for more information about tags.
 
 ### Policy set execution modes
 

--- a/content/terraform-docs-common/docs/cloud-docs/workspaces/policy-enforcement/manage-policy-sets/configure.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/workspaces/policy-enforcement/manage-policy-sets/configure.mdx
@@ -45,9 +45,9 @@ This page contains all of the policy sets available in the organization, includi
 1. Choose a policy set scope:
    - Enable the **Policies enforced globally** option to automatically enforce this policy set on all of the organization's existing and future workspaces. You can optionally click **Add exclusions** and choose projects, workspaces, or tags to exempt from the policy set.
    - Enable the **Policies enforced on selected projects and workspaces** option to enforce the policy set on specific workspaces or all workspaces in a project. This affects all current and future workspaces for any projects you choose.
-   - Enable the **Policies applied to tags** option to enforce the policy set on all workspaces that match the selected tags. You must select at least one tag.
-1. If you choose **Policies applied to tags**, use **Add tags** to select one or more tags from your organization. HCP Terraform and Terraform Enterprise display workspaces that match the selected tags.
-1. Optional: Click **Add exclusions** to exclude projects, workspaces, or tags from the selected scope. When you use tag-based scope, you cannot exclude a tag that is already selected for inclusion.
+   - Enable the **Policies applied to tags (Beta)** option to enforce the policy set on all workspaces that match the selected tags. You must select at least one tag.
+1. If you choose **Policies applied to tags (Beta)**, use **Add tags** to select one or more tags from your organization. HCP Terraform and Terraform Enterprise display workspaces that match the selected tags.
+1. Optional: Click **Add exclusions** to exclude projects, workspaces, or tags (Beta) from the selected scope. When you use tag-based scope, you cannot exclude a tag that is already selected for inclusion.
 1. For Sentinel policy sets, choose a policy execution mode. Refer to [Policy set execution modes](#policy-set-execution-modes) for details about each option. For OPA policy sets, configure the following settings:
    - Choose an OPA version from the **Runtime version** drop-down menu.
    - Enable the **This policy set can be overridden in the event of mandatory failures** option to let users with override policy permissions apply plans, even when a mandatory policy fails. Refer to [Policy enforcement levels](/terraform/cloud-docs/workspaces/policy-enforcement/manage-policy-sets#policy-enforcement-levels) for more information.

--- a/content/terraform-docs-common/docs/cloud-docs/workspaces/policy-enforcement/manage-policy-sets/configure.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/workspaces/policy-enforcement/manage-policy-sets/configure.mdx
@@ -10,7 +10,7 @@ last_modified: 2026-03-12T03:10:35.000Z
 
 # Configure connections to policy sets
 
-Policy sets are collections of policies that you can apply to an entire organization or to specific projects and workspaces. For more information about defining policies, refer to [Define policies](/terraform/cloud-docs/workspaces/policy-enforcement/define-policies). For information about using policies created and maintained by HashiCorp, refer to [Run pre-written Sentinel policies](/terraform/cloud-docs/workspaces/policy-enforcement/prewritten-sentinel).   
+Policy sets are collections of policies that you can apply to an entire organization, specific projects and workspaces, or workspaces with specific tags. For more information about defining policies, refer to [Define policies](/terraform/cloud-docs/workspaces/policy-enforcement/define-policies). For information about using policies created and maintained by HashiCorp, refer to [Run pre-written Sentinel policies](/terraform/cloud-docs/workspaces/policy-enforcement/prewritten-sentinel).   
 
 ## Overview
 
@@ -43,9 +43,12 @@ This page contains all of the policy sets available in the organization, includi
 1. Specify a unique and descriptive name for the policy set. You can use any combination of letters, numbers, `-`, and `_`. A name is required.
 1. It is optional, but you can add a description. We recommend adding a description so that the purpose of the policy set is clear to team members.
 1. Choose a policy set scope:
-   - Enable the **Policies enforced globally** option to automatically enforce this policy set on all of the organization's existing and future workspaces. You can optionally click **Add exclusions** and choose projects or workspaces to exempt from the policy set.
-   - Enable the **Policies enforced on selected projects and workspaces** option to enforce the policy set on specific workspaces or all workspaces in project. This affects all current and future workspaces for any projects you choose.  
-1. For Sentinal policy sets, choose a policy execution mode. Refer to [Policy set execution modes](#policy-set-execution-modes) for details about each option. For OPA policy sets, configure the following settings:
+   - Enable the **Policies enforced globally** option to automatically enforce this policy set on all of the organization's existing and future workspaces. You can optionally click **Add exclusions** and choose projects, workspaces, or tags to exempt from the policy set.
+   - Enable the **Policies enforced on selected projects and workspaces** option to enforce the policy set on specific workspaces or all workspaces in a project. This affects all current and future workspaces for any projects you choose.
+   - Enable the **Policies applied to tags** option to enforce the policy set on all workspaces that match the selected tags. You must select at least one tag.
+1. If you choose **Policies applied to tags**, use **Add tags** to select one or more tags from your organization. HCP Terraform and Terraform Enterprise display workspaces that match the selected tags.
+1. Optional: Click **Add exclusions** to exclude projects, workspaces, or tags from the selected scope. When you use tag-based scope, you cannot exclude a tag that is already selected for inclusion.
+1. For Sentinel policy sets, choose a policy execution mode. Refer to [Policy set execution modes](#policy-set-execution-modes) for details about each option. For OPA policy sets, configure the following settings:
    - Choose an OPA version from the **Runtime version** drop-down menu.
    - Enable the **This policy set can be overridden in the event of mandatory failures** option to let users with override policy permissions apply plans, even when a mandatory policy fails. Refer to [Policy enforcement levels](/terraform/cloud-docs/workspaces/policy-enforcement/manage-policy-sets#policy-enforcement-levels) for more information.
 1. Click **Next**, then configure the following settings depending on the source you chose in step 3:

--- a/content/terraform-docs-common/docs/cloud-docs/workspaces/policy-enforcement/manage-policy-sets/index.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/workspaces/policy-enforcement/manage-policy-sets/index.mdx
@@ -18,7 +18,13 @@ Policies are rules that HCP Terraform enforces on Terraform runs. You can define
 
 <!-- END: TFC:only name:pnp-callout -->
 
-Policy sets are collections of policies you can apply globally, to specific [projects](/terraform/cloud-docs/projects/manage) and workspaces, or to workspaces with specific tags (Beta) in your organization. For each run in the applicable workspaces, HCP Terraform checks the Terraform plan against the policy set. Depending on the [enforcement level](#policy-enforcement-levels), failed policies can stop a run in a workspace. If you do not want to enforce a policy set on a specific project, workspace, or tag (Beta), you can exclude it from that set.
+Policy sets are collections of policies you can apply globally, to specific [projects](/terraform/cloud-docs/projects/manage) and workspaces, or to workspaces with specific tags in your organization. For each run in the applicable workspaces, HCP Terraform checks the Terraform plan against the policy set. Depending on the [enforcement level](#policy-enforcement-levels), failed policies can stop a run in a workspace. If you do not want to enforce a policy set on a specific project, workspace, or tag, you can exclude it from that set.
+
+<Note>
+
+Using tags to set the scope of your policy sets is in beta. Do not use beta functionality in production environments.
+
+</Note>
 
 ## Policy checks versus policy evaluations
 

--- a/content/terraform-docs-common/docs/cloud-docs/workspaces/policy-enforcement/manage-policy-sets/index.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/workspaces/policy-enforcement/manage-policy-sets/index.mdx
@@ -18,7 +18,7 @@ Policies are rules that HCP Terraform enforces on Terraform runs. You can define
 
 <!-- END: TFC:only name:pnp-callout -->
 
-Policy sets are collections of policies you can apply globally or to specific [projects](/terraform/cloud-docs/projects/manage) and workspaces in your organization. For each run in the applicable workspaces, HCP Terraform checks the Terraform plan against the policy set. Depending on the [enforcement level](#policy-enforcement-levels), failed policies can stop a run in a workspace. If you do not want to enforce a policy set on a specific project or workspace, you can exclude the project or workspace from that set.
+Policy sets are collections of policies you can apply globally, to specific [projects](/terraform/cloud-docs/projects/manage) and workspaces, or to workspaces with specific tags in your organization. For each run in the applicable workspaces, HCP Terraform checks the Terraform plan against the policy set. Depending on the [enforcement level](#policy-enforcement-levels), failed policies can stop a run in a workspace. If you do not want to enforce a policy set on a specific project, workspace, or tag, you can exclude it from that set.
 
 ## Policy checks versus policy evaluations
 

--- a/content/terraform-docs-common/docs/cloud-docs/workspaces/policy-enforcement/manage-policy-sets/index.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/workspaces/policy-enforcement/manage-policy-sets/index.mdx
@@ -18,7 +18,7 @@ Policies are rules that HCP Terraform enforces on Terraform runs. You can define
 
 <!-- END: TFC:only name:pnp-callout -->
 
-Policy sets are collections of policies you can apply globally, to specific [projects](/terraform/cloud-docs/projects/manage) and workspaces, or to workspaces with specific tags in your organization. For each run in the applicable workspaces, HCP Terraform checks the Terraform plan against the policy set. Depending on the [enforcement level](#policy-enforcement-levels), failed policies can stop a run in a workspace. If you do not want to enforce a policy set on a specific project, workspace, or tag, you can exclude it from that set.
+Policy sets are collections of policies you can apply globally, to specific [projects](/terraform/cloud-docs/projects/manage) and workspaces, or to workspaces with specific tags (Beta) in your organization. For each run in the applicable workspaces, HCP Terraform checks the Terraform plan against the policy set. Depending on the [enforcement level](#policy-enforcement-levels), failed policies can stop a run in a workspace. If you do not want to enforce a policy set on a specific project, workspace, or tag (Beta), you can exclude it from that set.
 
 ## Policy checks versus policy evaluations
 


### PR DESCRIPTION
## Summary
- update policy set management docs to include tag-based scope in the UI flow
- add the new `Policies applied to tags` scope option in setup steps
- document tag-based exclusions behavior, including include/exclude conflict behavior for selected tags
- update overview language to reflect tag-based targeting support
- fix typo: `Sentinal` -> `Sentinel`

## Scope
- docs-only change for Phase 2 behavior
- no API or provider documentation changes in this PR