### PR TITLE
Consul/CE-416: Usage doc for service mesh upstreams

### DIFF
--- a/content/consul/v1.21.x/content/docs/connect/k8s/index.mdx
+++ b/content/consul/v1.21.x/content/docs/connect/k8s/index.mdx
@@ -29,6 +29,7 @@ Additional configuration examples are available to help you configure your workl
 - [Connecting to mesh-enabled Services](/consul/docs/connect/k8s/workload#connecting-to-mesh-enabled-services)
 - [Kubernetes Jobs](/consul/docs/connect/k8s/workload#kubernetes-jobs)
 - [Kubernetes Pods with multiple ports](/consul/docs/connect/k8s/workload#kubernetes-pods-with-multiple-ports)
+- [Kubernetes service upstreams in Consul service mesh](/consul/docs/connect/k8s/upstreams)
 
 ## Service names
 

--- a/content/consul/v1.21.x/content/docs/connect/k8s/upstreams.mdx
+++ b/content/consul/v1.21.x/content/docs/connect/k8s/upstreams.mdx
@@ -1,0 +1,131 @@
+---
+layout: docs
+page_title: Kubernetes service upstreams in Consul Service mesh
+description: >-
+  Service upstreams define service mesh behaviors in order to connect and manage upstream communication. Learn about Consul's different methods of defining and addressing upstream services.
+---
+
+# Kubernetes service upstreams in Consul Service mesh
+
+## Introduction
+
+The method of addressing service upstreams depends on whether you have Consul's Transparent Proxy enabled.
+
+When [Transparent Proxy is not enabled](#transparent-proxy-not-enabled), you must use an explicit declaration via annotation in the K8s deployment. This data element must be placed under `spec.template.metadata.annotations`. Here's an example of an annotation for an `payment-api` upstream.
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    metadata:
+      annotations:
+        consul.hashicorp.com/connect-inject: 'true'
+        consul.hashicorp.com/connect-service-upstreams: 'payment-api:9091'
+[...]
+```
+
+When [Transparent Proxy is enabled](#transparent-proxy-enabled), you can directly address the service in the workload without preconfiguring the deployment. This is done by either using a K8s DNS service like `kube-dns` or `CoreDNS`, or Consul Virtual IPs with [Consul DNS](/consul/docs/discover/dns/k8s).
+
+In both cases, the destination hostname is constructed based on the means of reaching the upstream service. For example, if admin partitions or cluster peerings are traversed to reach the upstream service.
+
+## Transparent proxy not enabled
+
+Here follow examples of annotations for a `payment-api` service.
+
+### Within an admin partition
+
+- Same namespace, same cluster
+
+| Explicit Declaration in K8s deployment | Connection target in application |
+| --- | --- |
+| `consul.hashicorp.com/connect-service-upstreams: 'payment-api:9091'` | `localhost:9091` |
+
+- Across namespaces, same cluster
+
+| Explicit Declaration in K8s deployment | Connection target in application |
+| --- | --- |
+| `consul.hashicorp.com/connect-service-upstreams: 'payment-api.<consul-namespace>:9091'` | `localhost:9091` |
+
+- Same namespace, across cluster peering
+
+| Explicit Declaration in K8s deployment | Connection target in application |
+| --- | --- |
+| `consul.hashicorp.com/connect-service-upstreams: 'payment-api:9091'` | `localhost:9091` |
+
+### Across admin partitions
+
+| Explicit Declaration in K8s deployment | Connection target in application |
+| --- | --- |
+| `consul.hashicorp.com/connect-service-upstreams: 'payment-api.<consul-namespace>.<consul-adminpartition>:9091'` | `localhost:9091` |
+
+### Across K8s clusters over Consul WAN Federation
+
+- Same namespace
+
+| Explicit Declaration in K8s deployment | Connection target in application |
+| --- | --- |
+| `consul.hashicorp.com/connect-service-upstreams: 'payment-api:9091:<consul-datacenter>'` | `localhost:9091` |
+
+- Across namespaces
+
+| Explicit Declaration in K8s deployment | Connection target in application |
+| --- | --- |
+| `consul.hashicorp.com/connect-service-upstreams: 'payment-api.<consul-namespace>:9091:<consul-datacenter>'` | `localhost:9091` |
+
+### Across K8s clusters over Consul Cluster Peering 
+
+| Explicit Declaration in K8s deployment | Connection target in application |
+| --- | --- |
+| `consul.hashicorp.com/connect-service-upstreams: 'payment-api.svc.<consul-namespace>.ns.<consul-datacenter>-<consul-adminpartition>.peer:9091'` | `localhost:9091` |
+
+## Transparent proxy enabled
+
+With Transparent Proxy enabled, you can directly address the service in the workload without preconfiguring the deployment. When choosing between the K8s DNS solutions `kube-dns` or `CoreDNS`, we recommend the latter option.
+
+### Within an admin partition
+
+- Same namespace, same cluster
+
+| K8S DNS | Consul DNS |
+| --- | --- |
+| `payment-api.<consul-namespace>.svc.cluster.local` | `payment-api.virtual.consul` |
+| | `payment-api.virtual.<consul-namespace>.ns.<consul-datacenter>.dc.consul` |
+
+- Across namespaces, same cluster
+
+| K8S DNS | Consul DNS |
+| --- | --- |
+| `payment-api.<consul-namespace>.svc.cluster.local` | `payment-api.virtual.<consul-namespace>.ns.<consul-datacenter>.dc.consul` |
+
+
+- Same namespace, across cluster peering
+
+| K8S DNS | Consul DNS |
+| --- | --- |
+| Not supported | `payment-api.virtual.consul` |
+| | `payment-api.virtual.<consul-namespace>.ns.<consul-datacenter>.dc.consul` |
+
+### Across admin partitions
+
+| K8S DNS | Consul DNS |
+| --- | --- |
+| Not supported | `payment-api.virtual.<consul-namespace>.ns.<consul-adminpartition>.ap.<consul-datacenter>.dc.consul` |
+
+### Across K8s clusters over Consul WAN Federation
+
+Directly addressing a service without preconfiguring the deployment is not supported across Kubernetes clusters over WAN federation.
+
+### Across K8s clusters over Consul Cluster Peering 
+
+- Same namespace
+
+| K8S DNS | Consul DNS |
+| --- | --- |
+| Not supported | `payment-api.virtual.<consul-adminpartition>.ap.<consul-clusterpeer>.peer.consul` |
+
+- Across namespaces
+
+| K8S DNS | Consul DNS |
+| --- | --- |
+| Not supported | `payment-api.virtual.<consul-namespace>.ns.<consul-adminpartition>.ap.<consul-clusterpeer>.peer.consul` |

--- a/content/consul/v1.21.x/content/docs/connect/k8s/upstreams.mdx
+++ b/content/consul/v1.21.x/content/docs/connect/k8s/upstreams.mdx
@@ -2,7 +2,7 @@
 layout: docs
 page_title: Kubernetes service upstreams in Consul Service mesh
 description: >-
-  Service upstreams define service mesh behaviors in order to connect and manage upstream communication. Learn about Consul's different methods of defining and addressing upstream services.
+  Learn about Consul's different methods of defining and addressing upstream services.
 ---
 
 # Kubernetes service upstreams in Consul Service mesh

--- a/content/consul/v1.21.x/data/docs-nav-data.json
+++ b/content/consul/v1.21.x/data/docs-nav-data.json
@@ -1698,6 +1698,10 @@
             "path": "connect/k8s/crds"
           },
           {
+            "title": "Consul service upstreams",
+            "path": "connect/k8s/upstreams"
+          },
+          {
             "title": "Workload scenario examples",
             "path": "connect/k8s/workload"
           }

--- a/content/consul/v1.22.x/content/docs/connect/k8s/index.mdx
+++ b/content/consul/v1.22.x/content/docs/connect/k8s/index.mdx
@@ -29,6 +29,7 @@ Additional configuration examples are available to help you configure your workl
 - [Connecting to mesh-enabled Services](/consul/docs/connect/k8s/workload#connecting-to-mesh-enabled-services)
 - [Kubernetes Jobs](/consul/docs/connect/k8s/workload#kubernetes-jobs)
 - [Kubernetes Pods with multiple ports](/consul/docs/connect/k8s/workload#kubernetes-pods-with-multiple-ports)
+- [Kubernetes service upstreams in Consul service mesh](/consul/docs/connect/k8s/upstreams)
 
 ## Service names
 

--- a/content/consul/v1.22.x/content/docs/connect/k8s/upstreams.mdx
+++ b/content/consul/v1.22.x/content/docs/connect/k8s/upstreams.mdx
@@ -1,0 +1,131 @@
+---
+layout: docs
+page_title: Kubernetes service upstreams in Consul Service mesh
+description: >-
+  Service upstreams define service mesh behaviors in order to connect and manage upstream communication. Learn about Consul's different methods of defining and addressing upstream services.
+---
+
+# Kubernetes service upstreams in Consul Service mesh
+
+## Introduction
+
+The method of addressing service upstreams depends on whether you have Consul's Transparent Proxy enabled.
+
+When [Transparent Proxy is not enabled](#transparent-proxy-not-enabled), you must use an explicit declaration via annotation in the K8s deployment. This data element must be placed under `spec.template.metadata.annotations`. Here's an example of an annotation for an `payment-api` upstream.
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    metadata:
+      annotations:
+        consul.hashicorp.com/connect-inject: 'true'
+        consul.hashicorp.com/connect-service-upstreams: 'payment-api:9091'
+[...]
+```
+
+When [Transparent Proxy is enabled](#transparent-proxy-enabled), you can directly address the service in the workload without preconfiguring the deployment. This is done by either using a K8s DNS service like `kube-dns` or `CoreDNS`, or Consul Virtual IPs with [Consul DNS](/consul/docs/discover/dns/k8s).
+
+In both cases, the destination hostname is constructed based on the means of reaching the upstream service. For example, if admin partitions or cluster peerings are traversed to reach the upstream service.
+
+## Transparent proxy not enabled
+
+Here follow examples of annotations for a `payment-api` service.
+
+### Within an admin partition
+
+- Same namespace, same cluster
+
+| Explicit Declaration in K8s deployment | Connection target in application |
+| --- | --- |
+| `consul.hashicorp.com/connect-service-upstreams: 'payment-api:9091'` | `localhost:9091` |
+
+- Across namespaces, same cluster
+
+| Explicit Declaration in K8s deployment | Connection target in application |
+| --- | --- |
+| `consul.hashicorp.com/connect-service-upstreams: 'payment-api.<consul-namespace>:9091'` | `localhost:9091` |
+
+- Same namespace, across cluster peering
+
+| Explicit Declaration in K8s deployment | Connection target in application |
+| --- | --- |
+| `consul.hashicorp.com/connect-service-upstreams: 'payment-api:9091'` | `localhost:9091` |
+
+### Across admin partitions
+
+| Explicit Declaration in K8s deployment | Connection target in application |
+| --- | --- |
+| `consul.hashicorp.com/connect-service-upstreams: 'payment-api.<consul-namespace>.<consul-adminpartition>:9091'` | `localhost:9091` |
+
+### Across K8s clusters over Consul WAN Federation
+
+- Same namespace
+
+| Explicit Declaration in K8s deployment | Connection target in application |
+| --- | --- |
+| `consul.hashicorp.com/connect-service-upstreams: 'payment-api:9091:<consul-datacenter>'` | `localhost:9091` |
+
+- Across namespaces
+
+| Explicit Declaration in K8s deployment | Connection target in application |
+| --- | --- |
+| `consul.hashicorp.com/connect-service-upstreams: 'payment-api.<consul-namespace>:9091:<consul-datacenter>'` | `localhost:9091` |
+
+### Across K8s clusters over Consul Cluster Peering 
+
+| Explicit Declaration in K8s deployment | Connection target in application |
+| --- | --- |
+| `consul.hashicorp.com/connect-service-upstreams: 'payment-api.svc.<consul-namespace>.ns.<consul-datacenter>-<consul-adminpartition>.peer:9091'` | `localhost:9091` |
+
+## Transparent proxy enabled
+
+With Transparent Proxy enabled, you can directly address the service in the workload without preconfiguring the deployment. When choosing between the K8s DNS solutions `kube-dns` or `CoreDNS`, we recommend the latter option.
+
+### Within an admin partition
+
+- Same namespace, same cluster
+
+| K8S DNS | Consul DNS |
+| --- | --- |
+| `payment-api.<consul-namespace>.svc.cluster.local` | `payment-api.virtual.consul` |
+| | `payment-api.virtual.<consul-namespace>.ns.<consul-datacenter>.dc.consul` |
+
+- Across namespaces, same cluster
+
+| K8S DNS | Consul DNS |
+| --- | --- |
+| `payment-api.<consul-namespace>.svc.cluster.local` | `payment-api.virtual.<consul-namespace>.ns.<consul-datacenter>.dc.consul` |
+
+
+- Same namespace, across cluster peering
+
+| K8S DNS | Consul DNS |
+| --- | --- |
+| Not supported | `payment-api.virtual.consul` |
+| | `payment-api.virtual.<consul-namespace>.ns.<consul-datacenter>.dc.consul` |
+
+### Across admin partitions
+
+| K8S DNS | Consul DNS |
+| --- | --- |
+| Not supported | `payment-api.virtual.<consul-namespace>.ns.<consul-adminpartition>.ap.<consul-datacenter>.dc.consul` |
+
+### Across K8s clusters over Consul WAN Federation
+
+Directly addressing a service without preconfiguring the deployment is not supported across Kubernetes clusters over WAN federation.
+
+### Across K8s clusters over Consul Cluster Peering 
+
+- Same namespace
+
+| K8S DNS | Consul DNS |
+| --- | --- |
+| Not supported | `payment-api.virtual.<consul-adminpartition>.ap.<consul-clusterpeer>.peer.consul` |
+
+- Across namespaces
+
+| K8S DNS | Consul DNS |
+| --- | --- |
+| Not supported | `payment-api.virtual.<consul-namespace>.ns.<consul-adminpartition>.ap.<consul-clusterpeer>.peer.consul` |

--- a/content/consul/v1.22.x/content/docs/connect/k8s/upstreams.mdx
+++ b/content/consul/v1.22.x/content/docs/connect/k8s/upstreams.mdx
@@ -2,7 +2,7 @@
 layout: docs
 page_title: Kubernetes service upstreams in Consul Service mesh
 description: >-
-  Service upstreams define service mesh behaviors in order to connect and manage upstream communication. Learn about Consul's different methods of defining and addressing upstream services.
+  Learn about Consul's different methods of defining and addressing upstream services.
 ---
 
 # Kubernetes service upstreams in Consul Service mesh

--- a/content/consul/v1.22.x/data/docs-nav-data.json
+++ b/content/consul/v1.22.x/data/docs-nav-data.json
@@ -1698,6 +1698,10 @@
             "path": "connect/k8s/crds"
           },
           {
+            "title": "Consul service upstreams",
+            "path": "connect/k8s/upstreams"
+          },
+          {
             "title": "Workload scenario examples",
             "path": "connect/k8s/workload"
           }

--- a/content/consul/v2.0.x/content/docs/connect/k8s/index.mdx
+++ b/content/consul/v2.0.x/content/docs/connect/k8s/index.mdx
@@ -29,6 +29,7 @@ Additional configuration examples are available to help you configure your workl
 - [Connecting to mesh-enabled Services](/consul/docs/connect/k8s/workload#connecting-to-mesh-enabled-services)
 - [Kubernetes Jobs](/consul/docs/connect/k8s/workload#kubernetes-jobs)
 - [Kubernetes Pods with multiple ports](/consul/docs/connect/k8s/workload#kubernetes-pods-with-multiple-ports)
+- [Kubernetes service upstreams in Consul service mesh](/consul/docs/connect/k8s/upstreams)
 
 ## Service names
 

--- a/content/consul/v2.0.x/content/docs/connect/k8s/upstreams.mdx
+++ b/content/consul/v2.0.x/content/docs/connect/k8s/upstreams.mdx
@@ -1,0 +1,131 @@
+---
+layout: docs
+page_title: Kubernetes service upstreams in Consul Service mesh
+description: >-
+  Service upstreams define service mesh behaviors in order to connect and manage upstream communication. Learn about Consul's different methods of defining and addressing upstream services.
+---
+
+# Kubernetes service upstreams in Consul Service mesh
+
+## Introduction
+
+The method of addressing service upstreams depends on whether you have Consul's Transparent Proxy enabled.
+
+When [Transparent Proxy is not enabled](#transparent-proxy-not-enabled), you must use an explicit declaration via annotation in the K8s deployment. This data element must be placed under `spec.template.metadata.annotations`. Here's an example of an annotation for an `payment-api` upstream.
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    metadata:
+      annotations:
+        consul.hashicorp.com/connect-inject: 'true'
+        consul.hashicorp.com/connect-service-upstreams: 'payment-api:9091'
+[...]
+```
+
+When [Transparent Proxy is enabled](#transparent-proxy-enabled), you can directly address the service in the workload without preconfiguring the deployment. This is done by either using a K8s DNS service like `kube-dns` or `CoreDNS`, or Consul Virtual IPs with [Consul DNS](/consul/docs/discover/dns/k8s).
+
+In both cases, the destination hostname is constructed based on the means of reaching the upstream service. For example, if admin partitions or cluster peerings are traversed to reach the upstream service.
+
+## Transparent proxy not enabled
+
+Here follow examples of annotations for a `payment-api` service.
+
+### Within an admin partition
+
+- Same namespace, same cluster
+
+| Explicit Declaration in K8s deployment | Connection target in application |
+| --- | --- |
+| `consul.hashicorp.com/connect-service-upstreams: 'payment-api:9091'` | `localhost:9091` |
+
+- Across namespaces, same cluster
+
+| Explicit Declaration in K8s deployment | Connection target in application |
+| --- | --- |
+| `consul.hashicorp.com/connect-service-upstreams: 'payment-api.<consul-namespace>:9091'` | `localhost:9091` |
+
+- Same namespace, across cluster peering
+
+| Explicit Declaration in K8s deployment | Connection target in application |
+| --- | --- |
+| `consul.hashicorp.com/connect-service-upstreams: 'payment-api:9091'` | `localhost:9091` |
+
+### Across admin partitions
+
+| Explicit Declaration in K8s deployment | Connection target in application |
+| --- | --- |
+| `consul.hashicorp.com/connect-service-upstreams: 'payment-api.<consul-namespace>.<consul-adminpartition>:9091'` | `localhost:9091` |
+
+### Across K8s clusters over Consul WAN Federation
+
+- Same namespace
+
+| Explicit Declaration in K8s deployment | Connection target in application |
+| --- | --- |
+| `consul.hashicorp.com/connect-service-upstreams: 'payment-api:9091:<consul-datacenter>'` | `localhost:9091` |
+
+- Across namespaces
+
+| Explicit Declaration in K8s deployment | Connection target in application |
+| --- | --- |
+| `consul.hashicorp.com/connect-service-upstreams: 'payment-api.<consul-namespace>:9091:<consul-datacenter>'` | `localhost:9091` |
+
+### Across K8s clusters over Consul Cluster Peering 
+
+| Explicit Declaration in K8s deployment | Connection target in application |
+| --- | --- |
+| `consul.hashicorp.com/connect-service-upstreams: 'payment-api.svc.<consul-namespace>.ns.<consul-datacenter>-<consul-adminpartition>.peer:9091'` | `localhost:9091` |
+
+## Transparent proxy enabled
+
+With Transparent Proxy enabled, you can directly address the service in the workload without preconfiguring the deployment. When choosing between the K8s DNS solutions `kube-dns` or `CoreDNS`, we recommend the latter option.
+
+### Within an admin partition
+
+- Same namespace, same cluster
+
+| K8S DNS | Consul DNS |
+| --- | --- |
+| `payment-api.<consul-namespace>.svc.cluster.local` | `payment-api.virtual.consul` |
+| | `payment-api.virtual.<consul-namespace>.ns.<consul-datacenter>.dc.consul` |
+
+- Across namespaces, same cluster
+
+| K8S DNS | Consul DNS |
+| --- | --- |
+| `payment-api.<consul-namespace>.svc.cluster.local` | `payment-api.virtual.<consul-namespace>.ns.<consul-datacenter>.dc.consul` |
+
+
+- Same namespace, across cluster peering
+
+| K8S DNS | Consul DNS |
+| --- | --- |
+| Not supported | `payment-api.virtual.consul` |
+| | `payment-api.virtual.<consul-namespace>.ns.<consul-datacenter>.dc.consul` |
+
+### Across admin partitions
+
+| K8S DNS | Consul DNS |
+| --- | --- |
+| Not supported | `payment-api.virtual.<consul-namespace>.ns.<consul-adminpartition>.ap.<consul-datacenter>.dc.consul` |
+
+### Across K8s clusters over Consul WAN Federation
+
+Directly addressing a service without preconfiguring the deployment is not supported across Kubernetes clusters over WAN federation.
+
+### Across K8s clusters over Consul Cluster Peering 
+
+- Same namespace
+
+| K8S DNS | Consul DNS |
+| --- | --- |
+| Not supported | `payment-api.virtual.<consul-adminpartition>.ap.<consul-clusterpeer>.peer.consul` |
+
+- Across namespaces
+
+| K8S DNS | Consul DNS |
+| --- | --- |
+| Not supported | `payment-api.virtual.<consul-namespace>.ns.<consul-adminpartition>.ap.<consul-clusterpeer>.peer.consul` |

--- a/content/consul/v2.0.x/content/docs/connect/k8s/upstreams.mdx
+++ b/content/consul/v2.0.x/content/docs/connect/k8s/upstreams.mdx
@@ -2,7 +2,7 @@
 layout: docs
 page_title: Kubernetes service upstreams in Consul Service mesh
 description: >-
-  Service upstreams define service mesh behaviors in order to connect and manage upstream communication. Learn about Consul's different methods of defining and addressing upstream services.
+  Learn about Consul's different methods of defining and addressing upstream services.
 ---
 
 # Kubernetes service upstreams in Consul Service mesh

--- a/content/consul/v2.0.x/data/docs-nav-data.json
+++ b/content/consul/v2.0.x/data/docs-nav-data.json
@@ -1732,6 +1732,10 @@
             "path": "connect/k8s/crds"
           },
           {
+            "title": "Consul service upstreams",
+            "path": "connect/k8s/upstreams"
+          },
+          {
             "title": "Workload scenario examples",
             "path": "connect/k8s/workload"
           }


### PR DESCRIPTION
## Description

This usage doc explains configuring upstreams for different Consul deployments.

## Links

Jira: [CE-416]
[Source document](https://hashicorp.atlassian.net/wiki/spaces/SAAPJ/blog/2023/03/13/2591752203/Developer+Guide+to+configure+upstream+service+URLs)

## Contributor checklists

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [x] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [x] Verify that all status checks passed
- [x] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [x] I added redirects for any moved or removed pages
- [x] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [x] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [ ] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.


[CE-416]: https://hashicorp.atlassian.net/browse/CE-416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ