### PR TITLE
docs: Create forward port label for Boundary

### DIFF
--- a/.github/forward-port-config.yml
+++ b/.github/forward-port-config.yml
@@ -18,7 +18,7 @@ tf-forward-porting-testing:
 boundary-1.0-forward-port:
   sourceVersionFolder: v0.21.x
   targetProduct: boundary
-  targetBranch: boundary-1.0.0-port
+  targetBranch: main
   targetVersionFolder: v1.0.x
 
 # ── Consul ───────────────────────────────────────────────────────────────────

--- a/.github/forward-port-config.yml
+++ b/.github/forward-port-config.yml
@@ -15,11 +15,11 @@ tf-forward-porting-testing:
   targetVersionFolder: v1.15.x
 
 # ── Boundary ─────────────────────────────────────────────────────────────────
-boundary-placeholder-label:
-  sourceVersionFolder: v0.20.x
+boundary-1.0-forward-port:
+  sourceVersionFolder: v0.21.x
   targetProduct: boundary
-  targetBranch: boundary/0.22.0
-  targetVersionFolder: v0.21.x
+  targetBranch: boundary-1.0.0-port
+  targetVersionFolder: v1.0.x
 
 # ── Consul ───────────────────────────────────────────────────────────────────
 consul-placeholder-label:


### PR DESCRIPTION
Creates a new label to forward port Boundary docs from v0.21.x to v1.0.x
