### PR TITLE
vault: move plugin perm doc

### DIFF
--- a/content/vault/v1.19.x/content/docs/configuration/index.mdx
+++ b/content/vault/v1.19.x/content/docs/configuration/index.mdx
@@ -169,14 +169,14 @@ to specify where the configuration is.
 
 - `plugin_tmpdir` `(string: "")` - A directory that Vault can create temporary
   files in to support Unix socket communication with containerized plugins. If
-  not set, Vault will use the system's default directory for temporary files.
-  Not necessary unless you are using
+  you leave `plugin_tmpdir` unset, Vault uses the default OS-determined directory
+  for temporary files. You only need to set `plugin_tmpdir` if you plan to use
   [containerized plugins](/vault/docs/plugins/containerized-plugins) and Vault
-  does not share a temporary folder with other processes, such as if using
-  systemd's [PrivateTmp](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#PrivateTmp=)
-  setting. This can also be specified via the `VAULT_PLUGIN_TMPDIR` environment
-  variable. `plugin_tmpdir` will not affect where socket files are created for
-  non-containerized plugins.
+  does not share a temporary folder with other processes, such as the
+  [PrivateTmp](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#PrivateTmp=)
+  setting for `systemd`. You can also set the temp directory with the
+  `VAULT_PLUGIN_TMPDIR` environment variable. Vault does not use `plugin_tmpdir`
+  to determine where to create socket files for non-containerized plugins.
 
 - `telemetry` `([Telemetry][telemetry]: <none>)` – Specifies the telemetry
   reporting system.

--- a/content/vault/v1.19.x/content/docs/configuration/index.mdx
+++ b/content/vault/v1.19.x/content/docs/configuration/index.mdx
@@ -156,16 +156,6 @@ to specify where the configuration is.
   allowed to be loaded. Vault must have permission to read files in this
   directory to successfully load plugins, and the value cannot be a symbolic link.
 
-- `plugin_tmpdir` `(string: "")` - A directory that Vault can create temporary
-  files in to support Unix socket communication with containerized plugins. If
-  not set, Vault will use the system's default directory for temporary files.
-  Generally not necessary unless you are using
-  [containerized plugins](/vault/docs/plugins/containerized-plugins) and Vault
-  does not share a temporary folder with other processes, such as if using
-  systemd's [PrivateTmp](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#PrivateTmp=)
-  setting. This can also be specified via the `VAULT_PLUGIN_TMPDIR` environment
-  variable.
-
   @include 'plugin-file-permissions-check.mdx'
 
 - `plugin_file_uid` `(integer: 0)` – Uid of the plugin directories and plugin binaries if they
@@ -176,6 +166,17 @@ to specify where the configuration is.
   directories and plugin binaries if they have write or execute permissions for group or others.
   This only needs to be set if the file permissions check is enabled via the environment variable
   `VAULT_ENABLE_FILE_PERMISSIONS_CHECK`.
+
+- `plugin_tmpdir` `(string: "")` - A directory that Vault can create temporary
+  files in to support Unix socket communication with containerized plugins. If
+  not set, Vault will use the system's default directory for temporary files.
+  Not necessary unless you are using
+  [containerized plugins](/vault/docs/plugins/containerized-plugins) and Vault
+  does not share a temporary folder with other processes, such as if using
+  systemd's [PrivateTmp](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#PrivateTmp=)
+  setting. This can also be specified via the `VAULT_PLUGIN_TMPDIR` environment
+  variable. `plugin_tmpdir` will not affect where socket files are created for
+  non-containerized plugins.
 
 - `telemetry` `([Telemetry][telemetry]: <none>)` – Specifies the telemetry
   reporting system.

--- a/content/vault/v1.20.x/content/docs/configuration/index.mdx
+++ b/content/vault/v1.20.x/content/docs/configuration/index.mdx
@@ -159,16 +159,6 @@ to specify where the configuration is.
   allowed to be loaded. Vault must have permission to read files in this
   directory to successfully load plugins, and the value cannot be a symbolic link.
 
-- `plugin_tmpdir` `(string: "")` - A directory that Vault can create temporary
-  files in to support Unix socket communication with containerized plugins. If
-  not set, Vault will use the system's default directory for temporary files.
-  Generally not necessary unless you are using
-  [containerized plugins](/vault/docs/plugins/containerized-plugins) and Vault
-  does not share a temporary folder with other processes, such as if using
-  systemd's [PrivateTmp](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#PrivateTmp=)
-  setting. This can also be specified via the `VAULT_PLUGIN_TMPDIR` environment
-  variable.
-
   @include 'plugin-file-permissions-check.mdx'
 
 - `plugin_file_uid` `(integer: 0)` – Uid of the plugin directories and plugin binaries if they
@@ -179,6 +169,17 @@ to specify where the configuration is.
   directories and plugin binaries if they have write or execute permissions for group or others.
   This only needs to be set if the file permissions check is enabled via the environment variable
   `VAULT_ENABLE_FILE_PERMISSIONS_CHECK`.
+
+- `plugin_tmpdir` `(string: "")` - A directory that Vault can create temporary
+  files in to support Unix socket communication with containerized plugins. If
+  not set, Vault will use the system's default directory for temporary files.
+  Not necessary unless you are using
+  [containerized plugins](/vault/docs/plugins/containerized-plugins) and Vault
+  does not share a temporary folder with other processes, such as if using
+  systemd's [PrivateTmp](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#PrivateTmp=)
+  setting. This can also be specified via the `VAULT_PLUGIN_TMPDIR` environment
+  variable. `plugin_tmpdir` will not affect where socket files are created for
+  non-containerized plugins.
 
 - `telemetry` `([Telemetry][telemetry]: <none>)` – Specifies the telemetry
   reporting system.

--- a/content/vault/v1.20.x/content/docs/configuration/index.mdx
+++ b/content/vault/v1.20.x/content/docs/configuration/index.mdx
@@ -172,14 +172,14 @@ to specify where the configuration is.
 
 - `plugin_tmpdir` `(string: "")` - A directory that Vault can create temporary
   files in to support Unix socket communication with containerized plugins. If
-  not set, Vault will use the system's default directory for temporary files.
-  Not necessary unless you are using
+  you leave `plugin_tmpdir` unset, Vault uses the default OS-determined directory
+  for temporary files. You only need to set `plugin_tmpdir` if you plan to use
   [containerized plugins](/vault/docs/plugins/containerized-plugins) and Vault
-  does not share a temporary folder with other processes, such as if using
-  systemd's [PrivateTmp](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#PrivateTmp=)
-  setting. This can also be specified via the `VAULT_PLUGIN_TMPDIR` environment
-  variable. `plugin_tmpdir` will not affect where socket files are created for
-  non-containerized plugins.
+  does not share a temporary folder with other processes, such as the
+  [PrivateTmp](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#PrivateTmp=)
+  setting for `systemd`. You can also set the temp directory with the
+  `VAULT_PLUGIN_TMPDIR` environment variable. Vault does not use `plugin_tmpdir`
+  to determine where to create socket files for non-containerized plugins.
 
 - `telemetry` `([Telemetry][telemetry]: <none>)` – Specifies the telemetry
   reporting system.

--- a/content/vault/v2.x/content/docs/configuration/index.mdx
+++ b/content/vault/v2.x/content/docs/configuration/index.mdx
@@ -172,14 +172,14 @@ to specify where the configuration is.
 
 - `plugin_tmpdir` `(string: "")` - A directory that Vault can create temporary
   files in to support Unix socket communication with containerized plugins. If
-  not set, Vault will use the system's default directory for temporary files.
-  Not necessary unless you are using
+  you leave `plugin_tmpdir` unset, Vault uses the default OS-determined directory
+  for temporary files. You only need to set `plugin_tmpdir` if you plan to use
   [containerized plugins](/vault/docs/plugins/containerized-plugins) and Vault
-  does not share a temporary folder with other processes, such as if using
-  systemd's [PrivateTmp](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#PrivateTmp=)
-  setting. This can also be specified via the `VAULT_PLUGIN_TMPDIR` environment
-  variable. `plugin_tmpdir` will not affect where socket files are created for
-  non-containerized plugins.
+  does not share a temporary folder with other processes, such as the
+  [PrivateTmp](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#PrivateTmp=)
+  setting for `systemd`. You can also set the temp directory with the
+  `VAULT_PLUGIN_TMPDIR` environment variable. Vault does not use `plugin_tmpdir`
+  to determine where to create socket files for non-containerized plugins.
 
 - `telemetry` `([Telemetry][telemetry]: <none>)` – Specifies the telemetry
   reporting system.

--- a/content/vault/v2.x/content/docs/configuration/index.mdx
+++ b/content/vault/v2.x/content/docs/configuration/index.mdx
@@ -178,7 +178,8 @@ to specify where the configuration is.
   does not share a temporary folder with other processes, such as if using
   systemd's [PrivateTmp](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#PrivateTmp=)
   setting. This can also be specified via the `VAULT_PLUGIN_TMPDIR` environment
-  variable.
+  variable. `plugin_tmpdir` will not affect where socket files are created for
+  non-containerized plugins.
 
 - `telemetry` `([Telemetry][telemetry]: <none>)` – Specifies the telemetry
   reporting system.

--- a/content/vault/v2.x/content/docs/configuration/index.mdx
+++ b/content/vault/v2.x/content/docs/configuration/index.mdx
@@ -159,16 +159,6 @@ to specify where the configuration is.
   allowed to be loaded. Vault must have permission to read files in this
   directory to successfully load plugins, and the value cannot be a symbolic link.
 
-- `plugin_tmpdir` `(string: "")` - A directory that Vault can create temporary
-  files in to support Unix socket communication with containerized plugins. If
-  not set, Vault will use the system's default directory for temporary files.
-  Generally not necessary unless you are using
-  [containerized plugins](/vault/docs/plugins/containerized-plugins) and Vault
-  does not share a temporary folder with other processes, such as if using
-  systemd's [PrivateTmp](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#PrivateTmp=)
-  setting. This can also be specified via the `VAULT_PLUGIN_TMPDIR` environment
-  variable.
-
   @include 'plugin-file-permissions-check.mdx'
 
 - `plugin_file_uid` `(integer: 0)` – Uid of the plugin directories and plugin binaries if they
@@ -179,6 +169,16 @@ to specify where the configuration is.
   directories and plugin binaries if they have write or execute permissions for group or others.
   This only needs to be set if the file permissions check is enabled via the environment variable
   `VAULT_ENABLE_FILE_PERMISSIONS_CHECK`.
+
+- `plugin_tmpdir` `(string: "")` - A directory that Vault can create temporary
+  files in to support Unix socket communication with containerized plugins. If
+  not set, Vault will use the system's default directory for temporary files.
+  Not necessary unless you are using
+  [containerized plugins](/vault/docs/plugins/containerized-plugins) and Vault
+  does not share a temporary folder with other processes, such as if using
+  systemd's [PrivateTmp](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#PrivateTmp=)
+  setting. This can also be specified via the `VAULT_PLUGIN_TMPDIR` environment
+  variable.
 
 - `telemetry` `([Telemetry][telemetry]: <none>)` – Specifies the telemetry
   reporting system.


### PR DESCRIPTION
The plugin file permission blurb is not relevant to the `plugin_tmpdir` so ensure it appears under the relevant `plugin_directory` section. Move `plugin_tmpdir` after the file permission settings.


Please go to the `Preview` tab and select the appropriate template:

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
