### PR TITLE
docs: add migration guide for the new template syntax

### DIFF
--- a/content/nomad/v2.0.x/content/tools/nomad-pack/migrate-template-syntax.mdx
+++ b/content/nomad/v2.0.x/content/tools/nomad-pack/migrate-template-syntax.mdx
@@ -2,30 +2,45 @@
 layout: docs
 page_title: Migrate to the current template syntax
 description: |-
-  Update a Nomad Pack from the original `.my` and `.nomad_pack` template syntax to the
-  current `var` and `meta` template functions, including dependencies and helpers.
+  Update a Nomad Pack from the original `.my` and `.nomad_pack` template syntax to
+  the current `var` and `meta` template functions, including dependencies and
+  helpers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-07-03T11:42:00+05:30
+last_modified: 2026-07-06T17:48:31.000Z
+# END AUTO GENERATED METADATA
 ---
 
 # Migrate to the current template syntax
 
-Use this guide to update a pack from the template syntax used by earlier versions of
-[Nomad Pack][pack-repo] to the current syntax. Earlier versions read a pack's variables
-and metadata with dotted paths such as `[[ .my.name ]]`. Current templates call
-functions instead, such as `[[ var "name" . ]]`.
+Use this guide to update a pack from the original [Nomad Pack][pack-repo]
+template syntax to the current syntax. The original syntax reads a pack's
+variables and metadata with dotted paths such as `[[ .my.name ]]`. Current
+templates call functions instead, such as `[[ var "name" . ]]`.
 
-In this guide, you learn how to:
+Nomad Pack v0.1.0 and later use the current syntax by default. Earlier releases
+use the original syntax. When you run a pack that uses the original syntax on
+v0.1.0 or later, Nomad Pack reports an error unless you pass the `--parser-v1`
+flag.
+
+This guide shows you how to:
 
 - access variables and metadata with the `var` and `meta` functions
 - access a pack's dependencies
-- migrate helper and output templates
+- update helper and output templates
 - run a pack that still uses the original syntax
 
 For an overview of writing packs, including the available template functions,
 refer to [Create custom packs][create-packs].
 
+## Requirements
+
+- Nomad Pack v0.1.0 or later
+- A pack that uses the original `.my` and `.nomad_pack` template syntax
+
 ## Access variables
 
-Earlier versions accessed pack variables as fields on the template context,
+The original syntax accesses pack variables as fields on the template context,
 either through the `.my` alias or the pack's name. To read a variable, call the
 `var` function with the variable name and the context to read it from.
 
@@ -39,7 +54,7 @@ For example, a template that reads a variable named `message` changes from
 The trailing `.` passes the current context to the function so it knows which
 pack to read from.
 
-The original syntax reached nested values with additional dots. Those become a
+The original syntax reaches nested values with additional dots. Those become a
 single dotted key, so `[[ .my.resources.cpu ]]` becomes:
 
 ```hcl
@@ -73,8 +88,8 @@ to:
 
 ## Access metadata
 
-Earlier versions accessed pack metadata through the `.nomad_pack` field. To read
-metadata, call the `meta` function, which works the same way as `var`. A
+The original syntax accesses pack metadata through the `.nomad_pack` field. To
+read metadata, call the `meta` function, which works the same way as `var`. A
 reference to the pack name changes from `[[ .nomad_pack.pack.name ]]` to:
 
 ```hcl
@@ -89,10 +104,10 @@ To read every metadata value for a pack at once, use the `metas` function:
 
 ## Access dependencies
 
-The original syntax put every pack's values on a single shared context. When a
-pack had dependencies, particularly aliased or nested ones, it was hard to tell
-which pack a value came from. The current syntax gives each dependency its own
-context, so it is always clear which pack you are reading from.
+The original syntax puts every pack's values on a single shared context. When a
+pack has dependencies, particularly aliased or nested ones, it is hard to tell
+which pack a value comes from. The current syntax gives each dependency its own
+context, so it is always clear which pack you read from.
 
 Each dependency is a field on the parent context. Pass it to `var` or `meta` in
 place of the current context.
@@ -243,7 +258,7 @@ packs with the current syntax.
 ## Troubleshoot
 
 When you run a legacy pack without the `--parser-v1` flag, Nomad Pack reports
-the field it could not find and suggests the equivalent function call.
+the field it cannot find and suggests the equivalent function call.
 
 ```plaintext
 The legacy ".my.message" syntax should be updated to use `var "message" .`. You can run legacy packs unmodified by using the `--parser-v1` flag
@@ -267,12 +282,8 @@ the missing key.
 
 ## Next steps
 
-In this guide you learned how to migrate a pack to the current template syntax,
-including how to access variables, metadata, and dependencies, update helper and
-output templates, and run a pack that still uses the original syntax with the
-`--parser-v1` flag.
-
-To learn more about authoring packs, refer to [Create custom packs][create-packs].
+To learn more about authoring packs, including the full list of template
+functions, refer to [Create custom packs][create-packs].
 
 [pack-repo]: https://github.com/hashicorp/nomad-pack
 [create-packs]: /nomad/tools/nomad-pack/create-packs

--- a/content/nomad/v2.0.x/content/tools/nomad-pack/migrate-template-syntax.mdx
+++ b/content/nomad/v2.0.x/content/tools/nomad-pack/migrate-template-syntax.mdx
@@ -8,11 +8,10 @@ description: |-
 
 # Migrate to the current template syntax
 
-This guide will walk you through updating a pack from the template syntax used
-by earlier versions of [Nomad Pack][pack-repo] to the current syntax. Earlier
-versions read a pack's variables and metadata with dotted paths such as
-`[[ .my.name ]]`. Current templates call functions instead, such as
-`[[ var "name" . ]]`.
+Use this guide to update a pack from the template syntax used by earlier versions of
+[Nomad Pack][pack-repo] to the current syntax. Earlier versions read a pack's variables
+and metadata with dotted paths such as `[[ .my.name ]]`. Current templates call
+functions instead, such as `[[ var "name" . ]]`.
 
 In this guide, you will learn how to:
 

--- a/content/nomad/v2.0.x/content/tools/nomad-pack/migrate-template-syntax.mdx
+++ b/content/nomad/v2.0.x/content/tools/nomad-pack/migrate-template-syntax.mdx
@@ -2,8 +2,8 @@
 layout: docs
 page_title: Migrate to the current template syntax
 description: |-
-  Update a Nomad Pack from the original .my and .nomad_pack template syntax to the
-  current var and meta template functions, including dependencies and helpers.
+  Update a Nomad Pack from the original `.my` and `.nomad_pack` template syntax to the
+  current `var` and `meta` template functions, including dependencies and helpers.
 ---
 
 # Migrate to the current template syntax

--- a/content/nomad/v2.0.x/content/tools/nomad-pack/migrate-template-syntax.mdx
+++ b/content/nomad/v2.0.x/content/tools/nomad-pack/migrate-template-syntax.mdx
@@ -13,7 +13,7 @@ Use this guide to update a pack from the template syntax used by earlier version
 and metadata with dotted paths such as `[[ .my.name ]]`. Current templates call
 functions instead, such as `[[ var "name" . ]]`.
 
-In this guide, you will learn how to:
+In this guide, you learn how to:
 
 - access variables and metadata with the `var` and `meta` functions
 - access a pack's dependencies

--- a/content/nomad/v2.0.x/content/tools/nomad-pack/migrate-template-syntax.mdx
+++ b/content/nomad/v2.0.x/content/tools/nomad-pack/migrate-template-syntax.mdx
@@ -7,7 +7,7 @@ description: |-
   helpers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2026-07-03T11:42:00+05:30
-last_modified: 2026-07-06T17:48:31.000Z
+last_modified: 2026-07-06T18:35:14.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -38,94 +38,115 @@ refer to [Create custom packs][create-packs].
 - Nomad Pack v0.1.0 or later
 - A pack that uses the original `.my` and `.nomad_pack` template syntax
 
-## Access variables
+## Steps
 
-The original syntax accesses pack variables as fields on the template context,
-either through the `.my` alias or the pack's name. To read a variable, call the
-`var` function with the variable name and the context to read it from.
+To migrate a pack, update each place its templates read variables, metadata, and
+dependencies, then verify the result. Complete the following steps.
 
-For example, a template that reads a variable named `message` changes from
-`[[ .my.message ]]` to:
+1. **Update variable references.** The original syntax accesses pack variables
+   as fields on the template context, either through the `.my` alias or the
+   pack's name. Call the `var` function with the variable name and the context
+   to read it from instead. For example, a template that reads a variable named
+   `message` changes from `[[ .my.message ]]` to the following function call:
 
-```hcl
-[[ var "message" . ]]
-```
+   ```hcl
+   [[ var "message" . ]]
+   ```
 
-The trailing `.` passes the current context to the function so it knows which
-pack to read from.
+   The trailing `.` passes the current context to the function so it knows which
+   pack to read from. The original syntax reaches nested values with additional
+   dots, which become a single dotted key. For example,
+   `[[ .my.resources.cpu ]]` becomes `[[ var "resources.cpu" . ]]`. A dotted key
+   only works when the parent variable is an object. To read every variable for
+   a pack at once, use the `vars` function, as in `[[ vars . ]]`. When a
+   variable holds a collection, call `var` wherever the original template used
+   the field, including as the target of a `range`:
 
-The original syntax reaches nested values with additional dots. Those become a
-single dotted key, so `[[ .my.resources.cpu ]]` becomes:
+   ```hcl
+   [[ range $k, $v := var "env" . ]][[ $k ]] = [[ $v | quote ]]
+   [[ end ]]
+   ```
 
-```hcl
-[[ var "resources.cpu" . ]]
-```
+1. **Update metadata references.** The original syntax accesses pack metadata
+   through the `.nomad_pack` field. Call the `meta` function instead, which
+   works the same way as `var`. A reference to the pack name changes from
+   `[[ .nomad_pack.pack.name ]]` to the following function call:
 
-A dotted key only works when the parent variable is an object, so this example
-assumes `resources` is an object variable with a `cpu` field.
+   ```hcl
+   [[ meta "pack.name" . ]]
+   ```
 
-To read every variable for a pack at once, use the `vars` function:
+   To read every metadata value for a pack at once, use the `metas` function, as
+   in `[[ metas . ]]`.
 
-```hcl
-[[ vars . ]]
-```
+1. **Update dependency references.** The original syntax puts every pack's
+   values on a single shared context, which makes aliased or nested
+   dependencies hard to trace. The current syntax gives each dependency its own
+   context. Each dependency is a field on the parent context that you pass to
+   `var` or `meta` in place of the current context:
 
-When a variable holds a collection, call `var` wherever the original template
-used the field, including as the target of a `range`. A loop over an `env` map
-changes from:
+   ```hcl
+   [[ var "job_name" . ]]
+   [[ var "job_name" .child ]]
+   ```
 
-```hcl
-[[ range $k, $v := .my.env ]][[ $k ]] = [[ $v | quote ]]
-[[ end ]]
-```
+   The `.` reads the `job_name` variable from the current pack and `.child`
+   reads the `job_name` variable from a dependency named `child`. Dependencies
+   can nest, and the `deps` function returns a pack's direct dependencies so you
+   can loop over them:
 
-to:
+   ```hcl
+   [[ range $dep := deps . ]][[ var "job_name" $dep ]]
+   [[ end ]]
+   ```
 
-```hcl
-[[ range $k, $v := var "env" . ]][[ $k ]] = [[ $v | quote ]]
-[[ end ]]
-```
+1. **Update helper and output templates.** The same rules apply everywhere a
+   pack renders templates, not only in jobspec files. Output templates
+   (`outputs.tpl`) and named helper templates defined with `define` share the
+   same context and functions. A helper that receives the pack context reads
+   variables and metadata like the main template. A helper that sets a job's
+   name changes from the original syntax:
 
-## Access metadata
+   ```hcl
+   [[ define "job_name" ]]
+   [[- if eq .my.job_name "" -]]
+   [[- .nomad_pack.pack.name | quote -]]
+   [[- else -]]
+   [[- .my.job_name | quote -]]
+   [[- end ]]
+   [[- end ]]
+   ```
 
-The original syntax accesses pack metadata through the `.nomad_pack` field. To
-read metadata, call the `meta` function, which works the same way as `var`. A
-reference to the pack name changes from `[[ .nomad_pack.pack.name ]]` to:
+   to the current syntax:
 
-```hcl
-[[ meta "pack.name" . ]]
-```
+   ```hcl
+   [[ define "job_name" ]]
+   [[- if eq (var "job_name" .) "" -]]
+   [[- meta "pack.name" . | quote -]]
+   [[- else -]]
+   [[- var "job_name" . | quote -]]
+   [[- end ]]
+   [[- end ]]
+   ```
 
-To read every metadata value for a pack at once, use the `metas` function:
+   Invoke the helper with the pack context so the functions can resolve values,
+   as in `job [[ template "job_name" . ]] {`. A helper that receives a plain
+   value rather than the pack context does not change, because it reads the
+   fields of whatever value you pass in. Update only the invocation to source
+   that value with `var`, so `[[ template "resources" .my.resources ]]` becomes
+   `[[ template "resources" (var "resources" .) ]]`.
 
-```hcl
-[[ metas . ]]
-```
+1. **Verify the migrated pack.** The `var` and `meta` functions return an empty
+   string when a key is not found, so a misspelled name renders as empty instead
+   of reporting an error. While you migrate, use `must_var` and `must_meta`,
+   which stop rendering and report the missing key:
 
-## Access dependencies
+   ```hcl
+   [[ must_var "message" . ]]
+   ```
 
-The original syntax puts every pack's values on a single shared context. When a
-pack has dependencies, particularly aliased or nested ones, it is hard to tell
-which pack a value comes from. The current syntax gives each dependency its own
-context, so it is always clear which pack you read from.
-
-Each dependency is a field on the parent context. Pass it to `var` or `meta` in
-place of the current context.
-
-```hcl
-[[ var "job_name" . ]]
-[[ var "job_name" .child ]]
-```
-
-Here `.` reads the `job_name` variable from the current pack and `.child` reads
-the `job_name` variable from a dependency named `child`. Dependencies can nest,
-and the `deps` function returns a pack's direct dependencies so you can loop
-over them.
-
-```hcl
-[[ range $dep := deps . ]][[ var "job_name" $dep ]]
-[[ end ]]
-```
+   Render the pack and confirm the output matches the original. If Nomad Pack
+   reports a field it cannot find, refer to [Troubleshoot](#troubleshoot).
 
 ## Complete example
 
@@ -191,52 +212,6 @@ job [[ coalesce (var "job_name" .) (meta "pack.name" .) | quote ]] {
 
 </CodeBlockConfig>
 
-## Helper and output templates
-
-The same rules apply everywhere a pack renders templates, not only in jobspec
-files. Output templates (`outputs.tpl`) and named helper templates defined with
-`define` share the same context and functions.
-
-A helper that receives the pack context reads variables and metadata like the
-main template. A helper that sets a job's name changes from:
-
-```hcl
-[[ define "job_name" ]]
-[[- if eq .my.job_name "" -]]
-[[- .nomad_pack.pack.name | quote -]]
-[[- else -]]
-[[- .my.job_name | quote -]]
-[[- end ]]
-[[- end ]]
-```
-
-to:
-
-```hcl
-[[ define "job_name" ]]
-[[- if eq (var "job_name" .) "" -]]
-[[- meta "pack.name" . | quote -]]
-[[- else -]]
-[[- var "job_name" . | quote -]]
-[[- end ]]
-[[- end ]]
-```
-
-Invoke the helper with the pack context so the functions can resolve values:
-
-```hcl
-job [[ template "job_name" . ]] {
-```
-
-A helper that receives a plain value rather than the pack context does not
-change, because it reads the fields of whatever value you pass in. You update
-only the invocation to source that value with `var`, so
-`[[ template "resources" .my.resources ]]` becomes:
-
-```hcl
-[[ template "resources" (var "resources" .) ]]
-```
-
 ## Run legacy packs
 
 You can still run a pack you have not migrated yet by passing the `--parser-v1`
@@ -268,17 +243,6 @@ The opposite happens when you run a migrated pack with the `--parser-v1` flag.
 The template functions are unavailable, so Nomad Pack reports that the function
 is not implemented for the v1 syntax. Remove the `--parser-v1` flag to parse the
 pack with the current syntax.
-
-### Missing values
-
-The `var` and `meta` functions return an empty string when a key is not found,
-so a misspelled name renders as empty instead of raising an error. While you
-migrate, use `must_var` and `must_meta` instead, which stop rendering and report
-the missing key.
-
-```hcl
-[[ must_var "message" . ]]
-```
 
 ## Next steps
 

--- a/content/nomad/v2.0.x/content/tools/nomad-pack/migrate-template-syntax.mdx
+++ b/content/nomad/v2.0.x/content/tools/nomad-pack/migrate-template-syntax.mdx
@@ -1,0 +1,279 @@
+---
+layout: docs
+page_title: Migrate to the current template syntax
+description: |-
+  Update a Nomad Pack from the original .my and .nomad_pack template syntax to the
+  current var and meta template functions, including dependencies and helpers.
+---
+
+# Migrate to the current template syntax
+
+This guide will walk you through updating a pack from the template syntax used
+by earlier versions of [Nomad Pack][pack-repo] to the current syntax. Earlier
+versions read a pack's variables and metadata with dotted paths such as
+`[[ .my.name ]]`. Current templates call functions instead, such as
+`[[ var "name" . ]]`.
+
+In this guide, you will learn how to:
+
+- access variables and metadata with the `var` and `meta` functions
+- access a pack's dependencies
+- migrate helper and output templates
+- run a pack that still uses the original syntax
+
+For an overview of writing packs, including the available template functions,
+refer to [Create custom packs][create-packs].
+
+## Access variables
+
+Earlier versions accessed pack variables as fields on the template context,
+either through the `.my` alias or the pack's name. To read a variable, call the
+`var` function with the variable name and the context to read it from.
+
+For example, a template that reads a variable named `message` changes from
+`[[ .my.message ]]` to:
+
+```hcl
+[[ var "message" . ]]
+```
+
+The trailing `.` passes the current context to the function so it knows which
+pack to read from.
+
+The original syntax reached nested values with additional dots. Those become a
+single dotted key, so `[[ .my.resources.cpu ]]` becomes:
+
+```hcl
+[[ var "resources.cpu" . ]]
+```
+
+A dotted key only works when the parent variable is an object, so this example
+assumes `resources` is an object variable with a `cpu` field.
+
+To read every variable for a pack at once, use the `vars` function:
+
+```hcl
+[[ vars . ]]
+```
+
+When a variable holds a collection, call `var` wherever the original template
+used the field, including as the target of a `range`. A loop over an `env` map
+changes from:
+
+```hcl
+[[ range $k, $v := .my.env ]][[ $k ]] = [[ $v | quote ]]
+[[ end ]]
+```
+
+to:
+
+```hcl
+[[ range $k, $v := var "env" . ]][[ $k ]] = [[ $v | quote ]]
+[[ end ]]
+```
+
+## Access metadata
+
+Earlier versions accessed pack metadata through the `.nomad_pack` field. To read
+metadata, call the `meta` function, which works the same way as `var`. A
+reference to the pack name changes from `[[ .nomad_pack.pack.name ]]` to:
+
+```hcl
+[[ meta "pack.name" . ]]
+```
+
+To read every metadata value for a pack at once, use the `metas` function:
+
+```hcl
+[[ metas . ]]
+```
+
+## Access dependencies
+
+The original syntax put every pack's values on a single shared context. When a
+pack had dependencies, particularly aliased or nested ones, it was hard to tell
+which pack a value came from. The current syntax gives each dependency its own
+context, so it is always clear which pack you are reading from.
+
+Each dependency is a field on the parent context. Pass it to `var` or `meta` in
+place of the current context.
+
+```hcl
+[[ var "job_name" . ]]
+[[ var "job_name" .child ]]
+```
+
+Here `.` reads the `job_name` variable from the current pack and `.child` reads
+the `job_name` variable from a dependency named `child`. Dependencies can nest,
+and the `deps` function returns a pack's direct dependencies so you can loop
+over them.
+
+```hcl
+[[ range $dep := deps . ]][[ var "job_name" $dep ]]
+[[ end ]]
+```
+
+## Complete example
+
+The following jobspec template uses the original syntax.
+
+<CodeBlockConfig filename="example.nomad.tpl">
+
+```hcl
+job [[ coalesce .simple_raw_exec.job_name .nomad_pack.pack.name | quote ]] {
+  datacenters = [[ .simple_raw_exec.datacenters | toJson ]]
+  type        = "service"
+
+  group "app" {
+    count = [[ .simple_raw_exec.count ]]
+
+    task "server" {
+      driver = "raw_exec"
+
+      config {
+        command = "/bin/bash"
+        args    = ["-c", [[ .simple_raw_exec.command | quote ]]]
+      }
+
+      resources {
+        cpu    = [[ .simple_raw_exec.resources.cpu ]]
+        memory = [[ .simple_raw_exec.resources.memory ]]
+      }
+    }
+  }
+}
+```
+
+</CodeBlockConfig>
+
+The same template using the current syntax.
+
+<CodeBlockConfig filename="example.nomad.tpl">
+
+```hcl
+job [[ coalesce (var "job_name" .) (meta "pack.name" .) | quote ]] {
+  datacenters = [[ var "datacenters" . | toJson ]]
+  type        = "service"
+
+  group "app" {
+    count = [[ var "count" . ]]
+
+    task "server" {
+      driver = "raw_exec"
+
+      config {
+        command = "/bin/bash"
+        args    = ["-c", [[ var "command" . | quote ]]]
+      }
+
+      resources {
+        cpu    = [[ var "resources.cpu" . ]]
+        memory = [[ var "resources.memory" . ]]
+      }
+    }
+  }
+}
+```
+
+</CodeBlockConfig>
+
+## Helper and output templates
+
+The same rules apply everywhere a pack renders templates, not only in jobspec
+files. Output templates (`outputs.tpl`) and named helper templates defined with
+`define` share the same context and functions.
+
+A helper that receives the pack context reads variables and metadata like the
+main template. A helper that sets a job's name changes from:
+
+```hcl
+[[ define "job_name" ]]
+[[- if eq .my.job_name "" -]]
+[[- .nomad_pack.pack.name | quote -]]
+[[- else -]]
+[[- .my.job_name | quote -]]
+[[- end ]]
+[[- end ]]
+```
+
+to:
+
+```hcl
+[[ define "job_name" ]]
+[[- if eq (var "job_name" .) "" -]]
+[[- meta "pack.name" . | quote -]]
+[[- else -]]
+[[- var "job_name" . | quote -]]
+[[- end ]]
+[[- end ]]
+```
+
+Invoke the helper with the pack context so the functions can resolve values:
+
+```hcl
+job [[ template "job_name" . ]] {
+```
+
+A helper that receives a plain value rather than the pack context does not
+change, because it reads the fields of whatever value you pass in. You update
+only the invocation to source that value with `var`, so
+`[[ template "resources" .my.resources ]]` becomes:
+
+```hcl
+[[ template "resources" (var "resources" .) ]]
+```
+
+## Run legacy packs
+
+You can still run a pack you have not migrated yet by passing the `--parser-v1`
+flag, which parses it with the original syntax. The commands that parse pack
+templates accept the flag: `run`, `plan`, `render`, `info`, `stop`, and
+`destroy`.
+
+```shell-session
+$ nomad-pack run ./my-pack --parser-v1
+```
+
+<Note>
+
+Treat `--parser-v1` as a temporary measure while you update a pack. Write new
+packs with the current syntax.
+
+</Note>
+
+## Troubleshoot
+
+When you run a legacy pack without the `--parser-v1` flag, Nomad Pack reports
+the field it could not find and suggests the equivalent function call.
+
+```plaintext
+The legacy ".my.message" syntax should be updated to use `var "message" .`. You can run legacy packs unmodified by using the `--parser-v1` flag
+```
+
+The opposite happens when you run a migrated pack with the `--parser-v1` flag.
+The template functions are unavailable, so Nomad Pack reports that the function
+is not implemented for the v1 syntax. Remove the `--parser-v1` flag to parse the
+pack with the current syntax.
+
+### Missing values
+
+The `var` and `meta` functions return an empty string when a key is not found,
+so a misspelled name renders as empty instead of raising an error. While you
+migrate, use `must_var` and `must_meta` instead, which stop rendering and report
+the missing key.
+
+```hcl
+[[ must_var "message" . ]]
+```
+
+## Next steps
+
+In this guide you learned how to migrate a pack to the current template syntax,
+including how to access variables, metadata, and dependencies, update helper and
+output templates, and run a pack that still uses the original syntax with the
+`--parser-v1` flag.
+
+To learn more about authoring packs, refer to [Create custom packs][create-packs].
+
+[pack-repo]: https://github.com/hashicorp/nomad-pack
+[create-packs]: /nomad/tools/nomad-pack/create-packs

--- a/content/nomad/v2.0.x/data/tools-nav-data.json
+++ b/content/nomad/v2.0.x/data/tools-nav-data.json
@@ -281,6 +281,10 @@
         "path": "nomad-pack/create-packs"
       },
       {
+        "title": "Migrate to the current template syntax",
+        "path": "nomad-pack/migrate-template-syntax"
+      },
+      {
         "title": "CLI reference",
         "routes": [
           {


### PR DESCRIPTION
Description

We don't currently have any docs that explains how to move a pack off the old .my / .nomad_pack syntax onto the var and meta functions, so this adds a guide for it.

https://github.com/hashicorp/nomad-pack/issues/437
