### PR TITLE
Add database (static roles) as a Secrets Sync source

### DIFF
--- a/content/vault/v2.x/content/api-docs/system/secrets-sync.mdx
+++ b/content/vault/v2.x/content/api-docs/system/secrets-sync.mdx
@@ -752,6 +752,18 @@ $ curl \
 }
 ```
 
+## Source parameters
+
+The `associations/set` and `associations/remove` endpoints identify a source secret using the `mount` and
+`secret_name` parameters. The source secrets engine is inferred automatically from `mount`. The accepted
+values for each supported source are:
+
+| Source secrets engine    | Value for `mount`          | Value for `secret_name`                            |
+|--------------------------|----------------------------|----------------------------------------------------|
+| KV version 2             | Path of the KV v2 mount    | Path of the secret within the mount                |
+| Database (static roles)  | Path of the database mount | `static-roles/<role_name>`, where `<role_name>` is the name of an existing static role and `static-roles/` is the required role-type prefix |
+
+
 ## Set association
 
 The set endpoint links a secret to an existing destination using the secret name
@@ -763,7 +775,8 @@ failure has been resolved.
 
 <Note>
 
-  Only KV-v2 secrets are supported at the moment.
+  For the list of supported source secrets engines, refer to
+  [supported sources](/vault/docs/sync#supported-sources).
 
 </Note>
 
@@ -777,11 +790,11 @@ failure has been resolved.
 
 - `name` `(string: <required>)` - Specifies the name for this destination. This is specified as part of the URL.
 
-- `mount` `(string: <required>)` - Specifies the mount where the secret is located. For example, if you can read a secret
-with `vault kv get -mount=my-kv my-secret-1`, the mount name is `my-kv`.
+- `mount` `(string: <required>)` - Specifies the mount path of a supported source secrets engine where the
+secret is located. Refer to [source parameters](#source-parameters) for the accepted values.
 
-- `secret_name` `(string: <required>)` - Specifies the name of the secret to synchronize. For example, if you can read a secret
-with `vault kv get -mount=my-kv my-secret-1`, the secret name is `my-secret-1`.
+- `secret_name` `(string: <required>)` - Specifies the source-relative path that identifies the secret to
+synchronize. Refer to [source parameters](#source-parameters) for the exact format each source uses.
 
 ### Sample payload
 ```json
@@ -845,11 +858,11 @@ secret was already removed from the external system.
 
 - `name` `(string: <required>)` - Specifies the name for this destination. This is specified as part of the URL.
 
-- `mount` `(string: <required>)` - Specifies the mount where the secret is located. For example, if you can read a secret
-with `vault kv get -mount=my-kv my-secret-1`, the mount name is `my-kv`.
+- `mount` `(string: <required>)` - Specifies the mount path of a supported source secrets engine where the
+secret is located. Refer to [source parameters](#source-parameters) for the accepted values.
 
-- `secret_name` `(string: <required>)` - Specifies the name of the secret to synchronize. For example, if you can read a secret
-with `vault kv get -mount=my-kv my-secret-1`, the secret name is `my-secret-1`.
+- `secret_name` `(string: <required>)` - Specifies the source-relative path that identifies the secret to
+synchronize. Refer to [source parameters](#source-parameters) for the exact format each source uses.
 
 ### Sample payload
 ```json

--- a/content/vault/v2.x/content/docs/license/product-usage-reporting.mdx
+++ b/content/vault/v2.x/content/docs/license/product-usage-reporting.mdx
@@ -264,6 +264,8 @@ IBM collects the following product usage metrics as numerical data. Vault does n
 | `vault.secretsync.destinations.vercel-project.count` | Total number of secret sync destinations to Vercel Project configured. |
 | `vault.secretsync.destinations.wif.count` | Total number of secret sync destinations configured using WIF. |
 | `vault.secretsync.sources.count` | Total number of secret sync sources configured. |
+| `vault.secretsync.sources.engine.database.count` | Number of synced sources configured from Database engine mounts. |
+| `vault.secretsync.sources.engine.kv.count` | Number of synced sources configured from KV engine mounts. |
 | `vault.storage.max_entry_size` | User configured maximum size of entries on Enterprise Raft clusters. |
 | `vault.storage.max_mount_and_namespace_table_entry_size` | User configured maximum mount and namespace entries on Enterprise Raft clusters. |
 | `vault.telemetry.filters.count` | The count of metric prefix filters specified in the telemetry stanza in config file. |

--- a/content/vault/v2.x/content/docs/sync/index.mdx
+++ b/content/vault/v2.x/content/docs/sync/index.mdx
@@ -76,8 +76,7 @@ engines are supported:
 | [KV version 2](/vault/docs/secrets/kv/kv-v2)             | Vault reads the secret from `<mount>/data/<secret_name>`. |
 | [Database (static roles)](/vault/docs/secrets/databases)  | Vault reads the credentials from `<mount>/static-creds/<role_name>`. Dynamic roles are not supported. |
 
-For the `mount` and `secret_name` values each source expects when creating an association, refer to
-[source parameters](/vault/api-docs/system/secrets-sync#source-parameters) in the API documentation.
+For the `mount` and `secret_name` values expected by each source when creating an association, refer to [source parameters](/vault/api-docs/system/secrets-sync#source-parameters) in the API documentation.
 
 
 ## Sync statuses

--- a/content/vault/v2.x/content/docs/sync/index.mdx
+++ b/content/vault/v2.x/content/docs/sync/index.mdx
@@ -14,14 +14,14 @@ last_modified: 2026-04-15T00:15:55.000Z
 @include 'alerts/enterprise-and-hcp.mdx'
 
 In certain circumstances, fetching secrets directly from Vault is impossible or impractical. To help with this challenge,
-Vault can maintain a one-way sync for KVv2 secrets into various destinations that are easier to access for some clients.
-With this, Vault remains the system of records but can cache a subset of secrets on various external systems acting as
-trusted last-mile delivery systems.
+Vault can maintain a one-way sync for secrets from [supported source secrets engines](#supported-sources) into various
+destinations that are easier to access for some clients. With this, Vault remains the system of records but can cache a
+subset of secrets on various external systems acting as trusted last-mile delivery systems.
 
-A secret that is associated from a Vault KVv2 Secrets Engine into an external destination is actively managed by a continuous
-process. If the secret value is updated in Vault, the secret is updated in the destination as well. If the secret is deleted
-from Vault, it is deleted on the external system as well. This process is asynchronous and event-based. Vault propagates
-modifications into the proper destinations automatically in a handful of seconds.
+A secret that is associated from a supported source secrets engine into an external destination is actively managed by a
+continuous process. If the secret value is updated in Vault, the secret is updated in the destination as well. If the secret
+is deleted from Vault, it is deleted on the external system as well. This process is asynchronous and event-based. Vault
+propagates modifications into the proper destinations automatically in a handful of seconds.
 
 ## Activating the feature
 
@@ -60,9 +60,25 @@ Secrets can be synced into various external systems, called destinations. The su
 ## Associations
 
 Syncing a secret into one of the external systems is done by creating a connection between it and a destination, which is
-called an association. These associations are created via Vault's API by adding a KVv2 secret target to one of the configured
-destinations. Each association keeps track of that secret's current sync status, the timestamp of its last status change, and
-the error code of the last sync or unsync operation if it failed. Each destination can have any number of secret associations.
+called an association. These associations are created via Vault's API by adding a secret from a
+[supported source secrets engine](#supported-sources) to one of the configured destinations. Each association keeps track of
+that secret's current sync status, the timestamp of its last status change, and the error code of the last sync or unsync
+operation if it failed. Each destination can have any number of secret associations.
+
+## Supported sources
+
+Secrets sync reads secrets from a source secrets engine and pushes them to a destination. When you create an association, the
+source is inferred automatically from the `mount`, so no additional parameter is required. The following source secrets
+engines are supported:
+
+| Source secrets engine    | Notes                                                                        |
+|--------------------------|------------------------------------------------------------------------------|
+| [KV version 2](/vault/docs/secrets/kv/kv-v2)             | Vault reads the secret from `<mount>/data/<secret_name>`. |
+| [Database (static roles)](/vault/docs/secrets/databases)  | Vault reads the credentials from `<mount>/static-creds/<role_name>`. Dynamic roles are not supported. |
+
+For the `mount` and `secret_name` values each source expects when creating an association, refer to
+[source parameters](/vault/api-docs/system/secrets-sync#source-parameters) in the API documentation.
+
 
 ## Sync statuses
 
@@ -147,7 +163,7 @@ to secret names, tag keys and values are normalized according to the valid chara
 
 ## Granularity
 
-Vault KV-v2 secrets are multi-value and their data is represented in JSON. Multi-value secrets are useful to bundle closely
+Vault secrets are often multi-value and their data is represented in JSON. Multi-value secrets are useful to bundle closely
 related information together like a username & password pair. However, most secret management systems only support single-value
 entries. Secrets sync allows you to choose the granularity that best suits your use case for each destination by specifying a `granularity`
 field.


### PR DESCRIPTION
Extends the Vault Secrets Sync documentation to reflect support for the **database secrets engine (static roles)** as a sync source, in addition to KV v2.
No new API endpoints or fields are introduced , the existing `mount` and `secret_name` parameters are extended, so the docs are updated accordingly.

Wording is kept **source-agnostic** in API description so future source engines can be added without further churn. 

JIRA: [VAULT-43913](https://hashicorp.atlassian.net/browse/VAULT-43913)

Please go to the `Preview` tab and select the appropriate template:

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)


[VAULT-43913]: https://hashicorp.atlassian.net/browse/VAULT-43913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ