### PR TITLE
[VAULT-46135] Add docs for Terraform Secret Engine Root rotation

### DIFF
--- a/content/vault/v2.x/content/api-docs/secret/terraform.mdx
+++ b/content/vault/v2.x/content/api-docs/secret/terraform.mdx
@@ -38,6 +38,14 @@ Terraform Cloud tokens.
   use. This token must have the needed permissions to manage all Organization,
   Team, and User tokens desired for this mount.
 
+- `explicit_max_ttl` `(integer: 0)` – Specifies the maximum lifetime, in seconds,
+  set on the root token in Terraform Cloud or Enterprise when Vault rotates it.
+  Acts as an upper-bound safety net; Vault manages the root token lifecycle. The
+  default (`0`) omits the expiration so Terraform applies its default token
+  expiry. The same value is used for both manual and automatic rotation.
+
+@include 'rotationfields.mdx'
+
 ### Sample payload
 
 ```json
@@ -76,10 +84,75 @@ $ curl \
 ### Sample response
 
 ```json
+{
   "data": {
     "address": "https://app.terraform.io",
-    "base_path": "/api/v2/"
+    "base_path": "/api/v2/",
+    "explicit_max_ttl": 0,
+    "token_owner_type": "user",
+    "owner_id": "user-glhf1234",
+    "rotation_period": 0,
+    "rotation_schedule": "0 0 * * SAT",
+    "rotation_window": 3600,
+    "disable_automated_rotation": false,
+    "last_vault_rotation": "2026-04-02T23:30:00Z",
+    "next_vault_rotation": "2026-04-09T00:00:00Z"
   }
+}
+```
+
+The `token_owner_type` and `owner_id` fields describe the root token Vault
+manages. Vault discovers them from Terraform Cloud or Enterprise the first time
+it rotates the token, so they remain empty until the first rotation. Vault
+includes the `last_vault_rotation` and `next_vault_rotation` fields only after a
+rotation occurs or you configure a rotation schedule.
+
+## Rotate root token
+
+This endpoint rotates the [configured root token](#configure-access) that Vault
+uses to authenticate with Terraform Cloud or Enterprise. Vault creates a new
+token of the same type (organization, team, or user), validates it, stores it as
+the new root token, and revokes the previous token where Terraform supports
+revocation.
+
+Use this endpoint for on-demand rotation. It does not require Vault Enterprise.
+Configure scheduled, automatic rotation with the rotation fields on the
+[`/terraform/config`](#configure-access) endpoint, which requires Vault
+Enterprise.
+
+The first time Vault rotates a team or user token whose ID it does not yet know,
+Vault cannot revoke the previous token and returns a warning asking you to revoke
+it manually. Subsequent rotations revoke the previous token automatically. For
+organization tokens, Terraform implicitly replaces the token when Vault creates a
+new one, so Vault performs no explicit revocation.
+
+| Method | Path                     |
+| :----- | :----------------------- |
+| `POST` | `/terraform/rotate-root` |
+
+### Parameters
+
+There are no parameters to this operation.
+
+### Sample request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    --request POST \
+    http://127.0.0.1:8200/v1/terraform/rotate-root
+```
+
+### Sample response
+
+```json
+{
+  "data": {
+    "token_owner_type": "user",
+    "owner_id": "user-glhf1234",
+    "last_vault_rotation": "2026-04-02T23:30:00Z"
+  }
+}
 ```
 
 ## Create/Update role

--- a/content/vault/v2.x/content/api-docs/secret/terraform.mdx
+++ b/content/vault/v2.x/content/api-docs/secret/terraform.mdx
@@ -101,8 +101,8 @@ $ curl \
     "rotation_schedule": "0 0 * * SAT",
     "rotation_window": 3600,
     "disable_automated_rotation": false,
-    "last_vault_rotation": "2026-04-02T23:30:00Z",
-    "next_vault_rotation": "2026-04-09T00:00:00Z"
+    "last_vault_rotation": "2026-04-04T00:00:00Z",
+    "next_vault_rotation": "2026-04-11T00:00:00Z"
   }
 }
 ```

--- a/content/vault/v2.x/content/api-docs/secret/terraform.mdx
+++ b/content/vault/v2.x/content/api-docs/secret/terraform.mdx
@@ -41,8 +41,14 @@ Terraform Cloud tokens.
 - `explicit_max_ttl` `(integer: 0)` – Specifies the maximum lifetime, in seconds,
   set on the root token in Terraform Cloud or Enterprise when Vault rotates it.
   Acts as an upper-bound safety net; Vault manages the root token lifecycle. The
-  default (`0`) omits the expiration so Terraform applies its default token
-  expiry. The same value is used for both manual and automatic rotation.
+  default (`0`) omits the expiration, so Terraform Cloud or Enterprise applies its
+  default token lifetime of two years from the time of creation. The same value
+  applies to both manual and automatic rotation. Refer to the Terraform token API
+  documentation for
+  [organization](/terraform/cloud-docs/api-docs/organization-tokens#request-body),
+  [team](/terraform/cloud-docs/api-docs/team-tokens#request-body), and
+  [user](/terraform/cloud-docs/api-docs/user-tokens#request-body) tokens for
+  details on the default expiration.
 
 @include 'rotationfields.mdx'
 
@@ -120,11 +126,20 @@ Configure scheduled, automatic rotation with the rotation fields on the
 [`/terraform/config`](#configure-access) endpoint, which requires Vault
 Enterprise.
 
-The first time Vault rotates a team or user token whose ID it does not yet know,
-Vault cannot revoke the previous token and returns a warning asking you to revoke
-it manually. Subsequent rotations revoke the previous token automatically. For
-organization tokens, Terraform implicitly replaces the token when Vault creates a
-new one, so Vault performs no explicit revocation.
+To revoke the previous token during rotation, Vault must know its token ID. On
+HCP Terraform and Terraform Enterprise v2.1 and later, Vault discovers the token
+ID automatically from the `auth-token` link in the
+[`/account/details`](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/account#sample-response)
+response, so it revokes the previous team or user token on every rotation.
+
+On earlier versions of Terraform Enterprise that do not return the `auth-token`
+link, Vault cannot determine the ID of the initially-configured token. The first
+time Vault rotates a team or user token, it returns a warning asking you to revoke
+that initial token manually in Terraform. Vault records the ID of each token it
+creates, so subsequent rotations revoke the previous token automatically.
+
+For organization tokens, Terraform implicitly replaces the token when Vault
+creates a new one, so Vault performs no explicit revocation.
 
 | Method | Path                     |
 | :----- | :----------------------- |

--- a/content/vault/v2.x/content/docs/secrets/terraform.mdx
+++ b/content/vault/v2.x/content/docs/secrets/terraform.mdx
@@ -313,9 +313,13 @@ time Vault rotates that token, it returns a warning asking you to revoke the
 initial token manually in Terraform. Vault records the ID of each token it
 creates, so subsequent rotations revoke the previous token automatically.
 
-~> **Note:** On-demand rotation with `terraform/rotate-root` is available in both
+<Note>
+
+On-demand rotation with `terraform/rotate-root` is available in both
 Vault Community and Enterprise editions. Scheduled, automatic rotation requires
 Vault Enterprise.
+
+</Note>
 
 ### Schedule-based root token rotation
 

--- a/content/vault/v2.x/content/docs/secrets/terraform.mdx
+++ b/content/vault/v2.x/content/docs/secrets/terraform.mdx
@@ -103,7 +103,7 @@ Key                Value
 lease_id           terraform/creds/my-team-role/A_LEASE_ID_abc123
 lease_duration     300s
 lease_renewable    true
-token              tftk.abcdef1234567890
+token              <example token>
 token_id           at-456defghi789
 description        CI/CD automation token(42)
 expired_at         2025-11-08T21:30:00Z

--- a/content/vault/v2.x/content/docs/secrets/terraform.mdx
+++ b/content/vault/v2.x/content/docs/secrets/terraform.mdx
@@ -275,3 +275,98 @@ team_id         team-<id>
 token           <example token>
 token_id        at-fqvtdTQ5kQWcjUfG
 ```
+
+## Root token rotation
+
+The root token configured at `terraform/config` is the token Vault uses to
+authenticate with HCP Terraform or Terraform Enterprise. Vault can rotate this
+token so that only Vault knows its value.
+
+Trigger an on-demand rotation with the `terraform/rotate-root` endpoint:
+
+```shell-session
+$ vault write -f terraform/rotate-root
+Key                    Value
+---                    -----
+last_vault_rotation    2026-04-02T23:30:00Z
+owner_id               user-glhf1234
+token_owner_type       user
+```
+
+Vault creates a new token of the same type as the configured token, validates
+it, stores it as the new root token, and revokes the previous token. The
+behavior differs slightly by token type:
+
+- For **organization tokens**, Terraform implicitly replaces the token when Vault
+  creates a new one, so Vault performs no explicit revocation.
+- For **team and user tokens**, Vault revokes the previous token after storing the
+  new one. The first time you rotate a team or user token that you configured
+  manually, Vault does not know the previous token's ID and cannot revoke it.
+  Vault returns a warning asking you to revoke the original token manually in
+  Terraform. Subsequent rotations revoke the previous token automatically.
+
+~> **Note:** On-demand rotation with `terraform/rotate-root` is available in both
+Vault Community and Enterprise editions. Scheduled, automatic rotation requires
+Vault Enterprise.
+
+### Schedule-based root token rotation
+
+@include 'alerts/enterprise-only.mdx'
+
+Vault Enterprise can rotate the root token automatically on a schedule or after a
+fixed period. Configure automatic rotation with the rotation fields on the
+`terraform/config` endpoint.
+
+Use [`rotation_schedule`](/vault/api-docs/secret/terraform#rotation_schedule) to
+rotate the root token on a cron-style schedule. For example, the following
+command rotates the token every Saturday at midnight (00:00):
+
+```shell-session
+$ vault write terraform/config \
+    token="<token>" \
+    rotation_schedule="0 0 * * SAT"
+```
+
+Scheduled rotation can also use a
+[`rotation_window`](/vault/api-docs/secret/terraform#rotation_window) that limits
+how long Vault may take to complete a scheduled rotation. If Vault cannot rotate
+the token within the window, it waits until the next scheduled rotation:
+
+```shell-session
+$ vault write terraform/config \
+    token="<token>" \
+    rotation_schedule="0 0 * * SAT" \
+    rotation_window="1h"
+```
+
+Alternatively, use
+[`rotation_period`](/vault/api-docs/secret/terraform#rotation_period) to rotate
+the token after a fixed amount of time. You cannot set both `rotation_schedule`
+and `rotation_period`:
+
+```shell-session
+$ vault write terraform/config \
+    token="<token>" \
+    rotation_period="24h"
+```
+
+Set [`explicit_max_ttl`](/vault/api-docs/secret/terraform#explicit_max_ttl) to
+bound the lifetime of the token Vault issues during rotation. The default (`0`)
+omits the expiration so Terraform applies its default token expiry:
+
+```shell-session
+$ vault write terraform/config \
+    token="<token>" \
+    rotation_schedule="0 0 * * SAT" \
+    explicit_max_ttl="720h"
+```
+
+You can temporarily disable automatic rotation by setting
+[`disable_automated_rotation`](/vault/api-docs/secret/terraform#disable_automated_rotation)
+to `true`. Vault stops all upcoming rotations until you reset the field to
+`false`.
+
+For more details on the rotation fields, refer to the
+[Terraform Cloud secret backend API](/vault/api-docs/secret/terraform#configure-access)
+documentation.
+

--- a/content/vault/v2.x/content/docs/secrets/terraform.mdx
+++ b/content/vault/v2.x/content/docs/secrets/terraform.mdx
@@ -300,10 +300,18 @@ behavior differs slightly by token type:
 - For **organization tokens**, Terraform implicitly replaces the token when Vault
   creates a new one, so Vault performs no explicit revocation.
 - For **team and user tokens**, Vault revokes the previous token after storing the
-  new one. The first time you rotate a team or user token that you configured
-  manually, Vault does not know the previous token's ID and cannot revoke it.
-  Vault returns a warning asking you to revoke the original token manually in
-  Terraform. Subsequent rotations revoke the previous token automatically.
+  new one, as long as it knows the token ID.
+
+Vault determines the ID of the current token from the `auth-token` link in the
+[`/account/details`](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/account#sample-response)
+response. HCP Terraform and Terraform Enterprise v2.1 and later return this link,
+so Vault revokes the previous team or user token on every rotation.
+
+Earlier versions of Terraform Enterprise do not return the `auth-token` link, so
+Vault cannot determine the ID of the token you configured manually. The first
+time Vault rotates that token, it returns a warning asking you to revoke the
+initial token manually in Terraform. Vault records the ID of each token it
+creates, so subsequent rotations revoke the previous token automatically.
 
 ~> **Note:** On-demand rotation with `terraform/rotate-root` is available in both
 Vault Community and Enterprise editions. Scheduled, automatic rotation requires
@@ -352,7 +360,16 @@ $ vault write terraform/config \
 
 Set [`explicit_max_ttl`](/vault/api-docs/secret/terraform#explicit_max_ttl) to
 bound the lifetime of the token Vault issues during rotation. The default (`0`)
-omits the expiration so Terraform applies its default token expiry:
+omits the expiration, so Terraform Cloud or Enterprise applies its default token
+lifetime of two years from the time of creation. Refer to the Terraform token API
+documentation for
+[organization](/terraform/cloud-docs/api-docs/organization-tokens#request-body),
+[team](/terraform/cloud-docs/api-docs/team-tokens#request-body), and
+[user](/terraform/cloud-docs/api-docs/user-tokens#request-body) tokens for more
+details on the default expiration.
+
+The following command sets a 30-day (`720h`) maximum lifetime on the rotated
+token:
 
 ```shell-session
 $ vault write terraform/config \

--- a/content/vault/v2.x/content/docs/secrets/terraform.mdx
+++ b/content/vault/v2.x/content/docs/secrets/terraform.mdx
@@ -12,14 +12,14 @@ last_modified: 2026-04-15T00:15:53.000Z
 # HCP Terraform secrets engine
 
 The HCP Terraform secrets engine for Vault generates
-[HCP Terraform](https://cloud.hashicorp.com/products/terraform)
+[HCP Terraform](https://hashicorp.com/products/terraform)
 API tokens dynamically for Organizations, Teams, and Users.
 
 This page will show a quick start for this backend. For detailed documentation
 on every path, use `vault path-help` after mounting the backend.
 
 ~> **Terraform Enterprise Support:** this secret engine supports both Terraform
-Cloud ([app.terraform.io](https://app.terraform.io/session)) as well as on-prem
+Cloud ([app.terraform.io](https://app.terraform.io/login)) as well as on-prem
 Terraform Enterprise. Any version requirements will be documented alongside the
 features that require them, if any.
 
@@ -128,7 +128,7 @@ interferes with your intended workflows.
 
 Generating a new Organization API token by reading the credentials in
 Vault or otherwise generating them on
-[app.terraform.io](https://app.terraform.io/session) will effectively revoke
+[app.terraform.io](https://app.terraform.io/login) will effectively revoke
 **any** existing API token for that Organization.
 
 Due to this behavior, Organization API tokens created by Vault will be
@@ -242,7 +242,7 @@ token_id           at-GDMeMTvn3NhUernt
 The HCP Terraform API limits Legacy Team roles to **one active
 token at any given time**. Generating a new Legacy Team API token by
 reading the credentials in Vault or otherwise generating them on
-[app.terraform.io](https://app.terraform.io/session) will effectively revoke **any**
+[app.terraform.io](https://app.terraform.io/login) will effectively revoke **any**
 existing API token for that Team.
 
 Due to this behavior, Legacy Team API tokens created by Vault will be stored and


### PR DESCRIPTION
Documents root token rotation for the HCP Terraform (Terraform Cloud/Enterprise) secrets engine, which ships in Vault 2.1.0. Adds on-demand rotation (terraform/rotate-root), scheduled automatic rotation (Enterprise), and the explicit_max_ttl token-lifetime bound.

Changed pages (both under content/vault/v2.x/):

* Terraform Cloud secret backend HTTP API: content/vault/v2.x/content/api-docs/secret/terraform.mdx
* Added the explicit_max_ttl parameter and @include 'rotationfields.mdx' (shared partial documenting rotation_period / rotation_schedule / rotation_window / disable_automated_rotation) to Configure access.
* Updated the Read access configuration sample response with the new fields and a note explaining token_owner_type / owner_id and the rotation timestamps.
* Added a new Rotate root token endpoint section (POST /terraform/rotate-root).

HCP Terraform secrets engine (guide): content/vault/v2.x/content/docs/secrets/terraform.mdx
* Added a Root token rotation section (manual rotation + per-type organization/team/user behavior).
* Added a Schedule-based root token rotation subsection (Enterprise) with rotation_schedule / rotation_window / rotation_period / explicit_max_ttl / disable_automated_rotation examples.
