### PR TITLE
TF-38407: document AWS multi-region key (MRK) support for HYOK

### DIFF
--- a/content/terraform-docs-common/docs/cloud-docs/api-docs/hold-your-own-key/configurations.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/api-docs/hold-your-own-key/configurations.mdx
@@ -86,7 +86,7 @@ KMS Options are additional options that can be found in `data.attributes.kms-opt
 | Option | Description |
 | --- | --- |
 | `key_region` | The AWS region where your key is located. Required for AWS. When `multi-region` is `true`, the agent resolves the region at runtime and uses this value as a fallback. |
-| `multi-region` | Boolean flag that indicates whether the `kek-id` refers to an AWS KMS multi-region key. Only supported for AWS. Defaults to `false`. See [Region selection for multi-region keys](/terraform/cloud-docs/hold-your-own-key/configure#region-selection-for-multi-region-keys).  |
+| `multi-region` | Boolean flag that indicates whether the `kek-id` refers to an AWS KMS multi-region key. Only supported for AWS. Defaults to `false`. Refer to [Region selection for multi-region keys](/terraform/cloud-docs/hold-your-own-key/configure#region-selection-for-multi-region-keys).  |
 | `key_location` | A key ring is the root resource for Google Cloud KMS keys and key versions. Each key ring exists within a given location.  |
 | `key_ring_id` | A key ring is the root resource for Google Cloud KMS keys and key versions. Each key ring exists within a given location. |
 

--- a/content/terraform-docs-common/docs/cloud-docs/api-docs/hold-your-own-key/configurations.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/api-docs/hold-your-own-key/configurations.mdx
@@ -86,7 +86,7 @@ KMS Options are additional options that can be found in `data.attributes.kms-opt
 | Option | Description |
 | --- | --- |
 | `key_region` | The AWS region where your key is located. Required for AWS. When `multi-region` is `true`, the agent resolves the region at runtime and uses this value as a fallback. |
-| `multi-region` | Boolean flag that indicates whether the `kek-id` refers to an AWS KMS multi-region key. Only supported for AWS. Defaults to `false`. Refer to [Region selection for multi-region keys](/terraform/cloud-docs/hold-your-own-key/configure#region-selection-for-multi-region-keys).  |
+| `multi-region` | Boolean flag that indicates whether the `kek-id` refers to an AWS KMS multi-region key. Only supported for AWS. Defaults to `false`. Refer to [Region selection for AWS multi-region keys](/terraform/cloud-docs/hold-your-own-key/configure#region-selection-for-aws-multi-region-keys).  |
 | `key_location` | A key ring is the root resource for Google Cloud KMS keys and key versions. Each key ring exists within a given location.  |
 | `key_ring_id` | A key ring is the root resource for Google Cloud KMS keys and key versions. Each key ring exists within a given location. |
 

--- a/content/terraform-docs-common/docs/cloud-docs/api-docs/hold-your-own-key/configurations.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/api-docs/hold-your-own-key/configurations.mdx
@@ -85,7 +85,8 @@ KMS Options are additional options that can be found in `data.attributes.kms-opt
 
 | Option | Description |
 | --- | --- |
-| `key_region` | The AWS region where your key is located. |
+| `key_region` | The AWS region where your key is located. Required for AWS. When `multi-region` is `true`, the agent resolves the region at runtime and uses this value as a fallback. |
+| `multi-region` | Boolean flag that indicates whether the `kek-id` refers to an AWS KMS multi-region key. Only supported for AWS. Defaults to `false`. See [Region selection for multi-region keys](/terraform/cloud-docs/hold-your-own-key/configure#region-selection-for-multi-region-keys).  |
 | `key_location` | A key ring is the root resource for Google Cloud KMS keys and key versions. Each key ring exists within a given location.  |
 | `key_ring_id` | A key ring is the root resource for Google Cloud KMS keys and key versions. Each key ring exists within a given location. |
 

--- a/content/terraform-docs-common/docs/cloud-docs/api-docs/hold-your-own-key/configurations.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/api-docs/hold-your-own-key/configurations.mdx
@@ -9,33 +9,33 @@ last_modified: 2025-09-03T15:00:20-07:00
 # END AUTO GENERATED METADATA
 ---
 
-[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/200
 
-[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
+[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/201
 
-[202]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202
+[202]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/202
 
-[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
+[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/204
 
-[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
+[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/400
 
-[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
+[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/401
 
-[403]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
+[403]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/403
 
-[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/404
 
-[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
+[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/409
 
-[412]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412
+[412]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/412
 
-[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
+[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/422
 
-[429]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429
+[429]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/429
 
-[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/500
 
-[504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
+[504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/504
 
 [JSON API document]: /terraform/cloud-docs/api-docs#json-api-documents
 

--- a/content/terraform-docs-common/docs/cloud-docs/hold-your-own-key/concepts.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/hold-your-own-key/concepts.mdx
@@ -137,6 +137,8 @@ The DEK is a random 256-bit string. HCP Terraform sends the DEK to your KMS for 
 - [GCP Cloud KMS cryptroKeys.encrypt](https://cloud.google.com/kms/docs/reference/rest/v1/projects.locations.keyRings.cryptoKeys/encrypt)
 - [Azure Key Vault Encrypt](https://learn.microsoft.com/en-us/rest/api/keyvault/keys/encrypt/encrypt?view=rest-keyvault-keys-7.4&tabs=HTTP)
 
+For AWS, you can configure HYOK to use an [AWS KMS multi-region key](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html) so that agents running in different regions encrypt and decrypt data with a region-local replica of the same key. Refer to [Region selection for multi-region keys](/terraform/cloud-docs/hold-your-own-key/configure#region-selection-for-multi-region-keys) to learn how the agent chooses a region.
+
 When you revoke an HYOK configuration in HCP Terraform, it sends the encrypted DEK to the HCP Terraform agent. The agent first decrypts the DEK using the KMS configuration you are revoking, and then re-encrypts the key using your primary HYOK configuration before uploading the new encrypted DEK to HCP Terraform.
 
 ![Diagram: HYOK encrypted DEK generation](/img/docs/tfc-hyok-dek-generation.png)

--- a/content/terraform-docs-common/docs/cloud-docs/hold-your-own-key/concepts.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/hold-your-own-key/concepts.mdx
@@ -134,8 +134,8 @@ The DEK is a random 256-bit string. HCP Terraform sends the DEK to your KMS for 
 
 - [Vault Transit Secrets Engine Encrypt](/vault/api-docs/secret/transit#encrypt-data)
 - [AWS KMS Encrypt](https://docs.aws.amazon.com/kms/latest/APIReference/API_Encrypt.html)
-- [GCP Cloud KMS cryptroKeys.encrypt](https://cloud.google.com/kms/docs/reference/rest/v1/projects.locations.keyRings.cryptoKeys/encrypt)
-- [Azure Key Vault Encrypt](https://learn.microsoft.com/en-us/rest/api/keyvault/keys/encrypt/encrypt?view=rest-keyvault-keys-7.4&tabs=HTTP)
+- [GCP Cloud KMS cryptroKeys.encrypt](https://docs.cloud.google.com/kms/docs/reference/rest/v1/projects.locations.keyRings.cryptoKeys/encrypt)
+- [Azure Key Vault Encrypt](https://learn.microsoft.com/en-us/rest/api/keyvault/keys/encrypt/encrypt?view=rest-keyvault-keys-2025-07-01&viewFallbackFrom=rest-keyvault-keys-7.4&tabs=HTTP)
 
 For AWS, you can configure HYOK to use an [AWS KMS multi-region key](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html) so that agents running in different regions encrypt and decrypt data with a region-local replica of the same key. Refer to [Region selection for multi-region keys](/terraform/cloud-docs/hold-your-own-key/configure#region-selection-for-multi-region-keys) to learn how the agent chooses a region.
 

--- a/content/terraform-docs-common/docs/cloud-docs/hold-your-own-key/concepts.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/hold-your-own-key/concepts.mdx
@@ -137,7 +137,7 @@ The DEK is a random 256-bit string. HCP Terraform sends the DEK to your KMS for 
 - [GCP Cloud KMS cryptroKeys.encrypt](https://docs.cloud.google.com/kms/docs/reference/rest/v1/projects.locations.keyRings.cryptoKeys/encrypt)
 - [Azure Key Vault Encrypt](https://learn.microsoft.com/en-us/rest/api/keyvault/keys/encrypt/encrypt?view=rest-keyvault-keys-2025-07-01&viewFallbackFrom=rest-keyvault-keys-7.4&tabs=HTTP)
 
-For AWS, you can configure HYOK to use an [AWS KMS multi-region key](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html) so that agents running in different regions encrypt and decrypt data with a region-local replica of the same key. Refer to [Region selection for multi-region keys](/terraform/cloud-docs/hold-your-own-key/configure#region-selection-for-multi-region-keys) to learn how the agent chooses a region.
+For AWS, you can configure HYOK to use an [AWS KMS multi-region key](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html) so that agents running in different regions encrypt and decrypt data with a region-local replica of the same key. Refer to [Region selection for AWS multi-region keys](/terraform/cloud-docs/hold-your-own-key/configure#region-selection-for-aws-multi-region-keys) to learn how the agent chooses a region.
 
 When you revoke an HYOK configuration in HCP Terraform, it sends the encrypted DEK to the HCP Terraform agent. The agent first decrypts the DEK using the KMS configuration you are revoking, and then re-encrypts the key using your primary HYOK configuration before uploading the new encrypted DEK to HCP Terraform.
 

--- a/content/terraform-docs-common/docs/cloud-docs/hold-your-own-key/configure.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/hold-your-own-key/configure.mdx
@@ -32,6 +32,8 @@ To use hold your own key, first ensure you meet the following requirements:
 - Configure healthy key management policies on your KMS to prevent data loss. Otherwise, if a key is deleted from a KMS while HCP Terraform is using it, you can experience state loss.
 - Configure your workspaces to use Terraform 1.3+.
 
+HYOK requires HCP Terraform agents on version `1.23.0` or later. Using a multi-region key with AWS KMS requires HCP Terraform agents on version `1.30.0` or later.
+
 ## Create key configuration
 
 To configure hold your own key, begin by letting your key management system accept the necessary OpenID Connect (OIDC) requests from HCP Terraform. Then, set up your keys and grant the necessary roles and permissions in your cloud provider.
@@ -177,15 +179,13 @@ same key. This supports disaster recovery when an AWS region is unavailable.
 
 To use a multi-region key with HYOK:
 
-1. Create a multi-region primary key, then
-   [replicate it](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-replicate.html)
-   into every region where you run agents. Replica keys share the same key
-   material and key ID suffix as the primary key.
-1. Add the IAM role you created earlier as a key user on the primary key and on
-   every replica.
+1. Create a multi-region primary key.
+1. Replicate the primary key to every region where you run agents. 
+   Replica keys share the same key material and key ID suffix as the primary key. 
+   Refer to the [AWS documentation](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-replicate.html) for instructions.   
+1. Add the IAM role you created in [Create an OIDC Identity Provider](#create-an-oidc-identity-provider) as a key user on the primary key and on every replica.
 
-Using a multi-region key requires HCP Terraform agents on version `1.30.0` or
-later.
+Using a multi-region key requires HCP Terraform agents on version `1.30.0` or later.
 
 </Tab>
 
@@ -531,7 +531,7 @@ To configure your key in HCP Terraform, you need the following values from AWS:
 - The **Region** that the key is located in. HCP Terraform always requires a
   region for AWS keys. When you enable multi-region support, the agent can
   override this region at runtime, and uses this value as a fallback. Refer to
-  [Region selection for multi-region keys](#region-selection-for-multi-region-keys).
+  [Region selection for AWS multi-region keys](#region-selection-for-aws-multi-region-keys).
 - **Multi-region key** support. Enable this option when your key identifier
   refers to an AWS KMS [multi-region key](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html)
   that you have replicated into every region where you run agents. This option requires agents on version `1.30.0` or later.
@@ -570,7 +570,7 @@ failures are:
 - Permissions have not been set correctly in your KMS.
 - The required resources are not fully provisioned in your KMS. In rare cases, it can take up to 15 minutes for keys to be accessible to HCP Terraform after creation, particularly for Azure and GCP.
 
-## Region selection for multi-region keys
+## Region selection for AWS multi-region keys
 
 When you enable multi-region key support on an AWS HYOK configuration, the
 agent selects the AWS region it uses for KMS operations at runtime instead of

--- a/content/terraform-docs-common/docs/cloud-docs/hold-your-own-key/configure.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/hold-your-own-key/configure.mdx
@@ -578,12 +578,12 @@ always using the region you configured. This lets an agent encrypt and decrypt
 data with the replica of your key that is local to the region where the agent
 runs.
 
-The agent selects the region as follows:
+The agent selects the region according to the following configurations:
 
-- **Single-region keys** (`multi_region` disabled): the agent always uses the
+- Single-region keys: When `multi_region` is disabled, the agent always uses the
   region you set in the HYOK configuration.
-- **Multi-region keys** (`multi_region` enabled): the agent uses the AWS SDK's
-  default region resolution to determine the region, and falls back to the
+- Multi-region keys: When `multi_region` is enabled, the agent uses the AWS SDK's
+  default region resolution to determine the region and falls back to the
   configured region only when the SDK cannot resolve a region.
 
 ### How the agent resolves the region
@@ -591,13 +591,12 @@ The agent selects the region as follows:
 HCP Terraform agents use the [AWS SDK for Go v2](https://docs.aws.amazon.com/sdk-for-go/v2/developer-guide/configure-gosdk.html),
 which resolves the region from the agent's environment using the
 [standard AWS region setting](https://docs.aws.amazon.com/sdkref/latest/guide/feature-region.html).
-The SDK checks the following sources, in order:
+The SDK checks the following sources in order:
 
-1. The `AWS_REGION` environment variable, then the `AWS_DEFAULT_REGION`
-   environment variable.
-1. The `region` setting in the shared AWS configuration file (by default
-   `~/.aws/config`) for the active profile.
-1. The instance or container metadata service, when the agent runs on Amazon EC2
+1. `AWS_REGION` environment variable.
+1. `AWS_DEFAULT_REGION` environment variable.
+1. `region` setting in the shared AWS configuration file. By default, the configuration is stored in `~/.aws/config` for the active profile.
+1. Instance or container metadata service for agents running on Amazon EC2
    or Amazon ECS.
 
 Set the region in the environment of each agent so that it matches the region of

--- a/content/terraform-docs-common/docs/cloud-docs/hold-your-own-key/configure.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/hold-your-own-key/configure.mdx
@@ -201,7 +201,7 @@ To use GCP with HYOK, you will configure the following:
 
 ### Create a Key Ring and Key
 
-To begin, [Create a key ring](https://cloud.google.com/kms/docs/create-key-ring)
+To begin, [Create a key ring](https://docs.cloud.google.com/kms/docs/create-key-ring)
 and a [Create a symmetric encryption
 key](https://cloud.google.com/kms/docs/create-key#create-symmetric) in Google
 Cloud KMS.
@@ -212,7 +212,7 @@ later when you create your HYOK configuration in HCP Terraform.
 ### Create a Service Account
 
 Next, [create a service
-account](https://cloud.google.com/iam/docs/service-accounts-create) with
+account](https://docs.cloud.google.com/iam/docs/service-accounts-create) with
 permissions to encrypt and decrypt data with the key you created. The HCP
 Terraform Agent will assume the role of this service account in order to use
 this key to encrypt and decrypt your data encryption keys.

--- a/content/terraform-docs-common/docs/cloud-docs/hold-your-own-key/configure.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/hold-your-own-key/configure.mdx
@@ -168,6 +168,25 @@ symmetric encryption KMS key](https://docs.aws.amazon.com/kms/latest/developergu
 Add the IAM role you created in the previous step as a key user, so that the HCP
 Terraform agent can use it to perform cryptographic operations.
 
+#### Use a multi-region key
+
+If you run agents in more than one AWS region, you can configure HYOK to use an
+[AWS KMS multi-region key](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html)
+so that each agent encrypts and decrypts data with a region-local replica of the
+same key. This supports disaster recovery when an AWS region is unavailable.
+
+To use a multi-region key with HYOK:
+
+1. Create a multi-region primary key, then
+   [replicate it](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-replicate.html)
+   into every region where you run agents. Replica keys share the same key
+   material and key ID suffix as the primary key.
+1. Add the IAM role you created earlier as a key user on the primary key and on
+   every replica.
+
+Using a multi-region key requires HCP Terraform agents on version `1.30.0` or
+later.
+
 </Tab>
 
 <Tab heading="GCP" group="gcp">
@@ -502,8 +521,20 @@ To configure your key in HCP Terraform, you need the full **Key URI** for the ke
 
 To configure your key in HCP Terraform, you need the following values from AWS:
 
-- The full **Key ARN** for the KMS key.
-- The **Region** that the key is located in.
+- The **Key identifier** for the KMS key. The accepted format depends on whether
+  you enable multi-region support:
+    - **Single-region key** (default): use the key's full **ARN** or an
+      **alias**.
+    - **Multi-region key**: use a native multi-region key ID (`mrk-<KEY_ID>`) or
+      an **alias**. HCP Terraform rejects a plain key ARN or an alias ARN in this
+      mode, because those identifiers are region-specific.
+- The **Region** that the key is located in. HCP Terraform always requires a
+  region for AWS keys. When you enable multi-region support, the agent can
+  override this region at runtime, and uses this value as a fallback. Refer to
+  [Region selection for multi-region keys](#region-selection-for-multi-region-keys).
+- **Multi-region key** support. Enable this option when your key identifier
+  refers to an AWS KMS [multi-region key](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html)
+  that you have replicated into every region where you run agents. This option requires agents on version `1.30.0` or later.
 
 </Tab>
 <Tab heading="GCP" group="gcp">
@@ -538,6 +569,41 @@ failures are:
   **Agent Pool**.
 - Permissions have not been set correctly in your KMS.
 - The required resources are not fully provisioned in your KMS. In rare cases, it can take up to 15 minutes for keys to be accessible to HCP Terraform after creation, particularly for Azure and GCP.
+
+## Region selection for multi-region keys
+
+When you enable multi-region key support on an AWS HYOK configuration, the
+agent selects the AWS region it uses for KMS operations at runtime instead of
+always using the region you configured. This lets an agent encrypt and decrypt
+data with the replica of your key that is local to the region where the agent
+runs.
+
+The agent selects the region as follows:
+
+- **Single-region keys** (`multi_region` disabled): the agent always uses the
+  region you set in the HYOK configuration.
+- **Multi-region keys** (`multi_region` enabled): the agent uses the AWS SDK's
+  default region resolution to determine the region, and falls back to the
+  configured region only when the SDK cannot resolve a region.
+
+### How the agent resolves the region
+
+HCP Terraform agents use the [AWS SDK for Go v2](https://docs.aws.amazon.com/sdk-for-go/v2/developer-guide/configure-gosdk.html),
+which resolves the region from the agent's environment using the
+[standard AWS region setting](https://docs.aws.amazon.com/sdkref/latest/guide/feature-region.html).
+The SDK checks the following sources, in order:
+
+1. The `AWS_REGION` environment variable, then the `AWS_DEFAULT_REGION`
+   environment variable.
+1. The `region` setting in the shared AWS configuration file (by default
+   `~/.aws/config`) for the active profile.
+1. The instance or container metadata service, when the agent runs on Amazon EC2
+   or Amazon ECS.
+
+Set the region in the environment of each agent so that it matches the region of
+the key replica you want that agent to use. If the SDK cannot resolve a region
+from any of these sources, the agent falls back to the **Region** you set in the
+HYOK configuration.
 
 ## Use a key configuration to encrypt a workspace
 


### PR DESCRIPTION
## Description

Documents AWS KMS multi-region key (MRK) support for the HYOK feature. Customers running HCP Terraform agents in multiple AWS regions can configure HYOK to use a multi-region key so that each agent encrypts and decrypts data with a region-local replica of the same key, supporting disaster recovery.

### Changes

- **`hold-your-own-key/configure.mdx`**
  - New "Use a multi-region key" subsection under *Create an AWS KMS Key* (replication steps, minimum agent version `1.30.0`).
  - Updated *Configure key settings* (AWS) to document the multi-region option, accepted key identifiers (alias or `mrk-*`; plain ARN / alias ARN rejected in MRK mode), and that the configured region is still required and acts as a fallback.
  - New "Region selection for multi-region keys" section explaining runtime region selection and the AWS SDK for Go v2 resolution order.
- **`api-docs/hold-your-own-key/configurations.mdx`**
  - Documented the `multi-region` KMS option and clarified `key_region` behavior.
- **`hold-your-own-key/concepts.mdx`**
  - Cross-reference to the multi-region region-selection docs.

## Related

- Jira: [TF-38407](https://hashicorp.atlassian.net/browse/TF-38407)


[TF-38407]: https://hashicorp.atlassian.net/browse/TF-38407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ