### PR TITLE
fix typo across versions

### DIFF
--- a/content/terraform-enterprise/1.0.x/docs/enterprise/application-administration/integration.mdx
+++ b/content/terraform-enterprise/1.0.x/docs/enterprise/application-administration/integration.mdx
@@ -12,7 +12,7 @@ last_modified: 2025-08-11T21:14:21-07:00
 
 This topic describes how to integrate Terraform Enterprise with external services so that Terraform Enterprise can send communications and authenticate users. Refer to the [Admin Settings API](/terraform/enterprise/api-docs/admin/settings) for instructions on configuring integrations using the API.
 
-## Introdution
+## Introduction
 
 You can integrate with the following external services: 
 

--- a/content/terraform-enterprise/1.1.x/docs/enterprise/application-administration/integration.mdx
+++ b/content/terraform-enterprise/1.1.x/docs/enterprise/application-administration/integration.mdx
@@ -12,7 +12,7 @@ last_modified: 2025-10-15T15:59:29Z
 
 This topic describes how to integrate Terraform Enterprise with external services so that Terraform Enterprise can send communications and authenticate users. Refer to the [Admin Settings API](/terraform/enterprise/api-docs/admin/settings) for instructions on configuring integrations using the API.
 
-## Introdution
+## Introduction
 
 You can integrate with the following external services: 
 

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/application-administration/integration.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/application-administration/integration.mdx
@@ -12,7 +12,7 @@ last_modified: 2026-02-04T15:01:51-08:00
 
 This topic describes how to integrate Terraform Enterprise with external services so that Terraform Enterprise can send communications and authenticate users. Refer to the [Admin Settings API](/terraform/enterprise/api-docs/admin/settings) for instructions on configuring integrations using the API.
 
-## Introdution
+## Introduction
 
 You can integrate with the following external services: 
 

--- a/content/terraform-enterprise/2.0.x/docs/enterprise/application-administration/integration.mdx
+++ b/content/terraform-enterprise/2.0.x/docs/enterprise/application-administration/integration.mdx
@@ -12,7 +12,7 @@ last_modified: 2026-02-04T15:01:51-08:00
 
 This topic describes how to integrate Terraform Enterprise with external services so that Terraform Enterprise can send communications and authenticate users. Refer to the [API reference documentation](/terraform/enterprise/api-docs) for instructions on configuring integrations using the API.
 
-## Introdution
+## Introduction
 
 You can integrate with the following external services: 
 

--- a/content/terraform-enterprise/v202411-1/docs/enterprise/application-administration/integration.mdx
+++ b/content/terraform-enterprise/v202411-1/docs/enterprise/application-administration/integration.mdx
@@ -12,7 +12,7 @@ last_modified: 2023-01-01T00:00:00.000Z
 
 This topic describes how to integrate Terraform Enterprise with external services so that Terraform Enterprise can send communications and authenticate users. Refer to the [Admin Settings API](/terraform/enterprise/api-docs/admin/settings) for instructions on configuring integrations using the API.
 
-## Introdution
+## Introduction
 
 You can integrate with the following external services: 
 

--- a/content/terraform-enterprise/v202411-2/docs/enterprise/application-administration/integration.mdx
+++ b/content/terraform-enterprise/v202411-2/docs/enterprise/application-administration/integration.mdx
@@ -12,7 +12,7 @@ last_modified: 2023-01-01T00:00:00.000Z
 
 This topic describes how to integrate Terraform Enterprise with external services so that Terraform Enterprise can send communications and authenticate users. Refer to the [Admin Settings API](/terraform/enterprise/api-docs/admin/settings) for instructions on configuring integrations using the API.
 
-## Introdution
+## Introduction
 
 You can integrate with the following external services: 
 

--- a/content/terraform-enterprise/v202501-1/docs/enterprise/application-administration/integration.mdx
+++ b/content/terraform-enterprise/v202501-1/docs/enterprise/application-administration/integration.mdx
@@ -12,7 +12,7 @@ last_modified: 2023-01-01T00:00:00.000Z
 
 This topic describes how to integrate Terraform Enterprise with external services so that Terraform Enterprise can send communications and authenticate users. Refer to the [Admin Settings API](/terraform/enterprise/api-docs/admin/settings) for instructions on configuring integrations using the API.
 
-## Introdution
+## Introduction
 
 You can integrate with the following external services: 
 

--- a/content/terraform-enterprise/v202502-1/docs/enterprise/application-administration/integration.mdx
+++ b/content/terraform-enterprise/v202502-1/docs/enterprise/application-administration/integration.mdx
@@ -12,7 +12,7 @@ last_modified: 2023-01-01T00:00:00.000Z
 
 This topic describes how to integrate Terraform Enterprise with external services so that Terraform Enterprise can send communications and authenticate users. Refer to the [Admin Settings API](/terraform/enterprise/api-docs/admin/settings) for instructions on configuring integrations using the API.
 
-## Introdution
+## Introduction
 
 You can integrate with the following external services: 
 

--- a/content/terraform-enterprise/v202502-2/docs/enterprise/application-administration/integration.mdx
+++ b/content/terraform-enterprise/v202502-2/docs/enterprise/application-administration/integration.mdx
@@ -12,7 +12,7 @@ last_modified: 2023-01-01T00:00:00.000Z
 
 This topic describes how to integrate Terraform Enterprise with external services so that Terraform Enterprise can send communications and authenticate users. Refer to the [Admin Settings API](/terraform/enterprise/api-docs/admin/settings) for instructions on configuring integrations using the API.
 
-## Introdution
+## Introduction
 
 You can integrate with the following external services: 
 

--- a/content/terraform-enterprise/v202503-1/docs/enterprise/application-administration/integration.mdx
+++ b/content/terraform-enterprise/v202503-1/docs/enterprise/application-administration/integration.mdx
@@ -12,7 +12,7 @@ last_modified: 2023-01-01T00:00:00.000Z
 
 This topic describes how to integrate Terraform Enterprise with external services so that Terraform Enterprise can send communications and authenticate users. Refer to the [Admin Settings API](/terraform/enterprise/api-docs/admin/settings) for instructions on configuring integrations using the API.
 
-## Introdution
+## Introduction
 
 You can integrate with the following external services: 
 

--- a/content/terraform-enterprise/v202504-1/docs/enterprise/application-administration/integration.mdx
+++ b/content/terraform-enterprise/v202504-1/docs/enterprise/application-administration/integration.mdx
@@ -12,7 +12,7 @@ last_modified: 2023-01-01T00:00:00.000Z
 
 This topic describes how to integrate Terraform Enterprise with external services so that Terraform Enterprise can send communications and authenticate users. Refer to the [Admin Settings API](/terraform/enterprise/api-docs/admin/settings) for instructions on configuring integrations using the API.
 
-## Introdution
+## Introduction
 
 You can integrate with the following external services: 
 

--- a/content/terraform-enterprise/v202505-1/docs/enterprise/application-administration/integration.mdx
+++ b/content/terraform-enterprise/v202505-1/docs/enterprise/application-administration/integration.mdx
@@ -12,7 +12,7 @@ last_modified: 2023-01-01T00:00:00.000Z
 
 This topic describes how to integrate Terraform Enterprise with external services so that Terraform Enterprise can send communications and authenticate users. Refer to the [Admin Settings API](/terraform/enterprise/api-docs/admin/settings) for instructions on configuring integrations using the API.
 
-## Introdution
+## Introduction
 
 You can integrate with the following external services: 
 

--- a/content/terraform-enterprise/v202506-1/docs/enterprise/application-administration/integration.mdx
+++ b/content/terraform-enterprise/v202506-1/docs/enterprise/application-administration/integration.mdx
@@ -12,7 +12,7 @@ last_modified: 2023-01-01T00:00:00.000Z
 
 This topic describes how to integrate Terraform Enterprise with external services so that Terraform Enterprise can send communications and authenticate users. Refer to the [Admin Settings API](/terraform/enterprise/api-docs/admin/settings) for instructions on configuring integrations using the API.
 
-## Introdution
+## Introduction
 
 You can integrate with the following external services: 
 

--- a/content/terraform-enterprise/v202507-1/docs/enterprise/application-administration/integration.mdx
+++ b/content/terraform-enterprise/v202507-1/docs/enterprise/application-administration/integration.mdx
@@ -12,7 +12,7 @@ last_modified: 2025-07-03T17:17:22Z
 
 This topic describes how to integrate Terraform Enterprise with external services so that Terraform Enterprise can send communications and authenticate users. Refer to the [Admin Settings API](/terraform/enterprise/api-docs/admin/settings) for instructions on configuring integrations using the API.
 
-## Introdution
+## Introduction
 
 You can integrate with the following external services: 
 


### PR DESCRIPTION
Fixes a type on the Terraform Enterprise integrations overview page. 