### PR TITLE
VAULT-46977: Add oauth resource server endpoint to lookup by config ID

### DIFF
--- a/content/vault/v2.x/content/api-docs/system/config-oauth-resource-server.mdx
+++ b/content/vault/v2.x/content/api-docs/system/config-oauth-resource-server.mdx
@@ -168,6 +168,76 @@ $ curl \
 }
 ```
 
+## Read profile by config ID
+
+Read the OAuth Resource Server configuration profile whose `config_id` matches the
+value you provide.
+
+| Method | Path                                      |
+| :----- | :---------------------------------------- |
+| `GET`  | `/sys/config/oauth-resource-server/id/:config_id` |
+
+### Parameters
+
+- `config_id` `(string: <required>)` – Config ID of the profile to read.
+
+### Sample request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    http://127.0.0.1:8200/v1/sys/config/oauth-resource-server/id/a1e4d782-5b3c-4f09-8e7a-2d9c3f6a1b04
+```
+
+### Sample response (JWKS mode)
+
+```json
+{
+  "data": {
+    "config_id": "b2f5c891-3a7d-4e12-9f8a-1c6d4e7b2a03",
+    "profile_name": "github-actions",
+    "issuer_id": "https://token.actions.githubusercontent.com",
+    "use_jwks": true,
+    "jwks_uri": "https://token.actions.githubusercontent.com/.well-known/jwks",
+    "audiences": ["https://github.com/my-org"],
+    "no_default_policy": false,
+    "optional_authorization_details": false,
+    "user_claim": "sub",
+    "supported_algorithms": ["RS256"],
+    "jwt_type": "access_token",
+    "clock_skew_leeway": 30,
+    "enabled": true
+  }
+}
+```
+
+### Sample response (static keys mode)
+
+```json
+{
+  "data": {
+    "config_id": "a1e4d782-5b3c-4f09-8e7a-2d9c3f6a1b04",
+    "profile_name": "corporate-idp",
+    "issuer_id": "https://idp.example.com",
+    "use_jwks": false,
+    "public_keys": [
+      {
+        "key_id": "key-2026-01",
+        "pem": "-----BEGIN PUBLIC KEY-----\nMIIBI..."
+      }
+    ],
+    "audiences": ["vault"],
+    "no_default_policy": false,
+    "optional_authorization_details": false,
+    "user_claim": "sub",
+    "supported_algorithms": ["RS256", "ES256"],
+    "jwt_type": "access_token",
+    "clock_skew_leeway": 0,
+    "enabled": true
+  }
+}
+```
+
 ## Create profile
 
 Create a new OAuth Resource Server configuration profile.


### PR DESCRIPTION
Please go to the `Preview` tab and select the appropriate template:

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
