### PR TITLE
nomad-driver-podman doc updates for release v0.6.5

### DIFF
--- a/content/nomad/v2.0.x/content/plugins/drivers/podman.mdx
+++ b/content/nomad/v2.0.x/content/plugins/drivers/podman.mdx
@@ -267,7 +267,8 @@ The `podman` driver implements the following [capabilities](/nomad/plugins/autho
   every container the task starts will have the same hostname.
 
 - `image` - The image to run. Accepted transports are `docker` (default if
-  missing), `oci-archive` and `docker-archive`. Images referenced as
+  missing), `oci-archive`, and `docker-archive`. Archive references can point
+  to local files or `http://` and `https://` URLs. Images referenced as
   [short-names] will be treated according to user-configured preferences.
 
   ```hcl
@@ -275,6 +276,37 @@ The `podman` driver implements the following [capabilities](/nomad/plugins/autho
     image = "docker://redis"
   }
   ```
+
+  ```hcl
+  config {
+    image = "oci-archive:https://artifacts.example.com/images/myapp.tar"
+  }
+  ```
+
+- `os` - (Optional) Override the OS used when pulling the image. This mirrors
+  Podman's `--os` flag.
+
+- `arch` - (Optional) Override the architecture used when pulling the image.
+  This mirrors Podman's `--arch` flag.
+
+- `variant` - (Optional) Override the variant used when pulling the image.
+  This mirrors Podman's `--variant` flag.
+
+  ```hcl
+  config {
+    image   = "docker.io/library/alpine:latest"
+    os      = "linux"
+    arch    = "amd64"
+    variant = "v8"
+  }
+  ```
+
+  When you set `os`, `arch`, or `variant`, the driver always pulls the image so
+  it fetches the correct platform variant. Podman skips the download when the
+  matching image is already present. Nomad servers cannot validate these
+  overrides at scheduling time, so use
+  [`constraint`](/nomad/docs/job-specification/constraint) blocks to pin the
+  workload to compatible nodes.
 
 - `image_pull_timeout` - (Optional) Time duration for your pull timeout
   (default to `"5m"`). Cannot be longer than the [`client_http_timeout`].
@@ -302,6 +334,26 @@ The `podman` driver implements the following [capabilities](/nomad/plugins/autho
     init_path = "/usr/libexec/podman/catatonit"
   }
   ```
+
+- `ipc_mode` - (Optional) Set the IPC mode for the container. The default is
+  Podman's private namespace.
+
+  - `host` - Use the host IPC namespace.
+  - `private` - Use a private IPC namespace.
+  - `shareable` - Use a private IPC namespace that other containers may join.
+  - `none` - Use a private IPC namespace without `/dev/shm` mounted.
+  - `container:<id>` - Join another container's IPC namespace.
+  - `ns:<path>` - Join the IPC namespace at a path.
+  - `task:<name>` - Join another task's IPC namespace in the same allocation.
+
+  ```hcl
+  config {
+    ipc_mode = "task:mps-daemon"
+  }
+  ```
+
+  If you set `shm_size`, the IPC mode must create a `private` or `shareable`
+  namespace.
 
 - `labels` - (Optional) Set labels on the container.
 
@@ -396,6 +448,11 @@ The `podman` driver implements the following [capabilities](/nomad/plugins/autho
   for rootless containers on Podman version less than 5.0.0, or `pasta` for
   rootless containers on Podman v5.0.0 or greater.
 
+  You can also set `network_mode` to the name of an existing Podman network
+  created with `podman network create`. The network must already exist,
+  otherwise the task fails with a clear error. This requires Podman 4.0 or
+  later.
+
   - `bridge` - (Default for rootful) Create a network stack on the default
   Podman bridge.
   - `container:id` - Reuse another container's network stack.
@@ -416,6 +473,12 @@ The `podman` driver implements the following [capabilities](/nomad/plugins/autho
   ```hcl
   config {
     network_mode = "bridge"
+  }
+  ```
+
+  ```hcl
+  config {
+    network_mode = "mynet"
   }
   ```
 


### PR DESCRIPTION
<!--
**Merge branch**

Make sure you create your PR against the correct **base** branch. For instructions, refer to
GitHub's **Change the branch range and destination repository guide** (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request).

If your content is an update to:

- Currently published content

  Choose **base: main** when you are updating published documentation, and you
  want your changes published when the PR is merged. We publish Nomad content
  from the `main` branch.

- Upcoming Nomad release

  Choose the branch for the Nomad release that your content is for. Nomad
  release branches use the `nomad/<exact-release-number>` format. If you are not
  able to find the upcoming Nomad release branch that you are looking for,
  contact the tech writer that works with the Nomad team.

- Upcoming Nomad release but not sure which one

  - Choose the `main` branch.
  - Add the "do not merge" label.
  - Convert the PR to a DRAFT.
  - Put an explanation in the **Description** section.

  The tech writer coordinates with Nomad engineering and updates
  the docs PR base branch when the code is slotted into an upcoming release.

**Backports**

This repo stores previous version docs in folders instead of branches. There are
no backport labels.  If you backported your code PR to previous branches, update
the docs content in the corresponding folders. For example, if the current
release is 1.10.x and you backported your code to 1.9.x and 1.8.x, update the docs content
in the v1.10.x, v1.9.x, and v1.8.x folders. If you can't find the relevant files in previous versions,
add a note to your PR description. The tech writer will help ensure that the previous versions
receive the correct updates.
-->

## Description
This PR updates the nomad-driver-podman documentation for the v0.5.0 release.

[Ticket](https://hashicorp.atlassian.net/browse/NMD-1628)

<!-- 
Please describe why you're making this change and point out any important details the reviewers
should be aware of. A robust description helps the tech writer create a fabulous release note.
If your code PR has a splendid description, link to the code PR in the links section so that
the tech writer can update this PR's description. 

Include the target release as well as prior versions if applicable.
-->

## Changes
<!--
**Please link to the related Nomad repo code PR!** if there is one. 
The tech writer does look at the code PR description, Jira ticket, and/or GH issue before reviewing docs content.

Include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a docs bug fix, please ensure related issues are linked so they will close when this PR is
merged.

// GH-Jira integration generates the link and updates the Jira ticket.
Jira: [<jira-ticket-number>]  // for example, Jira: [NMD-1234] 

GitHub Issue: <issue-link>

Deploy previews: The bot does publish a root-level link to the deploy preview, but the preview URL changes with each build.
-->

**Image platform overrides ([PR](https://github.com/hashicorp/nomad-driver-podman/pull/514) , [JIRA Ticket](https://hashicorp.atlassian.net/browse/NMD-1320))**

- Documents the new os, arch, and variant task config fields that override the platform used when pulling an image (mirroring podman's --os, --arch, --variant flags)
- Adds an example and explains the always-pull behavior when any override is set, plus constraint guidance for pinning workloads to compatible nodes

**IPC namespace mode ([PR](https://github.com/hashicorp/nomad-driver-podman/pull/515) , [JIRA Ticket](https://hashicorp.atlassian.net/browse/NMD-1582))**

- Documents the new ipc_mode task config with all supported values (host, private, shareable, none, container:<id>, ns:<path>, task:<name>)
- Adds a task:mps-daemon example and the shm_size compatibility note

**Custom Podman network names ([PR](https://github.com/hashicorp/nomad-driver-podman/pull/509) , [JIRA Ticket](https://hashicorp.atlassian.net/browse/NMD-1518 ))**

- Documents that network_mode accepts the name of a pre-existing Podman network created with podman network create
- Notes the network must already exist and that this requires Podman 4.0 or later; adds a network_mode = "mynet" example

**HTTP(S) archive URLs for images ([PR](https://github.com/hashicorp/nomad-driver-podman/pull/517) ,[ JIRA Ticket](https://hashicorp.atlassian.net/browse/NMD-1000))**

- Documents that the image field's oci-archive and docker-archive transports accept http(s):// URLs, not just local archive paths
- Adds an oci-archive:https://... example


## Contributor checklists

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [ ] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [ ] Verify that the PR is set to merge into the correct base branch
- [ ] Verify that all status checks passed
- [ ] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [ ] I added redirects for any moved or removed pages
- [x] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [ ] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [ ] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.


[NMD-1234]: https://hashicorp.atlassian.net/browse/NMD-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ