### PR TITLE
Nomad Pack: Add content from nomad-pack repo 

### DIFF
--- a/content/nomad/v2.0.x/content/tools/nomad-pack/advanced-usage.mdx
+++ b/content/nomad/v2.0.x/content/tools/nomad-pack/advanced-usage.mdx
@@ -2,8 +2,8 @@
 layout: docs
 page_title: Nomad Pack advanced usage
 description: |-
-  Generate a variables files, render a Nomad Pack, plan a Pack deployment, and
-  manage your local Pack registry.
+  Generate variable files, render a pack, plan a pack deployment, and
+  manage your local pack registry.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-11-17T20:24:06-05:00
 last_modified: 2025-11-17T20:24:06-05:00
@@ -12,25 +12,28 @@ last_modified: 2025-11-17T20:24:06-05:00
 
 # Nomad Pack advanced usage
 
-In the [Nomad Pack overview guide][pack-intro] you learned about Nomad Pack, how to deploy applications with it, and how to discover community packs.
+In the [Nomad Pack overview guide][pack-intro], you learned about Nomad Pack, how to deploy applications with it, and how to discover community packs.
 
 In this guide, you will learn about more advanced usage including:
 
 - Generating a variable file
-- Rendering a Pack
+- Rendering a pack
 - Advanced `run` options
 - Planning with `plan`
 - Registry management
 
-## Generating a variable file
+## Generate a variable file
 
-You can pass in variables to a pack with a variables file.
+You can pass in variables to a pack with a variables file. You can pass
+`-f/--var-file` multiple times. Variable files are processed in the same order
+they are provided on the command line. If the same key is defined in multiple
+variable files, the value from the last file wins.
 
 ```shell-session
 $ nomad-pack run hello_world -f ./my-variables.hcl
 ```
 
-The `generate var-file` command can generate variable files from a pack.
+The `generate var-file` command generates variable files from a pack.
 
 ```shell-session
 $ nomad-pack generate var-file hello_world -o ./my-variables.hcl
@@ -42,11 +45,11 @@ You can also use the path to a pack instead of a pack name.
 $ nomad-pack generate var-file ./my-local-pack -o ./my-variables.hcl
 ```
 
-## Rendering a Pack
+## Render a pack
 
-At times, you may wish to use Nomad Pack to render jobspecs, but you will not want to immediately deploy these to Nomad.
+Use Nomad Pack to render jobspecs without immediately deploying them to Nomad.
 
-This can be useful when writing a pack, debugging deployments, integrating Nomad Pack into a CI/CD environment, or if you have another mechanism for handling Nomad deploys.
+This is useful when writing a pack, debugging deployments, integrating Nomad Pack into a CI/CD environment, or using another deployment mechanism.
 
 The `render` command takes the same `--var` and `--var-file` flags that `run` takes.
 
@@ -94,41 +97,77 @@ This allows Nomad Pack to manage multiple deployments of the same pack.
 $ nomad-pack run hello_world --name hola-mundo
 ```
 
-It is also possible to run a local pack directly from the pack directory by passing in the directory instead of the pack name.
-This can be helpful while developing a pack.
+To run a local pack from its directory, pass the directory path instead of the pack name.
+This is useful when developing a pack.
 
+```shell-session
+$ nomad-pack run .
 ```
-nomad pack run .
-```
 
-## Planning with `plan`
+## Plan
 
-If you want see details on how Nomad Pack will deploy a pack but are not ready to immediately deploy the pack, run the `plan` command.
+If you want to see details on how Nomad Pack deploys a pack but are not ready to immediately deploy the pack, run the `plan` command.
 
 This invokes Nomad in a dry-run mode using the [Nomad Plan](/nomad/api-docs/jobs#create-job-plan) API endpoint.
 
-```
-nomad-pack plan hello_world
+```shell-session
+$ nomad-pack plan hello_world
 ```
 
-Similar to `run`, `plan` takes the `--name` flag to look for packs deployments with that name. Nomad Pack uses the pack name by default.
+Similar to `run`, `plan` takes the `--name` flag to look for pack deployments with that name. Nomad Pack uses the pack name by default.
 
-```
-nomad-pack plan hello_world --name hola-mundo
+```shell-session
+$ nomad-pack plan hello_world --name hola-mundo
 ```
 
 The `plan` command also takes the `--var` and `-f` flags like the `run` command.
 
-```
-nomad-pack plan hello_world -f ./my-variables.hcl --var greeting=hallo
+```shell-session
+$ nomad-pack plan hello_world -f ./my-variables.hcl --var greeting=hallo
 ```
 
 The `plan` command also supports `--deploy-override` when you want to plan over
 an existing non-pack job.
 
+```shell-session
+$ nomad-pack plan hello_world --deploy-override
 ```
-nomad-pack plan hello_world --deploy-override
+
+### Plan exit codes
+
+The `plan` command returns different exit codes depending on the result of the plan operation:
+
+- `0` - Plan completed with no changes
+- `1` - Plan completed and changes will be made
+- `255` - An error occurred during the plan operation
+
+You can override these exit codes using CLI flags or environment variables. CLI flags take precedence over environment variables.
+
+#### Using CLI flags
+
+```shell-session
+$ nomad-pack plan hello_world --exit-code-no-changes=0 --exit-code-makes-changes=0 --exit-code-error=1
 ```
+
+#### Using environment variables
+
+You can set the following environment variables to override the default exit codes:
+
+- `NOMAD_PACK_PLAN_EXIT_CODE_NO_CHANGES` - Exit code when plan shows no changes (default: 0)
+- `NOMAD_PACK_PLAN_EXIT_CODE_MAKES_CHANGES` - Exit code when plan shows changes (default: 1)
+- `NOMAD_PACK_PLAN_EXIT_CODE_ERROR` - Exit code when there is an error (default: 255)
+
+Example:
+
+```shell-session
+$ export NOMAD_PACK_PLAN_EXIT_CODE_NO_CHANGES=0
+$ export NOMAD_PACK_PLAN_EXIT_CODE_MAKES_CHANGES=0
+$ export NOMAD_PACK_PLAN_EXIT_CODE_ERROR=1
+$ nomad-pack plan hello_world
+```
+
+This is useful in CI/CD pipelines where you want to avoid treating a successful plan with changes as a failure. By setting `NOMAD_PACK_PLAN_EXIT_CODE_MAKES_CHANGES=0`, the command exits with code `0` even when changes are made, allowing your pipeline to continue.
+
 
 ### Reading HCL diagnostics
 
@@ -142,9 +181,9 @@ The [Introduction to Nomad Pack guide][pack-intro] explains the basics of adding
 
 ### Initialization and directory structure
 
-The first time you run `list`, Nomad Pack will add a `nomad/packs`
+The first time you run `list`, Nomad Pack adds a `nomad/packs`
 directory to your desktop user's cache directory—`$XDG_CACHE_DIR` on Linux,
-`~/Library/Caches` on macOS, `%AppData%` on Windows, etc. This folder stores
+`~/Library/Caches` on macOS, `%AppData%` on Windows, and so on. This folder stores
 information about cloned registries and their available packs.
 
 During initialization, Nomad Pack downloads a default registry of packs from the
@@ -152,7 +191,7 @@ During initialization, Nomad Pack downloads a default registry of packs from the
 
 The directory structure is as follows:
 
-```
+```text
 parent-directories (see above)
 └── nomad
     └── packs
@@ -164,7 +203,7 @@ parent-directories (see above)
 
 Nomad Pack requires the contents of the pack cache directory to work properly, but you should not manually manage or change these files. Instead, you can use the `registry` commands.
 
-### Adding new registries
+### Add new registries
 
 The `registry` command includes several sub-commands for interacting with registries.
 
@@ -178,7 +217,7 @@ For example, to add the entire [Nomad Pack Community Registry](https://github.co
 $ nomad-pack registry add community github.com/hashicorp/nomad-pack-community-registry
 ```
 
-### Adding an individual pack from a registry
+### Add an individual pack from a registry
 
 To add a single pack from the registry, use the `--target` flag.
 
@@ -186,7 +225,7 @@ To add a single pack from the registry, use the `--target` flag.
 $ nomad-pack registry add community github.com/hashicorp/nomad-pack-community-registry --target=nginx
 ```
 
-### Adding a registry at a specific commit
+### Add a registry at a specific commit
 
 To download a single pack or an entire registry at a specific version/SHA, use the `--ref` flag.
 
@@ -196,7 +235,7 @@ Refs can include slashes, such as `pack-name/v0.4.2`.
 $ nomad-pack registry add community github.com/hashicorp/nomad-pack-community-registry --ref=v0.0.1
 ```
 
-### Removing a registry
+### Remove a registry
 
 To remove a registry or pack from your local cache, use the `registry delete` command.
 This command also supports the `--target` and `--ref` flags.
@@ -205,7 +244,7 @@ This command also supports the `--target` and `--ref` flags.
 $ nomad-pack registry delete community
 ```
 
-### Updating a registry
+### Update a registry
 
 To update a registry, use the `registry update` command.
 
@@ -215,12 +254,15 @@ $ nomad-pack registry update default
 
 ## Next steps
 
-In this guide you learned how to interact with Nomad Pack in an advanced way. You learned how to generate a variable file, render a pack, use additional `run` options, use the `plan` command, and interact with Nomad Pack registries.
+In this guide you learned how to interact with Nomad Pack in an advanced way.
+You learned how to generate a variable file, render a pack, use additional `run`
+options, use the `plan` command, and interact with Nomad Pack registries.
 
-The official and community packs available to Nomad Pack are valuable because it allows you to quickly deploy apps using the best practices and leverage the knowledge of the Nomad community.
+Use official and community packs to deploy applications quickly using best
+practices and knowledge from the Nomad community.
 
 To learn how to write your own Nomad Packs or convert your existing Nomad job
-specifications into reusable packs, continue on to the [Creating packs
+specifications into reusable packs, continue on to the [Create custom packs
 guide][writing-packs].
 
 [nomad-site]: /nomad/

--- a/content/nomad/v2.0.x/content/tools/nomad-pack/create-packs.mdx
+++ b/content/nomad/v2.0.x/content/tools/nomad-pack/create-packs.mdx
@@ -11,7 +11,7 @@ last_modified: 2025-11-17T20:24:06-05:00
 
 # Create custom packs
 
-This guide will walk you through the steps involved in writing your own packs and registries for [Nomad Pack][pack-repo].
+This guide covers writing your own packs and registries for [Nomad Pack][pack-repo].
 
 In this guide, you will learn:
 
@@ -22,7 +22,7 @@ In this guide, you will learn:
 
 ## Create a custom registry
 
-First, you need to create a pack registry. This will be a repository that provides the structure, templates,
+First, create a pack registry—a repository that provides the structure, templates,
 and metadata that define your custom packs.
 
 To get started, use the `generate` command to create a new registry. Then, move into the directory of the registry.
@@ -75,9 +75,9 @@ Creating "hello_pack" Pack in "."...
 
 Next, you will create each of these files for your custom pack.
 
-#### metadata.hcl
+### metadata.hcl
 
-The `metadata.hcl` file contains important key value information about the pack. It contains the following blocks and their associated fields:
+The `metadata.hcl` file contains important key-value information about the pack. It contains the following blocks and their associated fields:
 
 - `app` - Information about the application that the pack deploys
   - `url` - The HTTP(S) URL of the homepage of the application. This attribute can also be used to provide a reference to the documentation and help pages.
@@ -113,9 +113,9 @@ Add a `metadata.hcl` file with the following contents:
 
 </CodeBlockConfig>
 
-#### variables.hcl
+### variables.hcl
 
-The `variables.hcl` file defines the variables required to fully render and deploy all the templates found within the "templates" directory.
+The `variables.hcl` file defines the variables required to fully render and deploy all the templates found within the `templates` directory.
 
 Variable definitions support `optional()` type constraints for object
 attributes.
@@ -171,20 +171,72 @@ variable "service" {
 }
 ```
 
-#### outputs.tpl
+### Nomad variables
+
+In addition to pack variables, you can define Nomad variables that Nomad Pack
+automatically creates in Nomad's native variable storage when you deploy your
+pack. These variables are useful for storing secrets, configuration, and other
+data that needs to be accessible to your Nomad jobs.
+
+Nomad variables are defined using `nomad_variable` blocks in your `variables.hcl` file:
+
+```hcl
+nomad_variable "app_secrets" {
+  path      = "nomad/jobs/myapp/secrets"
+  namespace = "default"
+  items = {
+    db_password = "secret123"
+    api_key     = "key456"
+  }
+}
+
+nomad_variable "app_config" {
+  path = "nomad/jobs/myapp/config"
+  items = {
+    log_level    = "info"
+    feature_flag = "enabled"
+  }
+}
+
+#### Variable creation timing
+
+<Note>
+  Nomad variables are created **after** the job is deployed. If variable
+  creation fails, the job continues running, but the command reports an error.
+</Note>
+
+To recover from a failed variable creation:
+
+1. Fix the problem in your `variables.hcl`.
+2. Run `nomad-pack run my-app` again.
+
+For example, the following output shows a successful job deployment with a variable creation failure:
+
+```shell-session
+$ nomad-pack run my-app
+```
+
+```text
+Job deployed
+Variable creation failed
+```
+
+In this case, `my-app` is running, but variables were not created.
+
+### outputs.tpl
 
 The `outputs.tpl` is an optional file that defines an output to be printed when a pack is deployed.
 
-Output files have access to the pack variables defined in `variables.hcl`, metadata, and any
-helper templates (see below). A simple example:
+Output files have access to the pack variables defined in `variables.hcl`,
+metadata, and any helper templates (see below). A simple example:
 
-```
+```text
 Congrats on deploying [[ meta "pack.name" . ]].
 
 There are [[ var "count" . ]] instances of your job now running on Nomad.
 ```
 
-#### README and CHANGELOG
+### README and CHANGELOG
 
 No specific format is required for the `README.md` or `CHANGELOG.md` files.
 
@@ -196,21 +248,21 @@ $ touch CHANGELOG && echo "#Hello Packs" >> README.md
 
 ## Write the templates
 
-Each file at the top level of the `templates` directory that uses the extension ".nomad.tpl" defines a resource (such as a job) that will be applied to Nomad. These files can use any UTF-8 encoded prefix as the name.
+Each file at the top level of the `templates` directory that uses the extension `.nomad.tpl` defines a resource (such as a job) that will be applied to Nomad. These files can use any UTF-8 encoded prefix as the name.
 
-Helper templates, which can be included within larger templates, have names prefixed with an underscore “\_” and use a ".tpl" extension.
+Helper templates, which can be included within larger templates, have names prefixed with an underscore `_` and use a `.tpl` extension.
 
-In a deployment, Nomad Pack will render each job template using the variables provided and apply it to Nomad.
+Nomad Pack renders each job template using the provided variables and applies it to Nomad.
 
-Nomad Pack will render any files ending in `.tpl` but without `.nomad` when calling the `render` command. This can be useful for templatizing configuration files for other non-jobspec files for a job. Nomad Pack will not do anything with these files other than render them.
+Nomad Pack renders any files ending in `.tpl` but without `.nomad` when you run the `render` command. This can be useful for templatizing configuration files for other non-jobspec files for a job. Nomad Pack will not do anything with these files other than render them.
 
-#### Template basics
+### Template basics
 
-Templates are written using [Go Template Syntax](/nomad/docs/reference/go-template-syntax). This enables templates to have complex logic where necessary.
+Nomad Pack templates use [Go Template Syntax](/nomad/docs/reference/go-template-syntax). This enables templates to have complex logic where necessary.
 
 Unlike default Go Template syntax, Nomad Pack uses `"[["` and `"]]"` as delimiters.
 
-Go ahead make your first template at `./templates/hello_pack.nomad.tpl` with the content below. This defines
+Create your first template at `./templates/hello_pack.nomad.tpl` with the following content. This defines
 a job called "hello_pack" and allows you to provide variable values for `region`, `datacenters`,
 `app_count`, and `resources`.
 
@@ -263,7 +315,7 @@ is possible as well.
 
 </Note>
 
-#### Template functions
+### Template functions
 
 The [`masterminds/sprig`](https://github.com/Masterminds/sprig) library supplements the standard Go Template set of template functions. This adds helper functions for various use cases such as string manipulation, cryptography, and data conversion (for instance to and from JSON).
 
@@ -274,35 +326,35 @@ Custom Nomad-specific and debugging functions are also provided:
 - `nomadNamespace` takes a single string parameter of a namespace ID which will be read via `/v1/namespace/:namespace`.
 - `spewDump` dumps the entirety of the passed object as a string. The output includes the content types and values. This uses the `spew.SDump` function.
 - `spewPrintf` dumps the supplied arguments into a string according to the supplied format. This uses the `spew.Printf` function.
-- `fileContents` takes an argument to a file of the local host, reads its contents and provides this as a string.
+- `fileContents` takes an argument to a file on the local host relative to the directory `nomad-pack` is invoked in, reads its contents, and provides the output as a string.
 - `fileRelative` takes a file path relative to the current pack root and
   returns the file content.
 - `packPath` returns the path to the current pack.
 - `tpl` evaluates a template string using the current template context. This is
-  useful when variables store template fragments.
+  useful for dynamic templates stored in variables.
 
 A custom function within a template is called like any other:
 
-```
+```text
 [[ nomadRegions ]]
 [[ nomadRegions | spewDump ]]
 ```
 
 You will not use any of the helper functions in this tutorial, but they are available to help you write custom packs in the future.
 
-#### Helper templates
+### Helper templates
 
 For more complex packs, you may want to reuse template snippets across multiple resources.
 
-For instance, suppose you have two jobs defined in your pack and both jobs reuse
-the same `region` logic. You can create a helper template to centralize that
+For example, if two jobs in your pack reuse
+the same `region` logic, create a helper template to centralize that logic.
 logic.
 
 Helper template names are prepended with an underscore `_` and end in `.tpl`.
 
-Go ahead and define your first helper template at `./templates/_region.tpl`.
+Create your first helper template at `./templates/_region.tpl`.
 
-<CodeBlockConfig filename="_region.tp">
+<CodeBlockConfig filename="_region.tpl">
 
 ```hcl
 [[ define "region" -]]
@@ -314,10 +366,10 @@ Go ahead and define your first helper template at `./templates/_region.tpl`.
 
 </CodeBlockConfig>
 
-This template will only specify the "region" value on the job if the `region` variable
-has been passed into Nomad Pack.
+This template specifies the `region` value only when the `region` variable
+is provided.
 
-You can now use this helper template in your job file.
+Use this helper template in your job file.
 
 <CodeBlockConfig filename="hello_pack.nomad.tpl">
 
@@ -337,7 +389,7 @@ job "hello_pack" {
 
 If this pack defined multiple jobs, this logic could now be reused throughout the pack.
 
-#### Conditional jobs
+### Conditional jobs
 
 Some packs will have multiple jobs, and occasionally some of these jobs should only be run
 if certain variable values are provided.
@@ -352,7 +404,7 @@ job "postgres" {
 [[ end ]]
 ```
 
-#### Pack dependencies
+### Pack dependencies
 
 Packs can depend on content from other packs.
 
@@ -366,8 +418,7 @@ You must place copies of dependent packs into the `deps` directory. This process
       └── ...Pack B's contents...
 ```
 
-This allows Pack A to use any helper templates defined in Pack B, and Pack A will
-automatically deploy any jobs defined in Pack B when it deploys.
+This allows Pack A to use any helper templates defined in Pack B, and Pack A automatically deploys any jobs defined in Pack B when it runs.
 
 In addition to the filesystem, packs must define their dependencies in `metadata.hcl`.
 An example pack block with a dependency looks like the following.
@@ -392,9 +443,9 @@ dependency "demo_dep" {
 
 </CodeBlockConfig>
 
-Nomad Pack provides a helper command to take packs defined as dependencies and vendor them.
-Running this command from a pack's root directory will download the files associated with any
-pack dependency and put them in the `deps` directory.
+Nomad Pack provides a helper command to take packs defined as dependencies and
+vendor them. Running this command from a pack's root directory downloads the
+associated pack files and places them in the `deps` directory.
 
 ```shell-session
 $ nomad-pack deps vendor
@@ -402,13 +453,13 @@ $ nomad-pack deps vendor
 
 <Note>
 
-While developing a dependent pack alongside a parent pack, it can be helpful to symlink
-a reference to the dependent pack in the `deps` directory.
+While developing a dependent pack alongside a parent pack, it can be helpful to
+symlink a reference to the dependent pack in the `deps` directory.
 
 </Note>
 
-This allows templates of `hello_pack_with_deps` to use `demo_dep`'s helper templates, and deploy
-any jobs in demo_dep when running `hello_pack_with_deps`.
+This allows templates of `hello_pack_with_deps` to use `demo_dep`'s helper
+templates, and deploy any jobs in demo_dep when running `hello_pack_with_deps`.
 
 ```hcl
 [[ template "helper_data" . ]]
@@ -420,11 +471,10 @@ You can pass in variables for a dependent pack with a reference to their name or
 $ nomad-pack run hello_pack_with_deps --var demo_dep.message="example"
 ```
 
-## Testing your pack
+## Test your pack
 
-As you write packs, you may want to test them. To do this, pass the
-directory path as the name of the pack to the `run`, `plan`, `render`, `info`,
-`stop`, or `destroy` commands. Relative paths are supported.
+Test your pack by passing the directory path to the `run`, `plan`, `render`,
+`info`, `stop`, or `destroy` commands. These commands support relative paths.
 
 ```shell-session
 $ nomad-pack info .
@@ -441,9 +491,9 @@ $ nomad-pack run .
 ## Publish and find your custom repository
 
 To use and share your new pack, push the git repository to a URL
-accessible by your command line tool. In this demo you will push to a GitHub repository.
+accessible to your command line tool. In this tutorial, you push to a GitHub repository.
 
-If you wish to share your packs with the Nomad community, please consider adding them to the
+To share your packs with the Nomad community, add them to the
 [Nomad Pack Community Registry][nomad-pack-community-registry].
 
 ## Deploy your custom pack from a custom registry
@@ -455,8 +505,8 @@ If you have added your own registry to GitHub, add it to your local Nomad Pack u
 $ nomad-pack registry add my_packs git@github.com/<YOUR_ORG>/<YOUR_REPO>
 ```
 
-This will download the packs defined in the GitHub repository to your local
-filesystem. They will be found using the registry value "my_packs".
+Nomad Pack downloads the packs defined in the GitHub repository to your local
+filesystem. Reference them using the registry name `my_packs`.
 
 Deploy your custom pack.
 
@@ -466,17 +516,20 @@ $ nomad-pack run hello_pack --var app_count=1 --registry=my_packs
 
 ## Next steps
 
-In this tutorial you learned:
+In this guide you learned:
 
-- how packs and pack registries are structured
-- how to write a custom pack
-- how to test your pack locally
-- how to deploy a custom pack
+- How packs and pack registries are structured
+- How to write a custom pack
+- How to test your pack locally
+- How to deploy a custom pack
 
-As you write packs, consider contributing them to the [Nomad Pack Community Registry][nomad-pack-community-registry].
-This is a great source of feedback, best-practices, and shared-knowledge.
+As you write packs, consider contributing them to the [Nomad Pack Community
+Registry][nomad-pack-community-registry]. This is a great source of feedback,
+best practices, and shared knowledge.
 
-To help speed up your pack development and testing, check out the [Setup HashiCorp Nomad Pack][nomad-pack-github-action] GitHub Action - it takes care of setting up the Nomad Pack binary and making it available to your GitHub Actions workflow.
+To streamline your pack development and testing, use the [Setup HashiCorp Nomad
+Pack][nomad-pack-github-action] GitHub Action to install the Nomad Pack binary
+in your GitHub Actions workflow.
 
 [pack-repo]: https://github.com/hashicorp/nomad-pack
 [example-nomad-pack-registry]: https://github.com/hashicorp/example-nomad-pack-registry

--- a/content/nomad/v2.0.x/content/tools/nomad-pack/functions.mdx
+++ b/content/nomad/v2.0.x/content/tools/nomad-pack/functions.mdx
@@ -1,0 +1,710 @@
+---
+layout: docs
+page_title: Nomad Pack template functions
+description: |-
+  Reference for the template helper functions available in Nomad Pack, including Nomad API, debugging, and helper functions.
+---
+
+# Nomad Pack functions
+
+The `nomad-pack` template renderer contains various helper functions used while rendering
+templates.
+
+Nomad Pack provides all the [Sprig template functions][Sprig] for text manipulation.
+
+Nomad Pack also provides additional functions for accessing Nomad, testing IP
+addresses, and template debugging.
+
+## Functions by topic
+
+- [Nomad API][topicNomadAPI]
+- [Network functions][topicNetwork]
+- [Debugging][topicDebugging]
+- [Helpers][topicHelpers]
+
+You can also view [the list of functions in alphabetical order][fnByAlpha].
+
+## Nomad API <a id="topicNomadAPI"></a>
+
+### Namespace functions
+
+#### `nomadNamespace` <a id="nomadNamespace"></a>
+
+The `nomadNamespace` function returns the details for the namespace with the given name.
+
+<Warning>
+
+  The `nomadNamespace` function errors on missing namespaces, which prevents the
+  template from rendering. Use a namespace name from `nomadNamespaces` for
+  additional safety.
+
+</Warning>
+
+##### Parameters
+
+- 1: `string` - The target namespace's name
+
+##### Returns
+
+- `error` or [`*api.Namespace`][] for the requested namespace.
+
+##### Example
+
+Get the name and description for each template accessible to the current user.
+
+```hcl
+[[ range $ns := nomadNamespaces]]
+    [[ with nomadNamespace $ns ]]
+      [[printf "%s: %s\n" .Name .Description ]]
+    [[ end ]]
+[[ end ]]
+```
+
+#### `nomadNamespaces` <a id="nomadNamespaces"></a>
+
+Retrieves a list of namespaces visible to the current user.
+
+##### Parameters
+
+- None
+
+##### Returns
+
+- `error` or \[][`*api.Namespace`][].
+
+##### Example
+
+```hcl
+[[- range nomadNamespaces -]]
+    [[- printf "%v: %v\n" .Name .Description -]]
+[[- end -]]
+```
+
+```text
+default: Default shared namespace
+```
+
+### Variable functions
+
+#### `nomadVariables` <a id="nomadVariables"></a>
+
+The `nomadVariables` function retrieves a list of all Nomad Variables stored in the specified namespace.
+
+##### Parameters
+
+- 1: `string` - The target namespace name
+- 2: `string` (optional) - Prefix to filter variables by path
+
+##### Returns
+
+- `error` or `[]*api.VariableMetadata` — A list of variable metadata objects including path, namespace, and timestamps.
+
+<Note>
+  
+  The return value contains metadata only and does not include the variable's
+  key-value items. Use `nomadVariable` to retrieve the full variable object.
+  
+</Note>
+
+##### Example
+
+List all variables in a namespace:
+
+```hcl
+[[ range nomadVariables "production" ]]
+Path: [[ .Path ]]
+Namespace: [[ .Namespace ]]
+Modified: [[ .ModifyTime ]]
+[[ end ]]
+```
+
+Filter variables by prefix:
+
+```hcl
+[[ range nomadVariables "production" "secret/" ]]
+Path: [[ .Path ]]
+[[ end ]]
+```
+
+Get variable data:
+
+```hcl
+[[ $meta := index (nomadVariables "production") 0 ]]
+[[ $var := nomadVariable $meta.Path "production" ]]
+Password: [[ $var.Items.password ]]
+```
+
+#### `nomadVariable` <a id="nomadVariable"></a>
+
+The `nomadVariable` function retrieves a specific Nomad Variable by path and namespace.
+
+##### Parameters
+
+- 1: `string` - The path of the variable
+- 2: `string` - The namespace
+
+##### Returns
+
+- `error` or `*api.Variable` - The Variable object
+
+##### Example
+
+```hcl
+[[ with nomadVariable "secret/db" "production" ]]
+password = "[[ .Items.password ]]"
+[[ end ]]
+```
+
+### Region functions
+
+#### `nomadRegions` <a id="nomadRegions"></a>
+
+Retrieves a list of regions known to the Nomad cluster.
+
+##### Parameters
+
+- None
+
+##### Returns
+
+- `error` or `[]string` containing the names of regions known to the cluster.
+
+##### Example
+
+```hcl
+[[ range nomadRegions ]]
+Region: [[ . ]]
+[[ end ]]
+```
+
+## Network functions <a id="topicNetwork"></a>
+
+Nomad Pack provides helper functions for IP address parsing and validation that
+leverage Go's [`netip`](https://pkg.go.dev/net/netip) package.
+
+<Note>
+  
+  Individual function documentation for this section is not yet available.
+
+</Note>
+
+<Warning>
+  
+  The parse functions error for invalid addresses, which prevents the template
+  from rendering. Guard any usage of `parseAddr` or `parseAddrPort` with the
+  corresponding validation function, `validAddr` or `validAddrPort`.
+
+</Warning>
+
+## Debugging functions <a id="topicDebugging"></a>
+
+### `spewDump` <a id="spewDump"></a>
+
+Returns a string representation of the provided value to the template using
+`spew.Sdump`.
+
+`Sdump` displays the passed parameters to standard out with newlines,
+customizable indentation, and additional debug information such as complete
+types and all pointer addresses used to indirect to the final value. It provides
+ the following features over the built-in printing facilities provided by the
+ `fmt` package:
+
+- Pointers are dereferenced and followed
+- Circular data structures are detected and handled properly
+- Custom `Stringer`/`error` interfaces are optionally invoked, including on
+  unexported types
+- Custom types which only implement the `Stringer`/`error` interfaces via a
+  pointer receiver are optionally invoked when passing non-pointer variables
+- Byte arrays and slices are dumped like the `hexdump -C` command which includes
+  offsets, byte values in hex, and ASCII output
+
+The configuration for the standard Spew printer is as follows:
+
+```go
+Indent: " "
+MaxDepth: 0
+DisableMethods: false
+DisablePointerMethods: false
+ContinueOnMethod: false
+SortKeys: false
+```
+
+##### Parameters
+
+- 1: `any` - The object to print via `spew.Sdump`
+
+##### Returns
+
+- A string representation of the object passed as the parameter
+
+##### Example
+
+Dump the current context value for debugging purposes
+
+```hcl
+[[ spewDump . ]]
+```
+
+### `spewPrintf` <a id="spewPrintf"></a>
+
+Formats a string representation of one or more values using `spew.Sprintf`.
+
+`spewPrintf` is a direct alias for [`spew.Sprintf`][Spew], which works like `fmt.Sprintf` but
+uses Spew's enhanced type-aware formatting for each argument. Use it to
+produce formatted debug output in a template without printing to a separate
+buffer.
+
+##### Parameters
+
+- 1: `string` - A format string using `fmt.Sprintf` verbs (for example, `"%v"`, `"%+v"`).
+- 2+: `any` - One or more values to format.
+
+##### Returns
+
+- `string` - The formatted string representation of the provided values.
+
+##### Example
+
+Print the current template context with full type information:
+
+```hcl
+[[ spewPrintf "%v" . ]]
+```
+
+Format multiple values on one line:
+
+```hcl
+[[ spewPrintf "name=%v region=%v" .name .region ]]
+```
+
+### Custom debug output format functions
+
+The [Spew][] package provides a custom debug output format for Go data
+structures to aid in debugging. The following functions are used to create a
+custom Spew configuration.
+
+#### `customSpew` <a id="customSpew"></a>
+
+Returns a new [`spew.ConfigState`][] with default configuration. Capture it as a variable for reuse. The `customSpew` function is implemented
+by `spew.NewDefaultConfig`.
+
+`NewDefaultConfig` returns a `spew.ConfigState` with the following default settings.
+
+```go
+Indent: " "
+MaxDepth: 0
+DisableMethods: false
+DisablePointerMethods: false
+ContinueOnMethod: false
+SortKeys: false
+```
+
+##### Parameters
+
+- None
+
+##### Returns
+
+- `spew.ConfigState`, which is a customized Sprig printer suitable to be passed as
+    an argument to the customizing functions for further settings changes.
+
+##### Example
+
+Change the default indentation from one space to a tab and dump the current
+template context in place.
+
+```hcl
+[[ $cs := ( customSpew | withIndent "  " ) ]][[ $cs.Sdump . ]]
+```
+
+#### `withIndent` <a id="withIndent"></a>
+
+Sets the `Indent` flag for a customized Spew printer. From the Spew documentation:
+
+`Indent` specifies the string to use for each indentation level.  The
+global config instance that all top-level functions use sets this to a
+single space by default.  If you would like more indentation, you might
+set this to a tab with `"\t"` or perhaps two spaces with `"  "`.
+
+##### Parameters
+
+- 1: `string` - The value to set the `Indent` value of the `s` parameter to.
+- 2: `spew.ConfigState` - A customized Sprig printer created by `customSpew`
+
+##### Returns
+
+- The modified Sprig printer
+
+##### Example
+
+Change the default indentation from one space to a tab and dump the current
+template context in place.
+
+```hcl
+[[ $cs := ( customSpew | withIndent "  " ) ]][[ $cs.Sdump . ]]
+```
+
+#### `withMaxDepth` <a id="withMaxDepth"></a>
+
+Sets the `MaxDepth` flag for a customized Spew printer. From the Spew documentation:
+
+`MaxDepth` controls the maximum number of levels to descend into nested
+data structures.  The default, `0`, means there is no limit.
+
+Circular data structures are properly detected, so it is not
+necessary to set this value unless you specifically want to limit deeply
+nested data structures.
+
+##### Parameters
+
+- 1: `int` - The value to set the `MaxDepth` value of the `s` parameter to.
+- 2: `spew.ConfigState` - A customized Sprig printer created by `customSpew`
+
+##### Returns
+
+- The modified Sprig printer
+
+##### Example
+
+```hcl
+[[ $cs := ( customSpew | withMaxDepth 3 ) ]][[ $cs.Sdump . ]]
+```
+
+#### `withDisableMethods` <a id="withDisableMethods"></a>
+
+Sets the `DisableMethods` flag for a customized Spew printer. From the Spew documentation:
+
+`DisableMethods` specifies whether or not `error` and `Stringer` interfaces are
+invoked for types that implement them.
+
+##### Parameters
+
+- 1: `bool` - The value to set the `DisableMethods` value of the `s` parameter to.
+- 2: `spew.ConfigState` - A customized Sprig printer created by `customSpew`
+
+##### Returns
+
+- The modified Sprig printer
+
+##### Example
+
+```hcl
+[[ $cs := ( customSpew | withDisableMethods true ) ]][[ $cs.Sdump . ]]
+```
+
+#### `withDisablePointerMethods` <a id="withDisablePointerMethods"></a>
+
+Sets the `DisablePointerMethods` flag for a customized Spew printer. From the
+Spew documentation:
+
+`DisablePointerMethods` specifies whether or not to check for and invoke
+`error` and `Stringer` interfaces on types which only accept a pointer
+receiver when the current type is not a pointer.
+
+This might be an unsafe action since calling one of these methods
+with a pointer receiver could technically mutate the value, however,
+in practice, types which choose to satisfy an `error` or `Stringer`
+interface with a pointer receiver should not be mutating their state
+inside these interface methods.  As a result, this option relies on
+access to the `unsafe` package, so it will not have any effect when
+running in environments without access to the `unsafe` package such as
+Google App Engine or with the "safe" build tag specified.
+
+##### Parameters
+
+- 1: `bool` - The value to set the `DisablePointerMethods` value of the `s` parameter to.
+- 2: `spew.ConfigState` - A customized Sprig printer created by `customSpew`
+
+##### Returns
+
+- The modified Sprig printer
+
+##### Example
+
+```hcl
+[[ $cs := ( customSpew | withDisablePointerMethods true ) ]][[ $cs.Sdump . ]]
+```
+
+#### `withDisablePointerAddresses` <a id="withDisablePointerAddresses"></a>
+
+Sets the `DisablePointerAddresses` flag for a customized Spew printer. From the Spew documentation:
+
+`DisablePointerAddresses` specifies whether to disable the printing of
+pointer addresses. This is useful when diffing data structures in tests.
+
+##### Parameters
+
+- 1: `bool` - The value to set the `DisablePointerAddresses` value of the `s` parameter to.
+- 2: `spew.ConfigState` - A customized Sprig printer created by `customSpew`
+
+##### Returns
+
+- The modified Sprig printer
+
+##### Example
+
+```hcl
+[[ $cs := ( customSpew | withDisablePointerAddresses true ) ]][[ $cs.Sdump . ]]
+```
+
+#### `withDisableCapacities` <a id="withDisableCapacities"></a>
+
+Sets the `DisableCapacities` flag for a customized Spew printer. From the Spew documentation:
+
+`DisableCapacities` specifies whether to disable the printing of capacities
+for arrays, slices, maps and channels. This is useful when diffing
+data structures in tests.
+
+##### Parameters
+
+- 1: `bool` - The value to set the `DisableCapacities` value of the `s` parameter to.
+- 2: `spew.ConfigState` - A customized Sprig printer created by `customSpew`
+
+##### Returns
+
+- The modified Sprig printer
+
+##### Example
+
+```hcl
+[[ $cs := ( customSpew | withDisableCapacities true ) ]][[ $cs.Sdump . ]]
+```
+
+#### `withContinueOnMethod` <a id="withContinueOnMethod"></a>
+
+Sets the `ContinueOnMethod` flag for a customized Spew printer. From the Spew documentation:
+
+`ContinueOnMethod` specifies whether or not recursion should continue once
+a custom error or Stringer interface is invoked.  The default, `false`,
+means it will print the results of invoking the custom `error` or `Stringer`
+interface and return immediately instead of continuing to recurse into
+the internals of the data type.
+
+This flag does not have any effect if method invocation is disabled
+via the `DisableMethods` or `DisablePointerMethods` options.
+
+##### Parameters
+
+- 1: `bool` - The value to set the `ContinueOnMethod` value of the `s` parameter to.
+- 2: `spew.ConfigState` - A customized Sprig printer created by `customSpew`
+
+##### Returns
+
+- The modified Sprig printer
+
+##### Example
+
+```hcl
+[[ $cs := ( customSpew | withContinueOnMethod true ) ]][[ $cs.Sdump . ]]
+```
+
+#### `withSortKeys` <a id="withSortKeys"></a>
+
+Sets the `SortKeys` flag for a customized Spew printer. From the Spew documentation:
+
+`SortKeys` specifies map keys should be sorted before being printed. Use
+this to have a more deterministic, diffable output.  Note that only
+native types (`bool`, `int`, `uint`, `floats`, `uintptr`, and `string`) and types
+that support the error or `Stringer` interfaces (if methods are
+enabled) are supported, with other types sorted according to the
+`reflect.Value.String()` output which guarantees display stability.
+
+##### Parameters
+
+- 1: `bool` - The value to set the `SortKeys` value of the `s` parameter to.
+- 2: `spew.ConfigState` - A customized Sprig printer created by `customSpew`
+
+##### Returns
+
+- The modified Sprig printer
+
+##### Example
+
+```hcl
+[[ $cs := ( customSpew | withSortKeys true ) ]][[ $cs.Sdump . ]]
+```
+
+#### `withSpewKeys` <a id="withSpewKeys"></a>
+
+Sets the `SpewKeys` flag for a customized Spew printer. From the Spew documentation:
+
+`SpewKeys` specifies that, as a last resort attempt, map keys should
+be spewed to strings and sorted by those strings.  This is only
+considered if `SortKeys` is true.
+
+##### Parameters
+
+- 1: `bool` - The value to set the `SpewKeys` value of the `s` parameter to.
+- 2: `spew.ConfigState` - A customized Sprig printer created by `customSpew`
+
+##### Returns
+
+- The modified Sprig printer
+
+##### Example
+
+```hcl
+[[ $cs := ( customSpew | withSpewKeys true ) ]][[ $cs.Sdump . ]]
+```
+
+### Helper functions <a id="topicHelpers"></a>
+
+#### `fileContents` <a id="fileContents"></a>
+
+Imports the contents of a file on the local file system into the template at runtime.
+Nomad Pack runs the `fileContents` function when it parses the template.
+
+##### Parameters
+
+- 1: `string` - The path to the file to read.
+
+##### Returns
+
+- The contents of the file.
+
+##### Example
+
+**./assets/hello.txt**
+
+```plaintext
+hello from file
+```
+
+**Template**
+
+```hcl
+**[[ fileContents ./assets/hello.txt ]]**
+```
+
+**Output**
+
+```text
+**hello from file**
+```
+
+#### `tpl` <a id="tpl"></a>
+
+The `tpl` function renders a template string using the current template context. This is useful for rendering dynamic templates stored in variables or for evaluating template expressions within strings.
+
+The function has access to the same FuncMap and variables as the parent template, including all Sprig functions and Nomad Pack custom functions.
+
+##### Parameters
+
+- 1: `string` - The template string to render
+- 2: `interface{}` - The data context to use for rendering (typically `.` to pass the current context)
+
+##### Returns
+
+- `string` - The rendered template output
+- `error` - Any error encountered during template parsing or execution
+
+##### Example
+
+Render a template stored in a variable:
+
+```hcl
+[[ $tmpl := "Hello, [[ .name ]]!" -]]
+[[ tpl $tmpl (dict "name" "World") ]]
+```
+
+**Output**
+
+```text
+Hello, World!
+```
+
+Render using pack variables with the `var` function:
+
+```hcl
+[[ $greeting := "Deploying [[ var \"job_name\" . ]] to [[ var \"region\" . ]]" -]]
+[[ tpl $greeting . ]]
+```
+
+**Output**
+
+```text
+Deploying my-job to us-west-1
+```
+
+#### `toStringList` <a id="toStringList"></a>
+
+The `toStringList` function converts a slice of `any` into an HCL/JSON-like
+representation by using Go's native Sprintf "%q" formatting.
+
+##### Parameters
+
+- 1: `[]any` - A slice of items to convert into an HCL list.
+
+##### Returns
+
+- A string representation of the provided slice
+
+##### Example
+
+Convert a list of datacenter names to an HCL list:
+
+```hcl
+[[ toStringList .datacenters ]]
+```
+
+**Output**
+
+```text
+["dc1", "dc2", "dc3"]
+```
+
+## Alphabetical list of functions <a id="fnByAlpha"></a>
+
+These are the additional functions supplied by Nomad Pack itself.
+
+- [`customSpew`][] - Returns a new `spew.ConfigState` with default configuration; used to build a custom Spew printer.
+- [`fileContents`][] - Returns the contents of a file as a string.
+- [`nomadNamespace`][] - Returns the current namespace from the Nomad client.
+- [`nomadNamespaces`][] - Returns a list of namespaces from the Nomad client.
+- [`nomadRegions`][] - Returns a list of regions from the Nomad client.
+- [`nomadVariable`][] - Retrieves a specific Nomad Variable by path and namespace.
+- [`nomadVariables`][] - Lists all Nomad Variables in the specified namespace.
+- [`spewDump`][] - Returns a string representation of a value using `spew.Sdump`.
+- [`spewPrintf`][] - Returns a formatted string representation of a value using `spew.Sprintf`.
+- [`toStringList`][] - Converts a value to a string list.
+- [`tpl`][] - Renders a template string using the current template context.
+- [`withContinueOnMethod`][] - Sets the `ContinueOnMethod` flag for a `customSpew`.
+- [`withDisableCapacities`][] - Sets the `DisableCapacities` flag for a `customSpew`.
+- [`withDisableMethods`][] - Sets the `DisableMethods` flag for a `customSpew`.
+- [`withDisablePointerAddresses`][] - Sets the `DisablePointerAddresses` flag for a `customSpew`.
+- [`withDisablePointerMethods`][] - Sets the `DisablePointerMethods` flag for a `customSpew`.
+- [`withIndent`][] - Sets the indentation level for a `customSpew`.
+- [`withMaxDepth`][] - Sets the maximum depth for a `customSpew`.
+- [`withSortKeys`][] - Sets the `SortKeys` flag for a `customSpew`.
+- [`withSpewKeys`][] - Sets the `SpewKeys` for a `customSpew`.
+
+
+[Spew]: https://pkg.go.dev/github.com/davecgh/go-spew/spew
+[`spew.ConfigState`]: https://pkg.go.dev/github.com/davecgh/go-spew/spew#ConfigState
+[Sprig]: https://masterminds.github.io/sprig/
+[`*api.Namespace`]: https://developer.hashicorp.com/nomad/api-docs/namespaces#sample-response-1
+
+[fnByAlpha]: #fnByAlpha
+[topicNomadAPI]: #topicNomadAPI
+[topicNetwork]: #topicNetwork
+[topicDebugging]: #topicDebugging
+[topicHelpers]: #topicHelpers
+
+[`customSpew`]: #customSpew
+[`fileContents`]: #fileContents
+[`nomadNamespaces`]: #nomadNamespaces
+[`nomadNamespace`]: #nomadNamespace
+[`nomadRegions`]: #nomadRegions
+[`toStringList`]: #toStringList
+[`tpl`]: #tpl
+[`spewDump`]: #spewDump
+[`spewPrintf`]: #spewPrintf
+[`withIndent`]: #withIndent
+[`withMaxDepth`]: #withMaxDepth
+[`withDisableMethods`]: #withDisableMethods
+[`withDisablePointerMethods`]: #withDisablePointerMethods
+[`withDisablePointerAddresses`]: #withDisablePointerAddresses
+[`withDisableCapacities`]: #withDisableCapacities
+[`withContinueOnMethod`]: #withContinueOnMethod
+[`withSortKeys`]: #withSortKeys
+[`withSpewKeys`]: #withSpewKeys

--- a/content/nomad/v2.0.x/content/tools/nomad-pack/index.mdx
+++ b/content/nomad/v2.0.x/content/tools/nomad-pack/index.mdx
@@ -12,24 +12,25 @@ last_modified: 2026-02-16T16:54:52.000Z
 
 # Nomad Pack
 
-This guide will walk you through basic usage of [Nomad Pack][pack-repo], a
+This guide covers basic usage of [Nomad Pack][pack-repo], a
 package manager and templating tool for Nomad.
 
 By the end of this guide, you will know what Nomad Pack does, be able to deploy
 applications to Nomad using Nomad Pack, and discover packs built by the Nomad community.
 
-## What is Nomad Pack?
+## About Nomad Pack
 
-Nomad Pack is a templating and packaging tool used with [HashiCorp Nomad][nomad-site].
+Nomad Pack is a templating and packaging tool for [HashiCorp Nomad][nomad-site].
 
-Nomad Pack is used to:
+Use Nomad Pack to:
 
-- Easily deploy popular applications to Nomad
-- Re-use common patterns across internal applications
+- Deploy popular applications to Nomad
+- Reuse common patterns across internal applications
 - Find and share job specifications with the Nomad community
 
-Nomad Pack can be thought of as a templating and deployment tool like [Levant](https://github.com/hashicorp/levant)
-with the ability to pull from remote registries and deploy multiple resources together, like [Helm](https://helm.sh/).
+Nomad Pack is similar to [Levant](https://github.com/hashicorp/levant), with the
+additional ability to pull from remote registries and deploy multiple resources
+together, like [Helm](https://helm.sh/).
 
 ## Requirements
 
@@ -38,24 +39,24 @@ with the ability to pull from remote registries and deploy multiple resources to
 
 <Note>
 
- If Nomad ACLs are enabled, a token with proper permissions must be defined in the `NOMAD_TOKEN` environment variable.
+ If Nomad ACLs are enabled, define a token with proper permissions in the `NOMAD_TOKEN` environment variable.
 
 </Note>
 
-## Installing Nomad Pack
+## Install Nomad Pack
 
 To use Nomad Pack, download the binary for your system from [HashiCorp Releases][releases].
 
 After downloading Nomad Pack, unzip the package, and make sure that the `nomad-pack` binary is available on your PATH.
 
-Alternatively, you can install it with Homebrew if you are on MacOS.
+Alternatively, install Nomad Pack with Homebrew on MacOS.
 
 ```shell-session
 $ brew tap hashicorp/tap
 $ brew install hashicorp/tap/nomad-pack
 ```
 
-You can now run `nomad-pack`.
+Run `nomad-pack` to get started.
 
 ## Basic use
 
@@ -75,16 +76,16 @@ $ nomad-pack list
   [...]
 ```
 
-The first time you run the `list` command, Nomad Pack will add a `nomad/packs`
+The first time you run the `list` command, Nomad Pack adds a `nomad/packs`
 directory to your desktop user's cache directory—`$XDG_CACHE_DIR` on Linux,
-`~/Library/Caches` on macOS, `%AppData%` on Windows, etc. This folder stores
+`~/Library/Caches` on macOS, `%AppData%` on Windows, and so on. This folder stores
 information about cloned registries and their available packs.
 
-During initializing, Nomad Pack downloads a default registry of packs from the
+During initialization, Nomad Pack downloads a default registry of packs from the
 [Nomad Pack community registry][community-registry].
 
 To deploy one of these packs, use the `run` command. This deploys each job defined in the pack to Nomad.
-To deploy the `hello_world` pack, you would run the following command:
+To deploy the `hello_world` pack, run the following command:
 
 ```shell-session
 $ nomad-pack run hello_world
@@ -98,12 +99,14 @@ Congrats! You deployed a simple service on Nomad.
 
 <Note>
 
-The syntax for Nomad Pack is different in version 0.1. To run packs written with the old syntax, provide the `--parser-v1` flag.
+Nomad Pack v0.1 used a different template syntax. To run packs written with the
+old syntax, provide the `--parser-v1` flag. Refer to the [Migrate to the current
+template syntax guide](/nomad/tools/nomad-pack/migrate-template-syntax) for more information.
 
 </Note>
 
-Each pack defines a set of variables that can be provided by the user. To get information on the pack
-and to see which variables can be passed in, run the `info` command.
+Each pack defines a set of variables that you can provide. To view pack
+information and available variables, run the `info` command.
 
 ```shell-session
 $ nomad-pack info hello_world
@@ -124,14 +127,14 @@ Pack "hello_world" Variables:
   - "count" (number) - The number of app instances to deploy
 ```
 
-Values for these variables are provided using the `--var` flag. Update your pack using
-the following command:
+Provide variable values using the `--var` flag. Update your pack with the
+following command:
 
 ```shell-session
 $ nomad-pack run hello_world --var message=hola
 ```
 
-Values can also be provided by passing in a variables file with the `-f` flag.
+You can also provide values by passing a variables file with the `-f` flag.
 
 ```shell-session
 $ tee -a ./my-variables.hcl << END
@@ -143,7 +146,7 @@ END
 $ nomad-pack run hello_world -f ./my-variables.hcl
 ```
 
-To see a list of deployed packs, run the `status` command
+To see a list of deployed packs, run the `status` command.
 
 ```shell-session
 $ nomad-pack status
@@ -178,11 +181,11 @@ To stop the jobs without removing them from Nomad, use the `stop` command:
 $ nomad-pack stop hello_world
 ```
 
-### Adding non-default Pack registries
+### Add non-default pack registries
 
 When using Nomad Pack, the default registry for packs is
 [the Nomad Pack Community Registry][community-registry].
-Packs from this registry will be made automatically available.
+Packs from this registry are automatically available.
 
 You can add more registries by using the `registry add` command. For instance, if you want to add a registry from GitLab with the alias `my_packs`, you can run the following command to download the registry and its contents.
 
@@ -243,8 +246,8 @@ $ nomad-pack list
   traefik                    | 0.1.0            | my_packs@7ca313c705b7966ed93078cba1604fafe0fa2334
 ```
 
-You can deploy packs from this registry with the `run` command and the alias given
-to the registry, in this case `my_packs`.
+You can deploy packs from this registry with the `run` command and the alias
+given to the registry, in this case `my_packs`.
 
 ```shell-session
 $ nomad-pack run nginx --registry=my_packs
@@ -260,10 +263,12 @@ https://learn.hashicorp.com/tutorials/nomad/load-balancing-nginx
 
 ## Next steps
 
-In this tutorial you learned what Nomad Pack does, how to deploy applications to Nomad
-using Nomad Pack, and how to discover packs built by the Nomad community.
+In this tutorial, you learned what Nomad Pack does, how to deploy applications
+to Nomad using Nomad Pack, and how to discover packs built by the Nomad
+community.
 
-Continue on to the [Usage guide][detailed-usage] for more detailed information about how to use Nomad Pack.
+Refer to the [Advanced usage guide][detailed-usage] for more information about
+using Nomad Pack.
 
 [nomad-site]: /nomad/
 [pack-repo]: https://github.com/hashicorp/nomad-pack

--- a/content/nomad/v2.0.x/content/tools/nomad-pack/migrate-template-syntax.mdx
+++ b/content/nomad/v2.0.x/content/tools/nomad-pack/migrate-template-syntax.mdx
@@ -2,8 +2,7 @@
 layout: docs
 page_title: Migrate to the current template syntax
 description: |-
-  Update a Nomad Pack from the original `.my` and `.nomad_pack` template syntax to
-  the current `var` and `meta` template functions, including dependencies and
+  Update a Nomad Pack from the original `.my` and `.nomad_pack` template syntax to the current `var` and `meta` template functions, including dependencies and
   helpers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2026-07-03T11:42:00+05:30
@@ -25,10 +24,10 @@ flag.
 
 This guide shows you how to:
 
-- access variables and metadata with the `var` and `meta` functions
-- access a pack's dependencies
-- update helper and output templates
-- run a pack that still uses the original syntax
+- Access variables and metadata with the `var` and `meta` functions
+- Access a pack's dependencies
+- Update helper and output templates
+- Run a pack that still uses the original syntax
 
 For an overview of writing packs, including the available template functions,
 refer to [Create custom packs][create-packs].
@@ -181,7 +180,7 @@ job [[ coalesce .simple_raw_exec.job_name .nomad_pack.pack.name | quote ]] {
 
 </CodeBlockConfig>
 
-The same template using the current syntax.
+The following template uses the current syntax.
 
 <CodeBlockConfig filename="example.nomad.tpl">
 

--- a/content/nomad/v2.0.x/data/tools-nav-data.json
+++ b/content/nomad/v2.0.x/data/tools-nav-data.json
@@ -285,6 +285,10 @@
         "path": "nomad-pack/migrate-template-syntax"
       },
       {
+        "title": "Template functions ",
+        "path": "nomad-pack/functions"
+      },
+      {
         "title": "CLI reference",
         "routes": [
           {


### PR DESCRIPTION
## Description

One of the interns updated docs content in the nomad-pack repo instead of here. He finished his internship so this PR updates content in prep for removing the docs directory from nomad-pack.

- Add functions.mdx.
- Update existing pages based on file history in nomad-pack repo.
- Apply style guide fixes to the existing file, which came over from the tutorials repo in 2025.

## Links

Jira: [IPE-1647]

## Contributor checklists

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [x] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [ ] Verify that all status checks passed
- [ ] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [ ] I added redirects for any moved or removed pages
- [x] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [ ] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [ ] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.


[IPE-1647]: https://hashicorp.atlassian.net/browse/IPE-1647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ