### PR TITLE
Fix: Remove non-existent `empty_message` log from machine-readable output docs for `init` command.

### DIFF
--- a/content/terraform/v1.10.x/docs/internals/machine-readable-ui.mdx
+++ b/content/terraform/v1.10.x/docs/internals/machine-readable-ui.mdx
@@ -92,7 +92,6 @@ Messages with `init_output` type have an additional `message_code` documented be
 
 - `initializing_terraform_cloud_message`: indicates progress during initialisation of HCP Terraform (`cloud` backend)
 - `initializing_backend_message`: indicates progress during initialisation of a backend
-- `empty_message`: describes an empty message; equivalent to a new line aiding formatting in terminal output
 - `output_init_empty_message`: indicates that an _empty_ directory was successfully initialised
 - `output_init_success_message`: indicates that a [not empty] directory was successfully initialised via CLI
 - `output_init_success_cloud_message`: indicates that a [not empty] directory was successfully initialised via HCP Terraform

--- a/content/terraform/v1.11.x/docs/internals/machine-readable-ui.mdx
+++ b/content/terraform/v1.11.x/docs/internals/machine-readable-ui.mdx
@@ -93,7 +93,6 @@ Messages with `init_output` type have an additional `message_code` documented be
 
 - `initializing_terraform_cloud_message`: indicates progress during initialisation of HCP Terraform (`cloud` backend)
 - `initializing_backend_message`: indicates progress during initialisation of a backend
-- `empty_message`: describes an empty message; equivalent to a new line aiding formatting in terminal output
 - `output_init_empty_message`: indicates that an _empty_ directory was successfully initialised
 - `output_init_success_message`: indicates that a [not empty] directory was successfully initialised via CLI
 - `output_init_success_cloud_message`: indicates that a [not empty] directory was successfully initialised via HCP Terraform

--- a/content/terraform/v1.12.x/docs/internals/machine-readable-ui.mdx
+++ b/content/terraform/v1.12.x/docs/internals/machine-readable-ui.mdx
@@ -93,7 +93,6 @@ Messages with `init_output` type have an additional `message_code` documented be
 
 - `initializing_terraform_cloud_message`: indicates progress during initialisation of HCP Terraform (`cloud` backend)
 - `initializing_backend_message`: indicates progress during initialisation of a backend
-- `empty_message`: describes an empty message; equivalent to a new line aiding formatting in terminal output
 - `output_init_empty_message`: indicates that an _empty_ directory was successfully initialised
 - `output_init_success_message`: indicates that a [not empty] directory was successfully initialised via CLI
 - `output_init_success_cloud_message`: indicates that a [not empty] directory was successfully initialised via HCP Terraform

--- a/content/terraform/v1.13.x/docs/internals/machine-readable-ui.mdx
+++ b/content/terraform/v1.13.x/docs/internals/machine-readable-ui.mdx
@@ -93,7 +93,6 @@ Messages with `init_output` type have an additional `message_code` documented be
 
 - `initializing_terraform_cloud_message`: indicates progress during initialisation of HCP Terraform (`cloud` backend)
 - `initializing_backend_message`: indicates progress during initialisation of a backend
-- `empty_message`: describes an empty message; equivalent to a new line aiding formatting in terminal output
 - `output_init_empty_message`: indicates that an _empty_ directory was successfully initialised
 - `output_init_success_message`: indicates that a [not empty] directory was successfully initialised via CLI
 - `output_init_success_cloud_message`: indicates that a [not empty] directory was successfully initialised via HCP Terraform

--- a/content/terraform/v1.14.x/docs/internals/machine-readable-ui.mdx
+++ b/content/terraform/v1.14.x/docs/internals/machine-readable-ui.mdx
@@ -93,7 +93,6 @@ Messages with `init_output` type have an additional `message_code` documented be
 
 - `initializing_terraform_cloud_message`: indicates progress during initialisation of HCP Terraform (`cloud` backend)
 - `initializing_backend_message`: indicates progress during initialisation of a backend
-- `empty_message`: describes an empty message; equivalent to a new line aiding formatting in terminal output
 - `output_init_empty_message`: indicates that an _empty_ directory was successfully initialised
 - `output_init_success_message`: indicates that a [not empty] directory was successfully initialised via CLI
 - `output_init_success_cloud_message`: indicates that a [not empty] directory was successfully initialised via HCP Terraform

--- a/content/terraform/v1.15.x/docs/internals/machine-readable-ui.mdx
+++ b/content/terraform/v1.15.x/docs/internals/machine-readable-ui.mdx
@@ -93,7 +93,6 @@ Messages with `init_output` type have an additional `message_code` documented be
 
 - `initializing_terraform_cloud_message`: indicates progress during initialisation of HCP Terraform (`cloud` backend)
 - `initializing_backend_message`: indicates progress during initialisation of a backend
-- `empty_message`: describes an empty message; equivalent to a new line aiding formatting in terminal output
 - `output_init_empty_message`: indicates that an _empty_ directory was successfully initialised
 - `output_init_success_message`: indicates that a [not empty] directory was successfully initialised via CLI
 - `output_init_success_cloud_message`: indicates that a [not empty] directory was successfully initialised via HCP Terraform

--- a/content/terraform/v1.9.x/docs/internals/machine-readable-ui.mdx
+++ b/content/terraform/v1.9.x/docs/internals/machine-readable-ui.mdx
@@ -92,7 +92,6 @@ Messages with `init_output` type have an additional `message_code` documented be
 
 - `initializing_terraform_cloud_message`: indicates progress during initialisation of HCP Terraform (`cloud` backend)
 - `initializing_backend_message`: indicates progress during initialisation of a backend
-- `empty_message`: describes an empty message; equivalent to a new line aiding formatting in terminal output
 - `output_init_empty_message`: indicates that an _empty_ directory was successfully initialised
 - `output_init_success_message`: indicates that a [not empty] directory was successfully initialised via CLI
 - `output_init_success_cloud_message`: indicates that a [not empty] directory was successfully initialised via HCP Terraform


### PR DESCRIPTION
### What

Remove description of the [empty_message JSON log](https://developer.hashicorp.com/terraform/internals/machine-readable-ui#empty_message) produced by the init command when JSON output is enabled.

### Why

This type of JSON log was never produced by `init`.

See https://github.com/hashicorp/terraform/pull/38864 's description for explanation of how we know this log type was _never_ produced since JSON output was added to `init` in v1.9.


### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] You added redirects to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages **across all affected versions**. Refer to [Redirects](https://github.com/hashicorp/web-unified-docs/blob/main/docs/content-guide/redirects.md#example-redirects) for examples and guidance. 
- [ ] Links to related content where appropriate (e.g., CLI, language, API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.