### PR TITLE
terraform: Add new backend initialisation JSON log type to the machine-readable UI docs for v1.15

### DIFF
--- a/content/terraform/v1.15.x/docs/internals/machine-readable-ui.mdx
+++ b/content/terraform/v1.15.x/docs/internals/machine-readable-ui.mdx
@@ -91,13 +91,17 @@ Messages with `init_output` type have an additional `message_code` documented be
 
 #### General
 
-- `initializing_terraform_cloud_message`: indicates progress during initialisation of HCP Terraform (`cloud` backend)
-- `initializing_backend_message`: indicates progress during initialisation of a backend
 - `output_init_empty_message`: indicates that an _empty_ directory was successfully initialised
 - `output_init_success_message`: indicates that a [not empty] directory was successfully initialised via CLI
 - `output_init_success_cloud_message`: indicates that a [not empty] directory was successfully initialised via HCP Terraform
 - `output_init_success_cli_message`: instructions for next steps after a directory was successfully initialised via CLI
 - `output_init_success_cli_cloud_message`: instructions for next steps after a directory was successfully initialised via HCP Terraform
+
+#### Backend Initialization
+
+- `initializing_terraform_cloud_message`: indicates progress during initialisation of HCP Terraform (`cloud` backend)
+- `initializing_backend_message`: indicates progress during initialisation of a backend
+- `backend_configured_success`: indicates a backend was successfully configured for the first time
 
 #### Provider Installation
 


### PR DESCRIPTION
### What
Add new JSON log output type to machine readable output docs for Terraform v1.15.

In doing so, I made a new section specific to backend-related log entries.

### Why
This message type was added in v1.15 here: https://github.com/hashicorp/terraform/commit/87b3390189c3f993d59274df00bb4d1424d9e976

In that PR a lot of message codes were added to `init` but `backend_configured_success` is the only one that's shown in JSON output. All other code added in that PR is unreachable when using -json because state migrations are incompatible with using -json.


### Screenshots
N/A
----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] Description links to related pull requests or issues, if any.

#### Content

None of these are applicable

- [x] You added redirects to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages **across all affected versions**. Refer to [Redirects](https://github.com/hashicorp/web-unified-docs/blob/main/docs/content-guide/redirects.md#example-redirects) for examples and guidance. 
- [x] Links to related content where appropriate (e.g., CLI, language, API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] New pages have metadata (page name and description) at the top.
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.