### PR TITLE
Nomad Docs: Add release note for Podman 0.6.5

### DIFF
--- a/content/nomad/v2.0.x/content/plugins/drivers/podman.mdx
+++ b/content/nomad/v2.0.x/content/plugins/drivers/podman.mdx
@@ -4,8 +4,8 @@ page_title: Podman task driver plugin
 description: >-
   The Podman task driver plugin uses the Pod Manager daemonless container runtime to execute Nomad workload tasks. Learn how to configure and install the Podman task driver plugin. Review capabilities, client requirements, plugin options, and network configuration. Learn how to use the Podman task driver in your Nomad job. Configure image registry authentication, Linux capabilities, host devices, entrypoint, paths, image, labels, logging, memory, network mode, ports, volumes, working directory, and container privileges.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2026-02-16T16:54:38.000Z
-last_modified: 2026-02-16T16:54:38.000Z
+created_at: 2026-02-16T10:52:39-06:00
+last_modified: 2026-07-13T18:20:36.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -17,7 +17,15 @@ The Podman task driver plugin for Nomad uses the [Pod Manager (podman)][podman]
 daemonless container runtime for executing Nomad tasks. Podman supports OCI
 containers and its command line tool is meant to be a drop-in replacement for Docker.
 
-Source is on [GitHub][github]
+You can find the source in the [nomad-driver-podman GitHub repository][github].
+The plugin is maintained by HashiCorp.
+
+## Releases
+
+| Release | Release Date | Nomad Versions |
+| ------- | ------------ | --------- |
+| [0.6.5](https://github.com/hashicorp/nomad-driver-podman/releases/tag/v0.6.5)   | July 13, 2026 | 1.8.x - 2.0.x |
+| [0.6.4](https://github.com/hashicorp/nomad-driver-podman/releases/tag/v0.6.4)  | December 10, 2025 | 1.8.x - 1.11.x |
 
 ## Installation
 
@@ -46,7 +54,7 @@ Add the HashiCorp [GPG key][gpg-key].
 $ wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
 ```
 
-Add the official HashiCorp Linux test repository.
+Add the official HashiCorp Linux repository.
 
 ```shell-session
 $ echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
@@ -84,7 +92,7 @@ $ sudo yum -y install nomad-driver-podman
 
 ## Usage
 
-The example job created by [`nomad init -short`][nomad-init] is easily adapted
+The example job created by [`nomad init -short`][nomad-init] can be adapted
 to use Podman instead:
 
 ```hcl
@@ -107,7 +115,7 @@ job "redis" {
 
 Refer to the project's [homepage][homepage] for details.
 
-## Client Requirements
+## Client requirements
 
 The Podman task driver is not built into Nomad. It must be
 [downloaded][downloaded] onto the client host in the configured plugin
@@ -118,8 +126,8 @@ directory.
   other things, follow [this tutorial][rootless_tutorial].
 
 You need a v3.x or higher podman binary and a system socket [activation unit]
-[rest_api]. It is recommended to install podman via your system's package
-manager, which will configure systemd for you.
+[rest_api]. It is recommended to install podman using your system's package
+manager, which configures systemd for you.
 
 Ensure that Nomad can find the plugin, refer to [`plugin_dir`][plugin_dir].
 
@@ -135,7 +143,7 @@ The `podman` driver implements the following [capabilities](/nomad/plugins/autho
 | network isolation    | host, group, task, none |
 | volume mounting      | true                    |
 
-## Task Configuration
+## Task configuration
 
 - `apparmor_profile` - (Optional) Name of an AppArmor profile to use instead of
   the default profile. The special value `unconfined` disables AppArmor for this container.
@@ -159,8 +167,8 @@ The `podman` driver implements the following [capabilities](/nomad/plugins/autho
   ```
 
 - `auth` - (Optional) Authenticate to the image registry using a static
-  credential. By setting `tls_verify` to false the driver will allow using self-
-  signed certificates or plain HTTP connections to the registry.
+  credential. Setting `tls_verify` to `false` lets the driver use self-signed
+  certificates or plain HTTP connections to the registry.
 
   ```hcl
   config {
@@ -211,7 +219,7 @@ The `podman` driver implements the following [capabilities](/nomad/plugins/autho
   }
   ```
 
-- `cpu_hard_limit` (Optional) `true` or `false`. Use hard CPU limiting instead
+- `cpu_hard_limit` - (Optional) `true` or `false`. Use hard CPU limiting instead
   of soft limiting. By default this is `false`, which means Podman uses soft
   limiting so that containers are able to burst above their CPU limit when there
   is idle capacity.
@@ -269,7 +277,7 @@ The `podman` driver implements the following [capabilities](/nomad/plugins/autho
 - `image` - The image to run. Accepted transports are `docker` (default if
   missing), `oci-archive`, and `docker-archive`. Archive references can point
   to local files or `http://` and `https://` URLs. Images referenced as
-  [short-names] will be treated according to user-configured preferences.
+  [short-names] are treated according to user-configured preferences.
 
   ```hcl
   config {
@@ -369,10 +377,10 @@ The `podman` driver implements the following [capabilities](/nomad/plugins/autho
   [`disable_log_collection`].
 
     - `driver = "nomad"` - (Default) Podman redirects its combined
-    `stdout/stderr` logstream directly to a Nomad `fifo`. Benefits of this
-    mode are: zero overhead, don't have to worry about log rotation at system
-    or Podman level. Downside: you cannot easily ship the logstream to a log
-    aggregator plus `stdout/stderr` is multiplexed into a single stream.
+    `stdout/stderr` logstream directly to a Nomad `fifo`. This mode has zero
+    overhead and requires no log rotation at the system or Podman level.
+    The trade-off is that you cannot ship the logstream to a log aggregator
+    and `stdout/stderr` is multiplexed into a single stream.
 
     ```hcl
     config {
@@ -383,14 +391,14 @@ The `podman` driver implements the following [capabilities](/nomad/plugins/autho
     ```
 
     - `driver = "journald"` - The container log is forwarded from Podman to the
-    `journald` on your host. Next, it's pulled by the Podman API back from the
+    `journald` on your host. The Podman API then pulls the log back from the
     journal into the Nomad `fifo` (controllable by [`disable_log_collection`]).
-    Benefits: all containers can log into the host journal, you can ship a
-    structured stream including metadata to your log aggregator. No log
-    rotation at Podman level. You can add additional tags to the journal.
-    Drawbacks: a bit more overhead, depends on Journal (will not work on WSL2).
-    You should configure some rotation policy for your Journal. Ensure you're
-    running Podman 3.1.0 or higher because of bugs in older versions.
+    All containers can log to the host journal, and you can ship a structured
+    stream including metadata to your log aggregator. No log rotation at the
+    Podman level. You can add additional tags to the journal. The trade-offs
+    are additional overhead, a dependency on Journal (does not work on WSL2),
+    and the need to configure a rotation policy for your journal. Requires
+    Podman 3.1.0 or higher.
 
     ```hcl
     config {
@@ -409,9 +417,9 @@ The `podman` driver implements the following [capabilities](/nomad/plugins/autho
   (kilobytes), `m` (megabytes), or `g` (gigabytes)).
 
   After setting memory reservation, when the system detects memory contention
-  or low memory, containers are forced to restrict their consumption to their
-  reservation. So you should always set the value below `--memory`, otherwise
-  the hard limit will take precedence. By default, memory reservation will be
+  or low memory, the system forces containers to restrict their consumption to
+  their reservation. Always set the value below `--memory`; otherwise,
+  the hard limit takes precedence. By default, memory reservation is
   the same as memory limit.
 
   ```hcl
@@ -443,7 +451,7 @@ The `podman` driver implements the following [capabilities](/nomad/plugins/autho
 
 - `network_mode` - (Optional) Set the [network mode][network-mode] for the
   container. By default, the task uses the network stack defined in the task
-  group [`network`][nomad_group_network] block. If the groups network behavior
+  group [`network`][nomad_group_network] block. If the group's network behavior
   is also undefined, it falls back to `bridge` in rootful mode, `slirp4netns`
   for rootless containers on Podman version less than 5.0.0, or `pasta` for
   rootless containers on Podman v5.0.0 or greater.
@@ -482,7 +490,7 @@ The `podman` driver implements the following [capabilities](/nomad/plugins/autho
   }
   ```
 
-- `pids_limit` - (Optional) An integer value that specified the PID limit for
+- `pids_limit` - (Optional) An integer value that specifies the PID limit for
   the container.
 
   ```hcl
@@ -497,7 +505,7 @@ The `podman` driver implements the following [capabilities](/nomad/plugins/autho
 - `privileged` - (Optional) `true` or `false` (default). A privileged container
   turns off the security features that isolate the container from the host.
   Dropped Capabilities, limited devices, read-only mount points,
-  Apparmor/SELinux separation, and Seccomp filters are all disabled.
+  AppArmor/SELinux separation, and Seccomp filters are all disabled.
 
 - `readonly_rootfs` - (Optional) `true` or `false` (default). Mount the rootfs
   as read-only.
@@ -530,9 +538,9 @@ The `podman` driver implements the following [capabilities](/nomad/plugins/autho
   }
   ```
 
-- `shm_size` - (Optional) Set the size of `/dev/shm`. Refer to [`podman run
-  --shm-size](https://docs.podman.io/en/latest/markdown/podman-run.1.html#shm-size-number-unit)
-  for more details.
+- `shm_size` - (Optional) Set the size of `/dev/shm`. Refer to
+  [`podman run --shm-size`](https://docs.podman.io/en/latest/markdown/podman-run.1.html#shm-size-number-unit)
+  for details.
 
 - `socket` - (Optional) The name of the socket as defined in the socket block in
   the client agent's plugin configuration. Defaults to the socket named "default".
@@ -600,7 +608,7 @@ The `podman` driver implements the following [capabilities](/nomad/plugins/autho
   }
   ```
 
-- `userns` - (Optional) Ser the user namespace mode for the container.
+- `userns` - (Optional) Set the user namespace mode for the container.
 
   ```hcl
   config {
@@ -611,11 +619,11 @@ The `podman` driver implements the following [capabilities](/nomad/plugins/autho
 Additionally, the Podman driver supports customization of the container's user
 through the task's [`user` option](/nomad/docs/job-specification/task#user).
 
-## Network Configuration
+## Network configuration
 
-Nomad [lifecycle hooks][nomad_lifecycle_hooks] combined with the drivers
-[`network_mode`] allows very flexible network namespace definitions. This
-feature does not build upon the native Podman pod structure but simply reuses
+Nomad [lifecycle hooks][nomad_lifecycle_hooks] combined with the driver's
+[`network_mode`] allow very flexible network namespace definitions. This
+feature does not build upon the native Podman pod structure but reuses
 the networking namespace of one container for other tasks in the same group.
 
 A typical example is a network server and a metric exporter or log shipping
@@ -623,7 +631,7 @@ sidecar. The metric exporter needs access to a private monitoring port which
 should not be exposed to the network and thus is usually bound to `localhost`.
 
 The [`nomad-driver-podman` repository][homepage] includes three different
-examples jobs for such a setup. All of them will start a
+example jobs for such a setup. All of them start a
 [nats](https://nats.io/) server and a
 [prometheus-nats-exporter](https://github.com/nats-io/prometheus-nats-exporter)
 using different approaches.
@@ -635,36 +643,41 @@ get Prometheus metrics:
 $ curl http://your-machine:7777/metrics
 ```
 
-### 2 Task setup, server defines the network
+### Task setup - server defines the network
 
 Reference [`examples/jobs/nats_simple_pod.nomad`].
 
 Here, the `server` task is started as main workload and the `exporter` runs as
 a `poststart` sidecar. Because of that, Nomad guarantees that the server is
-started first and thus the exporter can easily join the servers network
+started first and thus the exporter can join the server's network
 namespace via `network_mode = "task:server"`.
 
-Note, that the `server` configuration file binds the `http_port` to
-`localhost`.
+<Note>
 
-Be aware that ports must be defined in the parent network namespace, here
-`server`.
+The `server` configuration file binds `http_port` to `localhost`. Define ports
+in the parent network namespace (`server` in this example).
 
-### 3 Task setup, a pause container defines the network
+</Note>
+
+### Task setup - a pause container defines the network
 
 Reference [`examples/jobs/nats_pod.nomad`].
 
-A slightly different setup is demonstrated in this job. It reassembles more
-closesly the idea of a `pod` by starting a `pause` task, named `pod` via a
+A slightly different setup is demonstrated in this job. It resembles more
+closely the idea of a `pod` by starting a `pause` task, named `pod` using a
 [`prestart`] sidecar hook.
 
 Next, the main workload, `server` is started and joins the network namespace by
 using the `network_mode = "task:pod"` block. Finally, Nomad starts the
 `poststart` sidecar `exporter` which also joins the network.
 
-Note that all ports must be defined on the `pod` level.
+<Note>
 
-### 2 Task setup, shared Nomad network namespace
+Define all ports at the `pod` level.
+
+</Note>
+
+### Task setup - shared Nomad network namespace
 
 Reference [`examples/jobs/nats_group.nomad`].
 
@@ -672,7 +685,7 @@ This example is very different. Both `server` and `exporter` join a network
 namespace which is created and managed by Nomad itself. Refer to Nomad's
 [`network`] block to get started with this generic approach.
 
-## Plugin Options
+## Plugin options
 
 The Podman plugin has options which may be customized in the agent's
 configuration file.
@@ -694,11 +707,15 @@ configuration file.
 
 - `recover_stopped` - (Deprecated) Defaults to `false`. Allows the driver to
   start and reuse a previously stopped container after a Nomad client restart.
-  Consider a simple single node system and a complete reboot. All previously
-  managed containers will be reused instead of disposed and recreated.
+  Consider a single-node system and a complete reboot. All previously
+  managed containers are reused instead of disposed and recreated.
 
-  !> This option may cause Nomad client to hang on startup. It now defaults to
-  being disabled and may be removed in a future release.
+  <Warning>
+
+  This option may cause the Nomad client to hang on startup. It now defaults
+  to disabled and may be removed in a future release.
+
+  </Warning>
 
   ```hcl
   plugin "nomad-driver-podman" {
@@ -712,11 +729,10 @@ configuration file.
   running as `root` or a cgroup V1 system, and
   `unix://run/user/<USER_ID>/podman/io.podman` for rootless cgroup V2 systems.
 
-- `disable_log_collection` `(bool: false)` - Setting this to `true` will
-  disable Nomad logs collection of Podman tasks. If you don't rely on Nomad log
-  capabilities and exclusively use host based log aggregation, you may consider
-  this option to disable Nomad log collection overhead. Beware to you also lose
-  automatic log rotation.
+- `disable_log_collection` `(bool: false)` - Setting this to `true` disables
+  Nomad log collection for Podman tasks. If you rely exclusively on host-based
+  log aggregation, use this option to disable Nomad log collection overhead.
+  You also lose automatic log rotation.
 
   ```hcl
   plugin "nomad-driver-podman" {
@@ -741,7 +757,7 @@ configuration file.
 
   - `enabled` - Defaults to `true`. Allows tasks to bind host paths (volumes)
     inside their container.
-  - `selinuxlabel` - Allows the operator to set a SELinux label to the
+  - `selinuxlabel` - Allows the operator to set an SELinux label to the
     allocation and task local bind-mounts to containers. If used with
     `volumes.enabled` set to false, the labels will still be applied to the
     standard binds in the container.
@@ -770,8 +786,7 @@ file containing the details in a location such as
 }
 ```
 
-You can then instruct Nomad and the Podman driver to use this information by
-adding the following to the `/etc/nomad.d/nomad.env` file:
+To use this information, add the following to the `/etc/nomad.d/nomad.env` file:
 ```env
 REGISTRY_AUTH_FILE=/etc/nomad.d/registry/auth.json
 ```
@@ -779,7 +794,6 @@ REGISTRY_AUTH_FILE=/etc/nomad.d/registry/auth.json
 [github]: https://github.com/hashicorp/nomad-driver-podman
 [`count`]: /nomad/docs/job-specification/group#count
 [`disable_log_collection`]: #disable_log_collection
-[docker-ports]: /nomad/docs/job-declare/task-driver/docker#forwarding-and-exposing-ports
 [`examples/jobs/nats_group.nomad`]: https://github.com/hashicorp/nomad-driver-podman/blob/main/examples/jobs/nats_group.nomad
 [`examples/jobs/nats_simple_pod.nomad`]: https://github.com/hashicorp/nomad-driver-podman/blob/main/examples/jobs/nats_simple_pod.nomad
 [`examples/jobs/nats_pod.nomad`]: https://github.com/hashicorp/nomad-driver-podman/blob/main/examples/jobs/nats_pod.nomad
@@ -787,7 +801,6 @@ REGISTRY_AUTH_FILE=/etc/nomad.d/registry/auth.json
 [memory-value]: /nomad/docs/job-specification/resources#memory
 [`network`]: /nomad/docs/job-specification/network
 [nomad-init]: /nomad/commands/job/init
-[nomad_download]: /nomad/downloads
 [nomad_driver_ports]: /nomad/docs/job-declare/task-driver/docker#forwarding-and-exposing-ports
 [nomad_group_network]: /nomad/docs/job-specification/group#network
 [nomad_lifecycle_hooks]: /nomad/docs/job-specification/lifecycle
@@ -799,9 +812,9 @@ REGISTRY_AUTH_FILE=/etc/nomad.d/registry/auth.json
 [task]: /nomad/docs/job-specification/task#user
 [`network_mode`]: #network_mode
 [network-mode]: https://docs.podman.io/en/latest/markdown/podman-run.1.html#network-mode-net
-[slirp-issue]: https://github.com/containers/libpod/issues/6097
 [downloaded]: https://releases.hashicorp.com/nomad-driver-podman
 [short-names]: https://github.com/containers/image/blob/master/docs/containers-registries.conf.5.md#short-name-aliasing
 [`command`]: #command
 [`client_http_timeout`]: #client_http_timeout
 [rest_api]: https://www.redhat.com/sysadmin/podmans-new-rest-api
+[gpg-key]: https://apt.releases.hashicorp.com/gpg

--- a/content/nomad/v2.0.x/content/plugins/drivers/podman.mdx
+++ b/content/nomad/v2.0.x/content/plugins/drivers/podman.mdx
@@ -2,10 +2,12 @@
 layout: docs
 page_title: Podman task driver plugin
 description: >-
-  The Podman task driver plugin uses the Pod Manager daemonless container runtime to execute Nomad workload tasks. Learn how to configure and install the Podman task driver plugin. Review capabilities, client requirements, plugin options, and network configuration. Learn how to use the Podman task driver in your Nomad job. Configure image registry authentication, Linux capabilities, host devices, entrypoint, paths, image, labels, logging, memory, network mode, ports, volumes, working directory, and container privileges.
+  Learn how to install and configure the Podman task driver plugin for Nomad.
+  Covers capabilities, client requirements, task configuration, and network
+  setup for rootful and rootless containers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2026-02-16T10:52:39-06:00
-last_modified: 2026-07-13T18:20:36.000Z
+last_modified: 2026-07-13T20:05:21.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -13,12 +15,13 @@ last_modified: 2026-07-13T18:20:36.000Z
 
 Name: `podman`
 
-The Podman task driver plugin for Nomad uses the [Pod Manager (podman)][podman]
+The Podman task driver plugin for Nomad uses the [Podman][podman]
 daemonless container runtime for executing Nomad tasks. Podman supports OCI
-containers and its command line tool is meant to be a drop-in replacement for Docker.
+containers and its command line tool serves as a drop-in replacement for
+Docker.
 
-You can find the source in the [nomad-driver-podman GitHub repository][github].
-The plugin is maintained by HashiCorp.
+You can find the Podman task driver source in the [`nomad-driver-podman` GitHub
+repository][github]. HashiCorp maintains the plugin.
 
 ## Releases
 
@@ -32,60 +35,61 @@ The plugin is maintained by HashiCorp.
 <Tabs>
 <Tab heading="Manual installation" group="manual">
 
-You can download a [precompiled binary](https://releases.hashicorp.com/nomad-driver-podman/) and verify the
-binary using the available SHA-256 sums. After downloading nomad-driver-podman
-driver, unzip the package. Make sure that the `nomad-driver-podman` binary is
+1. Download a [precompiled binary](https://releases.hashicorp.com/nomad-driver-podman/) and verify the
+binary using the available SHA-256 sums. 
+1. Unzip the package. 
+1. Ensure the `nomad-driver-podman` binary is
 available on your [plugin_dir](/nomad/docs/configuration#plugin_dir) path,
 specified by the client's config file, before continuing with the other guides.
 
 </Tab>
 <Tab heading="Ubuntu/Debian" group="manual">
 
-Install the required packages.
+1. Install the required packages.
 
-```shell-session
-$ sudo apt-get update && \
-  sudo apt-get install wget gpg coreutils
-```
+   ```shell-session
+   sudo apt-get update && \
+   sudo apt-get install wget gpg coreutils
+   ```
 
-Add the HashiCorp [GPG key][gpg-key].
+1. Add the HashiCorp [GPG key][gpg-key].
 
-```shell-session
-$ wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
-```
+   ```shell-session
+   wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+   ```
 
-Add the official HashiCorp Linux repository.
+1. Add the official HashiCorp Linux repository.
 
-```shell-session
-$ echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
-```
+   ```shell-session
+   echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+   ```
 
-Update and install.
+1. Update and install.
 
-```shell-session
-$ sudo apt-get update && sudo apt-get install -y nomad-driver-podman
-```
+   ```shell-session
+   sudo apt-get update && sudo apt-get install -y nomad-driver-podman
+   ```
 
 </Tab>
 <Tab heading="CentOS/RHEL" group="linux">
 
-Install `yum-config-manager` to manage your repositories.
+1. Install `yum-config-manager` to manage your repositories.
 
-```shell-session
-$ sudo yum install -y yum-utils
-```
+   ```shell-session
+   sudo yum install -y yum-utils
+   ```
 
-Use `yum-config-manager` to add the official HashiCorp Linux repository.
+1. Use `yum-config-manager` to add the official HashiCorp Linux repository.
 
-```shell-session
-$ sudo yum-config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo
-```
+   ```shell-session
+   sudo yum-config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo
+   ```
 
-Install.
+1. Install.
 
-```shell-session
-$ sudo yum -y install nomad-driver-podman
-```
+   ```shell-session
+   sudo yum -y install nomad-driver-podman
+   ```
 
 </Tab>
 </Tabs>
@@ -117,16 +121,16 @@ Refer to the project's [homepage][homepage] for details.
 
 ## Client requirements
 
-The Podman task driver is not built into Nomad. It must be
-[downloaded][downloaded] onto the client host in the configured plugin
-directory.
+The Podman task driver is not built into Nomad. You must [download the
+driver][downloaded] onto the client host in the configured plugin directory.
 
 - Linux host with [`podman`][podman] installed
-- For rootless containers you need a system supporting cgroups v2 and a few
-  other things, follow [this tutorial][rootless_tutorial].
+- For rootless containers, you need a system supporting cgroups v2 and a few
+  other things. Refer to the [Podman rootless tutorial][rootless_tutorial] for
+  instructions.
 
-You need a v3.x or higher podman binary and a system socket [activation unit]
-[rest_api]. It is recommended to install podman using your system's package
+You need a v3.x or higher Podman binary and a system socket [activation unit]
+[rest_api]. We recommend installing Podman using your system's package
 manager, which configures systemd for you.
 
 Ensure that Nomad can find the plugin, refer to [`plugin_dir`][plugin_dir].
@@ -230,11 +234,11 @@ The `podman` driver implements the following [capabilities](/nomad/plugins/autho
   --cpu-period`](https://docs.podman.io/en/latest/markdown/podman-run.1.html#cpu-period-limit)
   for details.
 
-- `devices` - (Optional) A list of `host-device[:container-device][:permissions]`
-  definitions. Each entry adds a host device to the container. Optional
-  permissions can be used to specify device permissions, it is a combination of
-  `r` for read, `w` for write, and `m` for `mknod(2)`. Refer to Podman's
-  documentation for more details.
+- `devices` - (Optional) A list of
+  `host-device[:container-device][:permissions]` definitions. Each entry adds a
+  host device to the container. Optional permissions specify device permissions
+  as a combination of `r` for read, `w` for write, and `m` for `mknod(2)`. Refer
+  to Podman's documentation for more details.
 
   ```hcl
   config {
@@ -272,7 +276,7 @@ The `podman` driver implements the following [capabilities](/nomad/plugins/autho
 
 - `hostname` - (Optional) The hostname to assign to the container. When
   launching more than one of a task (using [`count`]) with this option set,
-  every container the task starts will have the same hostname.
+  every container the task starts has the same hostname.
 
 - `image` - The image to run. Accepted transports are `docker` (default if
   missing), `oci-archive`, and `docker-archive`. Archive references can point
@@ -466,16 +470,17 @@ The `podman` driver implements the following [capabilities](/nomad/plugins/autho
   - `container:id` - Reuse another container's network stack.
   - `host` - Use the Podman host network stack. Note: the host mode gives the
   container full access to local system services such as D-bus and is therefore
-  considered insecure.
+  insecure.
   - `none` - No networking.
-  - `pasta`: Use `pasta` to create a user network stack. This is the
+  - `pasta` - Use `pasta` to create a user network stack. This is the
     default for rootless containers on Podman v5.0.0 or greater.
-  - `slirp4netns`: Use `slirp4netns` to create a user network stack. This is the
-  default for rootless containers on Podman versions less than 5.0.0. Podman
-  does not support `slirp4netns` for root containers. Refer to [Podman
-  GitHub issue "podman-pod-create --network slirp4netns is unsupported for root containers"](https://github.com/containers/podman/issues/6097) for an
+  - `slirp4netns` - Use `slirp4netns` to create a user network stack. This is
+  the default for rootless containers on Podman versions less than 5.0.0. Podman
+  does not support `slirp4netns` for root containers. Refer to [Podman GitHub
+  issue "podman-pod-create --network slirp4netns is unsupported for root
+  containers"](https://github.com/containers/podman/issues/6097) for an
   explanation.
-  - `task:name-of-other-task`: Join the network of another task in the same
+  - `task:name-of-other-task` - Join the network of another task in the same
   allocation.
 
   ```hcl
@@ -640,7 +645,7 @@ You can use `curl` to prove that the job is working correctly and that you can
 get Prometheus metrics:
 
 ```shell-session
-$ curl http://your-machine:7777/metrics
+curl http://your-machine:7777/metrics
 ```
 
 ### Task setup - server defines the network
@@ -650,7 +655,7 @@ Reference [`examples/jobs/nats_simple_pod.nomad`].
 Here, the `server` task is started as main workload and the `exporter` runs as
 a `poststart` sidecar. Because of that, Nomad guarantees that the server is
 started first and thus the exporter can join the server's network
-namespace via `network_mode = "task:server"`.
+namespace using `network_mode = "task:server"`.
 
 <Note>
 
@@ -663,8 +668,8 @@ in the parent network namespace (`server` in this example).
 
 Reference [`examples/jobs/nats_pod.nomad`].
 
-A slightly different setup is demonstrated in this job. It resembles more
-closely the idea of a `pod` by starting a `pause` task, named `pod` using a
+This job demonstrates a slightly different setup. It more closely resembles
+the idea of a `pod` by starting a `pause` task, named `pod` using a
 [`prestart`] sidecar hook.
 
 Next, the main workload, `server` is started and joins the network namespace by
@@ -692,7 +697,7 @@ configuration file.
 
 - `gc` block:
 
-  - `container` - Defaults to `true`. This option can be used to disable Nomad
+  - `container` - Defaults to `true`. Set this option to `false` to prevent Nomad
     from removing a container when the task exits.
 
   ```hcl
@@ -759,7 +764,7 @@ configuration file.
     inside their container.
   - `selinuxlabel` - Allows the operator to set an SELinux label to the
     allocation and task local bind-mounts to containers. If used with
-    `volumes.enabled` set to false, the labels will still be applied to the
+    `volumes.enabled` set to false, the labels still apply to the
     standard binds in the container.
 
   ```hcl
@@ -808,7 +813,7 @@ REGISTRY_AUTH_FILE=/etc/nomad.d/registry/auth.json
 [podman]: https://podman.io/
 [`prestart`]: /nomad/docs/job-specification/lifecycle#prestart
 [releases]: https://releases.hashicorp.com/nomad-driver-podman
-[rootless_tutorial]: https://github.com/containers/libpod/blob/master/docs/tutorials/rootless_tutorial.md
+[rootless_tutorial]: https://github.com/containers/podman/blob/main/docs/tutorials/rootless_tutorial.md
 [task]: /nomad/docs/job-specification/task#user
 [`network_mode`]: #network_mode
 [network-mode]: https://docs.podman.io/en/latest/markdown/podman-run.1.html#network-mode-net

--- a/content/nomad/v2.0.x/content/plugins/drivers/podman.mdx
+++ b/content/nomad/v2.0.x/content/plugins/drivers/podman.mdx
@@ -7,7 +7,7 @@ description: >-
   setup for rootful and rootless containers.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2026-02-16T10:52:39-06:00
-last_modified: 2026-07-13T20:05:21.000Z
+last_modified: 2026-07-14T13:37:34.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -129,11 +129,15 @@ driver][downloaded] onto the client host in the configured plugin directory.
   other things. Refer to the [Podman rootless tutorial][rootless_tutorial] for
   instructions.
 
-You need a v3.x or higher Podman binary and a system socket [activation unit]
-[rest_api]. We recommend installing Podman using your system's package
-manager, which configures systemd for you.
+You need a v3.x or higher Podman binary and a system socket activation unit.
+Refer to the [Podman socket activation
+tutorial](https://github.com/podman-container-tools/podman/blob/main/docs/tutorials/socket_activation.md)
+for more information.
 
-Ensure that Nomad can find the plugin, refer to [`plugin_dir`][plugin_dir].
+We recommend installing Podman using your system's package manager, which
+configures systemd for you.
+
+Ensure that Nomad can find the plugin. Refer to [`plugin_dir`][plugin_dir] for details.
 
 ## Capabilities
 
@@ -813,7 +817,7 @@ REGISTRY_AUTH_FILE=/etc/nomad.d/registry/auth.json
 [podman]: https://podman.io/
 [`prestart`]: /nomad/docs/job-specification/lifecycle#prestart
 [releases]: https://releases.hashicorp.com/nomad-driver-podman
-[rootless_tutorial]: https://github.com/containers/podman/blob/main/docs/tutorials/rootless_tutorial.md
+[rootless_tutorial]: https://github.com/podman-container-tools/podman/blob/main/docs/tutorials/rootless_tutorial.md
 [task]: /nomad/docs/job-specification/task#user
 [`network_mode`]: #network_mode
 [network-mode]: https://docs.podman.io/en/latest/markdown/podman-run.1.html#network-mode-net


### PR DESCRIPTION
## Description

Podman task driver 0.6.5 released 7/13/26. The Nomad docs **Plugins** "site" is not versioned because the task drivers listed there have their own releases.

- Add a **Releases** heading before the **Installation** section.
- Update content for style guide and SEO.

Ritesh Harihar confirmed that Podman task driver works with Nomad 1.8.x-2.0.x.

## Links


Jira: [IPE-1651]


## Contributor checklists

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [x] 3 days: Small changes, easy reviews
- [ ] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [ ] Verify that all status checks passed
- [ ] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [ ] I added redirects for any moved or removed pages
- [ ] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [ ] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [ ] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.


[IPE-1651]: https://hashicorp.atlassian.net/browse/IPE-1651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ