### PR TITLE
Remove invoke action modal's instance dropdown references from docs

### DIFF
--- a/content/terraform-docs-common/docs/cloud-docs/actions.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/actions.mdx
@@ -77,9 +77,7 @@ Complete the following steps to invoke an action from the **Actions** page:
 1. Navigate to your workspace and click the **Actions** tab. 
 1. Choose **Invoke action** from the ellipses menu.
 1. When prompted, choose a run type for invoking the action. Refer to [Run modes and options](/terraform/cloud-docs/workspaces/run/modes-and-options) for more information about run types.
-1. If the `action` block provisions multiple instances, you can enable the **Invoke a specific instance key** option and choose a specific action instance to invoke. 
-
-   Depending on your configuration, you can either choose an instance name from the **Select an instance** drop-down or specify the address of the action instance in the **Manual input** field. You can't invoke an action called from a `module` block when the module is configured with multiple instances. Refer to [Multiple action instances](#multiple-action-instances) for more information.
+1. If the `action` block provisions multiple instances, you can enable the **Invoke a specific instance key** option and enter the count index or `for_each` instance key for the action instance you want to invoke. You can't invoke an action called from a `module` block when the module is configured with multiple instances. Refer to [Multiple action instances](#multiple-action-instances) for more information.
    
 1. Click **Invoke**. If you chose the **Preview with plan-only run** option, then <!-- BEGIN: TFC:only name:hcp-terraform -->HCP Terraform<!-- END: TFC:only name:hcp-terraform --><!-- BEGIN: TFEnterprise:only name:terraform-enterprise -->Terraform Enterprise<!-- END: TFEnterprise:only name:terraform-enterprise --> models the outcome in a Terraform plan but does not perform the operation. 
 
@@ -95,13 +93,7 @@ Complete the following steps to invoke an action from the invocation history pag
 
 You can invoke a specific instance of an action from the **Actions** page. To provision multiple instances, you can configure the `action` block with a `count` or `for_each` [meta-argument](/terraform/language/meta-arguments). Refer to the [`action` block reference](/terraform/language/block/action) for more information.  
 
-When the `action` configuration uses literal values or expressions that reference input values directly, such as `count = 3` or `for_each = var.my-action-instances`, the platform can evaulate the expression and render instance names so that you can choose the instance to invoke directly in the UI. The platform may not be able to evaluate  expressions and render instance names for the following expressions:
-
-- Complex expressions
-- Literal expressions wrapped in a function
-- Expressions defined in a `locals` block  
-
-In these cases, you must specify the address of the specific instance you want to invoke. Refer to your configuration to retrieve the instance address. 
+When the `action` configuration uses `count`, enter the count index for the action instance you want to invoke. When the `action` configuration uses `for_each`, enter the `for_each` instance key for the action instance you want to invoke. Refer to your configuration to retrieve the instance index or key.
 
 You can't invoke a specific instance from the **Actions** page, however, when all of the following conditions are true: 
 
@@ -112,5 +104,3 @@ You can't invoke a specific instance from the **Actions** page, however, when al
 The actions won't appear in the run history. Instead, you must invoke them directly from the CLI or API.
 
 You can't invoke actions that are nested more than 20 module calls deep from the **Actions** page. Instead, you must invoke them directly from the CLI or API.
-
-The UI does not show drop-down instance options when a resolved `for_each` action has more than 100 keys. You can manually enter the full action instance address, invoke the action through CLI or API, or choose **Re-invoke action** from a previous direct invocation when available.


### PR DESCRIPTION
This PR updates the Terraform Actions documentation to remove references to the Invoke Action modal’s instance dropdown.

The instance dropdown is being removed in the related [Atlas PR](https://github.com/hashicorp/atlas/pull/29941). Previously, the docs stated that users could select an action instance from the Select an instance dropdown when HCP Terraform could resolve instance keys from `count` or `for_each`. That behavior is no longer supported because the JSON plan may only provide variable references rather than fully resolved instance keys, which can make the dropdown incomplete or misleading.

With the updated behavior, users manually enter the specific action instance they want to invoke:
- For count, users enter the count index
- For for_each, users enter the for_each key
This PR updates the Actions page to reflect the manual-only instance input flow and removes the outdated dropdown-specific caveat for resolved for_each actions with more than 100 keys.

Please go to the `Preview` tab and select the appropriate template:

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
