### PR TITLE
Fix terraform-policy nesting

### DIFF
--- a/app/utils/allDocsPaths.ts
+++ b/app/utils/allDocsPaths.ts
@@ -29,13 +29,11 @@ export const getDocsPaths = async (
 				return []
 			}
 
-			const { version, releaseStage } = latestProductMetadata.value
+			const { version } = latestProductMetadata.value
 
 			let parsedVersion
 			if (!PRODUCT_CONFIG[productSlug].versionedDocs) {
 				parsedVersion = 'v0.0.x'
-			} else if (releaseStage !== 'stable') {
-				parsedVersion = `${version} (${releaseStage})`
 			} else {
 				parsedVersion = version
 			}

--- a/content/terraform-policy/v0.1.x (beta)/data/policy-nav-data.json
+++ b/content/terraform-policy/v0.1.x (beta)/data/policy-nav-data.json
@@ -70,9 +70,5 @@
         ]
       }
     ]
-  },
-  {
-    "title": "Changelog",
-    "path": "changelog"
   }
 ]

--- a/content/terraform-policy/v0.1.x (beta)/docs/policy/compare.mdx
+++ b/content/terraform-policy/v0.1.x (beta)/docs/policy/compare.mdx
@@ -2,13 +2,17 @@
 page_title: Compare policy frameworks
 description: >-
   Learn about how Terraform policy compares to other policy frameworks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-07-14T11:44:47-05:00
+last_modified: 2026-07-14T19:01:15.000Z
+# END AUTO GENERATED METADATA
 ---
 
 # Compare policy frameworks
 
 Terraform policy is a declarative, HCL-based policy as code solution deeply integrated with Terraform. It provides native support for evaluating policies at multiple stages of the Terraform lifecycle, from initialization through post-apply validation. We recommend using Terraform policy to enforce governance in Terraform workflows.
 
-@include "partials/beta.mdx"
+@include "beta.mdx"
 
 ## Overview
 

--- a/content/terraform-policy/v0.1.x (beta)/docs/policy/index.mdx
+++ b/content/terraform-policy/v0.1.x (beta)/docs/policy/index.mdx
@@ -2,13 +2,17 @@
 page_title: Terraform policy
 description: >-
   Learn about the Terraform policy framework. Terraform policy evaluates infrastructure as code policies and integrates with Terraform providers using HCL.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-07-14T11:44:47-05:00
+last_modified: 2026-07-14T19:01:18.000Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform policy
 
 Terraform policy is a policy-as-code framework that integrates directly with Terraform providers. You can write policies for the framework using HashiCorp Configuration Language (HCL) syntax, which lets you reference any resource defined in a Terraform provider. At runtime, HCP Terraform can evaluate and enforce them across your organization as part of your normal infrastructure workflows.
 
-@include "partials/beta.mdx"
+@include "beta.mdx"
 
 ## Workflow
 

--- a/content/terraform-policy/v0.1.x (beta)/docs/policy/install.mdx
+++ b/content/terraform-policy/v0.1.x (beta)/docs/policy/install.mdx
@@ -2,13 +2,17 @@
 page_title: Install the Terraform policy CLI
 description: >-
   Learn how to install the `tfpolicy` command-line interface, which you can use to validate and test policies on your local machine.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-07-14T11:44:47-05:00
+last_modified: 2026-07-14T19:01:20.000Z
+# END AUTO GENERATED METADATA
 ---
 
 # Install the Terraform policy CLI
 
 The Terraform policy command-line interface, `tfpolicy`, tests and validates policies locally. Testing your policies helps you to identify errors when you write and update your policies, before you enforce them against your Terraform workspaces. Install the `tfpolicy` command on your local system before you author your policies and policy tests.
 
-@include "partials/beta.mdx"
+@include "beta.mdx"
 
 ## Installation
 

--- a/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/cli/index.mdx
+++ b/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/cli/index.mdx
@@ -2,13 +2,17 @@
 page_title: Terraform policy CLI reference
 description: >-
   Reference documentation for the Terraform policy CLI (tfpolicy) commands and global flags.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-07-14T11:44:47-05:00
+last_modified: 2026-07-14T19:01:21.000Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform policy CLI
 
 The Terraform policy CLI (`tfpolicy`) provides commands for validating and testing your policies locally before enforcing them in HCP Terraform.
 
-@include "partials/beta.mdx"
+@include "beta.mdx"
 
 ## Usage
 

--- a/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/cli/test.mdx
+++ b/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/cli/test.mdx
@@ -1,14 +1,18 @@
 ---
-page_title: `tfpolicy test` command reference
+page_title: '`tfpolicy test` command reference'
 description: >-
   Reference for the tfpolicy test command to run policy tests locally.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-07-14T11:44:47-05:00
+last_modified: 2026-07-14T19:01:21.000Z
+# END AUTO GENERATED METADATA
 ---
 
 # `tfpolicy test`
 
 The `tfpolicy test` command runs policy tests to verify that your policies work as expected.
 
-@include "partials/beta.mdx"
+@include "beta.mdx"
 
 ## Usage
 

--- a/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/cli/validate.mdx
+++ b/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/cli/validate.mdx
@@ -1,14 +1,18 @@
 ---
-page_title: `tfpolicy validate` command reference
+page_title: '`tfpolicy validate` command reference'
 description: >-
   Reference for the `tfpolicy validate` command to validate policy syntax.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-07-14T11:44:47-05:00
+last_modified: 2026-07-14T19:01:23.000Z
+# END AUTO GENERATED METADATA
 ---
 
 # `tfpolicy validate`
 
 The `tfpolicy validate` command validates the syntax of your policy files.
 
-@include "partials/beta.mdx"
+@include "beta.mdx"
 
 ## Usage
 

--- a/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/cli/version.mdx
+++ b/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/cli/version.mdx
@@ -1,14 +1,18 @@
 ---
-page_title: `tfpolicy version` command reference
+page_title: '`tfpolicy version` command reference'
 description: >-
   Reference for the `tfpolicy version` command to print out the tfpolicy version.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-07-14T11:44:47-05:00
+last_modified: 2026-07-14T19:01:24.000Z
+# END AUTO GENERATED METADATA
 ---
 
 # `tfpolicy version`
 
 The `tfpolicy version` command prints out the version of the tfpolicy CLI.
 
-@include "partials/beta.mdx"
+@include "beta.mdx"
 
 ## Usage
 

--- a/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/functions/getdatasource.mdx
+++ b/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/functions/getdatasource.mdx
@@ -2,13 +2,17 @@
 page_title: core::getdatasource function
 description: >-
   Reference for the core::getdatasource function used to retrieve data sources in policy files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-07-14T11:44:47-05:00
+last_modified: 2026-07-14T19:01:24.000Z
+# END AUTO GENERATED METADATA
 ---
 
 # The `core::getdatasource` function
 
 The `core::getdatasource` function returns a data source of the specified type that matches the filter. Terraform policy passes the filtering attributes to the provider, and returns any matching data sources from the provider. Since this function returns a single data source, you must use filters if needed to specify a single data source.
 
-@include "partials/beta.mdx"
+@include "beta.mdx"
 
 ## Signature
 

--- a/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/functions/gethttprequest.mdx
+++ b/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/functions/gethttprequest.mdx
@@ -2,13 +2,17 @@
 page_title: core::gethttprequest function
 description: >-
   Reference for the core::gethttprequest function used to make HTTP requests in policy files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-07-14T11:44:47-05:00
+last_modified: 2026-07-14T19:01:26.000Z
+# END AUTO GENERATED METADATA
 ---
 
 # The `core::gethttprequest` function
 
 The `core::gethttprequest` function makes a GET request to the given URL with optional header content and returns the statusCode, status, and body.
 
-@include "partials/beta.mdx"
+@include "beta.mdx"
 
 ## Signature
 

--- a/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/functions/getresources.mdx
+++ b/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/functions/getresources.mdx
@@ -2,13 +2,17 @@
 page_title: core::getresources function
 description: >-
   Reference for the core::getresources function used to retrieve resources in policy files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-07-14T11:44:47-05:00
+last_modified: 2026-07-14T19:01:27.000Z
+# END AUTO GENERATED METADATA
 ---
 
 # The `core::getresources` function
 
 The `core::getresources` function returns a list of all resources of the specified type that match the filter, if any. You can also filter by attributes whose values are computed by Terraform, even if they are not explicitly defined in your configuration.
 
-@include "partials/beta.mdx"
+@include "beta.mdx"
 
 ## Signature
 

--- a/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/functions/index.mdx
+++ b/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/functions/index.mdx
@@ -2,13 +2,17 @@
 page_title: Functions reference
 description: >-
   Reference documentation for built-in functions available in Terraform Policy.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-07-14T11:44:47-05:00
+last_modified: 2026-07-14T19:01:29.000Z
+# END AUTO GENERATED METADATA
 ---
 
 # Functions reference
 
 Terraform policy includes built-in functions you can use when you write policies. You can also use many built-in Terraform functions, and write function plugins to implement reusable logic such as HTTP functions or arithmetic operations.
 
-@include "partials/beta.mdx"
+@include "beta.mdx"
 
 ## Terraform Policy functions
 

--- a/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/functions/semverconstraint.mdx
+++ b/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/functions/semverconstraint.mdx
@@ -2,13 +2,17 @@
 page_title: core::semverconstraint function
 description: >-
   Reference for the core::semverconstraint function used to validate semantic versions in policy files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-07-14T11:44:47-05:00
+last_modified: 2026-07-14T19:01:30.000Z
+# END AUTO GENERATED METADATA
 ---
 
 # The `core::semverconstraint` function
 
 The `core::semverconstraint` function compares the version given in the first argument with the version constraint given in the second argument. It returns `true` if the version matches the constraint, and `false` otherwise.
 
-@include "partials/beta.mdx"
+@include "beta.mdx"
 
 ## Signature
 

--- a/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/index.mdx
+++ b/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/index.mdx
@@ -2,13 +2,17 @@
 page_title: Terraform policy reference
 description: >-
   Reference documentation for Terraform policy CLI commands, policy syntax, functions, and test syntax.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-07-14T11:44:47-05:00
+last_modified: 2026-07-14T19:01:32.000Z
+# END AUTO GENERATED METADATA
 ---
 
 # Terraform policy reference overview
 
 This section provides detailed reference documentation for Terraform policy, including CLI commands, policy configuration syntax, functions, and test configuration syntax.
 
-@include "partials/beta.mdx"
+@include "beta.mdx"
 
 ## CLI Reference
 

--- a/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/operators.mdx
+++ b/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/operators.mdx
@@ -2,13 +2,17 @@
 page_title: Operators
 description: >-
   Reference for operators in Terraform policy.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-07-14T11:44:47-05:00
+last_modified: 2026-07-14T19:01:33.000Z
+# END AUTO GENERATED METADATA
 ---
 
 # Operators
 
 Terraform policy supports the following operators for writing policy conditions. Terraform policy operators behave like their Terraform counterparts. Refer to [Arithmetic and logical operators](/terraform/language/expressions/operators) for more information.
 
-@include "partials/beta.mdx"
+@include "beta.mdx"
 
 ## Arithmetic operators
 

--- a/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/policy/index.mdx
+++ b/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/policy/index.mdx
@@ -2,13 +2,17 @@
 page_title: Policy Configuration Reference
 description: >-
   Reference documentation for Terraform policy file syntax and configuration blocks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-07-14T11:44:47-05:00
+last_modified: 2026-07-14T19:01:34.000Z
+# END AUTO GENERATED METADATA
 ---
 
 # Policy Configuration Reference
 
 Terraform policy's syntax is based on HCL, and supports a number of block types that you can use when you write your policies. Unlike Terraform, Terraform policy evaluates each policy file in a given directory separately. We recommend that you include sets of policies that you want to enforce together in each policy file, and related policies in separate files in the same directory structure.
 
-@include "partials/beta.mdx"
+@include "beta.mdx"
 
 ## Policy block syntax
 

--- a/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/policy/input.mdx
+++ b/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/policy/input.mdx
@@ -2,13 +2,17 @@
 page_title: The input {} block
 description: >-
   Reference for the input {} block used to define input variables in policy files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-07-14T11:44:47-05:00
+last_modified: 2026-07-14T19:01:36.000Z
+# END AUTO GENERATED METADATA
 ---
 
 # The `input {}` block
 
 Terraform policy supports optional `input {}` blocks. These blocks behave like `variable` blocks within Terraform, allowing you to parameterize your policies.
 
-@include "partials/beta.mdx"
+@include "beta.mdx"
 
 ## Configuration model
 

--- a/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/policy/locals.mdx
+++ b/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/policy/locals.mdx
@@ -1,14 +1,18 @@
 ---
-page_title: `locals`
+page_title: '`locals`'
 description: >-
   Reference for the `locals {}` block used to define local values in policy files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-07-14T11:44:47-05:00
+last_modified: 2026-07-14T19:01:38.000Z
+# END AUTO GENERATED METADATA
 ---
 
 # `locals`
 
 Terraform policy supports `locals {}` blocks. These blocks behave like `locals` blocks within Terraform configuration language, allowing you to share data with useful names between blocks. You can include a locals block as a top-level block, in which case those values will be available to all of the policies you include in your configuration. You can also include a locals block nested within any policy block, in which case those local values will only be scoped to that policy.
 
-@include "partials/beta.mdx"
+@include "beta.mdx"
 
 ## Configuration model
 

--- a/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/policy/module-policy.mdx
+++ b/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/policy/module-policy.mdx
@@ -1,14 +1,18 @@
 ---
-page_title: `module_policy`
+page_title: '`module_policy`'
 description: >-
   Reference for the module_policy {} block used to write policies for Terraform modules.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-07-14T11:44:47-05:00
+last_modified: 2026-07-14T19:01:40.000Z
+# END AUTO GENERATED METADATA
 ---
 
 # `module_policy`
 
 The `module_policy` block defines policies for your workspaces' Terraform modules. Module policies allow you to set guardrails at the abstraction layer where infrastructure is often packaged and shared. The first label of the block specifies the module source. The second label is a unique name for the policy itself. You can use a wildcard (*) for the module source to apply the policy to every module in the workspace.
 
-@include "partials/beta.mdx"
+@include "beta.mdx"
 
 ## Configuration model
 

--- a/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/policy/policy.mdx
+++ b/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/policy/policy.mdx
@@ -1,14 +1,18 @@
 ---
-page_title: `policy`
+page_title: '`policy`'
 description: >-
   Reference for the `policy {}` block used to configure Terraform policy evaluation settings.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-07-14T11:44:47-05:00
+last_modified: 2026-07-14T19:01:42.000Z
+# END AUTO GENERATED METADATA
 ---
 
 # `policy`
 
 The `policy` block configures how Terraform policy evaluates your policies, including which version of Terraform to use to perform the evaluation.
 
-@include "partials/beta.mdx"
+@include "beta.mdx"
 
 ## Configuration model
 

--- a/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/policy/provider-policy.mdx
+++ b/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/policy/provider-policy.mdx
@@ -1,14 +1,18 @@
 ---
-page_title: `provider_policy`
+page_title: '`provider_policy`'
 description: >-
   Reference for the `provider_policy {}` block used to write policies for Terraform providers.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-07-14T11:44:47-05:00
+last_modified: 2026-07-14T19:01:43.000Z
+# END AUTO GENERATED METADATA
 ---
 
 # `provider_policy`
 
 The `provider_policy` block defines policies for Terraform providers. The first label of the block identifies the provider name, such as `aws`, `google`, or `azurerm`, and the second label is the policy name. You can use a wildcard (*) for the provider name to apply a single policy to every provider defined in the configuration.
 
-@include "partials/beta.mdx"
+@include "beta.mdx"
 
 ## Configuration model
 

--- a/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/policy/resource-policy.mdx
+++ b/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/policy/resource-policy.mdx
@@ -1,14 +1,18 @@
 ---
-page_title: `resource_policy`
+page_title: '`resource_policy`'
 description: >-
   Reference for the `resource_policy {}` block used to write policies for Terraform resources.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-07-14T11:44:47-05:00
+last_modified: 2026-07-14T19:01:45.000Z
+# END AUTO GENERATED METADATA
 ---
 
 # `resource_policy`
 
 The `resource_policy` block defines policies for infrastructure resources managed by Terraform. 
 
-@include "partials/beta.mdx"
+@include "beta.mdx"
 
 ## Configuration model
 

--- a/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/test/data.mdx
+++ b/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/test/data.mdx
@@ -1,14 +1,18 @@
 ---
-page_title: `data`
+page_title: '`data`'
 description: >-
   Reference for mock data source blocks used in policy test files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-07-14T11:44:47-05:00
+last_modified: 2026-07-14T19:01:47.000Z
+# END AUTO GENERATED METADATA
 ---
 
 # `data`
 
 Terraform data sources do not represent infrastructure directly managed by Terraform, so you will not directly write policies for them. However, in many Terraform configurations, data sources serve as the foundation for resource relationships, providing IDs or configurations fetched from existing infrastructure. You may need to mock these data sources in your policy tests to ensure that your policies correctly verify resources or modules that rely on this data.
 
-@include "partials/beta.mdx"
+@include "beta.mdx"
 
 ## Configuration model
 

--- a/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/test/index.mdx
+++ b/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/test/index.mdx
@@ -2,13 +2,17 @@
 page_title: Policy Test configuration reference
 description: >-
   Reference documentation for Terraform policy test file syntax and configuration blocks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-07-14T11:44:47-05:00
+last_modified: 2026-07-14T19:01:48.000Z
+# END AUTO GENERATED METADATA
 ---
 
 # Policy test configuration reference
 
 Like policy files, Terraform policy's test syntax is based on HCL, and supports a number of block types that you can use when you write tests for your policies.
 
-@include "partials/beta.mdx"
+@include "beta.mdx"
 
 ## Test file structure
 

--- a/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/test/input.mdx
+++ b/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/test/input.mdx
@@ -1,14 +1,18 @@
 ---
-page_title: `input`
+page_title: '`input`'
 description: >-
   Reference for the input {} block used to set input values in policy test files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-07-14T11:44:47-05:00
+last_modified: 2026-07-14T19:01:50.000Z
+# END AUTO GENERATED METADATA
 ---
 
 # `input`
 
 You can set values for policy inputs either per test case, or for the entire test file with the `input {}` block. The input block is allowed within provider, resource, data, and module blocks, or as a top-level block. Inputs set on a specific block override inputs set at the top level of the test file.
 
-@include "partials/beta.mdx"
+@include "beta.mdx"
 
 ## Configuration model
 

--- a/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/test/locals.mdx
+++ b/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/test/locals.mdx
@@ -1,14 +1,18 @@
 ---
-page_title: `locals`
+page_title: '`locals`'
 description: >-
   Reference for the locals {} block used to define local values in policy test files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-07-14T11:44:47-05:00
+last_modified: 2026-07-14T19:01:51.000Z
+# END AUTO GENERATED METADATA
 ---
 
 # `locals`
 
 Terraform policy supports `locals {}` blocks in test files. These blocks behave like `locals` blocks in policy files, allowing you to define reusable values within your tests.
 
-@include "partials/beta.mdx"
+@include "beta.mdx"
 
 ## Configuration model
 

--- a/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/test/module.mdx
+++ b/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/test/module.mdx
@@ -1,14 +1,18 @@
 ---
-page_title: `module`
+page_title: '`module`'
 description: >-
   Reference for mock module blocks used in policy test files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-07-14T11:44:47-05:00
+last_modified: 2026-07-14T19:01:53.000Z
+# END AUTO GENERATED METADATA
 ---
 
 # `module`
 
 To test a module policy, add a mock module block to your test file. Use the `meta` attribute to set meta-attributes, including the module source and version. Use the `attrs` block to set values for any input variables defined by the module.
 
-@include "partials/beta.mdx"
+@include "beta.mdx"
 
 ## Configuration model
 

--- a/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/test/policytest.mdx
+++ b/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/test/policytest.mdx
@@ -1,14 +1,18 @@
 ---
-page_title: `policytest`
+page_title: '`policytest`'
 description: >-
   Reference for the `policytest {}` block used to configure test targets in policy test files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-07-14T11:44:47-05:00
+last_modified: 2026-07-14T19:01:55.000Z
+# END AUTO GENERATED METADATA
 ---
 
 # `policytest`
 
 The `policytest {}` block defines the policies that Terraform policy will test.
 
-@include "partials/beta.mdx"
+@include "beta.mdx"
 
 ## Configuration model
 

--- a/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/test/provider.mdx
+++ b/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/test/provider.mdx
@@ -1,14 +1,18 @@
 ---
-page_title: `provider`
+page_title: '`provider`'
 description: >-
   Reference for mock provider blocks used in policy test files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-07-14T11:44:47-05:00
+last_modified: 2026-07-14T19:01:56.000Z
+# END AUTO GENERATED METADATA
 ---
 
 # `provider`
 
 To test a provider policy, add a mock provider block to your test file. Use the `meta` argument to set meta-attributes, including the provider source and version. Use the `attrs` argument to set values for any attributes defined by the provider itself.
 
-@include "partials/beta.mdx"
+@include "beta.mdx"
 
 ## Configuration model
 

--- a/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/test/resource.mdx
+++ b/content/terraform-policy/v0.1.x (beta)/docs/policy/reference/test/resource.mdx
@@ -1,14 +1,18 @@
 ---
-page_title: `resource`
+page_title: '`resource`'
 description: >-
   Reference for mock resource blocks used in policy test files.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-07-14T11:44:47-05:00
+last_modified: 2026-07-14T19:01:57.000Z
+# END AUTO GENERATED METADATA
 ---
 
 # `resource`
 
 To test a resource policy, add a mock resource block to your test file. Use the `meta` attribute to set meta-attributes for the resource, if required. Use the `attrs` attribute to set values for any resource attributes defined by the provider.
 
-@include "partials/beta.mdx"
+@include "beta.mdx"
 
 ## Configuration model
 

--- a/content/terraform-policy/v0.1.x (beta)/docs/policy/write/examples.mdx
+++ b/content/terraform-policy/v0.1.x (beta)/docs/policy/write/examples.mdx
@@ -2,13 +2,17 @@
 page_title: Policy examples
 description: >-
   Examples for writing, testing, and running policies with the Terraform policy framework.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-07-14T11:44:47-05:00
+last_modified: 2026-07-14T19:01:59.000Z
+# END AUTO GENERATED METADATA
 ---
 
 # Policy examples
 
 This page provides example policies written for the Terraform policy framework. Refer to these examples to learn how to implement your own policies.
 
-@include "partials/beta.mdx"
+@include "beta.mdx"
 
 ## Encrypt EBS volumes
 

--- a/content/terraform-policy/v0.1.x (beta)/docs/policy/write/index.mdx
+++ b/content/terraform-policy/v0.1.x (beta)/docs/policy/write/index.mdx
@@ -2,13 +2,17 @@
 page_title: Set up your Terraform policy project
 description: >-
   Learn how to organize and structure your Terraform policy projects.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-07-14T11:44:47-05:00
+last_modified: 2026-07-14T19:02:02.000Z
+# END AUTO GENERATED METADATA
 ---
 
 # Set up your Terraform policy project
 
 This section provides guidance on organizing your Terraform policy projects and writing policies, tests, and plugins.
 
-@include "partials/beta.mdx"
+@include "beta.mdx"
 
 ## Policy files
 

--- a/content/terraform-policy/v0.1.x (beta)/docs/policy/write/plugins.mdx
+++ b/content/terraform-policy/v0.1.x (beta)/docs/policy/write/plugins.mdx
@@ -2,13 +2,17 @@
 page_title: Write policy plugins
 description: >-
   Learn how to write and use policy plugins to extend Terraform policy with custom functions.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-07-14T11:44:47-05:00
+last_modified: 2026-07-14T19:02:03.000Z
+# END AUTO GENERATED METADATA
 ---
 
 # Write policy plugins
 
 Plugins provide a way to extend Terraform policy with additional functions that you can use to customize your policy authoring experience. Write Terraform policy plugins in Golang using the [`terraform-policy-plugin-framework`](https://github.com/hashicorp/terraform-policy-plugin-framework.git) open source library.
 
-@include "partials/beta.mdx"
+@include "beta.mdx"
 
 You must compile Terraform policy plugins and include them in your policy VCS repository before you can use them in your policies. In your policy files, use the `core::<functionname>` syntax to refer to functions built into Terraform or Terraform policy. Use the `plugin::<pluginname>::<functionname>` syntax to refer to functions from plugins that you write.
 

--- a/content/terraform-policy/v0.1.x (beta)/docs/policy/write/policies.mdx
+++ b/content/terraform-policy/v0.1.x (beta)/docs/policy/write/policies.mdx
@@ -2,13 +2,17 @@
 page_title: Write policies
 description: >-
   Learn how to write Terraform policies using Terraform policy's HCL-based configuration language.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-07-14T11:44:47-05:00
+last_modified: 2026-07-14T19:02:04.000Z
+# END AUTO GENERATED METADATA
 ---
 
 # Write policies
 
 Terraform policy's configuration language is based on HCL. You will write configuration blocks to configure Terraform policy, define input variables and locals, and write policies for Terraform providers, resources, and modules.
 
-@include "partials/beta.mdx"
+@include "beta.mdx"
 
 ## Policy syntax
 

--- a/content/terraform-policy/v0.1.x (beta)/docs/policy/write/tests.mdx
+++ b/content/terraform-policy/v0.1.x (beta)/docs/policy/write/tests.mdx
@@ -2,13 +2,17 @@
 page_title: Write and run policy tests
 description: >-
   Learn how to write and run Terraform policy tests locally to ensure they work as expected.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-07-14T11:44:47-05:00
+last_modified: 2026-07-14T19:02:05.000Z
+# END AUTO GENERATED METADATA
 ---
 
 # Write and run policy tests
 
 Once you have authored a policy, write tests that verify that your policy works as intended. Then, run your tests before you implement your new policy and whenever you update your policy.
 
-@include "partials/beta.mdx"
+@include "beta.mdx"
 
 ## Author policy tests
 

--- a/content/terraform-policy/v0.1.x (beta)/redirects.jsonc
+++ b/content/terraform-policy/v0.1.x (beta)/redirects.jsonc
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+/**
+ * Define your custom redirects within this file.
+ *
+ * Vercel"s redirect documentation:
+ * https://nextjs.org/docs/api-reference/next.config.js/redirects
+ *
+ * Relative paths with fragments (#) are not supported.
+ * For destinations with fragments, use an absolute URL.
+ *
+ * Playground for testing url pattern matching: https://npm.runkit.com/path-to-regexp
+ *
+ * Note that redirects defined in a product"s redirects file are applied to
+ * the developer.hashicorp.com domain, which is where the documentation content
+ * is rendered. Redirect sources should be prefixed with the product slug
+ * to ensure they are scoped to the product"s section. Any redirects that are
+ * not prefixed with a product slug will be ignored.
+ */
+[
+  /*
+  Example redirect:
+  {
+    "source": "/nomad/docs/internal-docs/my-page",
+    "destination": "/nomad/docs/internals/my-page",
+    "permanent": true,
+  },
+  */
+
+  /**
+   * /s/* redirects for useful links that need a stable URL but we may need to
+   * change its destination in the future. Some of these used in CLI output.
+   */
+]

--- a/productConfig.mjs
+++ b/productConfig.mjs
@@ -287,7 +287,6 @@ export const PRODUCT_CONFIG = {
 		versionedDocs: true,
 		websiteDir: 'website',
 	},
-	'terraform-docs-agents': {
 	'terraform-policy': {
 		assetDir: '',
 		basePaths: ['policy'],
@@ -299,7 +298,7 @@ export const PRODUCT_CONFIG = {
 		versionedDocs: true,
 		websiteDir: 'website',
 	},
-
+	'terraform-docs-agents': {
 		/**
 		 * 🟢🟢🟡 Initial migration attempt: CONTENT NOT FOUND on older versions
 		 *

--- a/scripts/prebuild/gather-version-metadata.mjs
+++ b/scripts/prebuild/gather-version-metadata.mjs
@@ -152,6 +152,11 @@ export async function gatherVersionMetadata(contentDir) {
 				isLatest: idx === latestVersionIndex,
 			})
 		}
+
+		// If only one version exists, it should always be the latest regardless of release stage
+		if (versionMetadata[product].length === 1) {
+			versionMetadata[product][0].isLatest = true
+		}
 	}
 	// Return the version metadata
 	return versionMetadata

--- a/scripts/prebuild/gather-version-metadata.test.ts
+++ b/scripts/prebuild/gather-version-metadata.test.ts
@@ -111,6 +111,23 @@ it('Support beta releases - support release candidate (rc)', async () => {
 	expect(result).toStrictEqual(expected)
 })
 
+it('Single version with non-stable release stage is always isLatest', async () => {
+	const expected = {
+		'terraform-enterprise': [
+			{ version: 'v202401-1', releaseStage: 'beta', isLatest: true },
+		],
+	}
+	vol.fromJSON(
+		{
+			'./terraform-enterprise/v202401-1 (beta)/': null,
+		},
+		'/content',
+	)
+
+	const result = await gatherVersionMetadata('/content')
+	expect(result).toStrictEqual(expected)
+})
+
 it('Support beta releases - throw error for invalid stage', async ({
 	expect,
 }: {


### PR DESCRIPTION
Fixes a few problems in`terraform-policy`:
1. was nested inside of `terraform-docs-agents` which caused it not be found by `dev-portal`
2. Needed a redirect.jsonc file
3. We had an assumption because that at least one stable release will exist, while this is launching as a beta. So this also fixes our metadata generation in this case.