### PR TITLE
Add Terraform policy (beta) entry to HCP Terraform changelog

### DIFF
--- a/content/terraform-docs-common/docs/cloud-docs/changelog.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/changelog.mdx
@@ -14,7 +14,7 @@ last_modified: 2026-04-14T20:50:21.000Z
 
 Keep track of changes to HCP Terraform.
 
-## 2026-07-15
+## 2026-07-16
 
 - HCP Terraform now evaluates policies written for Terraform policy (beta): Terraform policy is an HCL-based policy-as-code framework that integrates with HCP Terraform and helps platform teams enforce policies at each stage of the infrastructure lifecycle, including the initialization phase. Refer to [Terraform policy](/terraform/cloud-docs/workspaces/policy-enforcement/define-policies/terraform-policy) for more information.
 

--- a/content/terraform-docs-common/docs/cloud-docs/changelog.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/changelog.mdx
@@ -16,7 +16,7 @@ Keep track of changes to HCP Terraform.
 
 ## 2026-07-15
 
-* Terraform policy (beta): Platform teams can now use an HCL-based declarative policy-as-code framework that integrates deeply with Terraform to secure infrastructure at each stage of the infrastructure lifecycle. Providers and modules can now be secured before being downloaded, and resources can be evaluated both post-plan and post-apply. Refer to [Terraform policy](/terraform/cloud-docs/workspaces/policy-enforcement/define-policies/terraform-policy) for more information.
+- HCP Terraform now evaluates policies written for Terraform policy (beta): Terraform policy is an HCL-based policy-as-code framework that integrates with HCP Terraform and helps platform teams enforce policies at each stage of the infrastructure lifecycle, including the initialization phase. Refer to [Terraform policy](/terraform/cloud-docs/workspaces/policy-enforcement/define-policies/terraform-policy) for more information.
 
 ## 2026-06-24
 

--- a/content/terraform-docs-common/docs/cloud-docs/changelog.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/changelog.mdx
@@ -14,6 +14,10 @@ last_modified: 2026-04-14T20:50:21.000Z
 
 Keep track of changes to HCP Terraform.
 
+## 2026-07-15
+
+* Terraform policy (beta): Platform teams can now use an HCL-based declarative policy-as-code framework that integrates deeply with Terraform to secure infrastructure at each stage of the infrastructure lifecycle. Providers and modules can now be secured before being downloaded, and resources can be evaluated both post-plan and post-apply. Refer to [Terraform policy](/terraform/cloud-docs/workspaces/policy-enforcement/define-policies/terraform-policy) for more information.
+
 ## 2026-06-24
 
 - HCP Terraform metrics. HCP Terraform metrics now include new metrics such as workspace count, organization team token age, project count, billable resource count, workspace current run status, and workspace current run status count. Refer to [Metrics reference](/terraform/cloud-docs/users-teams-organizations/organizations/metrics#metrics-reference) for more information.


### PR DESCRIPTION
## Summary

Adds an HCP Terraform changelog entry announcing Terraform policy (beta).

## Changes

- adds a new `2026-07-15` changelog entry
- links to the [Terraform policy](https://developer.hashicorp.com/terraform/cloud-docs/workspaces/policy-enforcement/define-policies/terraform-policy) documentation for more information

Ref: [IPE-1653](https://hashicorp.atlassian.net/browse/IPE-1653)

[IPE-1653]: https://hashicorp.atlassian.net/browse/IPE-1653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ