### PR TITLE
[VAULT] Fix weirdly formatted links to address build errors

### DIFF
--- a/content/vault/v1.10.x/content/intro/getting-started/apis.mdx
+++ b/content/vault/v1.10.x/content/intro/getting-started/apis.mdx
@@ -3,8 +3,8 @@ layout: intro
 page_title: Using the HTTP APIs with Authentication
 description: Using the HTTP APIs for authentication and secret access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2023-09-27T00:00:00.000Z
-last_modified: 2023-09-27T00:00:00.000Z
+created_at: 2025-07-02T11:43:42-05:00
+last_modified: 2026-07-14T23:16:59.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -137,10 +137,9 @@ token. In this case we are passing the root token generated when we started
 the Vault server. We could also generate tokens using any other authentication
 mechanisms, but we will use the root token for simplicity.
 
-Now create an AppRole with desired set of [ACL
-policies](/vault/docs/concepts/policies). In the following command, it is being
-specified that the tokens issued under the AppRole `my-role`, should be
-associated with `dev-policy` and the `my-policy`.
+Now create an AppRole with desired set of [ACL policies](/vault/docs/concepts/policies).
+In the following command, it is being specified that the tokens issued under the
+AppRole `my-role`, should be associated with `dev-policy` and the `my-policy`.
 
 ```shell-session
 $ curl \
@@ -258,13 +257,12 @@ This should return a response like this:
 }
 ```
 
-You can see the documentation on the [HTTP APIs](/api) for
+You can see the documentation on the [HTTP APIs](/vault/api) for
 more details on other available endpoints.
 
 Congratulations! You now know all the basics to get started with Vault.
 
 ## Next
 
-Next, we have a page dedicated to [next
-steps](/intro/getting-started/next-steps) depending on what you would like
+Next, we have a page dedicated to [next steps](/vault/intro/getting-started/next-steps) depending on what you would like
 to achieve.

--- a/content/vault/v1.10.x/content/intro/getting-started/first-secret.mdx
+++ b/content/vault/v1.10.x/content/intro/getting-started/first-secret.mdx
@@ -3,8 +3,8 @@ layout: intro
 page_title: Your First Secret - Getting Started
 description: "With the Vault server running, let's read and write our first secret."
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2023-09-27T00:00:00.000Z
-last_modified: 2023-09-27T00:00:00.000Z
+created_at: 2025-07-02T11:43:42-05:00
+last_modified: 2026-07-14T23:17:00.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -16,12 +16,12 @@ read and write our first secret.
 One of the core features of Vault is the ability to read and write
 arbitrary secrets securely. On this page, we'll do this using the CLI,
 but there is also a complete
-[HTTP API](/api)
+[HTTP API](/vault/api)
 that can be used to programmatically do anything with Vault.
 
 Secrets written to Vault are encrypted and then written to backend
 storage. For our dev server, backend storage is in-memory, but in production
-this would more likely be on disk or in [Consul](https://www.consul.io).
+this would more likely be on disk or in [Consul](/consul/docs).
 Vault encrypts the value before it is ever handed to the storage driver.
 The backend storage mechanism _never_ sees the unencrypted value and doesn't
 have the means necessary to decrypt it without Vault.
@@ -113,4 +113,4 @@ In this section we learned how to use the powerful CRUD features of
 Vault to store arbitrary secrets. On its own this is already a useful
 but basic feature.
 
-Next, we'll learn the basics about [secrets engines](/intro/getting-started/secrets-engines).
+Next, we'll learn the basics about [secrets engines](/vault/intro/getting-started/secrets-engines).


### PR DESCRIPTION
Fixes broken links in the v1.10 Vault docs that recently started to cause build errors `¯\_(ツ)_/¯`