### PR TITLE
docs: Document HTTP redirect behavior for web targets

### DIFF
--- a/content/boundary/v1.0.x/content/docs/architecture/system-requirements.mdx
+++ b/content/boundary/v1.0.x/content/docs/architecture/system-requirements.mdx
@@ -95,6 +95,19 @@ limitations:
 - [Azure](https://learn.microsoft.com/en-us/azure/virtual-network/virtual-machine-network-throughput/)
 - [GCP](https://cloud.google.com/compute/docs/network-bandwidth/)
 
+### VPN usage
+
+Your local network configuration determines which network adapter your computer uses when you connect to a web target.
+For example, it might prioritize Ethernet over Wi-Fi.
+
+VPNs can be configured to route traffic only through a specific adapter.
+If your local computer prioritizes a different adapter, Boundary might not be able to route connections through the VPN.
+
+As a best practice, if you use a VPN, start it before you attempt to connect to a target.
+If the VPN requires a specific network adapter, prioritize that adapter in your local network settings.
+The steps to change adapter priority vary by operating system and environment.
+Refer to your operating system's documentation for more information.
+
 ## Network connectivity
 
 The following table outlines the default ingress network connectivity

--- a/content/boundary/v1.0.x/content/docs/targets/connections/index.mdx
+++ b/content/boundary/v1.0.x/content/docs/targets/connections/index.mdx
@@ -13,6 +13,15 @@ last_modified: 2026-01-26T13:07:13-05:00
 
 This topic provides an overview of the possible workflows you may use to connect to targets with Boundary.
 
+<Note>
+
+As a best practice, if you use a VPN, start it before you attempt to connect to a target.
+If the VPN requires a specific network adapter, prioritize that adapter in your local network settings.
+
+For more information, refer to [VPN usage](/boundary/docs/architecture/system-requirements#vpn-usage).
+
+</Note>
+
 ## Boundary connect
 
 When you run the `boundary connect` command against a target, Boundary establishes a local authenticated proxy to the address on the target's default port.

--- a/content/boundary/v1.0.x/content/docs/targets/create/tcp/web.mdx
+++ b/content/boundary/v1.0.x/content/docs/targets/create/tcp/web.mdx
@@ -13,7 +13,7 @@ last_modified: 2026-02-03T13:20:53-07:00
 
 TCP targets provide a generic way to connect to any service Boundary has access to, including HTTP and HTTPS services.
 
-If you use a TCP target to access a web application that relies on HTTP redirects for authentication, such as SSO or OAuth-based identity providers, the authentication flow may fail. Boundary proxies the initial TCP connection, but the redirect instructs the client to establish a connection to a new host. That connection can fail if the new host is outside the Boundary proxy.
+@include 'targets/http-redirects.mdx'
 
 The following examples use a direct target address for simplicity, but HashiCorp recommends that you [configure host catalogs and host sets](/boundary/docs/hosts) for scaled production deployments.
 

--- a/content/boundary/v1.0.x/content/docs/targets/create/tcp/web.mdx
+++ b/content/boundary/v1.0.x/content/docs/targets/create/tcp/web.mdx
@@ -13,6 +13,8 @@ last_modified: 2026-02-03T13:20:53-07:00
 
 TCP targets provide a generic way to connect to any service Boundary has access to, including HTTP and HTTPS services.
 
+If you use a TCP target to access a web application that relies on HTTP redirects for authentication, such as SSO or OAuth-based identity providers, the authentication flow may fail. Boundary proxies the initial TCP connection, but the redirect instructs the client to establish a connection to a new host. That connection can fail if the new host is outside the Boundary proxy.
+
 The following examples use a direct target address for simplicity, but HashiCorp recommends that you [configure host catalogs and host sets](/boundary/docs/hosts) for scaled production deployments.
 
 Complete the following steps to create a TCP target to connect to a web service. This example assumes an HTTPS service.

--- a/content/boundary/v1.0.x/content/docs/targets/index.mdx
+++ b/content/boundary/v1.0.x/content/docs/targets/index.mdx
@@ -39,11 +39,11 @@ TCP targets use the TCP protocol to establish sessions. They represent generic t
 
 A TCP target can be a database, SSH server, HTTP endpoint, Kubernetes cluster, or a Windows server. TCP targets are not aware of the details for any server you are connecting to. TCP targets are only aware of the address and port you define for sessions to connect with.
 
-@include 'targets/http-redirects.mdx'
-
 Different [connection workflows](/boundary/docs/targets/connections) exist for end users, such as the [Boundary Desktop Client](/boundary/tutorials/get-started-hcp/hcp-getting-started-desktop-app), the `boundary connect` command, and transparent sessions. Boundary also includes [connect helpers](/boundary/docs/targets/connections/connect-helpers) for the CLI to make connecting to TCP targets easier.
 
 To learn how to create and manage TCP targets, refer to the [Create a TCP target](/boundary/docs/targets/create/tcp) page.
+
+@include 'targets/http-redirects.mdx'
 
 ## SSH targets
 

--- a/content/boundary/v1.0.x/content/docs/targets/index.mdx
+++ b/content/boundary/v1.0.x/content/docs/targets/index.mdx
@@ -43,6 +43,10 @@ Different [connection workflows](/boundary/docs/targets/connections) exist for e
 
 To learn how to create and manage TCP targets, refer to the [Create a TCP target](/boundary/docs/targets/create/tcp) page.
 
+### Web targets and HTTP redirects
+
+If you use a TCP target to access a web application that relies on HTTP redirects for authentication, such as SSO or OAuth-based identity providers, the authentication flow may fail. Boundary proxies the initial TCP connection, but the redirect instructs the client to establish a connection to a new host. That connection can fail if the new host is outside the Boundary proxy.
+
 ## SSH targets
 
 [SSH targets](/boundary/docs/domain-model/targets#ssh-target-attributes) enable session recording and auditing by using a worker to intercept the SSH data stream and upload the recording into a storage backend. Configuring session recording is not required to use SSH target types.

--- a/content/boundary/v1.0.x/content/docs/targets/index.mdx
+++ b/content/boundary/v1.0.x/content/docs/targets/index.mdx
@@ -39,13 +39,11 @@ TCP targets use the TCP protocol to establish sessions. They represent generic t
 
 A TCP target can be a database, SSH server, HTTP endpoint, Kubernetes cluster, or a Windows server. TCP targets are not aware of the details for any server you are connecting to. TCP targets are only aware of the address and port you define for sessions to connect with.
 
+@include 'targets/http-redirects.mdx'
+
 Different [connection workflows](/boundary/docs/targets/connections) exist for end users, such as the [Boundary Desktop Client](/boundary/tutorials/get-started-hcp/hcp-getting-started-desktop-app), the `boundary connect` command, and transparent sessions. Boundary also includes [connect helpers](/boundary/docs/targets/connections/connect-helpers) for the CLI to make connecting to TCP targets easier.
 
 To learn how to create and manage TCP targets, refer to the [Create a TCP target](/boundary/docs/targets/create/tcp) page.
-
-### Web targets and HTTP redirects
-
-If you use a TCP target to access a web application that relies on HTTP redirects for authentication, such as SSO or OAuth-based identity providers, the authentication flow may fail. Boundary proxies the initial TCP connection, but the redirect instructs the client to establish a connection to a new host. That connection can fail if the new host is outside the Boundary proxy.
 
 ## SSH targets
 

--- a/content/boundary/v1.0.x/content/docs/targets/index.mdx
+++ b/content/boundary/v1.0.x/content/docs/targets/index.mdx
@@ -41,9 +41,9 @@ A TCP target can be a database, SSH server, HTTP endpoint, Kubernetes cluster, o
 
 Different [connection workflows](/boundary/docs/targets/connections) exist for end users, such as the [Boundary Desktop Client](/boundary/tutorials/get-started-hcp/hcp-getting-started-desktop-app), the `boundary connect` command, and transparent sessions. Boundary also includes [connect helpers](/boundary/docs/targets/connections/connect-helpers) for the CLI to make connecting to TCP targets easier.
 
-To learn how to create and manage TCP targets, refer to the [Create a TCP target](/boundary/docs/targets/create/tcp) page.
-
 @include 'targets/http-redirects.mdx'
+
+To learn how to create and manage TCP targets, refer to the [Create a TCP target](/boundary/docs/targets/create/tcp) page.
 
 ## SSH targets
 

--- a/content/boundary/v1.0.x/content/partials/targets/http-redirects.mdx
+++ b/content/boundary/v1.0.x/content/partials/targets/http-redirects.mdx
@@ -1,0 +1,1 @@
+If you use a TCP target to access a web application that relies on HTTP redirects for authentication, such as SSO flows or OAuth-based identity providers, the authentication flow might fail. Boundary proxies the initial TCP connection, but the redirect instructs the client to connect to a new host directly. If that host is outside the Boundary proxy, the connection fails.


### PR DESCRIPTION
<!--
**Merge branch**

Make sure your PR uses the correct **base** branch for the merge destination.

For more information, refer to **Change the branch range and destination repository** (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request).

To update:

- Existing content

  Choose **base: main** to update existing documentation.
  Your content will be published when the PR is merged.

- Content for an upcoming Boundary release

  Choose the branch for the relevant upcoming Boundary release.
  Boundary release branches use the `boundary/<exact-release-number>` format.
  Your content will be published when the upcoming release goes live.

If you are not sure which base branch to use, or you cannot find the release branch you are looking for:

  - Choose the `main` branch.
  - Add the "do not merge" label.
  - Convert the PR to a DRAFT.
  - Explain the update in the **Description**.

**Back porting to older versions**

This repo stores versioned documentation in folders instead of branches.
There are no backport labels.
If your update applies to multiple versions, you must update the content in each of the corresponding version folders.

For example, you make an update to the Boundary code in the current release, 0.21.0, and back port it to versions 0.20.x and 0.19.x.
To document the update for each of the relevant versions, you would update the documentation in the v0.21.x, v0.20.x, and v0.19.x folders.
-->

## Description

From a Slack conversation: https://ibm-hashicorp.slack.com/archives/C09L3DN152Q/p1783445402110749

A couple undocumented networking concerns came up:

1. If a web target is an application that uses HTTP redirects for authentication, the connection from Boundary will likely fail. We do not have this caveat documented anywhere. This PR adds the caveat to the following topics where we discuss web targets:

    - Overview of targets > [TCP targets](https://unified-docs-frontend-preview-6r2o5tgn3-hashicorp.vercel.app/boundary/docs/targets#tcp-targets)
    - [Create a web TCP target](https://unified-docs-frontend-preview-6r2o5tgn3-hashicorp.vercel.app/boundary/docs/targets/create/tcp/web)

2. VPNs can cause problems if the wrong adapter is selected. This PR creates a new section in the networking concerns section of the system requirements. It recommends that users start the VPN before attempting to make a connection and make sure their local network settings prioritize the correct adapter. It also adds a note referencing the new section in the Connection workflows overview topic.

    - System requirements > [VPN usage](https://unified-docs-frontend-preview-6r2o5tgn3-hashicorp.vercel.app/boundary/docs/architecture/system-requirements#vpn-usage)
    - [Connection workflows](https://unified-docs-frontend-preview-6r2o5tgn3-hashicorp.vercel.app/boundary/docs/targets/connections) 

## Links
<!--
Include links to any associated pull requests, GitHub issues, or documentation that is relevant to this update.

// GH-Jira integration generates the link and updates the Jira ticket.
Jira: [<jira-ticket-number>]  // for example, Jira: [ICU-1234]

GitHub Issue: <issue-link>
-->

Code PR:
Jira:
GitHub issue:
RFC/PRD:

## Contributor checklists

<!--
Help your reviewer understand the type of review you need by selecting the scope and urgency.
-->

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [x] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [x] Verify that all status checks passed
- [x] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [ ] I added redirects for any moved or removed pages
- [x] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [x] I looked at the local or Vercel build to make sure the content rendered correctly


[ICU-1234]: https://hashicorp.atlassian.net/browse/ICU-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ