### PR TITLE
Add event notification product usage metrics to docs

### DIFF
--- a/content/vault/v2.x/content/docs/license/product-usage-reporting.mdx
+++ b/content/vault/v2.x/content/docs/license/product-usage-reporting.mdx
@@ -137,6 +137,8 @@ IBM collects the following product usage metrics as numerical data. Vault does n
 | `vault.db.redshift.plugin.count` | Number of database plugins of type Redshift across all namespaces. |
 | `vault.db.snowflake.plugin.count` | Number of database plugins of type Snowflake across all namespaces. |
 | `vault.db.unknown.plugin.count` | Number of unrecognized db plugins across all namespaces. |
+| `vault.events.bounded_queue_enabled` | Whether bounded event notification queues are enabled (1) or not (0). |
+| `vault.events.subscriptions.count` | Total number of active event notification subscriptions. |
 | `vault.identity.case_sensitive_mode` | Whether or not the cluster is using case-sensitive identity name matching caused by historical duplicates. |
 | `vault.identity.force_deduplication_activated` | Whether or not the cluster has had the force_identity_deduplication activation flag activated. |
 | `vault.kv.version1.secrets.count` | Total number of version 1 KV secrets. |


### PR DESCRIPTION
Add metrics for the total number of active subscriptions and reports if customer has a buffer enabled (to be aggregated and reported as customer count with buffer enabled) 

- `vault.events.bounded_queue_enabled` 
- `vault.events.subscriptions.count`

Jira: https://hashicorp.atlassian.net/browse/VAULT-46310
Vault PR: https://github.com/hashicorp/vault-enterprise/pull/16480
