### PR TITLE
Nomad Docs: Add code ticks to metadata key in vault.mdx to fix rendering issue in prod

### DIFF
--- a/content/nomad/v2.0.x/content/docs/configuration/vault.mdx
+++ b/content/nomad/v2.0.x/content/docs/configuration/vault.mdx
@@ -163,7 +163,7 @@ agents with [`server.enabled`] set to `true`.
   - `${job.namespace}` - The job's namespace.
   - `${job.id}` - The job's ID.
   - `${job.node_pool}` - The node pool where the allocation is running.
-  - `${job.meta.<key>}` - The value of the job's metadata at the given <key>.
+  - `${job.meta.<key>}` - The value of the job's metadata at the given `<key>`.
   - `${group.name}` - The task group name of the task using Vault.
   - `${alloc.id}` - The allocation's ID.
   - `${task.name}` - The name of the task using Vault.


### PR DESCRIPTION


## Description

Fix prod rendering issue

## Links


Nomad Code PR:
Jira: [IPE-1662]
GitHub Issue:

## Contributor checklists

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [ ] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [ ] Verify that the PR is set to merge into the correct base branch
- [ ] Verify that all status checks passed
- [ ] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [ ] I added redirects for any moved or removed pages
- [ ] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [ ] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [ ] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.


[IPE-1662]: https://hashicorp.atlassian.net/browse/IPE-1662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ