### PR TITLE
Add deprecation notice for Vault Service Broker

### DIFF
--- a/content/vault/v2.x/content/docs/updates/deprecation.mdx
+++ b/content/vault/v2.x/content/docs/updates/deprecation.mdx
@@ -50,6 +50,8 @@ or raise a ticket with your support team.
 
 @include 'deprecation/list-allowed-parameters.mdx'
 
+@include 'deprecation/vault-service-broker.mdx
+
 ## Removed 
 
 @include 'deprecation/aws-field-change.mdx'

--- a/content/vault/v2.x/content/partials/deprecation/vault-service-broker.mdx
+++ b/content/vault/v2.x/content/partials/deprecation/vault-service-broker.mdx
@@ -1,0 +1,5 @@
+### Vault Service Broker ((#vault-service-broker))
+
+| Announced | Expected end of support | Expected removal |
+| --- | --- | --- |
+| JULY 2026 | OCT 2026 | OCT 2026 |


### PR DESCRIPTION
## Summary

Adds a deprecation partial for Vault Service Broker.

## Changes

- Adds `content/vault/v2.x/content/partials/deprecation/vault-service-broker.mdx`
- Uses the standard deprecation table format
- Sets:
  - Announced: `JULY 2026`
  - Expected end of support: `OCT 2026`
  - Expected removal: `OCT 2026`