### PR TITLE
Removed doubled 'the'

### DIFF
--- a/content/terraform/v1.11.x/docs/cli/commands/test.mdx
+++ b/content/terraform/v1.11.x/docs/cli/commands/test.mdx
@@ -36,7 +36,7 @@ The following options apply to the Terraform `terraform test` command:
 
 * `-json` - Displays machine-readable JSON output for your testing results.
 
-* `-junit-xml=<output file path>` - Saves a test report in JUnit XML format to the specified file. This is currently incompatible with remote test execution using the the `-cloud-run` option. The file path must be relative or absolute.
+* `-junit-xml=<output file path>` - Saves a test report in JUnit XML format to the specified file. This is currently incompatible with remote test execution using the `-cloud-run` option. The file path must be relative or absolute.
 
 * `-test-directory=<relative directory>` - Overrides the directory that Terraform looks into for test files. Note that Terraform always loads testing files within the main configuration directory. The default testing directory is `tests`.
 

--- a/content/terraform/v1.12.x/docs/cli/commands/test.mdx
+++ b/content/terraform/v1.12.x/docs/cli/commands/test.mdx
@@ -36,7 +36,7 @@ The following options apply to the Terraform `terraform test` command:
 
 * `-json` - Displays machine-readable JSON output for your testing results.
 
-* `-junit-xml=<output file path>` - Saves a test report in JUnit XML format to the specified file. This is currently incompatible with remote test execution using the the `-cloud-run` option. The file path must be relative or absolute.
+* `-junit-xml=<output file path>` - Saves a test report in JUnit XML format to the specified file. This is currently incompatible with remote test execution using the `-cloud-run` option. The file path must be relative or absolute.
 
 * `-test-directory=<relative directory>` - Overrides the directory that Terraform looks into for test files. Note that Terraform always loads testing files within the main configuration directory. The default testing directory is `tests`.
 

--- a/content/terraform/v1.12.x/docs/language/block/removed.mdx
+++ b/content/terraform/v1.12.x/docs/language/block/removed.mdx
@@ -257,7 +257,7 @@ Only [destroy-time provisioners](/terraform/language/provisioners#destroy-time-p
 
 ### `working_dir`
 
-The `working_dir` block specifies the working directory where Terraform executes the command specified in the the [`command`](#command) argument. You can specify a relative path to the current working directory or an absolute path. The directory must already exist.
+The `working_dir` block specifies the working directory where Terraform executes the command specified in the [`command`](#command) argument. You can specify a relative path to the current working directory or an absolute path. The directory must already exist.
 
 ```hcl
 resource {

--- a/content/terraform/v1.12.x/docs/language/block/resource.mdx
+++ b/content/terraform/v1.12.x/docs/language/block/resource.mdx
@@ -582,7 +582,7 @@ Terraform evaluates the command in a local shell and can use environment variabl
 
 ### `working_dir`
 
-The `working_dir` block specifies the working directory where Terraform executes the command specified in the the [`command`](#command) argument. You can specify a relative path to the current working directory or an absolute path. The directory must already exist.
+The `working_dir` block specifies the working directory where Terraform executes the command specified in the [`command`](#command) argument. You can specify a relative path to the current working directory or an absolute path. The directory must already exist.
 
 ```hcl
 resource {

--- a/content/terraform/v1.13.x/docs/cli/commands/test.mdx
+++ b/content/terraform/v1.13.x/docs/cli/commands/test.mdx
@@ -36,7 +36,7 @@ The following options apply to the Terraform `terraform test` command:
 
 * `-json` - Displays machine-readable JSON output for your testing results.
 
-* `-junit-xml=<output file path>` - Saves a test report in JUnit XML format to the specified file. This is currently incompatible with remote test execution using the the `-cloud-run` option. The file path must be relative or absolute.
+* `-junit-xml=<output file path>` - Saves a test report in JUnit XML format to the specified file. This is currently incompatible with remote test execution using the `-cloud-run` option. The file path must be relative or absolute.
 
 * `-test-directory=<relative directory>` - Overrides the directory that Terraform looks into for test files. Note that Terraform always loads testing files within the main configuration directory. The default testing directory is `tests`.
 

--- a/content/terraform/v1.13.x/docs/language/block/removed.mdx
+++ b/content/terraform/v1.13.x/docs/language/block/removed.mdx
@@ -257,7 +257,7 @@ Only [destroy-time provisioners](/terraform/language/provisioners#destroy-time-p
 
 ### `working_dir`
 
-The `working_dir` block specifies the working directory where Terraform executes the command specified in the the [`command`](#command) argument. You can specify a relative path to the current working directory or an absolute path. The directory must already exist.
+The `working_dir` block specifies the working directory where Terraform executes the command specified in the [`command`](#command) argument. You can specify a relative path to the current working directory or an absolute path. The directory must already exist.
 
 ```hcl
 resource {

--- a/content/terraform/v1.13.x/docs/language/block/resource.mdx
+++ b/content/terraform/v1.13.x/docs/language/block/resource.mdx
@@ -582,7 +582,7 @@ Terraform evaluates the command in a local shell and can use environment variabl
 
 ### `working_dir`
 
-The `working_dir` block specifies the working directory where Terraform executes the command specified in the the [`command`](#command) argument. You can specify a relative path to the current working directory or an absolute path. The directory must already exist.
+The `working_dir` block specifies the working directory where Terraform executes the command specified in the [`command`](#command) argument. You can specify a relative path to the current working directory or an absolute path. The directory must already exist.
 
 ```hcl
 resource {

--- a/content/terraform/v1.13.x/docs/language/stacks/deploy/conditions.mdx
+++ b/content/terraform/v1.13.x/docs/language/stacks/deploy/conditions.mdx
@@ -41,7 +41,7 @@ Deployment groups require you to define the rules that group enforces.
 
 The `deployment_auto_approve` rule is helpful when you know you want a certain type of plan to go ahead without manual intervention. For example, Stacks have a default auto-approve rule named `empty_plan`, which automatically approves a plan if it has no changes.
 
-Use the `deployment_auto_approve` block to define an auto-approval rule that automatically approves a deployment plan if the condition you set is met. In the the following example, the `no_changes` rule automatically approves a deployment plan if it has no changes:
+Use the `deployment_auto_approve` block to define an auto-approval rule that automatically approves a deployment plan if the condition you set is met. In the following example, the `no_changes` rule automatically approves a deployment plan if it has no changes:
 
 <CodeBlockConfig filename="deployments.tfdeploy.hcl">
 

--- a/content/terraform/v1.14.x/docs/cli/commands/test.mdx
+++ b/content/terraform/v1.14.x/docs/cli/commands/test.mdx
@@ -36,7 +36,7 @@ The following options apply to the Terraform `terraform test` command:
 
 * `-json` - Displays machine-readable JSON output for your testing results.
 
-* `-junit-xml=<output file path>` - Saves a test report in JUnit XML format to the specified file. This is currently incompatible with remote test execution using the the `-cloud-run` option. The file path must be relative or absolute.
+* `-junit-xml=<output file path>` - Saves a test report in JUnit XML format to the specified file. This is currently incompatible with remote test execution using the `-cloud-run` option. The file path must be relative or absolute.
 
 * `-test-directory=<relative directory>` - Overrides the directory that Terraform looks into for test files. Note that Terraform always loads testing files within the main configuration directory. The default testing directory is `tests`.
 

--- a/content/terraform/v1.14.x/docs/language/block/removed.mdx
+++ b/content/terraform/v1.14.x/docs/language/block/removed.mdx
@@ -257,7 +257,7 @@ Only [destroy-time provisioners](/terraform/language/provisioners#destroy-time-p
 
 ### `working_dir`
 
-The `working_dir` block specifies the working directory where Terraform executes the command specified in the the [`command`](#command) argument. You can specify a relative path to the current working directory or an absolute path. The directory must already exist.
+The `working_dir` block specifies the working directory where Terraform executes the command specified in the [`command`](#command) argument. You can specify a relative path to the current working directory or an absolute path. The directory must already exist.
 
 ```hcl
 resource {

--- a/content/terraform/v1.14.x/docs/language/block/resource.mdx
+++ b/content/terraform/v1.14.x/docs/language/block/resource.mdx
@@ -622,7 +622,7 @@ Terraform evaluates the command in a local shell and can use environment variabl
 
 ### `working_dir`
 
-The `working_dir` block specifies the working directory where Terraform executes the command specified in the the [`command`](#command) argument. You can specify a relative path to the current working directory or an absolute path. The directory must already exist.
+The `working_dir` block specifies the working directory where Terraform executes the command specified in the [`command`](#command) argument. You can specify a relative path to the current working directory or an absolute path. The directory must already exist.
 
 ```hcl
 resource {

--- a/content/terraform/v1.14.x/docs/language/stacks/deploy/conditions.mdx
+++ b/content/terraform/v1.14.x/docs/language/stacks/deploy/conditions.mdx
@@ -41,7 +41,7 @@ Deployment groups require you to define the rules that group enforces.
 
 The `deployment_auto_approve` rule is helpful when you know you want a certain type of plan to go ahead without manual intervention. For example, Stacks have a default auto-approve rule named `empty_plan`, which automatically approves a plan if it has no changes.
 
-Use the `deployment_auto_approve` block to define an auto-approval rule that automatically approves a deployment plan if the condition you set is met. In the the following example, the `no_changes` rule automatically approves a deployment plan if it has no changes:
+Use the `deployment_auto_approve` block to define an auto-approval rule that automatically approves a deployment plan if the condition you set is met. In the following example, the `no_changes` rule automatically approves a deployment plan if it has no changes:
 
 <CodeBlockConfig filename="deployments.tfdeploy.hcl">
 

--- a/content/terraform/v1.15.x/docs/cli/commands/test.mdx
+++ b/content/terraform/v1.15.x/docs/cli/commands/test.mdx
@@ -36,7 +36,7 @@ The following options apply to the Terraform `terraform test` command:
 
 * `-json` - Displays machine-readable JSON output for your testing results.
 
-* `-junit-xml=<output file path>` - Saves a test report in JUnit XML format to the specified file. This is currently incompatible with remote test execution using the the `-cloud-run` option. The file path must be relative or absolute.
+* `-junit-xml=<output file path>` - Saves a test report in JUnit XML format to the specified file. This is currently incompatible with remote test execution using the `-cloud-run` option. The file path must be relative or absolute.
 
 * `-test-directory=<relative directory>` - Overrides the directory that Terraform looks into for test files. Note that Terraform always loads testing files within the main configuration directory. The default testing directory is `tests`.
 

--- a/content/terraform/v1.15.x/docs/language/block/removed.mdx
+++ b/content/terraform/v1.15.x/docs/language/block/removed.mdx
@@ -257,7 +257,7 @@ Only [destroy-time provisioners](/terraform/language/provisioners#destroy-time-p
 
 ### `working_dir`
 
-The `working_dir` block specifies the working directory where Terraform executes the command specified in the the [`command`](#command) argument. You can specify a relative path to the current working directory or an absolute path. The directory must already exist.
+The `working_dir` block specifies the working directory where Terraform executes the command specified in the [`command`](#command) argument. You can specify a relative path to the current working directory or an absolute path. The directory must already exist.
 
 ```hcl
 resource {

--- a/content/terraform/v1.15.x/docs/language/block/resource.mdx
+++ b/content/terraform/v1.15.x/docs/language/block/resource.mdx
@@ -626,7 +626,7 @@ Terraform evaluates the command in a local shell and can use environment variabl
 
 ### `working_dir`
 
-The `working_dir` block specifies the working directory where Terraform executes the command specified in the the [`command`](#command) argument. You can specify a relative path to the current working directory or an absolute path. The directory must already exist.
+The `working_dir` block specifies the working directory where Terraform executes the command specified in the [`command`](#command) argument. You can specify a relative path to the current working directory or an absolute path. The directory must already exist.
 
 ```hcl
 resource {

--- a/content/terraform/v1.15.x/docs/language/stacks/deploy/conditions.mdx
+++ b/content/terraform/v1.15.x/docs/language/stacks/deploy/conditions.mdx
@@ -41,7 +41,7 @@ Deployment groups require you to define the rules that group enforces.
 
 The `deployment_auto_approve` rule is helpful when you know you want a certain type of plan to go ahead without manual intervention. For example, Stacks have a default auto-approve rule named `empty_plan`, which automatically approves a plan if it has no changes.
 
-Use the `deployment_auto_approve` block to define an auto-approval rule that automatically approves a deployment plan if the condition you set is met. In the the following example, the `no_changes` rule automatically approves a deployment plan if it has no changes:
+Use the `deployment_auto_approve` block to define an auto-approval rule that automatically approves a deployment plan if the condition you set is met. In the following example, the `no_changes` rule automatically approves a deployment plan if it has no changes:
 
 <CodeBlockConfig filename="deployments.tfdeploy.hcl">
 


### PR DESCRIPTION
Typo fix - removed doubled "the" from several pages