### PR TITLE
Fix Vault plugin register docs: remove incorrect beta label from -download flag

### DIFF
--- a/content/vault/v2.x/content/docs/commands/plugin/register.mdx
+++ b/content/vault/v2.x/content/docs/commands/plugin/register.mdx
@@ -122,7 +122,7 @@ flags](/vault/docs/commands) included on all commands.
    You can omit version to register a plugin binary, but you must provide
    an explicit version to register an extracted `.zip` file.
 
-- `-download` `(bool: false)` - <EnterpriseAlert inline="true" /> **( BETA )**
+- `-download` `(bool: false)` - <EnterpriseAlert inline="true" /> 
   Tells Vault to download the specified plugin from the
   [HashiCorp releases page](https://releases.hashicorp.com/). Automatic
   downloads only support secret and auth plugins with artifacts containing


### PR DESCRIPTION
Updated [register.mdx](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Removed the incorrect **( BETA )** label from the -download flag entry
This clarifies that vault plugin register -download is not a beta-only option in the docs
Fixes VAULT-45641 for the published Vault docs update