### PR TITLE
docs(vault-radar): Update cli commands's state and clean up some docs

### DIFF
--- a/content/hcp-docs/content/docs/vault-radar/agent/correlate-vault.mdx
+++ b/content/hcp-docs/content/docs/vault-radar/agent/correlate-vault.mdx
@@ -7,25 +7,17 @@ created_at: 2025-09-05T13:57:53-05:00
 last_modified: 2025-10-22T14:57:55-04:00
 # END AUTO GENERATED METADATA
 ---
-
 # Correlate findings with Vault
 
-<Highlight title="Vault Enterprise Only">
-
-Correlation between HCP Vault Radar and HashiCorp Vault is supported on HCP
-Vault Dedicated or Vault Enterprise clusters.
-
-</Highlight>
-
-When the Vault Radar agent connects to a Vault Dedicated or Vault Enterprise cluster, 
-Vault Radar can correlate findings with secrets stored in Vault. This allows you to identify 
-what secrets you need to rotate.
+When the Vault Radar agent connects to a Vault Dedicated or Vault Enterprise cluster,
+Vault Radar can correlate findings with secrets stored in Vault.
+This allows you to identify what secrets you need to rotate.
 
 ## Connect a Vault cluster
 
-Before you can correlate findings with Vault, you need to [deploy the Radar
-agent](/hcp/docs/vault-radar/agent/deploy). Once you deploy the agent, you can
-configure and connect Vault to the agent.
+Before you can correlate findings with Vault, you need to
+[deploy the Radar agent](/hcp/docs/vault-radar/agent/deploy).
+Once you deploy the agent, you can configure and connect Vault to the agent.
 
 ## Prerequisites
 
@@ -35,8 +27,8 @@ You need one of the following Vault authentication methods:
 - AppRole
 - Token
 
-The authentication methods require a policy that allows the Vault Radar agent to
-read all KV secrets from Vault.
+The authentication methods require a policy that allows the Vault Radar agent to read
+all KV secrets from Vault.
 
 ### Create a Vault policy
 
@@ -47,7 +39,8 @@ Vault Radar requires the following capabilities:
 - List all secrets in a KV secrets engine mount
 - Read all the versions of a secret in a KV secret engine mount
 
-A policy granting just the required level of access requires explicitly specifying the namespaces and KV mounts.
+A policy granting just the required level of access requires explicitly specifying the
+namespaces and KV mounts.
 
 ```hcl
 path "auth/token/lookup-self" {
@@ -129,8 +122,7 @@ path "+/+/+/+/data/*" {
 }
 ```
 
-For less restrictive environments, you can give broader permissions to Vault
-Radar.
+For less restrictive environments, you can give broader permissions to Vault Radar.
 
 A simple policy that grants Vault Radar broad access to your Vault cluster.
 
@@ -142,27 +134,30 @@ path "*" {
 
 ### Agent configuration with Vault
 
-Set up and manage a Vault cluster from the Vault Radar module in the [HCP Portal](https://portal.cloud.hashicorp.com/). Select **Settings**, then **Secret Managers**, and then click **Connect new secret manager**.
+Set up and manage a Vault cluster from the Vault Radar module in the
+[HCP Portal](https://portal.cloud.hashicorp.com/). Select **Settings**, then **Secret
+Managers**, and then click **Connect new secret manager**.
 ![Select a index source to scan](/img/docs/vault-radar/agent/agent-index-source-selection.png)
 
 1. Select Vault and the Vault deployment type
-1. Provide you Vault cluster URL
-1. Select auth method and fill in details on the form, and select Next to validate the connection.
+2. Provide you Vault cluster URL
+3. Select auth method and fill in details on the form, and select Next to validate the
+   connection.
 
 <Tabs>
 <Tab heading="Kubernetes">
 
-@include 'vault-radar/indexing/kubernetes-auth.mdx'
+@include ‘vault-radar/indexing/kubernetes-auth.mdx’
 
 </Tab>
 <Tab heading="App Role (push)">
 
-@include 'vault-radar/indexing/app-role-auth.mdx'
+@include ‘vault-radar/indexing/app-role-auth.mdx’
 
 </Tab>
 <Tab heading="Token">
 
-@include 'vault-radar/indexing/token-auth.mdx'
+@include ‘vault-radar/indexing/token-auth.mdx’
 
 </Tab>
 </Tabs>

--- a/content/hcp-docs/content/docs/vault-radar/agent/correlate-vault.mdx
+++ b/content/hcp-docs/content/docs/vault-radar/agent/correlate-vault.mdx
@@ -9,6 +9,14 @@ last_modified: 2025-10-22T14:57:55-04:00
 ---
 # Correlate findings with Vault
 
+<Highlight title="Vault Enterprise Only">
+
+Correlation between HCP Vault Radar and HashiCorp Vault is supported on HCP Vault
+Dedicated and Vault Enterprise clusters.
+Community Editions of Vault are not supported.
+
+</Highlight>
+
 When the Vault Radar agent connects to a Vault Dedicated or Vault Enterprise cluster,
 Vault Radar can correlate findings with secrets stored in Vault.
 This allows you to identify what secrets you need to rotate.

--- a/content/hcp-docs/content/docs/vault-radar/cli/scan/file.mdx
+++ b/content/hcp-docs/content/docs/vault-radar/cli/scan/file.mdx
@@ -7,16 +7,13 @@ created_at: 2025-09-05T13:57:53-05:00
 last_modified: 2025-09-05T13:57:53-05:00
 # END AUTO GENERATED METADATA
 ---
-
 # scan file
 
-@include 'beta-feature.mdx'
+@include ‘vault-radar/version-requirement.mdx’
 
-@include 'vault-radar/version-requirement.mdx'
-
-The `scan file` command is used for scanning a file. It is similar to
-[scan folder](/hcp/docs/vault-radar/cli/scan/folder) command but can scan a
-single file. One difference though is that it can read data from standard input.  
+The `scan file` command is used for scanning a file.
+It is similar to [scan folder](/hcp/docs/vault-radar/cli/scan/folder) command but can
+scan a single file. One difference though is that it can read data from standard input.
 
 ## Usage
 
@@ -30,8 +27,8 @@ Usage: vault-radar scan file [options]
 
 ### Scanning a file
 
-Scan a file and write the results to a file in CSV format, this is the default
-format for output.
+Scan a file and write the results to a file in CSV format, this is the default format
+for output.
 
 ```shell-session
 $ vault-radar scan file -p <PATH TO FILE> -o <PATH TO OUTPUT>.csv
@@ -39,8 +36,8 @@ $ vault-radar scan file -p <PATH TO FILE> -o <PATH TO OUTPUT>.csv
 
 ### Scanning a file and output in JSON
 
-Scan a file and write the results to a file in [JSON
-Lines](https://jsonlines.org/) format.  
+Scan a file and write the results to a file in [JSON Lines](https://jsonlines.org/)
+format.
 
 ```shell-session
 $ vault-radar scan file -p <PATH TO FILE> -o <PATH TO OUTPUT>.jsonl -f json
@@ -48,8 +45,9 @@ $ vault-radar scan file -p <PATH TO FILE> -o <PATH TO OUTPUT>.jsonl -f json
 
 ### Read data from stdin
 
-Scan data coming from stdin. The `--name` parameter can be used to name data
-coming from stdin, and it will be used in secret URI in the output file.
+Scan data coming from stdin.
+The `--name` parameter can be used to name data coming from stdin, and it will be used
+in secret URI in the output file.
 
 ```shell-session
 $ echo "password abcABC123" | vault-radar scan file \
@@ -59,9 +57,9 @@ $ echo "password abcABC123" | vault-radar scan file \
 
 ### Scanning using a baseline file
 
-Perform a scan using a previous scan's result and write the new changes to an
-outfile. With `-b` option, only new risks, risks that were not found in the
-previous scan will be reported.  
+Perform a scan using a previous scan’s result and write the new changes to an outfile.
+With `-b` option, only new risks, risks that were not found in the previous scan will be
+reported.
 
 ```shell-session
 $ vault-radar scan file -p <PATH TO FILE> \
@@ -71,17 +69,16 @@ $ vault-radar scan file -p <PATH TO FILE> \
 
 ### HCP connection scanning behavior
 
-The scan commands require an HCP cloud connection to ensure 
-that hashes are generated using a shared salt from the
-cloud keeping consistency across scans. In order to populate the HCP connection
-information needed, refer to the [HCP
-upload](/hcp/docs/vault-radar/cli/configuration/upload-results-to-hcp) page.
+The scan commands require an HCP cloud connection to ensure that hashes are generated
+using a shared salt from the cloud keeping consistency across scans.
+In order to populate the HCP connection information needed, refer to the
+[HCP upload](/hcp/docs/vault-radar/cli/configuration/upload-results-to-hcp) page.
 
 ### Scanning using a Vault index file
 
-Perform a scan using a generated vault index and write the results to an
-outfile. In this mode, if a risk was previously found in Vault, the scan results
-will report the location in Vault as well.
+Perform a scan using a generated vault index and write the results to an outfile.
+In this mode, if a risk was previously found in Vault, the scan results will report the
+location in Vault as well.
 
 ```shell-session
 $ vault-radar scan file -p <PATH TO FILE> -o <PATH TO OUTPUT>.csv \
@@ -92,8 +89,8 @@ $ vault-radar scan file -p <PATH TO FILE> -o <PATH TO OUTPUT>.csv \
 
 ### Scan and restrict the number of secrets found
 
-Scan a clone and write the results to an outfile and stop scanning when the
-defined number of secrets are found.
+Scan a clone and write the results to an outfile and stop scanning when the defined
+number of secrets are found.
 
 ```shell-session
 $ vault-radar scan file -p <PATH TO FILE> \

--- a/content/hcp-docs/content/docs/vault-radar/cli/scan/folder.mdx
+++ b/content/hcp-docs/content/docs/vault-radar/cli/scan/folder.mdx
@@ -7,12 +7,9 @@ created_at: 2025-09-05T13:57:53-05:00
 last_modified: 2025-09-05T13:57:53-05:00
 # END AUTO GENERATED METADATA
 ---
-
 # scan folder
 
-@include 'beta-feature.mdx'
-
-@include 'vault-radar/version-requirement.mdx'
+@include ‘vault-radar/version-requirement.mdx’
 
 The `scan folder` command is used for scanning a local folder.
 
@@ -26,21 +23,28 @@ Usage: vault-radar scan folder [options]
 
 </CodeBlockConfig>
 
-### Command options 
+### Command options
 
-- `--path, -p`: If specified scans the given folder, otherwise it scans current working dir
-- `--outfile, -o`: Specifies the file to store information about found secrets (required)
-- `--format, -f`: Specifies the output format, csv and json are supported. Defaults to csv
-- `--baseline, -b`: Specifies the file with previous scan results. Only new secrets will be reported.
-- `--limit, -l`: Specifies the maximum number of secrets to be reported. The scan will stop when the limit is reached
+- `--path, -p`: If specified scans the given folder, otherwise it scans current working
+  dir
+- `--outfile, -o`: Specifies the file to store information about found secrets
+  (required)
+- `--format, -f`: Specifies the output format, csv and json are supported.
+  Defaults to csv
+- `--baseline, -b`: Specifies the file with previous scan results.
+  Only new secrets will be reported.
+- `--limit, -l`: Specifies the maximum number of secrets to be reported.
+  The scan will stop when the limit is reached
 - `--host-name`: Specifies the host name to use in risk URI, defaults to local hostname
-- `--path-prefix`: Specifies the path prefix to use in risk URI. If not specified, then full local path will be used
-- `--index-file`: Specifies the index file path to use in order to determine which risks are Vaulted
+- `--path-prefix`: Specifies the path prefix to use in risk URI. If not specified, then
+  full local path will be used
+- `--index-file`: Specifies the index file path to use in order to determine which risks
+  are Vaulted
 
 ### Scanning a folder
 
-Scan a folder and write the results to a file in CSV format, this is the default
-format for output.
+Scan a folder and write the results to a file in CSV format, this is the default format
+for output.
 
 ```shell-session
 $ vault-radar scan folder -p <PATH TO FOLDER> -o <PATH TO OUTPUT>.csv
@@ -48,8 +52,8 @@ $ vault-radar scan folder -p <PATH TO FOLDER> -o <PATH TO OUTPUT>.csv
 
 ### Scanning a folder and output in JSON
 
-Scan a folder and write the results to a file in [JSON
-Lines](https://jsonlines.org/) format.  
+Scan a folder and write the results to a file in [JSON Lines](https://jsonlines.org/)
+format.
 
 ```shell-session
 $ vault-radar scan folder -p <PATH TO FOLDER> \
@@ -59,17 +63,16 @@ $ vault-radar scan folder -p <PATH TO FOLDER> \
 
 ### HCP connection scanning behavior
 
-The scan commands require an HCP cloud connection to ensure 
-that hashes are generated using a shared salt from the
-cloud keeping consistency across scans. In order to populate the HCP connection
-information needed, refer to the [HCP
-upload](/hcp/docs/vault-radar/cli/configuration/upload-results-to-hcp) page.
+The scan commands require an HCP cloud connection to ensure that hashes are generated
+using a shared salt from the cloud keeping consistency across scans.
+In order to populate the HCP connection information needed, refer to the
+[HCP upload](/hcp/docs/vault-radar/cli/configuration/upload-results-to-hcp) page.
 
 ### Scanning using a baseline file
 
-Perform a scan using a previous scan's result and write the new changes to an
-outfile. With `-b` option, only new risks, risks that were not found in the
-previous scan will be reported.  
+Perform a scan using a previous scan’s result and write the new changes to an outfile.
+With `-b` option, only new risks, risks that were not found in the previous scan will be
+reported.
 
 ```shell-session
 $ vault-radar scan folder -p <PATH TO FOLDER> \
@@ -79,9 +82,9 @@ $ vault-radar scan folder -p <PATH TO FOLDER> \
 
 ### Scanning using a Vault index file
 
-Perform a scan using a generated vault index and write the results to an output
-file. In this mode, if a risk was previously found in Vault, the scan results
-will report the location in Vault as well.
+Perform a scan using a generated vault index and write the results to an output file.
+In this mode, if a risk was previously found in Vault, the scan results will report the
+location in Vault as well.
 
 ```shell-session
 $ vault-radar scan folder -p <PATH TO FOLDER> \
@@ -93,8 +96,8 @@ $ vault-radar scan folder -p <PATH TO FOLDER> \
 
 ### Scan and restrict the number of secrets found
 
-Scan a clone and write the results to an outfile and stop scanning when the
-defined number of secrets are found.
+Scan a clone and write the results to an outfile and stop scanning when the defined
+number of secrets are found.
 
 ```shell-session
 $ vault-radar scan folder -p <PATH TO FOLDER> \
@@ -104,13 +107,13 @@ $ vault-radar scan folder -p <PATH TO FOLDER> \
 
 ### Modify the secret URI in the output file
 
-By default, the secret URI in the result file will be the full local file path
-where the secret has been found. If the results from scan runs on different
-machines must be combined for further analysis, `--host-name` and
-`--path-prefix` options could be used. `--host-name` specifies the host name to
-use in secret URI, defaults to local hostname. `--path-prefix` specifies the
-path prefix to use in secret URI. If not specified, then full local path will be
-used.
+By default, the secret URI in the result file will be the full local file path where the
+secret has been found.
+If the results from scan runs on different machines must be combined for further
+analysis, `--host-name` and `--path-prefix` options could be used.
+`--host-name` specifies the host name to use in secret URI, defaults to local hostname.
+`--path-prefix` specifies the path prefix to use in secret URI. If not specified, then
+full local path will be used.
 
 ```shell-session
 $ vault-radar scan folder -p <PATH TO FOLDER> \

--- a/content/hcp-docs/data/docs-nav-data.json
+++ b/content/hcp-docs/data/docs-nav-data.json
@@ -1158,11 +1158,11 @@
                 "path": "vault-radar/cli/scan/docker-image"
               },
               {
-                "title": "file <sup>Beta</sup>",
+                "title": "file",
                 "path": "vault-radar/cli/scan/file"
               },
               {
-                "title": "folder <sup>Beta</sup>",
+                "title": "folder",
                 "path": "vault-radar/cli/scan/folder"
               },
               {

--- a/content/hcp-docs/data/docs-nav-data.json
+++ b/content/hcp-docs/data/docs-nav-data.json
@@ -953,7 +953,7 @@
             "path": "vault-radar/agent/deploy"
           },
           {
-            "title": "Integrate Vault Enterprise",
+            "title": "Integrate Vault",
             "path": "vault-radar/agent/correlate-vault"
           },
           {


### PR DESCRIPTION
Updating `scan file` and `scan folder` (basically the same command) to not have the Beta branding. 
Also cleaned up some language on the instructions to set up Vault with the Agent. The feature works for both HVD and Vault Enterprise, but some messaging could confuse a reader into thinking HVD is not supported.

Please go to the `Preview` tab and select the appropriate template:

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
