### PR TITLE
docs(vault): document kv metadata patch subcommand

### DIFF
--- a/content/vault/v1.16.x/content/docs/commands/kv/metadata.mdx
+++ b/content/vault/v1.16.x/content/docs/commands/kv/metadata.mdx
@@ -29,6 +29,7 @@ Usage: vault kv metadata <subcommand> [options] [args]
 Subcommands:
     delete    Deletes all versions and metadata for a key in the KV store
     get       Retrieves key metadata from the KV store
+    patch     Patches key settings in the KV store
     put       Sets or updates key settings in the KV store
 ```
 
@@ -87,6 +88,108 @@ destroyed        false
 
 ...
 ```
+
+### kv metadata patch
+
+The `kv metadata patch` command patches key settings for a specified key in
+the KV v2 secrets engine. It applies a JSON merge patch, which is useful for
+updating individual metadata fields and for adding, updating, or removing
+custom metadata keys without replacing the entire `custom_metadata` map. You can
+also use it to create a blank key.
+
+#### Examples
+
+Create a key in the KV v2 with no data at the key "creds":
+
+```shell-session
+$ vault kv metadata patch -mount=secret creds
+Success! Data written to: secret/metadata/creds
+```
+
+Set the maximum number of versions to keep for the key "creds":
+
+```shell-session
+$ vault kv metadata patch -mount=secret -max-versions=5 creds
+Success! Data written to: secret/metadata/creds
+```
+
+**NOTE:** If not set, the backend’s configured max version is used. Once a key
+has more than the configured allowed versions the oldest version will be
+permanently deleted.
+
+Require Check-and-Set for the key "creds":
+
+```shell-session
+$ vault kv metadata patch -mount=secret -cas-required creds
+```
+
+**NOTE:** When check-and-set is required, the key will require the `cas`
+parameter to be set on all write requests. Otherwise, the backend’s
+configuration will be used.
+
+Set the length of time before a version is deleted for the key "creds":
+
+```shell-session
+$ vault kv metadata patch -mount=secret -delete-version-after="3h25m19s" creds
+```
+
+**NOTE:** If not set, the backend's configured Delete-Version-After is used. If
+set to a duration greater than the backend's, the backend's Delete-Version-After
+setting will be used. Any changes to the Delete-Version-After setting will only
+be applied to new versions.
+
+Add or update custom metadata without replacing existing custom metadata keys:
+
+```shell-session
+$ vault kv metadata patch -mount=secret \
+    -custom-metadata=foo=abc \
+    -custom-metadata=bar=123 \
+    creds
+Success! Data written to: secret/metadata/creds
+```
+
+Remove a custom metadata key from the key "creds":
+
+```shell-session
+$ vault kv metadata patch -mount=secret -remove-custom-metadata=bar creds
+Success! Data written to: secret/metadata/creds
+```
+
+#### Output options
+
+- `-format` `(string: "table")` - Print the output in the given format. Valid
+  formats are "table", "json", or "yaml". This can also be specified via the
+  `VAULT_FORMAT` environment variable.
+
+#### Subcommand options
+
+- `-cas-required` `(bool: false)` - If true the key will require the cas
+  parameter to be set on all write requests. If false, the backend’s
+  configuration will be used. The default is false.
+
+- `-max-versions` `(int: 0)` - The number of versions to keep per key. If not
+  set, the backend’s configured max version is used. Once a key has more than the
+  configured allowed versions the oldest version will be permanently deleted.
+
+- `-delete-version-after` `(string:"0s")` – Set the `delete-version-after` value
+  to a duration to specify the `deletion_time` for all new versions written to
+  this key. If not set, the backend's `delete_version_after` will be used. If
+  the value is greater than the backend's `delete_version_after`, the backend's
+  `delete_version_after` will be used. Accepts [duration format strings](/vault/docs/concepts/duration-format).
+
+- `-custom-metadata` `(string: "")` - Specifies a key-value pair for the
+  `custom_metadata` field. This can be specified multiple times to add or update
+  multiple pieces of metadata. Existing custom metadata keys that are not listed
+  are left unchanged.
+
+- `-remove-custom-metadata` `(string: "")` - Specifies a custom metadata key to
+  remove. This can be specified multiple times to remove multiple keys.
+
+- `-mount` `(string: "")` - Specifies the path where the KV backend is mounted. 
+  If specified, the next argument will be interpreted as the secret path. If 
+  this flag is not specified, the next argument will be interpreted as the 
+  combined mount path and secret path, with /metadata/ automatically appended
+  between KV v2 secrets.
 
 ### kv metadata put
 

--- a/content/vault/v1.17.x/content/docs/commands/kv/metadata.mdx
+++ b/content/vault/v1.17.x/content/docs/commands/kv/metadata.mdx
@@ -29,6 +29,7 @@ Usage: vault kv metadata <subcommand> [options] [args]
 Subcommands:
     delete    Deletes all versions and metadata for a key in the KV store
     get       Retrieves key metadata from the KV store
+    patch     Patches key settings in the KV store
     put       Sets or updates key settings in the KV store
 ```
 
@@ -87,6 +88,108 @@ destroyed        false
 
 ...
 ```
+
+### kv metadata patch
+
+The `kv metadata patch` command patches key settings for a specified key in
+the KV v2 secrets engine. It applies a JSON merge patch, which is useful for
+updating individual metadata fields and for adding, updating, or removing
+custom metadata keys without replacing the entire `custom_metadata` map. You can
+also use it to create a blank key.
+
+#### Examples
+
+Create a key in the KV v2 with no data at the key "creds":
+
+```shell-session
+$ vault kv metadata patch -mount=secret creds
+Success! Data written to: secret/metadata/creds
+```
+
+Set the maximum number of versions to keep for the key "creds":
+
+```shell-session
+$ vault kv metadata patch -mount=secret -max-versions=5 creds
+Success! Data written to: secret/metadata/creds
+```
+
+**NOTE:** If not set, the backend’s configured max version is used. Once a key
+has more than the configured allowed versions the oldest version will be
+permanently deleted.
+
+Require Check-and-Set for the key "creds":
+
+```shell-session
+$ vault kv metadata patch -mount=secret -cas-required creds
+```
+
+**NOTE:** When check-and-set is required, the key will require the `cas`
+parameter to be set on all write requests. Otherwise, the backend’s
+configuration will be used.
+
+Set the length of time before a version is deleted for the key "creds":
+
+```shell-session
+$ vault kv metadata patch -mount=secret -delete-version-after="3h25m19s" creds
+```
+
+**NOTE:** If not set, the backend's configured Delete-Version-After is used. If
+set to a duration greater than the backend's, the backend's Delete-Version-After
+setting will be used. Any changes to the Delete-Version-After setting will only
+be applied to new versions.
+
+Add or update custom metadata without replacing existing custom metadata keys:
+
+```shell-session
+$ vault kv metadata patch -mount=secret \
+    -custom-metadata=foo=abc \
+    -custom-metadata=bar=123 \
+    creds
+Success! Data written to: secret/metadata/creds
+```
+
+Remove a custom metadata key from the key "creds":
+
+```shell-session
+$ vault kv metadata patch -mount=secret -remove-custom-metadata=bar creds
+Success! Data written to: secret/metadata/creds
+```
+
+#### Output options
+
+- `-format` `(string: "table")` - Print the output in the given format. Valid
+  formats are "table", "json", or "yaml". This can also be specified via the
+  `VAULT_FORMAT` environment variable.
+
+#### Subcommand options
+
+- `-cas-required` `(bool: false)` - If true the key will require the cas
+  parameter to be set on all write requests. If false, the backend’s
+  configuration will be used. The default is false.
+
+- `-max-versions` `(int: 0)` - The number of versions to keep per key. If not
+  set, the backend’s configured max version is used. Once a key has more than the
+  configured allowed versions the oldest version will be permanently deleted.
+
+- `-delete-version-after` `(string:"0s")` – Set the `delete-version-after` value
+  to a duration to specify the `deletion_time` for all new versions written to
+  this key. If not set, the backend's `delete_version_after` will be used. If
+  the value is greater than the backend's `delete_version_after`, the backend's
+  `delete_version_after` will be used. Accepts [duration format strings](/vault/docs/concepts/duration-format).
+
+- `-custom-metadata` `(string: "")` - Specifies a key-value pair for the
+  `custom_metadata` field. This can be specified multiple times to add or update
+  multiple pieces of metadata. Existing custom metadata keys that are not listed
+  are left unchanged.
+
+- `-remove-custom-metadata` `(string: "")` - Specifies a custom metadata key to
+  remove. This can be specified multiple times to remove multiple keys.
+
+- `-mount` `(string: "")` - Specifies the path where the KV backend is mounted. 
+  If specified, the next argument will be interpreted as the secret path. If 
+  this flag is not specified, the next argument will be interpreted as the 
+  combined mount path and secret path, with /metadata/ automatically appended
+  between KV v2 secrets.
 
 ### kv metadata put
 

--- a/content/vault/v1.18.x/content/docs/commands/kv/metadata.mdx
+++ b/content/vault/v1.18.x/content/docs/commands/kv/metadata.mdx
@@ -29,6 +29,7 @@ Usage: vault kv metadata <subcommand> [options] [args]
 Subcommands:
     delete    Deletes all versions and metadata for a key in the KV store
     get       Retrieves key metadata from the KV store
+    patch     Patches key settings in the KV store
     put       Sets or updates key settings in the KV store
 ```
 
@@ -87,6 +88,108 @@ destroyed        false
 
 ...
 ```
+
+### kv metadata patch
+
+The `kv metadata patch` command patches key settings for a specified key in
+the KV v2 secrets engine. It applies a JSON merge patch, which is useful for
+updating individual metadata fields and for adding, updating, or removing
+custom metadata keys without replacing the entire `custom_metadata` map. You can
+also use it to create a blank key.
+
+#### Examples
+
+Create a key in the KV v2 with no data at the key "creds":
+
+```shell-session
+$ vault kv metadata patch -mount=secret creds
+Success! Data written to: secret/metadata/creds
+```
+
+Set the maximum number of versions to keep for the key "creds":
+
+```shell-session
+$ vault kv metadata patch -mount=secret -max-versions=5 creds
+Success! Data written to: secret/metadata/creds
+```
+
+**NOTE:** If not set, the backend’s configured max version is used. Once a key
+has more than the configured allowed versions the oldest version will be
+permanently deleted.
+
+Require Check-and-Set for the key "creds":
+
+```shell-session
+$ vault kv metadata patch -mount=secret -cas-required creds
+```
+
+**NOTE:** When check-and-set is required, the key will require the `cas`
+parameter to be set on all write requests. Otherwise, the backend’s
+configuration will be used.
+
+Set the length of time before a version is deleted for the key "creds":
+
+```shell-session
+$ vault kv metadata patch -mount=secret -delete-version-after="3h25m19s" creds
+```
+
+**NOTE:** If not set, the backend's configured Delete-Version-After is used. If
+set to a duration greater than the backend's, the backend's Delete-Version-After
+setting will be used. Any changes to the Delete-Version-After setting will only
+be applied to new versions.
+
+Add or update custom metadata without replacing existing custom metadata keys:
+
+```shell-session
+$ vault kv metadata patch -mount=secret \
+    -custom-metadata=foo=abc \
+    -custom-metadata=bar=123 \
+    creds
+Success! Data written to: secret/metadata/creds
+```
+
+Remove a custom metadata key from the key "creds":
+
+```shell-session
+$ vault kv metadata patch -mount=secret -remove-custom-metadata=bar creds
+Success! Data written to: secret/metadata/creds
+```
+
+#### Output options
+
+- `-format` `(string: "table")` - Print the output in the given format. Valid
+  formats are "table", "json", or "yaml". This can also be specified via the
+  `VAULT_FORMAT` environment variable.
+
+#### Subcommand options
+
+- `-cas-required` `(bool: false)` - If true the key will require the cas
+  parameter to be set on all write requests. If false, the backend’s
+  configuration will be used. The default is false.
+
+- `-max-versions` `(int: 0)` - The number of versions to keep per key. If not
+  set, the backend’s configured max version is used. Once a key has more than the
+  configured allowed versions the oldest version will be permanently deleted.
+
+- `-delete-version-after` `(string:"0s")` – Set the `delete-version-after` value
+  to a duration to specify the `deletion_time` for all new versions written to
+  this key. If not set, the backend's `delete_version_after` will be used. If
+  the value is greater than the backend's `delete_version_after`, the backend's
+  `delete_version_after` will be used. Accepts [duration format strings](/vault/docs/concepts/duration-format).
+
+- `-custom-metadata` `(string: "")` - Specifies a key-value pair for the
+  `custom_metadata` field. This can be specified multiple times to add or update
+  multiple pieces of metadata. Existing custom metadata keys that are not listed
+  are left unchanged.
+
+- `-remove-custom-metadata` `(string: "")` - Specifies a custom metadata key to
+  remove. This can be specified multiple times to remove multiple keys.
+
+- `-mount` `(string: "")` - Specifies the path where the KV backend is mounted. 
+  If specified, the next argument will be interpreted as the secret path. If 
+  this flag is not specified, the next argument will be interpreted as the 
+  combined mount path and secret path, with /metadata/ automatically appended
+  between KV v2 secrets.
 
 ### kv metadata put
 

--- a/content/vault/v1.19.x/content/docs/commands/kv/metadata.mdx
+++ b/content/vault/v1.19.x/content/docs/commands/kv/metadata.mdx
@@ -29,6 +29,7 @@ Usage: vault kv metadata <subcommand> [options] [args]
 Subcommands:
     delete    Deletes all versions and metadata for a key in the KV store
     get       Retrieves key metadata from the KV store
+    patch     Patches key settings in the KV store
     put       Sets or updates key settings in the KV store
 ```
 
@@ -87,6 +88,108 @@ destroyed        false
 
 ...
 ```
+
+### kv metadata patch
+
+The `kv metadata patch` command patches key settings for a specified key in
+the KV v2 secrets engine. It applies a JSON merge patch, which is useful for
+updating individual metadata fields and for adding, updating, or removing
+custom metadata keys without replacing the entire `custom_metadata` map. You can
+also use it to create a blank key.
+
+#### Examples
+
+Create a key in the KV v2 with no data at the key "creds":
+
+```shell-session
+$ vault kv metadata patch -mount=secret creds
+Success! Data written to: secret/metadata/creds
+```
+
+Set the maximum number of versions to keep for the key "creds":
+
+```shell-session
+$ vault kv metadata patch -mount=secret -max-versions=5 creds
+Success! Data written to: secret/metadata/creds
+```
+
+**NOTE:** If not set, the backend’s configured max version is used. Once a key
+has more than the configured allowed versions the oldest version will be
+permanently deleted.
+
+Require Check-and-Set for the key "creds":
+
+```shell-session
+$ vault kv metadata patch -mount=secret -cas-required creds
+```
+
+**NOTE:** When check-and-set is required, the key will require the `cas`
+parameter to be set on all write requests. Otherwise, the backend’s
+configuration will be used.
+
+Set the length of time before a version is deleted for the key "creds":
+
+```shell-session
+$ vault kv metadata patch -mount=secret -delete-version-after="3h25m19s" creds
+```
+
+**NOTE:** If not set, the backend's configured Delete-Version-After is used. If
+set to a duration greater than the backend's, the backend's Delete-Version-After
+setting will be used. Any changes to the Delete-Version-After setting will only
+be applied to new versions.
+
+Add or update custom metadata without replacing existing custom metadata keys:
+
+```shell-session
+$ vault kv metadata patch -mount=secret \
+    -custom-metadata=foo=abc \
+    -custom-metadata=bar=123 \
+    creds
+Success! Data written to: secret/metadata/creds
+```
+
+Remove a custom metadata key from the key "creds":
+
+```shell-session
+$ vault kv metadata patch -mount=secret -remove-custom-metadata=bar creds
+Success! Data written to: secret/metadata/creds
+```
+
+#### Output options
+
+- `-format` `(string: "table")` - Print the output in the given format. Valid
+  formats are "table", "json", or "yaml". This can also be specified via the
+  `VAULT_FORMAT` environment variable.
+
+#### Subcommand options
+
+- `-cas-required` `(bool: false)` - If true the key will require the cas
+  parameter to be set on all write requests. If false, the backend’s
+  configuration will be used. The default is false.
+
+- `-max-versions` `(int: 0)` - The number of versions to keep per key. If not
+  set, the backend’s configured max version is used. Once a key has more than the
+  configured allowed versions the oldest version will be permanently deleted.
+
+- `-delete-version-after` `(string:"0s")` – Set the `delete-version-after` value
+  to a duration to specify the `deletion_time` for all new versions written to
+  this key. If not set, the backend's `delete_version_after` will be used. If
+  the value is greater than the backend's `delete_version_after`, the backend's
+  `delete_version_after` will be used. Accepts [duration format strings](/vault/docs/concepts/duration-format).
+
+- `-custom-metadata` `(string: "")` - Specifies a key-value pair for the
+  `custom_metadata` field. This can be specified multiple times to add or update
+  multiple pieces of metadata. Existing custom metadata keys that are not listed
+  are left unchanged.
+
+- `-remove-custom-metadata` `(string: "")` - Specifies a custom metadata key to
+  remove. This can be specified multiple times to remove multiple keys.
+
+- `-mount` `(string: "")` - Specifies the path where the KV backend is mounted. 
+  If specified, the next argument will be interpreted as the secret path. If 
+  this flag is not specified, the next argument will be interpreted as the 
+  combined mount path and secret path, with /metadata/ automatically appended
+  between KV v2 secrets.
 
 ### kv metadata put
 

--- a/content/vault/v1.20.x/content/docs/commands/kv/metadata.mdx
+++ b/content/vault/v1.20.x/content/docs/commands/kv/metadata.mdx
@@ -29,6 +29,7 @@ Usage: vault kv metadata <subcommand> [options] [args]
 Subcommands:
     delete    Deletes all versions and metadata for a key in the KV store
     get       Retrieves key metadata from the KV store
+    patch     Patches key settings in the KV store
     put       Sets or updates key settings in the KV store
 ```
 
@@ -87,6 +88,108 @@ destroyed        false
 
 ...
 ```
+
+### kv metadata patch
+
+The `kv metadata patch` command patches key settings for a specified key in
+the KV v2 secrets engine. It applies a JSON merge patch, which is useful for
+updating individual metadata fields and for adding, updating, or removing
+custom metadata keys without replacing the entire `custom_metadata` map. You can
+also use it to create a blank key.
+
+#### Examples
+
+Create a key in the KV v2 with no data at the key "creds":
+
+```shell-session
+$ vault kv metadata patch -mount=secret creds
+Success! Data written to: secret/metadata/creds
+```
+
+Set the maximum number of versions to keep for the key "creds":
+
+```shell-session
+$ vault kv metadata patch -mount=secret -max-versions=5 creds
+Success! Data written to: secret/metadata/creds
+```
+
+**NOTE:** If not set, the backend’s configured max version is used. Once a key
+has more than the configured allowed versions the oldest version will be
+permanently deleted.
+
+Require Check-and-Set for the key "creds":
+
+```shell-session
+$ vault kv metadata patch -mount=secret -cas-required creds
+```
+
+**NOTE:** When check-and-set is required, the key will require the `cas`
+parameter to be set on all write requests. Otherwise, the backend’s
+configuration will be used.
+
+Set the length of time before a version is deleted for the key "creds":
+
+```shell-session
+$ vault kv metadata patch -mount=secret -delete-version-after="3h25m19s" creds
+```
+
+**NOTE:** If not set, the backend's configured Delete-Version-After is used. If
+set to a duration greater than the backend's, the backend's Delete-Version-After
+setting will be used. Any changes to the Delete-Version-After setting will only
+be applied to new versions.
+
+Add or update custom metadata without replacing existing custom metadata keys:
+
+```shell-session
+$ vault kv metadata patch -mount=secret \
+    -custom-metadata=foo=abc \
+    -custom-metadata=bar=123 \
+    creds
+Success! Data written to: secret/metadata/creds
+```
+
+Remove a custom metadata key from the key "creds":
+
+```shell-session
+$ vault kv metadata patch -mount=secret -remove-custom-metadata=bar creds
+Success! Data written to: secret/metadata/creds
+```
+
+#### Output options
+
+- `-format` `(string: "table")` - Print the output in the given format. Valid
+  formats are "table", "json", or "yaml". This can also be specified via the
+  `VAULT_FORMAT` environment variable.
+
+#### Subcommand options
+
+- `-cas-required` `(bool: false)` - If true the key will require the cas
+  parameter to be set on all write requests. If false, the backend’s
+  configuration will be used. The default is false.
+
+- `-max-versions` `(int: 0)` - The number of versions to keep per key. If not
+  set, the backend’s configured max version is used. Once a key has more than the
+  configured allowed versions the oldest version will be permanently deleted.
+
+- `-delete-version-after` `(string:"0s")` – Set the `delete-version-after` value
+  to a duration to specify the `deletion_time` for all new versions written to
+  this key. If not set, the backend's `delete_version_after` will be used. If
+  the value is greater than the backend's `delete_version_after`, the backend's
+  `delete_version_after` will be used. Accepts [duration format strings](/vault/docs/concepts/duration-format).
+
+- `-custom-metadata` `(string: "")` - Specifies a key-value pair for the
+  `custom_metadata` field. This can be specified multiple times to add or update
+  multiple pieces of metadata. Existing custom metadata keys that are not listed
+  are left unchanged.
+
+- `-remove-custom-metadata` `(string: "")` - Specifies a custom metadata key to
+  remove. This can be specified multiple times to remove multiple keys.
+
+- `-mount` `(string: "")` - Specifies the path where the KV backend is mounted. 
+  If specified, the next argument will be interpreted as the secret path. If 
+  this flag is not specified, the next argument will be interpreted as the 
+  combined mount path and secret path, with /metadata/ automatically appended
+  between KV v2 secrets.
 
 ### kv metadata put
 

--- a/content/vault/v1.21.x/content/docs/commands/kv/metadata.mdx
+++ b/content/vault/v1.21.x/content/docs/commands/kv/metadata.mdx
@@ -29,6 +29,7 @@ Usage: vault kv metadata <subcommand> [options] [args]
 Subcommands:
     delete    Deletes all versions and metadata for a key in the KV store
     get       Retrieves key metadata from the KV store
+    patch     Patches key settings in the KV store
     put       Sets or updates key settings in the KV store
 ```
 
@@ -87,6 +88,108 @@ destroyed        false
 
 ...
 ```
+
+### kv metadata patch
+
+The `kv metadata patch` command patches key settings for a specified key in
+the KV v2 secrets engine. It applies a JSON merge patch, which is useful for
+updating individual metadata fields and for adding, updating, or removing
+custom metadata keys without replacing the entire `custom_metadata` map. You can
+also use it to create a blank key.
+
+#### Examples
+
+Create a key in the KV v2 with no data at the key "creds":
+
+```shell-session
+$ vault kv metadata patch -mount=secret creds
+Success! Data written to: secret/metadata/creds
+```
+
+Set the maximum number of versions to keep for the key "creds":
+
+```shell-session
+$ vault kv metadata patch -mount=secret -max-versions=5 creds
+Success! Data written to: secret/metadata/creds
+```
+
+**NOTE:** If not set, the backend’s configured max version is used. Once a key
+has more than the configured allowed versions the oldest version will be
+permanently deleted.
+
+Require Check-and-Set for the key "creds":
+
+```shell-session
+$ vault kv metadata patch -mount=secret -cas-required creds
+```
+
+**NOTE:** When check-and-set is required, the key will require the `cas`
+parameter to be set on all write requests. Otherwise, the backend’s
+configuration will be used.
+
+Set the length of time before a version is deleted for the key "creds":
+
+```shell-session
+$ vault kv metadata patch -mount=secret -delete-version-after="3h25m19s" creds
+```
+
+**NOTE:** If not set, the backend's configured Delete-Version-After is used. If
+set to a duration greater than the backend's, the backend's Delete-Version-After
+setting will be used. Any changes to the Delete-Version-After setting will only
+be applied to new versions.
+
+Add or update custom metadata without replacing existing custom metadata keys:
+
+```shell-session
+$ vault kv metadata patch -mount=secret \
+    -custom-metadata=foo=abc \
+    -custom-metadata=bar=123 \
+    creds
+Success! Data written to: secret/metadata/creds
+```
+
+Remove a custom metadata key from the key "creds":
+
+```shell-session
+$ vault kv metadata patch -mount=secret -remove-custom-metadata=bar creds
+Success! Data written to: secret/metadata/creds
+```
+
+#### Output options
+
+- `-format` `(string: "table")` - Print the output in the given format. Valid
+  formats are "table", "json", or "yaml". This can also be specified via the
+  `VAULT_FORMAT` environment variable.
+
+#### Subcommand options
+
+- `-cas-required` `(bool: false)` - If true the key will require the cas
+  parameter to be set on all write requests. If false, the backend’s
+  configuration will be used. The default is false.
+
+- `-max-versions` `(int: 0)` - The number of versions to keep per key. If not
+  set, the backend’s configured max version is used. Once a key has more than the
+  configured allowed versions the oldest version will be permanently deleted.
+
+- `-delete-version-after` `(string:"0s")` – Set the `delete-version-after` value
+  to a duration to specify the `deletion_time` for all new versions written to
+  this key. If not set, the backend's `delete_version_after` will be used. If
+  the value is greater than the backend's `delete_version_after`, the backend's
+  `delete_version_after` will be used. Accepts [duration format strings](/vault/docs/concepts/duration-format).
+
+- `-custom-metadata` `(string: "")` - Specifies a key-value pair for the
+  `custom_metadata` field. This can be specified multiple times to add or update
+  multiple pieces of metadata. Existing custom metadata keys that are not listed
+  are left unchanged.
+
+- `-remove-custom-metadata` `(string: "")` - Specifies a custom metadata key to
+  remove. This can be specified multiple times to remove multiple keys.
+
+- `-mount` `(string: "")` - Specifies the path where the KV backend is mounted. 
+  If specified, the next argument will be interpreted as the secret path. If 
+  this flag is not specified, the next argument will be interpreted as the 
+  combined mount path and secret path, with /metadata/ automatically appended
+  between KV v2 secrets.
 
 ### kv metadata put
 

--- a/content/vault/v2.x/content/docs/commands/kv/metadata.mdx
+++ b/content/vault/v2.x/content/docs/commands/kv/metadata.mdx
@@ -29,6 +29,7 @@ Usage: vault kv metadata <subcommand> [options] [args]
 Subcommands:
     delete    Deletes all versions and metadata for a key in the KV store
     get       Retrieves key metadata from the KV store
+    patch     Patches key settings in the KV store
     put       Sets or updates key settings in the KV store
 ```
 
@@ -87,6 +88,108 @@ destroyed        false
 
 ...
 ```
+
+### kv metadata patch
+
+The `kv metadata patch` command patches key settings for a specified key in
+the KV v2 secrets engine. It applies a JSON merge patch, which is useful for
+updating individual metadata fields and for adding, updating, or removing
+custom metadata keys without replacing the entire `custom_metadata` map. You can
+also use it to create a blank key.
+
+#### Examples
+
+Create a key in the KV v2 with no data at the key "creds":
+
+```shell-session
+$ vault kv metadata patch -mount=secret creds
+Success! Data written to: secret/metadata/creds
+```
+
+Set the maximum number of versions to keep for the key "creds":
+
+```shell-session
+$ vault kv metadata patch -mount=secret -max-versions=5 creds
+Success! Data written to: secret/metadata/creds
+```
+
+**NOTE:** If not set, the backend’s configured max version is used. Once a key
+has more than the configured allowed versions the oldest version will be
+permanently deleted.
+
+Require Check-and-Set for the key "creds":
+
+```shell-session
+$ vault kv metadata patch -mount=secret -cas-required creds
+```
+
+**NOTE:** When check-and-set is required, the key will require the `cas`
+parameter to be set on all write requests. Otherwise, the backend’s
+configuration will be used.
+
+Set the length of time before a version is deleted for the key "creds":
+
+```shell-session
+$ vault kv metadata patch -mount=secret -delete-version-after="3h25m19s" creds
+```
+
+**NOTE:** If not set, the backend's configured Delete-Version-After is used. If
+set to a duration greater than the backend's, the backend's Delete-Version-After
+setting will be used. Any changes to the Delete-Version-After setting will only
+be applied to new versions.
+
+Add or update custom metadata without replacing existing custom metadata keys:
+
+```shell-session
+$ vault kv metadata patch -mount=secret \
+    -custom-metadata=foo=abc \
+    -custom-metadata=bar=123 \
+    creds
+Success! Data written to: secret/metadata/creds
+```
+
+Remove a custom metadata key from the key "creds":
+
+```shell-session
+$ vault kv metadata patch -mount=secret -remove-custom-metadata=bar creds
+Success! Data written to: secret/metadata/creds
+```
+
+#### Output options
+
+- `-format` `(string: "table")` - Print the output in the given format. Valid
+  formats are "table", "json", or "yaml". This can also be specified via the
+  `VAULT_FORMAT` environment variable.
+
+#### Subcommand options
+
+- `-cas-required` `(bool: false)` - If true the key will require the cas
+  parameter to be set on all write requests. If false, the backend’s
+  configuration will be used. The default is false.
+
+- `-max-versions` `(int: 0)` - The number of versions to keep per key. If not
+  set, the backend’s configured max version is used. Once a key has more than the
+  configured allowed versions the oldest version will be permanently deleted.
+
+- `-delete-version-after` `(string:"0s")` – Set the `delete-version-after` value
+  to a duration to specify the `deletion_time` for all new versions written to
+  this key. If not set, the backend's `delete_version_after` will be used. If
+  the value is greater than the backend's `delete_version_after`, the backend's
+  `delete_version_after` will be used. Accepts [duration format strings](/vault/docs/concepts/duration-format).
+
+- `-custom-metadata` `(string: "")` - Specifies a key-value pair for the
+  `custom_metadata` field. This can be specified multiple times to add or update
+  multiple pieces of metadata. Existing custom metadata keys that are not listed
+  are left unchanged.
+
+- `-remove-custom-metadata` `(string: "")` - Specifies a custom metadata key to
+  remove. This can be specified multiple times to remove multiple keys.
+
+- `-mount` `(string: "")` - Specifies the path where the KV backend is mounted. 
+  If specified, the next argument will be interpreted as the secret path. If 
+  this flag is not specified, the next argument will be interpreted as the 
+  combined mount path and secret path, with /metadata/ automatically appended
+  between KV v2 secrets.
 
 ### kv metadata put
 


### PR DESCRIPTION
## Summary

Documents the missing `vault kv metadata patch` CLI subcommand on the [kv metadata](https://developer.hashicorp.com/vault/docs/commands/kv/metadata) docs page.

The binary has supported `vault kv metadata patch` (including partial custom-metadata updates and `-remove-custom-metadata`) since KV metadata HTTP PATCH support was added, but the published CLI docs only listed `delete`, `get`, and `put`.

### Changes

- Add `patch` to the subcommands list
- Document `kv metadata patch` usage, examples, and flags (including `-custom-metadata` merge behavior and `-remove-custom-metadata`)
- Apply the same docs update across currently published Vault versions: `v2.x` (latest), `v1.21.x`–`v1.16.x`

Fixes hashicorp/vault#30954

## Test plan

- [x] Compared docs against `command/kv_metadata_patch.go` help text and flags
- [x] Matched existing `kv metadata put` docs structure and style
- [x] Verified all seven versioned `metadata.mdx` files include the new section