### PR TITLE
docs(nomad): correct coalesce empty-string behavior

### DIFF
--- a/content/nomad/v1.11.x/content/docs/reference/hcl2/functions/collection/coalesce.mdx
+++ b/content/nomad/v1.11.x/content/docs/reference/hcl2/functions/collection/coalesce.mdx
@@ -3,7 +3,7 @@ layout: docs
 page_title: coalesce - Functions - Configuration Language
 description: |-
   The coalesce function takes any number of arguments and returns the
-  first one that isn't null nor empty.
+  first one that isn't null.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-11-17T20:24:06-05:00
 last_modified: 2025-11-17T20:24:06-05:00
@@ -12,25 +12,36 @@ last_modified: 2025-11-17T20:24:06-05:00
 
 # `coalesce` Function
 
-`coalesce` takes any number of arguments and returns the first one
-that isn't null or an empty string.
+`coalesce` takes any number of arguments and returns the first one that isn't
+null. Empty strings are valid values and are **not** skipped. If every argument
+is null, the function returns an error.
 
 ## Examples
 
 ```shell-session
 > coalesce("a", "b")
 a
-> coalesce("", "b")
+> coalesce(null, "b")
 b
+> coalesce("", "b")
+""
 > coalesce(1,2)
 1
 ```
 
-To perform the `coalesce` operation with a list of strings, use the `...`
+To perform the `coalesce` operation with a list of values, use the `...`
 symbol to expand the list as arguments:
 
 ```shell-session
-> coalesce(["", "b"]...)
+> coalesce([null, "b"]...)
+b
+```
+
+To skip empty strings as well as null values, filter with
+[`compact`](/nomad/docs/reference/hcl2/functions/collection/compact) first:
+
+```shell-session
+> compact(["", "b"])[0]
 b
 ```
 
@@ -38,3 +49,4 @@ b
 
 - [`coalescelist`](/nomad/docs/reference/hcl2/functions/collection/coalescelist) performs a similar operation with
   list arguments rather than individual arguments.
+- [`compact`](/nomad/docs/reference/hcl2/functions/collection/compact) removes empty strings from a list of strings.

--- a/content/nomad/v2.0.x/content/docs/reference/hcl2/functions/collection/coalesce.mdx
+++ b/content/nomad/v2.0.x/content/docs/reference/hcl2/functions/collection/coalesce.mdx
@@ -3,7 +3,7 @@ layout: docs
 page_title: coalesce - Functions - Configuration Language
 description: |-
   The coalesce function takes any number of arguments and returns the
-  first one that isn't null nor empty.
+  first one that isn't null.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2026-02-16T16:54:05.000Z
 last_modified: 2026-02-16T16:54:05.000Z
@@ -12,25 +12,36 @@ last_modified: 2026-02-16T16:54:05.000Z
 
 # `coalesce` Function
 
-`coalesce` takes any number of arguments and returns the first one
-that isn't null or an empty string.
+`coalesce` takes any number of arguments and returns the first one that isn't
+null. Empty strings are valid values and are **not** skipped. If every argument
+is null, the function returns an error.
 
 ## Examples
 
 ```shell-session
 > coalesce("a", "b")
 a
-> coalesce("", "b")
+> coalesce(null, "b")
 b
+> coalesce("", "b")
+""
 > coalesce(1,2)
 1
 ```
 
-To perform the `coalesce` operation with a list of strings, use the `...`
+To perform the `coalesce` operation with a list of values, use the `...`
 symbol to expand the list as arguments:
 
 ```shell-session
-> coalesce(["", "b"]...)
+> coalesce([null, "b"]...)
+b
+```
+
+To skip empty strings as well as null values, filter with
+[`compact`](/nomad/docs/reference/hcl2/functions/collection/compact) first:
+
+```shell-session
+> compact(["", "b"])[0]
 b
 ```
 
@@ -38,3 +49,4 @@ b
 
 - [`coalescelist`](/nomad/docs/reference/hcl2/functions/collection/coalescelist) performs a similar operation with
   list arguments rather than individual arguments.
+- [`compact`](/nomad/docs/reference/hcl2/functions/collection/compact) removes empty strings from a list of strings.


### PR DESCRIPTION
## Summary

The `coalesce` docs said the function returns the first argument that isn't null **or an empty string**, and the examples showed `coalesce("", "b")` returning `b`.

That doesn't match the implementation. Nomad wires `coalesce` to go-cty's `stdlib.CoalesceFunc`, which only skips **null** values. An empty string is a real value, so:

```hcl
coalesce("", "foo")  # => ""
```

This came up in hashicorp/nomad#15599 and was confirmed as a docs issue.

This PR:

- Aligns the description with the null-only behavior
- Fixes the examples (`null` is skipped; `""` is not)
- Points people who want to skip empty strings at `compact`

Updated for the current docs version (`v2.0.x`) and `v1.11.x`.

Fixes hashicorp/nomad#15599

## Test plan

- [x] Compared against go-cty `CoalesceFunc` and Nomad's `jobspec2` function table
- [x] Examples match observed behavior (`coalesce("", "b")` => `""`)
- [ ] Docs preview / tech writer review