### PR TITLE
docs(nomad): explain how to bind ports to 0.0.0.0

### DIFF
--- a/content/nomad/v1.11.x/content/docs/configuration/client.mdx
+++ b/content/nomad/v1.11.x/content/docs/configuration/client.mdx
@@ -259,6 +259,14 @@ client {
   Although this parameter defaults to nil, Nomad creates a host network named "default"
   using the [`network_interface`](#network_interface) field.
 
+- `bind_wildcard_default_host_network` `(bool: true)` - When no custom
+  [`host_network`](#host_network-block) blocks are defined, controls whether
+  `bridge`/`cni/*` port-mapping rules match any destination address (`true`, the
+  default) or only the IP of the default host network (`false`). When one or more
+  `host_network` blocks are defined, this setting is ignored and port mapping
+  always uses the selected host network address. Set this to `false` only when
+  you need host ports published exclusively on the default interface IP.
+
 - `drain_on_shutdown` <code>([drain_on_shutdown](#drain_on_shutdown-block):
   nil)</code> - Controls the behavior of the client when
   [`leave_on_interrupt`][] or [`leave_on_terminate`][] are set and the client

--- a/content/nomad/v1.11.x/content/docs/configuration/client.mdx
+++ b/content/nomad/v1.11.x/content/docs/configuration/client.mdx
@@ -261,7 +261,7 @@ client {
 
 - `bind_wildcard_default_host_network` `(bool: true)` - When no custom
   [`host_network`](#host_network-block) blocks are defined, controls whether
-  `bridge`/`cni/*` port-mapping rules match any destination address (`true`, the
+  `bridge` or `cni/*` port-mapping rules match any destination address (`true`, the
   default) or only the IP of the default host network (`false`). When one or more
   `host_network` blocks are defined, this setting is ignored and port mapping
   always uses the selected host network address. Set this to `false` only when

--- a/content/nomad/v1.11.x/content/docs/job-specification/network.mdx
+++ b/content/nomad/v1.11.x/content/docs/job-specification/network.mdx
@@ -125,11 +125,30 @@ port "foo" {}
 
 When the task starts, it will be passed the following environment variables:
 
-- <tt>NOMAD_IP_foo</tt> - The IP to bind on for the given port label.
+- <tt>NOMAD_IP_foo</tt> - The host IP allocated for the given port label.
 - <tt>NOMAD_PORT_foo</tt> - The port value for the given port label.
 - <tt>NOMAD_ADDR_foo</tt> - A combined <tt>ip:port</tt> that can be used for convenience.
 
 The label of the port is just text - it has no special meaning to Nomad.
+
+#### Binding to `0.0.0.0`
+
+The `port` block allocates a host IP and port. It does **not** set the address
+your process listens on inside its network namespace. Configure that in the
+application:
+
+- Bind to `0.0.0.0` (all addresses in the namespace) with `NOMAD_PORT_<label>`
+  when the service should accept traffic forwarded on any interface.
+- Bind to `NOMAD_IP_<label>` when the service should listen only on the
+  scheduled host address.
+- Bind to `127.0.0.1` when the service should stay private to the allocation
+  (common with [`bridge`](#bridge) mode and a service mesh proxy).
+
+Host-side port publishing still uses the allocated host network address (see
+[`host_network`](#host_network)). For `bridge`/`cni/*` mode when the client has
+no custom [`host_network`](/nomad/docs/configuration/client#host_network)
+blocks, port-mapping rules match any destination address by default. Refer to
+[`bind_wildcard_default_host_network`](/nomad/docs/configuration/client#bind_wildcard_default_host_network).
 
 ## `dns` parameters
 
@@ -360,6 +379,11 @@ If `host_network` is set for a port, Nomad will schedule the allocations on a no
 If not set the "default" host network is used which is commonly the address with a default route associated with it.
 
 When Nomad does port mapping for ports with a defined `host_network`, the port mapping rule will use the host address as the destination address.
+Task drivers such as Docker publish the host port on that same address. There
+is no `port` attribute that publishes the host side as `0.0.0.0`; use a
+`host_network` that matches the interfaces you need, or rely on the default
+wildcard mapping behavior described in
+[Binding to `0.0.0.0`](#binding-to-0-0-0-0).
 
 ```hcl
 network {
@@ -375,6 +399,47 @@ network {
   port "admin" {
     to           = 9000
     host_network = "private"
+  }
+}
+```
+
+### Bind on all addresses
+
+This example maps a dynamic host port to container port `8080`. The process
+listens on `0.0.0.0:8080` inside the container so it accepts forwarded traffic:
+
+```hcl
+job "http" {
+  group "api" {
+    network {
+      port "http" {
+        to = 8080
+      }
+    }
+
+    task "server" {
+      driver = "docker"
+
+      config {
+        image = "hashicorp/http-echo:latest"
+        args  = ["-listen", ":8080", "-text", "hello"]
+        ports = ["http"]
+      }
+    }
+  }
+}
+```
+
+When the task uses the host network namespace and a dynamic port, pass
+`0.0.0.0` as the listen address and `NOMAD_PORT_<label>` as the port:
+
+```hcl
+task "server" {
+  driver = "raw_exec"
+
+  config {
+    command = "/usr/local/bin/my-service"
+    args    = ["--bind", "0.0.0.0", "--port", "${NOMAD_PORT_http}"]
   }
 }
 ```

--- a/content/nomad/v1.11.x/content/docs/job-specification/network.mdx
+++ b/content/nomad/v1.11.x/content/docs/job-specification/network.mdx
@@ -139,13 +139,15 @@ application:
 
 - Bind to `0.0.0.0` (all addresses in the namespace) with `NOMAD_PORT_<label>`
   when the service should accept traffic forwarded on any interface.
-- Bind to `NOMAD_IP_<label>` when the service should listen only on the
-  scheduled host address.
+- Bind to `NOMAD_ALLOC_IP_<label>` when the service should listen only on the
+  allocation address (the IP that host port mapping forwards to in bridge/CNI mode).
+- Bind to `NOMAD_IP_<label>` only in `host` network mode, when the process shares
+  the host network namespace and should listen on the scheduled host address.
 - Bind to `127.0.0.1` when the service should stay private to the allocation
   (common with [`bridge`](#bridge) mode and a service mesh proxy).
 
-Host-side port publishing still uses the allocated host network address (see
-[`host_network`](#host_network)). For `bridge`/`cni/*` mode when the client has
+Host-side port publishing uses the allocated host network address (see
+[`host_network`](#host_network)). For `bridge` or `cni/*` mode when the client has
 no custom [`host_network`](/nomad/docs/configuration/client#host_network)
 blocks, port-mapping rules match any destination address by default. Refer to
 [`bind_wildcard_default_host_network`](/nomad/docs/configuration/client#bind_wildcard_default_host_network).

--- a/content/nomad/v1.11.x/content/docs/networking/index.mdx
+++ b/content/nomad/v1.11.x/content/docs/networking/index.mdx
@@ -106,6 +106,32 @@ When using IP and port to connect allocations it is important to make sure your
 network topology and routing configuration allow the Nomad clients to
 communicate with each other.
 
+### Binding addresses and `0.0.0.0`
+
+Nomad's [`port`](/nomad/docs/job-specification/network#port-parameters) stanza
+reserves a host IP and port. Your workload still chooses the listen address
+inside its network namespace:
+
+| Listen address | Typical use |
+| --- | --- |
+| `0.0.0.0` | Accept connections on every address in the namespace. Use this when traffic is forwarded from the host (or other interfaces) and the process should not pin itself to a single IP. Pair it with [`NOMAD_PORT_<label>`](/nomad/docs/reference/runtime-environment-settings#network-related-variables) (host mode) or the mapped `to` port (bridge mode). |
+| `NOMAD_IP_<label>` | Listen only on the host IP Nomad allocated for that port. |
+| `127.0.0.1` | Keep the service private to the allocation (common with bridge mode and a service mesh proxy). |
+
+There is no job-level field that sets the host publish address to `0.0.0.0`.
+Host-side mapping uses the address of the selected
+[`host_network`](/nomad/docs/job-specification/network#host-networks) (the
+`"default"` network when unset). For `bridge` and `cni/*` modes, when the
+client defines no custom
+[`host_network`](/nomad/docs/configuration/client#host_network) blocks,
+[`bind_wildcard_default_host_network`](/nomad/docs/configuration/client#bind_wildcard_default_host_network)
+defaults to `true` so mapping rules match any destination address on the host
+port. Defining client `host_network` blocks pins mapping to those addresses
+instead.
+
+Refer to the [network block](/nomad/docs/job-specification/network#binding-to-0-0-0-0)
+reference for complete examples.
+
 ## Bridge networking
 
 Linux clients support a network

--- a/content/nomad/v2.0.x/content/docs/configuration/client.mdx
+++ b/content/nomad/v2.0.x/content/docs/configuration/client.mdx
@@ -259,6 +259,14 @@ client {
   Although this parameter defaults to nil, Nomad creates a host network named "default"
   using the [`network_interface`](#network_interface) field.
 
+- `bind_wildcard_default_host_network` `(bool: true)` - When no custom
+  [`host_network`](#host_network-block) blocks are defined, controls whether
+  `bridge`/`cni/*` port-mapping rules match any destination address (`true`, the
+  default) or only the IP of the default host network (`false`). When one or more
+  `host_network` blocks are defined, this setting is ignored and port mapping
+  always uses the selected host network address. Set this to `false` only when
+  you need host ports published exclusively on the default interface IP.
+
 - `drain_on_shutdown` <code>([drain_on_shutdown](#drain_on_shutdown-block):
   nil)</code> - Controls the behavior of the client when
   [`leave_on_interrupt`][] or [`leave_on_terminate`][] are set and the client

--- a/content/nomad/v2.0.x/content/docs/configuration/client.mdx
+++ b/content/nomad/v2.0.x/content/docs/configuration/client.mdx
@@ -261,7 +261,7 @@ client {
 
 - `bind_wildcard_default_host_network` `(bool: true)` - When no custom
   [`host_network`](#host_network-block) blocks are defined, controls whether
-  `bridge`/`cni/*` port-mapping rules match any destination address (`true`, the
+  `bridge` or `cni/*` port-mapping rules match any destination address (`true`, the
   default) or only the IP of the default host network (`false`). When one or more
   `host_network` blocks are defined, this setting is ignored and port mapping
   always uses the selected host network address. Set this to `false` only when

--- a/content/nomad/v2.0.x/content/docs/job-specification/network.mdx
+++ b/content/nomad/v2.0.x/content/docs/job-specification/network.mdx
@@ -125,11 +125,30 @@ port "foo" {}
 
 When the task starts, it will be passed the following environment variables:
 
-- <tt>NOMAD_IP_foo</tt> - The IP to bind on for the given port label.
+- <tt>NOMAD_IP_foo</tt> - The host IP allocated for the given port label.
 - <tt>NOMAD_PORT_foo</tt> - The port value for the given port label.
 - <tt>NOMAD_ADDR_foo</tt> - A combined <tt>ip:port</tt> that can be used for convenience.
 
 The label of the port is just text - it has no special meaning to Nomad.
+
+#### Binding to `0.0.0.0`
+
+The `port` block allocates a host IP and port. It does **not** set the address
+your process listens on inside its network namespace. Configure that in the
+application:
+
+- Bind to `0.0.0.0` (all addresses in the namespace) with `NOMAD_PORT_<label>`
+  when the service should accept traffic forwarded on any interface.
+- Bind to `NOMAD_IP_<label>` when the service should listen only on the
+  scheduled host address.
+- Bind to `127.0.0.1` when the service should stay private to the allocation
+  (common with [`bridge`](#bridge) mode and a service mesh proxy).
+
+Host-side port publishing still uses the allocated host network address (see
+[`host_network`](#host_network)). For `bridge`/`cni/*` mode when the client has
+no custom [`host_network`](/nomad/docs/configuration/client#host_network)
+blocks, port-mapping rules match any destination address by default. Refer to
+[`bind_wildcard_default_host_network`](/nomad/docs/configuration/client#bind_wildcard_default_host_network).
 
 ## `dns` parameters
 
@@ -360,6 +379,11 @@ If `host_network` is set for a port, Nomad will schedule the allocations on a no
 If not set the "default" host network is used which is commonly the address with a default route associated with it.
 
 When Nomad does port mapping for ports with a defined `host_network`, the port mapping rule will use the host address as the destination address.
+Task drivers such as Docker publish the host port on that same address. There
+is no `port` attribute that publishes the host side as `0.0.0.0`; use a
+`host_network` that matches the interfaces you need, or rely on the default
+wildcard mapping behavior described in
+[Binding to `0.0.0.0`](#binding-to-0-0-0-0).
 
 ```hcl
 network {
@@ -375,6 +399,47 @@ network {
   port "admin" {
     to           = 9000
     host_network = "private"
+  }
+}
+```
+
+### Bind on all addresses
+
+This example maps a dynamic host port to container port `8080`. The process
+listens on `0.0.0.0:8080` inside the container so it accepts forwarded traffic:
+
+```hcl
+job "http" {
+  group "api" {
+    network {
+      port "http" {
+        to = 8080
+      }
+    }
+
+    task "server" {
+      driver = "docker"
+
+      config {
+        image = "hashicorp/http-echo:latest"
+        args  = ["-listen", ":8080", "-text", "hello"]
+        ports = ["http"]
+      }
+    }
+  }
+}
+```
+
+When the task uses the host network namespace and a dynamic port, pass
+`0.0.0.0` as the listen address and `NOMAD_PORT_<label>` as the port:
+
+```hcl
+task "server" {
+  driver = "raw_exec"
+
+  config {
+    command = "/usr/local/bin/my-service"
+    args    = ["--bind", "0.0.0.0", "--port", "${NOMAD_PORT_http}"]
   }
 }
 ```

--- a/content/nomad/v2.0.x/content/docs/job-specification/network.mdx
+++ b/content/nomad/v2.0.x/content/docs/job-specification/network.mdx
@@ -139,13 +139,15 @@ application:
 
 - Bind to `0.0.0.0` (all addresses in the namespace) with `NOMAD_PORT_<label>`
   when the service should accept traffic forwarded on any interface.
-- Bind to `NOMAD_IP_<label>` when the service should listen only on the
-  scheduled host address.
+- Bind to `NOMAD_ALLOC_IP_<label>` when the service should listen only on the
+  allocation address (the IP that host port mapping forwards to in bridge/CNI mode).
+- Bind to `NOMAD_IP_<label>` only in `host` network mode, when the process shares
+  the host network namespace and should listen on the scheduled host address.
 - Bind to `127.0.0.1` when the service should stay private to the allocation
   (common with [`bridge`](#bridge) mode and a service mesh proxy).
 
-Host-side port publishing still uses the allocated host network address (see
-[`host_network`](#host_network)). For `bridge`/`cni/*` mode when the client has
+Host-side port publishing uses the allocated host network address (see
+[`host_network`](#host_network)). For `bridge` or `cni/*` mode when the client has
 no custom [`host_network`](/nomad/docs/configuration/client#host_network)
 blocks, port-mapping rules match any destination address by default. Refer to
 [`bind_wildcard_default_host_network`](/nomad/docs/configuration/client#bind_wildcard_default_host_network).

--- a/content/nomad/v2.0.x/content/docs/networking/index.mdx
+++ b/content/nomad/v2.0.x/content/docs/networking/index.mdx
@@ -106,6 +106,32 @@ When using IP and port to connect allocations it is important to make sure your
 network topology and routing configuration allow the Nomad clients to
 communicate with each other.
 
+### Binding addresses and `0.0.0.0`
+
+Nomad's [`port`](/nomad/docs/job-specification/network#port-parameters) stanza
+reserves a host IP and port. Your workload still chooses the listen address
+inside its network namespace:
+
+| Listen address | Typical use |
+| --- | --- |
+| `0.0.0.0` | Accept connections on every address in the namespace. Use this when traffic is forwarded from the host (or other interfaces) and the process should not pin itself to a single IP. Pair it with [`NOMAD_PORT_<label>`](/nomad/docs/reference/runtime-environment-settings#network-related-variables) (host mode) or the mapped `to` port (bridge mode). |
+| `NOMAD_IP_<label>` | Listen only on the host IP Nomad allocated for that port. |
+| `127.0.0.1` | Keep the service private to the allocation (common with bridge mode and a service mesh proxy). |
+
+There is no job-level field that sets the host publish address to `0.0.0.0`.
+Host-side mapping uses the address of the selected
+[`host_network`](/nomad/docs/job-specification/network#host-networks) (the
+`"default"` network when unset). For `bridge` and `cni/*` modes, when the
+client defines no custom
+[`host_network`](/nomad/docs/configuration/client#host_network) blocks,
+[`bind_wildcard_default_host_network`](/nomad/docs/configuration/client#bind_wildcard_default_host_network)
+defaults to `true` so mapping rules match any destination address on the host
+port. Defining client `host_network` blocks pins mapping to those addresses
+instead.
+
+Refer to the [network block](/nomad/docs/job-specification/network#binding-to-0-0-0-0)
+reference for complete examples.
+
 ## Bridge networking
 
 Linux clients support a network


### PR DESCRIPTION
## Summary

Folks looking at the job `port` docs often assume there is a field that makes Nomad publish or listen on `0.0.0.0`. There isn't — the stanza reserves a host IP/port, and the process still chooses its listen address. That gap showed up in hashicorp/nomad#18338 (and related discussion around multi-interface hosts).

This PR spells out the two layers:

1. **Inside the workload** — bind to `0.0.0.0`, `NOMAD_IP_<label>`, or `127.0.0.1` depending on who should reach the process.
2. **On the host** — publishing uses the selected `host_network` address. For bridge/CNI with no custom client `host_network` blocks, `bind_wildcard_default_host_network` (default `true`) matches any destination on that host port.

Also documents the previously missing `bind_wildcard_default_host_network` client option, with Docker/`raw_exec` examples.

Updated `v2.0.x` (latest) and `v1.11.x`.

Fixes hashicorp/nomad#18338

## Test plan

- [x] Cross-checked against client `bind_wildcard_default_host_network` / host network allocation code paths
- [x] Examples use existing job fields only (`port`, `to`, `ports`, driver config)
- [ ] Docs preview / tech writer review