### PR TITLE
docs(vault): correct TTL duration suffix docs for PKI/SSH roles

### DIFF
--- a/content/vault/v1.16.x/content/api-docs/secret/pki.mdx
+++ b/content/vault/v1.16.x/content/api-docs/secret/pki.mdx
@@ -3315,13 +3315,13 @@ request is denied.
 
 - `ttl` `(string: "")` - Specifies the Time To Live value to be used for the
   validity period of the requested certificate, provided as a string duration
-  with time suffix. Hour is the largest suffix. The value specified is strictly
+  using [duration format strings](/vault/docs/concepts/duration-format). The value specified is strictly
   used for future validity. If not set, uses the system default value or the
   value of `max_ttl`, whichever is shorter. See `not_after` as an alternative
   for setting an absolute end date (rather than a relative one).
 
 - `max_ttl` `(string: "")` - Specifies the maximum Time To Live provided as a
-  string duration with time suffix. Hour is the largest suffix. If not set,
+  string duration using [duration format strings](/vault/docs/concepts/duration-format). If not set,
   defaults to the system maximum lease TTL.
 
 - `allow_localhost` `(bool: true)` - Specifies if clients can request

--- a/content/vault/v1.16.x/content/api-docs/secret/ssh.mdx
+++ b/content/vault/v1.16.x/content/api-docs/secret/ssh.mdx
@@ -91,11 +91,11 @@ This endpoint creates or updates a named role.
   permitted.
 
 - `ttl` `(string: "")` – Specifies the Time To Live value provided as a string
-  duration with time suffix. Hour is the largest suffix. If not set, uses the
+  duration using [duration format strings](/vault/docs/concepts/duration-format). If not set, uses the
   system default value or the value of `max_ttl`, whichever is shorter.
 
 - `max_ttl` `(string: "")` – Specifies the maximum Time To Live provided as a
-  string duration with time suffix. Hour is the largest suffix. If not set,
+  string duration using [duration format strings](/vault/docs/concepts/duration-format). If not set,
   defaults to the system maximum lease TTL.
 
 - `allowed_critical_options` `(string: "")` – Specifies a comma-separated list

--- a/content/vault/v1.17.x/content/api-docs/secret/pki.mdx
+++ b/content/vault/v1.17.x/content/api-docs/secret/pki.mdx
@@ -432,7 +432,7 @@ mount.
    ACME is disabled, all requests to ACME directory URLs will return 404.
 
  - `max_ttl` `(string: "")` - Specifies the maximum Time To Live provided as a
-   string duration with time suffix. Hour is the largest suffix. If not set,
+   string duration using [duration format strings](/vault/docs/concepts/duration-format). If not set,
    defaults to the previous hard-coded behavior of 90 days (2160 hours).
 
 #### Sample payload
@@ -3424,13 +3424,13 @@ request is denied.
 
 - `ttl` `(string: "")` - Specifies the Time To Live value to be used for the
   validity period of the requested certificate, provided as a string duration
-  with time suffix. Hour is the largest suffix. The value specified is strictly
+  using [duration format strings](/vault/docs/concepts/duration-format). The value specified is strictly
   used for future validity. If not set, uses the system default value or the
   value of `max_ttl`, whichever is shorter. See `not_after` as an alternative
   for setting an absolute end date (rather than a relative one).
 
 - `max_ttl` `(string: "")` - Specifies the maximum Time To Live provided as a
-  string duration with time suffix. Hour is the largest suffix. If not set,
+  string duration using [duration format strings](/vault/docs/concepts/duration-format). If not set,
   defaults to the system maximum lease TTL.
 
 - `allow_localhost` `(bool: true)` - Specifies if clients can request

--- a/content/vault/v1.17.x/content/api-docs/secret/ssh.mdx
+++ b/content/vault/v1.17.x/content/api-docs/secret/ssh.mdx
@@ -91,11 +91,11 @@ This endpoint creates or updates a named role.
   permitted.
 
 - `ttl` `(string: "")` – Specifies the Time To Live value provided as a string
-  duration with time suffix. Hour is the largest suffix. If not set, uses the
+  duration using [duration format strings](/vault/docs/concepts/duration-format). If not set, uses the
   system default value or the value of `max_ttl`, whichever is shorter.
 
 - `max_ttl` `(string: "")` – Specifies the maximum Time To Live provided as a
-  string duration with time suffix. Hour is the largest suffix. If not set,
+  string duration using [duration format strings](/vault/docs/concepts/duration-format). If not set,
   defaults to the system maximum lease TTL.
 
 - `allowed_critical_options` `(string: "")` – Specifies a comma-separated list

--- a/content/vault/v1.18.x/content/api-docs/secret/pki/index.mdx
+++ b/content/vault/v1.18.x/content/api-docs/secret/pki/index.mdx
@@ -3102,13 +3102,13 @@ request is denied.
 
 - `ttl` `(string: "")` - Specifies the Time To Live value to be used for the
   validity period of the requested certificate, provided as a string duration
-  with time suffix. Hour is the largest suffix. The value specified is strictly
+  using [duration format strings](/vault/docs/concepts/duration-format). The value specified is strictly
   used for future validity. If not set, uses the system default value or the
   value of `max_ttl`, whichever is shorter. See `not_after` as an alternative
   for setting an absolute end date (rather than a relative one).
 
 - `max_ttl` `(string: "")` - Specifies the maximum Time To Live provided as a
-  string duration with time suffix. Hour is the largest suffix. If not set,
+  string duration using [duration format strings](/vault/docs/concepts/duration-format). If not set,
   defaults to the system maximum lease TTL.
 
 - `allow_localhost` `(bool: true)` - Specifies if clients can request

--- a/content/vault/v1.18.x/content/api-docs/secret/pki/issuance.mdx
+++ b/content/vault/v1.18.x/content/api-docs/secret/pki/issuance.mdx
@@ -331,7 +331,7 @@ mount.
    ACME is disabled, all requests to ACME directory URLs will return 404.
 
  - `max_ttl` `(string: "")` - Specifies the maximum Time To Live provided as a
-   string duration with time suffix. Hour is the largest suffix. If not set,
+   string duration using [duration format strings](/vault/docs/concepts/duration-format). If not set,
    defaults to the previous hard-coded behavior of 90 days (2160 hours).
 
 #### Sample payload

--- a/content/vault/v1.18.x/content/api-docs/secret/ssh.mdx
+++ b/content/vault/v1.18.x/content/api-docs/secret/ssh.mdx
@@ -91,11 +91,11 @@ This endpoint creates or updates a named role.
   permitted.
 
 - `ttl` `(string: "")` – Specifies the Time To Live value provided as a string
-  duration with time suffix. Hour is the largest suffix. If not set, uses the
+  duration using [duration format strings](/vault/docs/concepts/duration-format). If not set, uses the
   system default value or the value of `max_ttl`, whichever is shorter.
 
 - `max_ttl` `(string: "")` – Specifies the maximum Time To Live provided as a
-  string duration with time suffix. Hour is the largest suffix. If not set,
+  string duration using [duration format strings](/vault/docs/concepts/duration-format). If not set,
   defaults to the system maximum lease TTL.
 
 - `allowed_critical_options` `(string: "")` – Specifies a comma-separated list

--- a/content/vault/v1.19.x/content/api-docs/secret/pki/index.mdx
+++ b/content/vault/v1.19.x/content/api-docs/secret/pki/index.mdx
@@ -3189,13 +3189,13 @@ request is denied.
 
 - `ttl` `(string: "")` - Specifies the Time To Live value to be used for the
   validity period of the requested certificate, provided as a string duration
-  with time suffix. Hour is the largest suffix. The value specified is strictly
+  using [duration format strings](/vault/docs/concepts/duration-format). The value specified is strictly
   used for future validity. If not set, uses the system default value or the
   value of `max_ttl`, whichever is shorter. See `not_after` as an alternative
   for setting an absolute end date (rather than a relative one).
 
 - `max_ttl` `(string: "")` - Specifies the maximum Time To Live provided as a
-  string duration with time suffix. Hour is the largest suffix. If not set,
+  string duration using [duration format strings](/vault/docs/concepts/duration-format). If not set,
   defaults to the system maximum lease TTL.
 
 - `allow_localhost` `(bool: true)` - Specifies if clients can request

--- a/content/vault/v1.19.x/content/api-docs/secret/pki/issuance.mdx
+++ b/content/vault/v1.19.x/content/api-docs/secret/pki/issuance.mdx
@@ -338,7 +338,7 @@ mount.
    ACME is disabled, all requests to ACME directory URLs will return 404.
 
  - `max_ttl` `(string: "")` - Specifies the maximum Time To Live provided as a
-   string duration with time suffix. Hour is the largest suffix. If not set,
+   string duration using [duration format strings](/vault/docs/concepts/duration-format). If not set,
    defaults to the previous hard-coded behavior of 90 days (2160 hours).
 
  - `challenge_permitted_ip_ranges` `(list: [])` - List of CIDR blocks that are

--- a/content/vault/v1.19.x/content/api-docs/secret/ssh.mdx
+++ b/content/vault/v1.19.x/content/api-docs/secret/ssh.mdx
@@ -91,11 +91,11 @@ This endpoint creates or updates a named role.
   permitted.
 
 - `ttl` `(string: "")` – Specifies the Time To Live value provided as a string
-  duration with time suffix. Hour is the largest suffix. If not set, uses the
+  duration using [duration format strings](/vault/docs/concepts/duration-format). If not set, uses the
   system default value or the value of `max_ttl`, whichever is shorter.
 
 - `max_ttl` `(string: "")` – Specifies the maximum Time To Live provided as a
-  string duration with time suffix. Hour is the largest suffix. If not set,
+  string duration using [duration format strings](/vault/docs/concepts/duration-format). If not set,
   defaults to the system maximum lease TTL.
 
 - `allowed_critical_options` `(string: "")` – Specifies a comma-separated list

--- a/content/vault/v1.20.x/content/api-docs/secret/pki/index.mdx
+++ b/content/vault/v1.20.x/content/api-docs/secret/pki/index.mdx
@@ -3196,13 +3196,13 @@ request is denied.
 
 - `ttl` `(string: "")` - Specifies the Time To Live value to be used for the
   validity period of the requested certificate, provided as a string duration
-  with time suffix. Hour is the largest suffix. The value specified is strictly
+  using [duration format strings](/vault/docs/concepts/duration-format). The value specified is strictly
   used for future validity. If not set, uses the system default value or the
   value of `max_ttl`, whichever is shorter. See `not_after` as an alternative
   for setting an absolute end date (rather than a relative one).
 
 - `max_ttl` `(string: "")` - Specifies the maximum Time To Live provided as a
-  string duration with time suffix. Hour is the largest suffix. If not set,
+  string duration using [duration format strings](/vault/docs/concepts/duration-format). If not set,
   defaults to the system maximum lease TTL.
 
 - `allow_localhost` `(bool: true)` - Specifies if clients can request

--- a/content/vault/v1.20.x/content/api-docs/secret/pki/issuance.mdx
+++ b/content/vault/v1.20.x/content/api-docs/secret/pki/issuance.mdx
@@ -342,7 +342,7 @@ mount.
    ACME is disabled, all requests to ACME directory URLs will return 404.
 
  - `max_ttl` `(string: "")` - Specifies the maximum Time To Live provided as a
-   string duration with time suffix. Hour is the largest suffix. If not set,
+   string duration using [duration format strings](/vault/docs/concepts/duration-format). If not set,
    defaults to the previous hard-coded behavior of 90 days (2160 hours).
 
  - `challenge_permitted_ip_ranges` `(list: [])` - List of CIDR blocks that are

--- a/content/vault/v1.20.x/content/api-docs/secret/ssh.mdx
+++ b/content/vault/v1.20.x/content/api-docs/secret/ssh.mdx
@@ -91,11 +91,11 @@ This endpoint creates or updates a named role.
   permitted.
 
 - `ttl` `(string: "")` – Specifies the Time To Live value provided as a string
-  duration with time suffix. Hour is the largest suffix. If not set, uses the
+  duration using [duration format strings](/vault/docs/concepts/duration-format). If not set, uses the
   system default value or the value of `max_ttl`, whichever is shorter.
 
 - `max_ttl` `(string: "")` – Specifies the maximum Time To Live provided as a
-  string duration with time suffix. Hour is the largest suffix. If not set,
+  string duration using [duration format strings](/vault/docs/concepts/duration-format). If not set,
   defaults to the system maximum lease TTL.
 
 - `allowed_critical_options` `(string: "")` – Specifies a comma-separated list

--- a/content/vault/v1.21.x/content/api-docs/secret/pki/index.mdx
+++ b/content/vault/v1.21.x/content/api-docs/secret/pki/index.mdx
@@ -3244,13 +3244,13 @@ request is denied.
 
 - `ttl` `(string: "")` - Specifies the Time To Live value to be used for the
   validity period of the requested certificate, provided as a string duration
-  with time suffix. Hour is the largest suffix. The value specified is strictly
+  using [duration format strings](/vault/docs/concepts/duration-format). The value specified is strictly
   used for future validity. If not set, uses the system default value or the
   value of `max_ttl`, whichever is shorter. See `not_after` as an alternative
   for setting an absolute end date (rather than a relative one).
 
 - `max_ttl` `(string: "")` - Specifies the maximum Time To Live provided as a
-  string duration with time suffix. Hour is the largest suffix. If not set,
+  string duration using [duration format strings](/vault/docs/concepts/duration-format). If not set,
   defaults to the system maximum lease TTL.
 
 - `allow_localhost` `(bool: true)` - Specifies if clients can request

--- a/content/vault/v1.21.x/content/api-docs/secret/pki/issuance.mdx
+++ b/content/vault/v1.21.x/content/api-docs/secret/pki/issuance.mdx
@@ -342,7 +342,7 @@ mount.
    ACME is disabled, all requests to ACME directory URLs will return 404.
 
  - `max_ttl` `(string: "")` - Specifies the maximum Time To Live provided as a
-   string duration with time suffix. Hour is the largest suffix. If not set,
+   string duration using [duration format strings](/vault/docs/concepts/duration-format). If not set,
    defaults to the previous hard-coded behavior of 90 days (2160 hours).
 
  - `challenge_permitted_ip_ranges` `(list: [])` - List of CIDR blocks that are

--- a/content/vault/v1.21.x/content/api-docs/secret/ssh.mdx
+++ b/content/vault/v1.21.x/content/api-docs/secret/ssh.mdx
@@ -91,11 +91,11 @@ This endpoint creates or updates a named role.
   permitted.
 
 - `ttl` `(string: "")` – Specifies the Time To Live value provided as a string
-  duration with time suffix. Hour is the largest suffix. If not set, uses the
+  duration using [duration format strings](/vault/docs/concepts/duration-format). If not set, uses the
   system default value or the value of `max_ttl`, whichever is shorter.
 
 - `max_ttl` `(string: "")` – Specifies the maximum Time To Live provided as a
-  string duration with time suffix. Hour is the largest suffix. If not set,
+  string duration using [duration format strings](/vault/docs/concepts/duration-format). If not set,
   defaults to the system maximum lease TTL.
 
 - `allowed_critical_options` `(string: "")` – Specifies a comma-separated list

--- a/content/vault/v2.x/content/api-docs/secret/pki/index.mdx
+++ b/content/vault/v2.x/content/api-docs/secret/pki/index.mdx
@@ -3244,13 +3244,13 @@ request is denied.
 
 - `ttl` `(string: "")` - Specifies the Time To Live value to be used for the
   validity period of the requested certificate, provided as a string duration
-  with time suffix. Hour is the largest suffix. The value specified is strictly
+  using [duration format strings](/vault/docs/concepts/duration-format). The value specified is strictly
   used for future validity. If not set, uses the system default value or the
   value of `max_ttl`, whichever is shorter. See `not_after` as an alternative
   for setting an absolute end date (rather than a relative one).
 
 - `max_ttl` `(string: "")` - Specifies the maximum Time To Live provided as a
-  string duration with time suffix. Hour is the largest suffix. If not set,
+  string duration using [duration format strings](/vault/docs/concepts/duration-format). If not set,
   defaults to the system maximum lease TTL.
 
 - `allow_localhost` `(bool: true)` - Specifies if clients can request

--- a/content/vault/v2.x/content/api-docs/secret/pki/issuance.mdx
+++ b/content/vault/v2.x/content/api-docs/secret/pki/issuance.mdx
@@ -342,7 +342,7 @@ mount.
    ACME is disabled, all requests to ACME directory URLs will return 404.
 
  - `max_ttl` `(string: "")` - Specifies the maximum Time To Live provided as a
-   string duration with time suffix. Hour is the largest suffix. If not set,
+   string duration using [duration format strings](/vault/docs/concepts/duration-format). If not set,
    defaults to the previous hard-coded behavior of 90 days (2160 hours).
 
  - `challenge_permitted_ip_ranges` `(list: [])` - List of CIDR blocks that are

--- a/content/vault/v2.x/content/api-docs/secret/ssh.mdx
+++ b/content/vault/v2.x/content/api-docs/secret/ssh.mdx
@@ -91,11 +91,11 @@ This endpoint creates or updates a named role.
   permitted.
 
 - `ttl` `(string: "")` – Specifies the Time To Live value provided as a string
-  duration with time suffix. Hour is the largest suffix. If not set, uses the
+  duration using [duration format strings](/vault/docs/concepts/duration-format). If not set, uses the
   system default value or the value of `max_ttl`, whichever is shorter.
 
 - `max_ttl` `(string: "")` – Specifies the maximum Time To Live provided as a
-  string duration with time suffix. Hour is the largest suffix. If not set,
+  string duration using [duration format strings](/vault/docs/concepts/duration-format). If not set,
   defaults to the system maximum lease TTL.
 
 - `allowed_critical_options` `(string: "")` – Specifies a comma-separated list


### PR DESCRIPTION
## Description

The PKI (and SSH) create/update role API docs claimed that `Hour` is the largest duration suffix for `ttl` / `max_ttl`. Empirically, Vault accepts day units (and the other standard duration units), which matches the [duration string format](https://developer.hashicorp.com/vault/docs/concepts/duration-format) used elsewhere (e.g. `not_before_duration`).

### Changes

- Replace the incorrect "Hour is the largest suffix" wording with a link to the duration format docs
- Apply the same fix across currently published Vault versions: `v2.x` (latest), `v1.21.x`–`v1.16.x`
- Covers PKI create/update role, related PKI ACME `max_ttl`, and SSH role `ttl`/`max_ttl` which used the same incorrect text

## Links

GitHub issue: Fixes hashicorp/vault#31404

## Test plan

- [x] Confirmed duration format docs list `d` (days) as a valid unit
- [x] Matched existing `not_before_duration` / `safety_buffer` duration-format link style
- [x] Verified no remaining "Hour is the largest suffix" phrases in published version trees