### PR TITLE
docs(vault): fix automated upgrades link on HA upgrade pages

### DIFF
--- a/content/vault/v1.16.x/content/docs/upgrading/index.mdx
+++ b/content/vault/v1.16.x/content/docs/upgrading/index.mdx
@@ -34,7 +34,7 @@ during, or after the upgrade.
 ## Integrated storage autopilot
 
 Vault 1.11 introduced [automated
-upgrades](/vault/docs/concepts/integrated-storage/autopilot#automated-upgrades) as
+upgrades](/vault/docs/enterprise/automated-upgrades) as
 part of the Integrated Storage Autopilot feature. If your Vault environment is
 configured to use Integrated Storage, consider leveraging this new feature to
 upgrade your Vault environment.
@@ -81,7 +81,7 @@ upgrade notes.
 
 The recommended upgrade procedure depends on the version of Vault you're currently on and the storage backend of Vault. If you're currently running on Vault 1.11 or later with Integrated Storage and you have Autopilot enabled, you should let Autopilot do the upgrade for you, as that's easier and
 less prone to human error. Please refer to our [automated
-upgrades](/vault/docs/concepts/integrated-storage/autopilot#automated-upgrades) documentation for information on this feature and our
+upgrades](/vault/docs/enterprise/automated-upgrades) documentation for information on this feature and our
 [Automate Upgrades with Vault
 Enterprise](/vault/tutorials/raft/raft-upgrade-automation)
 tutorial for more details.

--- a/content/vault/v1.16.x/content/docs/upgrading/vault-ha-upgrade.mdx
+++ b/content/vault/v1.16.x/content/docs/upgrading/vault-ha-upgrade.mdx
@@ -14,7 +14,7 @@ last_modified: 2025-07-02T11:30:26-05:00
 This is our recommended upgrade procedure if **one** of the following applies:
 
 - Running Vault version earlier than 1.11
-- Opt-out the [Autopilot automated upgrade](/vault/docs/concepts/integrated-storage/autopilot#automated-upgrade) features with Vault 1.11 or later
+- Opt-out the [Autopilot automated upgrade](/vault/docs/enterprise/automated-upgrades) features with Vault 1.11 or later
 - Running Vault with external storage backend such as Consul
 
 You should consider how to apply the steps described in this document to your
@@ -24,7 +24,7 @@ leader, leader-only, or discovered via service discovery), etc.
 
 If you are running on Vault 1.11+ with Integrated Storage and wish to enable the
 Autopilot upgrade automation features, read to the [automated
-upgrades](/vault/docs/concepts/integrated-storage/autopilot#automated-upgrades)
+upgrades](/vault/docs/enterprise/automated-upgrades)
 documentation for details and the [Automate Upgrades with Vault
 Enterprise](/vault/tutorials/raft/raft-upgrade-automation) tutorial for
 additional guidance.

--- a/content/vault/v1.17.x/content/docs/upgrading/index.mdx
+++ b/content/vault/v1.17.x/content/docs/upgrading/index.mdx
@@ -39,7 +39,7 @@ the feature was removed or is scheduled to be removed.
 ## Integrated storage autopilot
 
 Vault 1.11 introduced [automated
-upgrades](/vault/docs/concepts/integrated-storage/autopilot#automated-upgrades) as
+upgrades](/vault/docs/enterprise/automated-upgrades) as
 part of the Integrated Storage Autopilot feature. If your Vault environment is
 configured to use Integrated Storage, consider leveraging this new feature to
 upgrade your Vault environment.
@@ -86,7 +86,7 @@ upgrade notes.
 
 The recommended upgrade procedure depends on the version of Vault you're currently on and the storage backend of Vault. If you're currently running on Vault 1.11 or later with Integrated Storage and you have Autopilot enabled, you should let Autopilot do the upgrade for you, as that's easier and
 less prone to human error. Please refer to our [automated
-upgrades](/vault/docs/concepts/integrated-storage/autopilot#automated-upgrades) documentation for information on this feature and our
+upgrades](/vault/docs/enterprise/automated-upgrades) documentation for information on this feature and our
 [Automate Upgrades with Vault
 Enterprise](/vault/tutorials/raft/raft-upgrade-automation)
 tutorial for more details.

--- a/content/vault/v1.17.x/content/docs/upgrading/vault-ha-upgrade.mdx
+++ b/content/vault/v1.17.x/content/docs/upgrading/vault-ha-upgrade.mdx
@@ -14,7 +14,7 @@ last_modified: 2025-07-02T11:30:26-05:00
 This is our recommended upgrade procedure if **one** of the following applies:
 
 - Running Vault version earlier than 1.11
-- Opt-out the [Autopilot automated upgrade](/vault/docs/concepts/integrated-storage/autopilot#automated-upgrade) features with Vault 1.11 or later
+- Opt-out the [Autopilot automated upgrade](/vault/docs/enterprise/automated-upgrades) features with Vault 1.11 or later
 - Running Vault with external storage backend such as Consul
 
 You should consider how to apply the steps described in this document to your
@@ -24,7 +24,7 @@ leader, leader-only, or discovered via service discovery), etc.
 
 If you are running on Vault 1.11+ with Integrated Storage and wish to enable the
 Autopilot upgrade automation features, read to the [automated
-upgrades](/vault/docs/concepts/integrated-storage/autopilot#automated-upgrades)
+upgrades](/vault/docs/enterprise/automated-upgrades)
 documentation for details and the [Automate Upgrades with Vault
 Enterprise](/vault/tutorials/raft/raft-upgrade-automation) tutorial for
 additional guidance.

--- a/content/vault/v1.18.x/content/docs/upgrading/index.mdx
+++ b/content/vault/v1.18.x/content/docs/upgrading/index.mdx
@@ -39,7 +39,7 @@ the feature was removed or is scheduled to be removed.
 ## Integrated storage autopilot
 
 Vault 1.11 introduced [automated
-upgrades](/vault/docs/concepts/integrated-storage/autopilot#automated-upgrades) as
+upgrades](/vault/docs/enterprise/automated-upgrades) as
 part of the Integrated Storage Autopilot feature. If your Vault environment is
 configured to use Integrated Storage, consider leveraging this new feature to
 upgrade your Vault environment.
@@ -86,7 +86,7 @@ upgrade notes.
 
 The recommended upgrade procedure depends on the version of Vault you're currently on and the storage backend of Vault. If you're currently running on Vault 1.11 or later with Integrated Storage and you have Autopilot enabled, you should let Autopilot do the upgrade for you, as that's easier and
 less prone to human error. Please refer to our [automated
-upgrades](/vault/docs/concepts/integrated-storage/autopilot#automated-upgrades) documentation for information on this feature and our
+upgrades](/vault/docs/enterprise/automated-upgrades) documentation for information on this feature and our
 [Automate Upgrades with Vault
 Enterprise](/vault/tutorials/raft/raft-upgrade-automation)
 tutorial for more details.

--- a/content/vault/v1.18.x/content/docs/upgrading/vault-ha-upgrade.mdx
+++ b/content/vault/v1.18.x/content/docs/upgrading/vault-ha-upgrade.mdx
@@ -14,7 +14,7 @@ last_modified: 2025-07-02T11:30:26-05:00
 This is our recommended upgrade procedure if **one** of the following applies:
 
 - Running Vault version earlier than 1.11
-- Opt-out the [Autopilot automated upgrade](/vault/docs/concepts/integrated-storage/autopilot#automated-upgrade) features with Vault 1.11 or later
+- Opt-out the [Autopilot automated upgrade](/vault/docs/enterprise/automated-upgrades) features with Vault 1.11 or later
 - Running Vault with external storage backend such as Consul
 
 You should consider how to apply the steps described in this document to your
@@ -24,7 +24,7 @@ leader, leader-only, or discovered via service discovery), etc.
 
 If you are running on Vault 1.11+ with Integrated Storage and wish to enable the
 Autopilot upgrade automation features, read to the [automated
-upgrades](/vault/docs/concepts/integrated-storage/autopilot#automated-upgrades)
+upgrades](/vault/docs/enterprise/automated-upgrades)
 documentation for details and the [Automate Upgrades with Vault
 Enterprise](/vault/tutorials/raft/raft-upgrade-automation) tutorial for
 additional guidance.

--- a/content/vault/v1.19.x/content/docs/upgrade/replicated-deployment.mdx
+++ b/content/vault/v1.19.x/content/docs/upgrade/replicated-deployment.mdx
@@ -17,7 +17,7 @@ Upgrade your replicated Vault deployment.
 
 The recommended upgrade procedure depends on the version of Vault you're currently on and the storage backend of Vault. If you're currently running on Vault 1.11 or later with Integrated Storage and you have Autopilot enabled, you should let Autopilot do the upgrade for you, as that's easier and
 less prone to human error. Please refer to our [automated
-upgrades](/vault/docs/concepts/integrated-storage/autopilot#automated-upgrades) documentation for information on this feature and our
+upgrades](/vault/docs/enterprise/automated-upgrades) documentation for information on this feature and our
 [Automate Upgrades with Vault
 Enterprise](/vault/tutorials/raft/raft-upgrade-automation)
 tutorial for more details.
@@ -104,7 +104,7 @@ along with the non-test cluster.
 
 The recommended upgrade procedure depends on the version of Vault you're currently on and the storage backend of Vault. If you're currently running on Vault 1.11 or later with Integrated Storage and you have Autopilot enabled, you should let Autopilot do the upgrade for you, as that's easier and
 less prone to human error. Please refer to our [automated
-upgrades](/vault/docs/concepts/integrated-storage/autopilot#automated-upgrades) documentation for information on this feature and our
+upgrades](/vault/docs/enterprise/automated-upgrades) documentation for information on this feature and our
 [Automate Upgrades with Vault
 Enterprise](/vault/tutorials/raft/raft-upgrade-automation)
 tutorial for more details.

--- a/content/vault/v1.20.x/content/docs/upgrade/replicated-deployment.mdx
+++ b/content/vault/v1.20.x/content/docs/upgrade/replicated-deployment.mdx
@@ -17,7 +17,7 @@ Upgrade your replicated Vault deployment.
 
 The recommended upgrade procedure depends on the version of Vault you're currently on and the storage backend of Vault. If you're currently running on Vault 1.11 or later with Integrated Storage and you have Autopilot enabled, you should let Autopilot do the upgrade for you, as that's easier and
 less prone to human error. Please refer to our [automated
-upgrades](/vault/docs/concepts/integrated-storage/autopilot#automated-upgrades) documentation for information on this feature and our
+upgrades](/vault/docs/enterprise/automated-upgrades) documentation for information on this feature and our
 [Automate Upgrades with Vault
 Enterprise](/vault/tutorials/raft/raft-upgrade-automation)
 tutorial for more details.

--- a/content/vault/v1.20.x/content/docs/upgrade/vault-ha-upgrade.mdx
+++ b/content/vault/v1.20.x/content/docs/upgrade/vault-ha-upgrade.mdx
@@ -14,7 +14,7 @@ last_modified: 2025-07-18T10:33:02-04:00
 This is our recommended upgrade procedure if **one** of the following applies:
 
 - Running Vault version earlier than 1.11
-- Opt-out the [Autopilot automated upgrade](/vault/docs/concepts/integrated-storage/autopilot#automated-upgrade) features with Vault 1.11 or later
+- Opt-out the [Autopilot automated upgrade](/vault/docs/enterprise/automated-upgrades) features with Vault 1.11 or later
 - Running Vault with external storage backend such as Consul
 
 You should consider how to apply the steps described in this document to your
@@ -24,7 +24,7 @@ leader, leader-only, or discovered via service discovery), etc.
 
 If you are running on Vault 1.11+ with Integrated Storage and wish to enable the
 Autopilot upgrade automation features, read to the [automated
-upgrades](/vault/docs/concepts/integrated-storage/autopilot#automated-upgrades)
+upgrades](/vault/docs/enterprise/automated-upgrades)
 documentation for details and the [Automate Upgrades with Vault
 Enterprise](/vault/tutorials/raft/raft-upgrade-automation) tutorial for
 additional guidance.

--- a/content/vault/v1.21.x/content/docs/upgrade/replicated-deployment.mdx
+++ b/content/vault/v1.21.x/content/docs/upgrade/replicated-deployment.mdx
@@ -17,7 +17,7 @@ Upgrade your replicated Vault deployment.
 
 The recommended upgrade procedure depends on the version of Vault you're currently on and the storage backend of Vault. If you're currently running on Vault 1.11 or later with Integrated Storage and you have Autopilot enabled, you should let Autopilot do the upgrade for you, as that's easier and
 less prone to human error. Please refer to our [automated
-upgrades](/vault/docs/concepts/integrated-storage/autopilot#automated-upgrades) documentation for information on this feature and our
+upgrades](/vault/docs/enterprise/automated-upgrades) documentation for information on this feature and our
 [Automate Upgrades with Vault
 Enterprise](/vault/tutorials/raft/raft-upgrade-automation)
 tutorial for more details.

--- a/content/vault/v1.21.x/content/docs/upgrade/vault-ha-upgrade.mdx
+++ b/content/vault/v1.21.x/content/docs/upgrade/vault-ha-upgrade.mdx
@@ -14,7 +14,7 @@ last_modified: 2025-10-22T13:53:42-07:00
 This is our recommended upgrade procedure if **one** of the following applies:
 
 - Running Vault version earlier than 1.11
-- Opt-out the [Autopilot automated upgrade](/vault/docs/concepts/integrated-storage/autopilot#automated-upgrade) features with Vault 1.11 or later
+- Opt-out the [Autopilot automated upgrade](/vault/docs/enterprise/automated-upgrades) features with Vault 1.11 or later
 - Running Vault with external storage backend such as Consul
 
 You should consider how to apply the steps described in this document to your
@@ -24,7 +24,7 @@ leader, leader-only, or discovered via service discovery), etc.
 
 If you are running on Vault 1.11+ with Integrated Storage and wish to enable the
 Autopilot upgrade automation features, read to the [automated
-upgrades](/vault/docs/concepts/integrated-storage/autopilot#automated-upgrades)
+upgrades](/vault/docs/enterprise/automated-upgrades)
 documentation for details and the [Automate Upgrades with Vault
 Enterprise](/vault/tutorials/raft/raft-upgrade-automation) tutorial for
 additional guidance.

--- a/content/vault/v2.x/content/docs/upgrade/replicated-deployment.mdx
+++ b/content/vault/v2.x/content/docs/upgrade/replicated-deployment.mdx
@@ -17,7 +17,7 @@ Upgrade your replicated Vault deployment.
 
 The recommended upgrade procedure depends on the version of Vault you're currently on and the storage backend of Vault. If you're currently running on Vault 1.11 or later with Integrated Storage and you have Autopilot enabled, you should let Autopilot do the upgrade for you, as that's easier and
 less prone to human error. Please refer to our [automated
-upgrades](/vault/docs/concepts/integrated-storage/autopilot#automated-upgrades) documentation for information on this feature and our
+upgrades](/vault/docs/enterprise/automated-upgrades) documentation for information on this feature and our
 [Automate Upgrades with Vault
 Enterprise](/vault/tutorials/raft/raft-upgrade-automation)
 tutorial for more details.

--- a/content/vault/v2.x/content/docs/upgrade/vault-ha-upgrade.mdx
+++ b/content/vault/v2.x/content/docs/upgrade/vault-ha-upgrade.mdx
@@ -14,7 +14,7 @@ last_modified: 2026-04-15T00:16:00.000Z
 This is our recommended upgrade procedure if **one** of the following applies:
 
 - Running Vault version earlier than 1.11
-- Opt-out the [Autopilot automated upgrade](/vault/docs/concepts/integrated-storage/autopilot#automated-upgrade) features with Vault 1.11 or later
+- Opt-out the [Autopilot automated upgrade](/vault/docs/enterprise/automated-upgrades) features with Vault 1.11 or later
 - Running Vault with external storage backend such as Consul
 
 You should consider how to apply the steps described in this document to your
@@ -24,7 +24,7 @@ leader, leader-only, or discovered via service discovery), etc.
 
 If you are running on Vault 1.11+ with Integrated Storage and wish to enable the
 Autopilot upgrade automation features, read to the [automated
-upgrades](/vault/docs/concepts/integrated-storage/autopilot#automated-upgrades)
+upgrades](/vault/docs/enterprise/automated-upgrades)
 documentation for details and the [Automate Upgrades with Vault
 Enterprise](/vault/tutorials/raft/raft-upgrade-automation) tutorial for
 additional guidance.


### PR DESCRIPTION
## Description

HA / replicated upgrade docs linked to `/vault/docs/concepts/integrated-storage/autopilot#automated-upgrades` for Autopilot automated upgrade guidance. That path is not the right destination for the full feature docs (and some pages used a singular `#automated-upgrade` fragment that does not exist).

The autopilot overview itself already directs readers to the dedicated Automated Upgrades page.

### Changes

- Update automated-upgrades links to `/vault/docs/enterprise/automated-upgrades`
- Fix the singular `#automated-upgrade` fragment on HA upgrade opt-out bullets
- Apply across currently published Vault versions: `v2.x` (latest), `v1.21.x`–`v1.16.x`

## Links

GitHub issue: Fixes hashicorp/vault#31161

## Test plan

- [x] Confirmed `/vault/docs/enterprise/automated-upgrades` exists in each published version tree
- [x] Confirmed no remaining `autopilot#automated-upgrade(s)` links in published upgrade docs
- [x] Matched the destination already used from the Autopilot overview page