### PR TITLE
docs: Expand on FFmpeg requirement for RDP session recording

### DIFF
--- a/content/boundary/v1.0.x/content/docs/session-recording/configuration/configure-worker-storage.mdx
+++ b/content/boundary/v1.0.x/content/docs/session-recording/configuration/configure-worker-storage.mdx
@@ -4,8 +4,8 @@ page_title: Configure workers for local storage
 description: >-
   Configure workers for session recording storage. View requirements and an example configuration. Understand possible storage states for local and remote storage.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-11-18T17:04:41-05:00
-last_modified: 2026-01-27T10:52:39-05:00
+created_at: 2026-05-11T10:18:43-04:00
+last_modified: 2026-07-22T13:56:11.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -30,7 +30,25 @@ Workers that you configure for storage must:
 - Have available disk space defined by `recording_storage_minimum_available_capacity`. If you do not configure the minimum available storage capacity, Boundary uses the default value of 500MiB.
 For more information about how much space is required to store BSR files, refer to [storage considerations](/boundary/docs/session-recording#storage-considerations).
 - Run Darwin, Windows, or Linux. The following binaries are not supported for session recording: NetBSD, OpenBSD, Solaris.
-- To create RDP session recording exports, a worker must have an FFmpeg binary present, with version `5.1.0` or later installed. The `libsvtav1` codec must also be present.
+- To record RDP sessions, you must install FFmpeg `5.1.0` or later with the `libsvtav1` codec on the worker used for local session recording storage. Refer to [FFmpeg](#ffmpeg) for more information.
+
+### FFmpeg
+
+FFmpeg is a free, open-source tool that records, converts, and streams video.
+Boundary requires FFmpeg to decode RDP session recording exports.
+To record RDP sessions, you must install FFmpeg `5.1.0` or later with the `libsvtav1` codec on the worker used for local session recording storage.
+
+You can download FFmpeg binaries for Linux, macOS, or Windows from the [FFmpeg download site](https://ffmpeg.org/download.html).
+Refer to the [FFmpeg libsvtav1 documentation](https:/https://www.ffmpeg.org/ffmpeg-all.html#libsvtav1) to configure a new FFmpeg build with `libsvtav1`.
+
+Some pre-built binaries include the `libsvtav1` codec, and many package managers bundle `libstav1` with FFmpeg by default.
+On macOS, you can use Homebrew to install FFmpeg with the `libsvtav1` codec.
+The official Debian apt repository also includes `libsvtav1` packaged with FFmpeg.
+
+For more information about FFmpeg and the `libsvtav1` codec, refer to the following official documentation:
+
+- [FFmpeg](https://ffmpeg.org)
+- [SVT-AV1 (libsvtav1)](https://https://trac.ffmpeg.org/wiki/Encode/AV1#SVT-AV1)
 
 ## Local storage
 

--- a/content/boundary/v1.0.x/content/docs/session-recording/configuration/configure-worker-storage.mdx
+++ b/content/boundary/v1.0.x/content/docs/session-recording/configuration/configure-worker-storage.mdx
@@ -5,7 +5,7 @@ description: >-
   Configure workers for session recording storage. View requirements and an example configuration. Understand possible storage states for local and remote storage.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2026-05-11T10:18:43-04:00
-last_modified: 2026-07-22T13:56:11.000Z
+last_modified: 2026-07-22T14:04:35.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -30,25 +30,24 @@ Workers that you configure for storage must:
 - Have available disk space defined by `recording_storage_minimum_available_capacity`. If you do not configure the minimum available storage capacity, Boundary uses the default value of 500MiB.
 For more information about how much space is required to store BSR files, refer to [storage considerations](/boundary/docs/session-recording#storage-considerations).
 - Run Darwin, Windows, or Linux. The following binaries are not supported for session recording: NetBSD, OpenBSD, Solaris.
-- To record RDP sessions, you must install FFmpeg `5.1.0` or later with the `libsvtav1` codec on the worker used for local session recording storage. Refer to [FFmpeg](#ffmpeg) for more information.
+- Have FFmpeg `5.1.0` or later with the `libsvtav1` codec to record RDP sessions. Refer to [FFmpeg](#ffmpeg) for more information.
 
 ### FFmpeg
 
 FFmpeg is a free, open-source tool that records, converts, and streams video.
-Boundary requires FFmpeg to decode RDP session recording exports.
-To record RDP sessions, you must install FFmpeg `5.1.0` or later with the `libsvtav1` codec on the worker used for local session recording storage.
+Boundary requires FFmpeg `5.1.0` or later with the `libsvtav1` codec to create RDP session recording exports.
 
 You can download FFmpeg binaries for Linux, macOS, or Windows from the [FFmpeg download site](https://ffmpeg.org/download.html).
-Refer to the [FFmpeg libsvtav1 documentation](https:/https://www.ffmpeg.org/ffmpeg-all.html#libsvtav1) to configure a new FFmpeg build with `libsvtav1`.
+Refer to the [FFmpeg libsvtav1 documentation](https://www.ffmpeg.org/ffmpeg-all.html#libsvtav1) to configure FFmpeg with `libsvtav1`.
 
-Some pre-built binaries include the `libsvtav1` codec, and many package managers bundle `libstav1` with FFmpeg by default.
+Some pre-built binaries include the `libsvtav1` codec, and many package managers bundle `libsvtav1` with FFmpeg by default.
 On macOS, you can use Homebrew to install FFmpeg with the `libsvtav1` codec.
 The official Debian apt repository also includes `libsvtav1` packaged with FFmpeg.
 
 For more information about FFmpeg and the `libsvtav1` codec, refer to the following official documentation:
 
 - [FFmpeg](https://ffmpeg.org)
-- [SVT-AV1 (libsvtav1)](https://https://trac.ffmpeg.org/wiki/Encode/AV1#SVT-AV1)
+- [SVT-AV1 (libsvtav1)](https://trac.ffmpeg.org/wiki/Encode/AV1#SVT-AV1)
 
 ## Local storage
 

--- a/content/boundary/v1.0.x/content/docs/session-recording/configuration/export-rdp.mdx
+++ b/content/boundary/v1.0.x/content/docs/session-recording/configuration/export-rdp.mdx
@@ -4,8 +4,8 @@ page_title: Export RDP sessions so that you can view recordings
 description: >-
   Create and view exported RDP sessions. You can create an export to download the video recording.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-11-18T17:04:41-05:00
-last_modified: 2026-01-27T10:52:39-05:00
+created_at: 2026-06-24T15:34:43-04:00
+last_modified: 2026-07-22T13:56:12.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -32,8 +32,9 @@ You select a connection recording to create a session recording export.
 
 <Note>
 
-To create RDP session recording exports, a worker must have an FFmpeg binary present, with version `5.1.0` or later installed.
-The `libsvtav1` codec must also be present.
+To record RDP sessions, you must install FFmpeg `5.1.0` or later with the `libsvtav1` codec on the worker used for local session recording storage.
+
+Refer to [FFmpeg](/boundary/docs/session-recording/configuration/configure-worker-storage#ffmpeg) for more information.
 
 </Note>
 


### PR DESCRIPTION
<!--
**Merge branch**

Make sure your PR uses the correct **base** branch for the merge destination.

For more information, refer to **Change the branch range and destination repository** (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request).

To update:

- Existing content

  Choose **base: main** to update existing documentation.
  Your content will be published when the PR is merged.

- Content for an upcoming Boundary release

  Choose the branch for the relevant upcoming Boundary release.
  Boundary release branches use the `boundary/<exact-release-number>` format.
  Your content will be published when the upcoming release goes live.

If you are not sure which base branch to use, or you cannot find the release branch you are looking for:

  - Choose the `main` branch.
  - Add the "do not merge" label.
  - Convert the PR to a DRAFT.
  - Explain the update in the **Description**.

**Back porting to older versions**

This repo stores versioned documentation in folders instead of branches.
There are no backport labels.
If your update applies to multiple versions, you must update the content in each of the corresponding version folders.

For example, you make an update to the Boundary code in the current release, 0.21.0, and back port it to versions 0.20.x and 0.19.x.
To document the update for each of the relevant versions, you would update the documentation in the v0.21.x, v0.20.x, and v0.19.x folders.
-->

## Description

Users must install FFmpeg with the `libsvtav1` codec to record RDP sessions. Some user feedback indicates that people are having trouble finding and understanding the requirement. This PR adds some additional text and links to help clarify the requirement and point users to the required downloads.

View the update in the preview environment:

- [Configure workers for storage](https://unified-docs-frontend-preview-pvvzzd4y9-hashicorp.vercel.app/boundary/docs/session-recording/configuration/configure-worker-storage)
- Export and view RDP sessions > [Create an export](https://unified-docs-frontend-preview-pvvzzd4y9-hashicorp.vercel.app/boundary/docs/session-recording/configuration/export-rdp#create-an-export)

## Links
<!--
Include links to any associated pull requests, GitHub issues, or documentation that is relevant to this update.

// GH-Jira integration generates the link and updates the Jira ticket.
Jira: [<jira-ticket-number>]  // for example, Jira: [ICU-1234]

GitHub Issue: <issue-link>
-->

Code PR:
Jira:
GitHub issue:
RFC/PRD:

## Contributor checklists

<!--
Help your reviewer understand the type of review you need by selecting the scope and urgency.
-->

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [ ] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [ ] Verify that the PR is set to merge into the correct base branch
- [ ] Verify that all status checks passed
- [ ] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [ ] I added redirects for any moved or removed pages
- [ ] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [ ] I looked at the local or Vercel build to make sure the content rendered correctly


[ICU-1234]: https://hashicorp.atlassian.net/browse/ICU-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ