### PR TITLE
Registry Policy Publishing Sign in Link

### DIFF
--- a/content/terraform-docs-common/docs/registry/policy-libraries/publishing.mdx
+++ b/content/terraform-docs-common/docs/registry/policy-libraries/publishing.mdx
@@ -64,7 +64,7 @@ To publish a policy library to the Terraform Registry:
 
 1. Ensure that your policy library's repository meets the [requirements](#requirements).
 1. If a GitHub organization owns the repository, verify that the Terraform Registry OAuth app has access to the organization. Go to your [GitHub Settings](https://github.com/settings/applications) and select the Terraform Registry Application under **Authorized OAuth Apps** to confirm.
-1. [Sign in to the Terraform Registry](/terraform/registry#user-account) with a GitHub account.
+1. [Sign in to the Terraform Registry](https://registry.terraform.io/sign-in/legacy) with a GitHub account (requires legacy Registry sign in).
 1. Select **Publish > Policy Library**.
 1. Select the repository you would like to publish.
 1. Choose the category for your policy library that most closely matches the types of infrastructure relevant to your policies.


### PR DESCRIPTION
This updates the documentation for publishing policy libraries to the Terraform Registry to point to the required legacy sign in page. Without this link, it is impossible to publish/manage policy sets in the registry. 