### PR TITLE
Update workspace tags mutation requirements documentation

### DIFF
--- a/content/terraform-docs-common/docs/cloud-docs/workspaces/tags.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/workspaces/tags.mdx
@@ -30,8 +30,8 @@ Your system may contain single-value tags created using Terraform v1.10 and olde
 
 ## Requirements
 
-- You must be member of a team with the **Write** permission group enabled for the workspace to create tags for a workspace.
-- You must have one of the following permissions to create and manage tags: 
+- You must have **Plan** permissions or higher for the workspace to create and update tags.
+- You must have one of the following permissions to delete and manage tags:
     - **Admin** permission group for the workspace.
     - **Manage all workspaces** permissions for the organization. This permissions allows you to manage tags for all workspaces.
 


### PR DESCRIPTION
### What
Updates workspace tags permission requirements documentation to align with the current needed permissions.

### Why
Following [this PR](https://github.com/hashicorp/atlas/pull/22234), only plan permissions are required to create/delete tags on a workspace.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages.
- [ ] API documentation and the API Changelog have been updated.
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.

