### PR TITLE
Removing error throw for failures in build metrics

### DIFF
--- a/scripts/capture-build-metrics.mjs
+++ b/scripts/capture-build-metrics.mjs
@@ -183,8 +183,9 @@ async function main() {
 			throw new AggregateError(failedSubmissions)
 		}
 	} catch (error) {
-		if (process.env.VERCEL_ENV === 'production') {
-			throw error
+		const errors = error instanceof AggregateError ? error.errors : [error]
+		for (const err of errors) {
+			console.error(`Failed to submit build metrics: ${err.message}`)
 		}
 	}
 }


### PR DESCRIPTION
Build shouldn't fail if build metrics run into errors

[Related error](https://github.com/hashicorp/web-unified-docs/actions/runs/29948559219/job/89036786353#step:7:184)

[Related support ticket](https://ibm-hashicorp.slack.com/archives/C09LU1THDDE/p1784743615590119)
