### PR TITLE
docs(vault): add tls_min_version and tls_max_version to LDAP secrets engine API reference

### DIFF
--- a/content/vault/v1.12.x/content/api-docs/secret/ldap.mdx
+++ b/content/vault/v1.12.x/content/api-docs/secret/ldap.mdx
@@ -70,6 +70,10 @@ to search and change entry passwords in LDAP.
 - `client_tls_cert` `(string: <optional>)` - Client certificate to provide to the LDAP server, must be x509
   PEM encoded.
 - `client_tls_key` `(string: <optional>)` - Client key to provide to the LDAP server, must be x509 PEM encoded.
+- `tls_min_version` `(string: tls12)` – Minimum TLS version to use. Accepted
+  values are `tls10`, `tls11`, `tls12` or `tls13`.
+- `tls_max_version` `(string: tls12)` – Maximum TLS version to use. Accepted
+  values are `tls10`, `tls11`, `tls12` or `tls13`.
 
 **Deprecated Parameters**:
 

--- a/content/vault/v1.13.x/content/api-docs/secret/ldap.mdx
+++ b/content/vault/v1.13.x/content/api-docs/secret/ldap.mdx
@@ -70,6 +70,10 @@ to search and change entry passwords in LDAP.
 - `client_tls_cert` `(string: <optional>)` - Client certificate to provide to the LDAP server, must be x509
   PEM encoded.
 - `client_tls_key` `(string: <optional>)` - Client key to provide to the LDAP server, must be x509 PEM encoded.
+- `tls_min_version` `(string: tls12)` – Minimum TLS version to use. Accepted
+  values are `tls10`, `tls11`, `tls12` or `tls13`.
+- `tls_max_version` `(string: tls12)` – Maximum TLS version to use. Accepted
+  values are `tls10`, `tls11`, `tls12` or `tls13`.
 
 **Deprecated Parameters**:
 

--- a/content/vault/v1.14.x/content/api-docs/secret/ldap.mdx
+++ b/content/vault/v1.14.x/content/api-docs/secret/ldap.mdx
@@ -70,6 +70,10 @@ to search and change entry passwords in LDAP.
 - `client_tls_cert` `(string: <optional>)` - Client certificate to provide to the LDAP server, must be x509
   PEM encoded.
 - `client_tls_key` `(string: <optional>)` - Client key to provide to the LDAP server, must be x509 PEM encoded.
+- `tls_min_version` `(string: tls12)` – Minimum TLS version to use. Accepted
+  values are `tls10`, `tls11`, `tls12` or `tls13`.
+- `tls_max_version` `(string: tls12)` – Maximum TLS version to use. Accepted
+  values are `tls10`, `tls11`, `tls12` or `tls13`.
 
 **Deprecated Parameters**:
 

--- a/content/vault/v1.15.x/content/api-docs/secret/ldap.mdx
+++ b/content/vault/v1.15.x/content/api-docs/secret/ldap.mdx
@@ -70,6 +70,10 @@ to search and change entry passwords in LDAP.
 - `client_tls_cert` `(string: <optional>)` - Client certificate to provide to the LDAP server, must be x509
   PEM encoded.
 - `client_tls_key` `(string: <optional>)` - Client key to provide to the LDAP server, must be x509 PEM encoded.
+- `tls_min_version` `(string: tls12)` – Minimum TLS version to use. Accepted
+  values are `tls10`, `tls11`, `tls12` or `tls13`.
+- `tls_max_version` `(string: tls12)` – Maximum TLS version to use. Accepted
+  values are `tls10`, `tls11`, `tls12` or `tls13`.
 
 **Deprecated Parameters**:
 

--- a/content/vault/v1.16.x/content/api-docs/secret/ldap.mdx
+++ b/content/vault/v1.16.x/content/api-docs/secret/ldap.mdx
@@ -67,6 +67,10 @@ to search and change entry passwords in LDAP.
 - `client_tls_cert` `(string: <optional>)` - Client certificate to provide to the LDAP server, must be x509
   PEM encoded.
 - `client_tls_key` `(string: <optional>)` - Client key to provide to the LDAP server, must be x509 PEM encoded.
+- `tls_min_version` `(string: tls12)` – Minimum TLS version to use. Accepted
+  values are `tls10`, `tls11`, `tls12` or `tls13`.
+- `tls_max_version` `(string: tls12)` – Maximum TLS version to use. Accepted
+  values are `tls10`, `tls11`, `tls12` or `tls13`.
 - `skip_static_role_import_rotation` `(bool: false)` - The default value to use for `skip_import_rotation` when
   creating static roles. This field can be overridden on an individual role level during [role creation](#static-roles).
   See the [static roles section](#static-roles) for more detailed information and caveats.

--- a/content/vault/v1.17.x/content/api-docs/secret/ldap.mdx
+++ b/content/vault/v1.17.x/content/api-docs/secret/ldap.mdx
@@ -67,6 +67,10 @@ to search and change entry passwords in LDAP.
 - `client_tls_cert` `(string: <optional>)` - Client certificate to provide to the LDAP server, must be x509
   PEM encoded.
 - `client_tls_key` `(string: <optional>)` - Client key to provide to the LDAP server, must be x509 PEM encoded.
+- `tls_min_version` `(string: tls12)` – Minimum TLS version to use. Accepted
+  values are `tls10`, `tls11`, `tls12` or `tls13`.
+- `tls_max_version` `(string: tls12)` – Maximum TLS version to use. Accepted
+  values are `tls10`, `tls11`, `tls12` or `tls13`.
 - `skip_static_role_import_rotation` `(bool: false)` - The default value to use for `skip_import_rotation` when
   creating static roles. This field can be overridden on an individual role level during [role creation](#static-roles).
   See the [static roles section](#static-roles) for more detailed information and caveats.

--- a/content/vault/v1.18.x/content/api-docs/secret/ldap.mdx
+++ b/content/vault/v1.18.x/content/api-docs/secret/ldap.mdx
@@ -69,6 +69,10 @@ to search and change entry passwords in LDAP.
 - `client_tls_cert` `(string: <optional>)` - Client certificate to provide to the LDAP server, must be x509
   PEM encoded.
 - `client_tls_key` `(string: <optional>)` - Client key to provide to the LDAP server, must be x509 PEM encoded.
+- `tls_min_version` `(string: tls12)` – Minimum TLS version to use. Accepted
+  values are `tls10`, `tls11`, `tls12` or `tls13`.
+- `tls_max_version` `(string: tls12)` – Maximum TLS version to use. Accepted
+  values are `tls10`, `tls11`, `tls12` or `tls13`.
 - `skip_static_role_import_rotation` `(bool: false)` - The default value to use for `skip_import_rotation` when
   creating static roles. This field can be overridden on an individual role level during [role creation](#static-roles).
   See the [static roles section](#static-roles) for more detailed information and caveats.

--- a/content/vault/v1.19.x/content/api-docs/secret/ldap.mdx
+++ b/content/vault/v1.19.x/content/api-docs/secret/ldap.mdx
@@ -69,6 +69,10 @@ to search and change entry passwords in LDAP.
 - `client_tls_cert` `(string: <optional>)` - Client certificate to provide to the LDAP server, must be x509
   PEM encoded.
 - `client_tls_key` `(string: <optional>)` - Client key to provide to the LDAP server, must be x509 PEM encoded.
+- `tls_min_version` `(string: tls12)` – Minimum TLS version to use. Accepted
+  values are `tls10`, `tls11`, `tls12` or `tls13`.
+- `tls_max_version` `(string: tls12)` – Maximum TLS version to use. Accepted
+  values are `tls10`, `tls11`, `tls12` or `tls13`.
 - `skip_static_role_import_rotation` `(bool: false)` - The default value to use for `skip_import_rotation` when
   creating static roles. This field can be overridden on an individual role level during [role creation](#static-roles).
   See the [static roles section](#static-roles) for more detailed information and caveats.

--- a/content/vault/v1.20.x/content/api-docs/secret/ldap.mdx
+++ b/content/vault/v1.20.x/content/api-docs/secret/ldap.mdx
@@ -69,6 +69,10 @@ to search and change entry passwords in LDAP.
 - `client_tls_cert` `(string: <optional>)` - Client certificate to provide to the LDAP server, must be x509
   PEM encoded.
 - `client_tls_key` `(string: <optional>)` - Client key to provide to the LDAP server, must be x509 PEM encoded.
+- `tls_min_version` `(string: tls12)` – Minimum TLS version to use. Accepted
+  values are `tls10`, `tls11`, `tls12` or `tls13`.
+- `tls_max_version` `(string: tls12)` – Maximum TLS version to use. Accepted
+  values are `tls10`, `tls11`, `tls12` or `tls13`.
 - `skip_static_role_import_rotation` `(bool: false)` - The default value to use for `skip_import_rotation` when
   creating static roles. This field can be overridden on an individual role level during [role creation](#static-roles).
   See the [static roles section](#static-roles) for more detailed information and caveats.

--- a/content/vault/v1.21.x/content/api-docs/secret/ldap.mdx
+++ b/content/vault/v1.21.x/content/api-docs/secret/ldap.mdx
@@ -69,6 +69,10 @@ to search and change entry passwords in LDAP.
 - `client_tls_cert` `(string: <optional>)` - Client certificate to provide to the LDAP server, must be x509
   PEM encoded.
 - `client_tls_key` `(string: <optional>)` - Client key to provide to the LDAP server, must be x509 PEM encoded.
+- `tls_min_version` `(string: tls12)` – Minimum TLS version to use. Accepted
+  values are `tls10`, `tls11`, `tls12` or `tls13`.
+- `tls_max_version` `(string: tls12)` – Maximum TLS version to use. Accepted
+  values are `tls10`, `tls11`, `tls12` or `tls13`.
 - `skip_static_role_import_rotation` `(bool: false)` - The default value to use for `skip_import_rotation` when
   creating static roles. This field can be overridden on an individual role level during [role creation](#static-roles).
   See the [static roles section](#static-roles) for more detailed information and caveats.

--- a/content/vault/v2.x/content/api-docs/secret/ldap.mdx
+++ b/content/vault/v2.x/content/api-docs/secret/ldap.mdx
@@ -76,6 +76,10 @@ to search and change entry passwords in LDAP.
 - `client_tls_cert` `(string: "")` - Client certificate to provide to the LDAP server, must be x509
   PEM encoded.
 - `client_tls_key` `(string: "")` - Client key to provide to the LDAP server, must be x509 PEM encoded.
+- `tls_min_version` `(string: tls12)` – Minimum TLS version to use. Accepted
+  values are `tls10`, `tls11`, `tls12` or `tls13`.
+- `tls_max_version` `(string: tls12)` – Maximum TLS version to use. Accepted
+  values are `tls10`, `tls11`, `tls12` or `tls13`.
 - `skip_static_role_import_rotation` `(bool: false)` - The default value to use for `skip_import_rotation` when
   creating static roles. This field can be overridden on an individual role level during [role creation](#static-roles).
   See the [static roles section](#static-roles) for more detailed information and caveats.


### PR DESCRIPTION
## Description

Adds `tls_min_version` and `tls_max_version` parameter definitions to the
LDAP secrets engine API reference (`api-docs/secret/ldap.mdx`) across all
affected versions: v1.12.x through v1.21.x and v2.x.

These parameters were already accepted by the engine and appeared in sample
JSON payloads, but were never listed as documented parameter definitions —
creating a gap between the LDAP auth method API docs (`api-docs/auth/ldap.mdx`)
where they have always been documented, and the secrets engine docs where they
were not.

The parameter definitions are copied verbatim from the auth method docs, which
are identical across all versions:

- `tls_min_version` `(string: tls12)` – Minimum TLS version to use. Accepted values are `tls10`, `tls11`, `tls12` or `tls13`.
- `tls_max_version` `(string: tls12)` – Maximum TLS version to use. Accepted values are `tls10`, `tls11`, `tls12` or `tls13`.

Files changed: 11 (one per affected version directory).

## Links

No associated ticket or issue.

## Contributor checklists

Review urgency:
- [ ] ASAP: Bug fixes, broken content, imminent releases
- [x] 3 days: Small changes, easy reviews
- [ ] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:
- [ ] Verify that the PR is set to merge into the correct base branch
- [ ] Verify that all status checks passed
- [ ] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:
- [ ] I added redirects for any moved or removed pages
- [x] I followed the Education style guide
- [ ] I looked at the local or Vercel build to make sure the content rendered correctly