### PR TITLE
Revert "Docs: Add usage metrics and descriptions (#2806)"

### DIFF
--- a/content/vault/v2.x/content/docs/license/product-usage-reporting.mdx
+++ b/content/vault/v2.x/content/docs/license/product-usage-reporting.mdx
@@ -95,8 +95,6 @@ IBM collects the following product usage metrics as numerical data. Vault does n
 | `vault.auth.method.aws.count` | Number of auth mounts of type AWS across all namespaces. |
 | `vault.auth.method.azure.count` | Number of auth mounts of type Azure across all namespaces. |
 | `vault.auth.method.cert.count` | Number of auth mounts of type Cert across all namespaces. |
-| `vault.auth.method.cert.crl.count` | Number of Cert auth CRLs across all namespaces and mounts. |
-| `vault.auth.method.cert.role.count` | Number of Cert auth roles across all namespaces and mounts. |
 | `vault.auth.method.cloudfoundry.count` | Number of auth mounts of type CloudFoundry across all namespaces. |
 | `vault.auth.method.gcp.count` | Number of auth mounts of type GCP across all namespaces. |
 | `vault.auth.method.github.count` | Number of auth mounts of type GitHub across all namespaces. |
@@ -111,10 +109,7 @@ IBM collects the following product usage metrics as numerical data. Vault does n
 | `vault.auth.method.plugin.count` | Number of auth mounts with unrecognized types (custom plugins) across all namespaces. |
 | `vault.auth.method.radius.count` | Number of auth mounts of type Radius across all namespaces. |
 | `vault.auth.method.saml.count` | Number of auth mounts of type SAML across all namespaces. |
-| `vault.auth.method.scep.role.count` | Number of SCEP auth roles across all namespaces and mounts. |
 | `vault.auth.method.spiffe.count` | Number of auth mounts of type Spiffe across all namespaces. |
-| `vault.auth.method.spiffe.role.count` | Number of Spiffe auth roles across all namespaces and mounts. |
-| `vault.auth.method.spiffe_enabled` | Whether the Spiffe auth method is enabled in any namespace. |
 | `vault.auth.method.token.count` | Number of auth mounts of type Token across all namespaces. |
 | `vault.auth.method.userpass.count` | Number of auth mounts of type Userpass across all namespaces. |
 | `vault.autopilot_upgrade_enabled` | Whether the autopilot upgrade is enabled on this Vault cluster. |
@@ -152,11 +147,6 @@ IBM collects the following product usage metrics as numerical data. Vault does n
 | `vault.loadedsnapshots.cloud.azure-blob.count` | The count of loaded snapshots created using Azure Blob as the source. |
 | `vault.loadedsnapshots.cloud.google-gcs.count` | The count of loaded snapshots created using Google GCS as the source. |
 | `vault.loadedsnapshots.manual.count` | The count of loaded snapshots created using a local snapshot as the source. |
-| `vault.managed.key.awskms.config.count` | Number of AWS KMS managed key configurations across all namespaces. |
-| `vault.managed.key.azurekeyvault.config.count` | Number of Azure Key Vault managed key configurations across all namespaces. |
-| `vault.managed.key.config.count` | Total number of managed key configurations across all namespaces and supported key types. |
-| `vault.managed.key.gcpckms.config.count` | Number of GCP Cloud KMS managed key configurations across all namespaces. |
-| `vault.managed.key.pkcs11.config.count` | Number of PKCS#11 managed key configurations across all namespaces. |
 | `vault.mfa.login.duo.count` | The count of MFA configurations using the Duo method enforced during login. |
 | `vault.mfa.login.okta.count` | The count of MFA configurations using the Okta method enforced during login. |
 | `vault.mfa.login.pingid.count` | The count of MFA configurations using the PingID method enforced during login. |
@@ -229,9 +219,6 @@ IBM collects the following product usage metrics as numerical data. Vault does n
 | `vault.secret.engine.keymgmt.kms.multi.region.key.count` | Number of multi region key across all namespaces in secret engine mounts of type Keymgmt. |
 | `vault.secret.engine.keymgmt.kms.multi.region.key.secondary.region.count` | Number of secondary region of multi region key across all namespaces in secret engine mounts of type Keymgmt. |
 | `vault.secret.engine.kmip.count` | Number of secret engine mounts of type KMIP across all namespaces. |
-| `vault.secret.engine.kmip.ca.count` | Number of KMIP CAs across all namespaces and mounts. |
-| `vault.secret.engine.kmip.scope.count` | Number of KMIP scopes across all namespaces and mounts. |
-| `vault.secret.engine.kmip.scope.role.count` | Number of KMIP scope roles across all namespaces and mounts. |
 | `vault.secret.engine.kubernetes.count` | Number of secret engine mounts of type Kubernetes across all namespaces. |
 | `vault.secret.engine.kv.count` | Number of secret engine mounts of type KV across all namespaces. |
 | `vault.secret.engine.ldap.count` | Number of secret engine mounts of type LDAP across all namespaces. |
@@ -251,18 +238,10 @@ IBM collects the following product usage metrics as numerical data. Vault does n
 | `vault.secret.engine.postgresql.count` | Number of secret engine mounts of type Postgresql across all namespaces. Note that this secret engine is deprecated. |
 | `vault.secret.engine.rabbitmq.count` | Number of secret engine mounts of type RabbitMQ across all namespaces. |
 | `vault.secret.engine.spiffe.count` | Number of secret engine mounts of type Spiffe across all namespaces. |
-| `vault.secret.engine.spiffe.role.count` | Number of Spiffe secret engine roles across all namespaces. |
 | `vault.secret.engine.ssh.count` | Number of secret engine mounts of type SSH across all namespaces. |
-| `vault.secret.engine.ssh.ca.role.count` | Number of SSH secret engine CA roles across all namespaces. |
-| `vault.secret.engine.ssh.otp.role.count` | Number of SSH secret engine OTP roles across all namespaces. |
 | `vault.secret.engine.terraform.count` | Number of secret engine mounts of type Terraform across all namespaces. |
 | `vault.secret.engine.totp.count` | Number of secret engine mounts of type TOTP across all namespaces. |
 | `vault.secret.engine.transform.count` | Number of secret engine mounts of type Transform across all namespaces. |
-| `vault.secret.engine.transform.alphabet.count` | Number of Transform alphabets across all namespaces and mounts. |
-| `vault.secret.engine.transform.role.count` | Number of Transform secret engine roles across all namespaces. |
-| `vault.secret.engine.transform.store.count` | Number of Transform stores across all namespaces and mounts. |
-| `vault.secret.engine.transform.template.count` | Number of Transform templates across all namespaces and mounts. |
-| `vault.secret.engine.transform.transformation.count` | Number of Transform transformations across all namespaces and mounts. |
 | `vault.secret.engine.transit.count` | Number of secret engine mounts of type Transit across all namespaces. |
 | `vault.secret.engine.transit.key.count` | Number of secret engine keys of type Transit across all namespaces and mounts. |
 | `vault.secretsync.destinations.aws-sm.count` | Total number of secret sync destinations to AWS-SM configured. |


### PR DESCRIPTION
This reverts commit b9cb6ec137f7cf13fb5f47ab35c66db2ab8ded11. This won't be released until 2.1.0 and thus needs to be in that release branch.

## Description

[<!-- ID for Jira ticket e.g [SPE-1234] -->](https://hashicorp.atlassian.net/browse/VAULT-45556)

:ticket: [[Jira ticket]](https://hashicorp.atlassian.net/browse/VAULT-44272)

<!-- This PR adds documentation for the Transit key count census metric to track the total number of Transit encryption keys across all namespaces and mounts in a Vault cluster. -->

### Requested review scope:

- [x] Content touched by the PR _only_ (typos, clarifications, tips)
- [ ] Code test (command and code block changes)
- [ ] Flow and language near changes (new/rearranged steps)
- [ ] Review everything (rewrites, major changes)

### Review urgency:

- [ ] ASAP (bug fixes, broken content, imminent releases)
- [ ] 3 days (small changes, easy reviews)
- [x] 1 week (default)
- [ ] Best effort (very non-urgent)

<!-- Fill out only the appropriate checklist for your type of feature (or both if necessary) and delete the other one! -->

## All updates:

<!-- This section is mandatory for all PRs: -->

I have:

- [x] Verified that all status checks have passed
- [ ] Verified that preview environment has successfully deployed
- [ ] Verified appropriate `label` applied (`hcp` + `product name`)
- [ ] Added all required reviewers (code owners and external)

## Content checklist (optional)

Please do these things before requesting a review. I have:

- [ ] Made any associated code repositories public
- [ ] Added the `hashicorp-education/teamName` to any additional code or example repos as repo admin
- [ ] Added redirects for any moved or removed pages
- [ ] Spell checked the tutorial(s)
- [ ] Followed the [unified style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [ ] Linted code snippets (Details per language [here](https://github.com/hashicorp/engineering-docs/blob/master/writing/markdown.md#code-blocks))
- [ ] Checked the steps for completeness (no steps are implied or hidden)
- [ ] Looked at the local or vercel build and checked each new or changed page for:
  - display on the product curriculum page
  - callout box formatting
  - code block highlighting
  - right-hand navigation
  - next and back buttons
  - URL path


[SPE-1234]: https://hashicorp.atlassian.net/browse/SPE-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

