### PR TITLE
VAULT-46623: make externalId optional and non-unique in SCIM docs

### DIFF
--- a/content/vault/v2.x/content/api-docs/secret/identity/scim.mdx
+++ b/content/vault/v2.x/content/api-docs/secret/identity/scim.mdx
@@ -101,8 +101,9 @@ SCIM users map to Vault entities as follows:
 - `externalId` maps to the entity external ID.
 - `active` maps to the inverse of the entity `disabled` state.
 
-Vault requires `userName` and `externalId` on create and makes `externalId`
-immutable after creation.
+Vault requires `userName` on create. `externalId` is optional and, if
+provided, is immutable after creation. Multiple users may share the same
+`externalId` value.
 
 ### Supported filters
 
@@ -215,8 +216,8 @@ Vault also declares `/identity/scim/v2/Me`, but the endpoint returns
 - Vault does not support group filters or complex SCIM filter expressions.
 - Group members must use Vault user entity IDs, not `userName` or
   `externalId`.
-- You must provide `externalId` when you create a user and you cannot update it
-  later.
+- `externalId` is optional when you create a user. If provided, it cannot be
+  updated later. Multiple users may share the same `externalId` value.
 - `alias_mount_accessor` is immutable after client creation and remains tied to
   the auth mount strategy you choose for that client.
 - `alias_mount_accessor` cannot refer to a local mount, only non-local ones.

--- a/content/vault/v2.x/content/docs/enterprise/scim-overview.mdx
+++ b/content/vault/v2.x/content/docs/enterprise/scim-overview.mdx
@@ -224,8 +224,8 @@ $ curl \
 
 Important behavior:
 
-- `externalId` is required when you create a SCIM user.
-- `externalId` stays fixed after creation.
+- `externalId` is optional when you create a SCIM user.
+- `externalId` stays fixed after creation and does not need to be unique within a namespace.
 - Group members must reference Vault user resource IDs.
 - Group membership is limited to users owned by the same SCIM client.
 
@@ -257,8 +257,8 @@ Vault returns SCIM responses as `application/scim+json`.
 - Vault does not support group filters or complex SCIM filter expressions.
 - Group members must use Vault user resource IDs, not `userName` or
   `externalId`.
-- `externalId` is required when you create a user and you cannot update it
-  later.
+- `externalId` is optional when you create a user and you cannot update it
+  later. Multiple users may share the same `externalId` value.
 - `alias_mount_accessor` is immutable after client creation and remains tied to
   the auth mount strategy you choose for that client.
 


### PR DESCRIPTION
Updates SCIM documentation to reflect that `externalId` is now optional on `POST /Users` and no longer required to be unique within a namespace.
Related PRs: https://github.com/hashicorp/vault-enterprise/pull/16686