### PR TITLE
Add breaking change for ldap automated rotation TTLs when a manual rotation is performed

### DIFF
--- a/content/vault/global/partials/important-changes/summary-tables/2xx.mdx
+++ b/content/vault/global/partials/important-changes/summary-tables/2xx.mdx
@@ -2,7 +2,7 @@
 
 Introduced | Recommendations | Edition    | Change
 ---------- | --------------- | ---------- | ------
-2.0.0      | **No**          | Enterprise | [LDAP static roles do not reset their rotation TTL after a manual rotation](/vault/docs/v2.x/updates/important-changes#ldap-manual-rotation-ttl-reset)
+2.0.0      | **Yes**          | Enterprise | [LDAP static roles do not reset their rotation TTL after a manual rotation](/vault/docs/v2.x/updates/important-changes#ldap-static-roles-do-not-reset-rotation-ttl-after-manual-rotation)
 2.0.0      | **Yes**         | All        | [Azure auth configuration takes precedence over environment variables](/vault/docs/v2.x/updates/important-changes#azure-auth-precedence)
 2.0.0      | **Yes**         | All        | [Previously unauthenticated endpoints require authentication](/vault/docs/v2.x/updates/important-changes#sys-endpoint-auth)
 2.0.0      | **Yes**         | All        | [Vault rejects uncleaned paths](/vault/docs/v2.x/updates/important-changes#cleaned-paths)

--- a/content/vault/global/partials/important-changes/summary-tables/2xx.mdx
+++ b/content/vault/global/partials/important-changes/summary-tables/2xx.mdx
@@ -2,6 +2,7 @@
 
 Introduced | Recommendations | Edition    | Change
 ---------- | --------------- | ---------- | ------
+2.0.0      | **No**          | Enterprise | [LDAP static roles do not reset their rotation TTL after a manual rotation](/vault/docs/v2.x/updates/important-changes#ldap-manual-rotation-ttl-reset)
 2.0.0      | **Yes**         | All        | [Azure auth configuration takes precedence over environment variables](/vault/docs/v2.x/updates/important-changes#azure-auth-precedence)
 2.0.0      | **Yes**         | All        | [Previously unauthenticated endpoints require authentication](/vault/docs/v2.x/updates/important-changes#sys-endpoint-auth)
 2.0.0      | **Yes**         | All        | [Vault rejects uncleaned paths](/vault/docs/v2.x/updates/important-changes#cleaned-paths)

--- a/content/vault/v2.x/content/docs/updates/important-changes.mdx
+++ b/content/vault/v2.x/content/docs/updates/important-changes.mdx
@@ -19,6 +19,20 @@ before upgrading Vault.
 
 ## Breaking changes
 
+## LDAP static roles do not reset rotation TTL after manual rotation ((#ldap-manual-rotation-ttl-reset))
+
+| Change       | Affected version | Vault edition
+| ------------ | ---------------- | -------------
+| Breaking     | 2.0.0+           | Enterprise
+
+[LDAP secrets engine static roles](/vault/docs/secrets/ldap) that have automated
+credential rotation configured with `rotation_period` no longer reset their
+rotation TTL after a manual rotation is performed.
+
+#### Recommendation
+
+...
+
 ### Precedence change for Azure authentication ((#azure-precedence))
 
 | Change       | Affected version | Vault edition

--- a/content/vault/v2.x/content/docs/updates/important-changes.mdx
+++ b/content/vault/v2.x/content/docs/updates/important-changes.mdx
@@ -26,7 +26,7 @@ before upgrading Vault.
 | Breaking     | 2.0.0+           | Enterprise
 
 [LDAP secrets engine static roles](/vault/docs/secrets/ldap) that have automated
-credential rotation configured with `rotation_period` now no longer reset their
+credential rotation configured now no longer reset their
 rotation TTL after a manual rotation is performed. The original rotation period
 cadence is preserved and will continue to be rotated automatically at the
 originally scheduled time.

--- a/content/vault/v2.x/content/docs/updates/important-changes.mdx
+++ b/content/vault/v2.x/content/docs/updates/important-changes.mdx
@@ -31,10 +31,6 @@ rotation TTL after a manual rotation is performed. The original rotation period
 cadence is preserved and will continue to be rotated automatically at the
 originally scheduled time.
 
-#### Recommendation
-
-...
-
 ### Precedence change for Azure authentication ((#azure-precedence))
 
 | Change       | Affected version | Vault edition

--- a/content/vault/v2.x/content/docs/updates/important-changes.mdx
+++ b/content/vault/v2.x/content/docs/updates/important-changes.mdx
@@ -26,8 +26,10 @@ before upgrading Vault.
 | Breaking     | 2.0.0+           | Enterprise
 
 [LDAP secrets engine static roles](/vault/docs/secrets/ldap) that have automated
-credential rotation configured with `rotation_period` no longer reset their
-rotation TTL after a manual rotation is performed.
+credential rotation configured with `rotation_period` now no longer reset their
+rotation TTL after a manual rotation is performed. The original rotation period
+cadence is preserved and will continue to be rotated automatically at the
+originally scheduled time.
 
 #### Recommendation
 

--- a/content/vault/v2.x/content/docs/updates/important-changes.mdx
+++ b/content/vault/v2.x/content/docs/updates/important-changes.mdx
@@ -27,8 +27,8 @@ before upgrading Vault.
 
 [LDAP secrets engine static roles](/vault/docs/secrets/ldap) that have automated
 credential rotation configured now no longer reset their
-rotation TTL after a manual rotation is performed. The original rotation period
-cadence is preserved and will continue to be rotated automatically at the
+rotation TTL when you perform a manual rotation. Vault preserves the original rotation period
+cadence and continues to rotate the static role automatically at the
 originally scheduled time.
 
 ### Precedence change for Azure authentication ((#azure-precedence))

--- a/content/vault/v2.x/content/docs/updates/important-changes.mdx
+++ b/content/vault/v2.x/content/docs/updates/important-changes.mdx
@@ -27,9 +27,17 @@ before upgrading Vault.
 
 [LDAP secrets engine static roles](/vault/docs/secrets/ldap) that have automated
 credential rotation configured now no longer reset their
-rotation TTL when you perform a manual rotation. Vault preserves the original rotation period
+rotation TTL when you perform a manual rotation. Vault preserves the original rotation 
 cadence and continues to rotate the static role automatically at the
 originally scheduled time.
+
+#### Recommendation
+
+The automated rotation cadence can be restarted by setting the field
+`disable_automated_rotation` to `true` to deregister the rotation entry,
+then set it back to `false` to re-register it with the rotation period
+or schedule needed. This forces Vault to reset the initial rotation
+time and recalculate the next `next_vault_rotation` timestamp.
 
 ### Precedence change for Azure authentication ((#azure-precedence))
 

--- a/content/vault/v2.x/content/docs/updates/important-changes.mdx
+++ b/content/vault/v2.x/content/docs/updates/important-changes.mdx
@@ -33,11 +33,12 @@ originally scheduled time.
 
 #### Recommendation
 
-The automated rotation cadence can be restarted by setting the field
-`disable_automated_rotation` to `true` to deregister the rotation entry,
-then set it back to `false` to re-register it with the rotation period
-or schedule needed. This forces Vault to reset the initial rotation
-time and recalculate the next `next_vault_rotation` timestamp.
+You can reset the automated rotation cadence by toggling automated rotation: 
+
+1. Deregister the rotation entry by setting `disable_automated_rotation` to `true` on the static role.
+1. Reregister the rotation entry by setting `disable_automated_rotation` back to `false`.
+
+When you reactivate rotation, Vault resets the initial rotation time and recalculates the `next_vault_rotation` timestamp.
 
 ### Precedence change for Azure authentication ((#azure-precedence))
 


### PR DESCRIPTION
Note that LDAP static roles do not update their automated rotation-based TTL's after a manual rotation and that the original rotation cadence will continue.