### PR TITLE
Populate Vercel with Instana environment vars from HCP Terraform

### DIFF
--- a/terraform/github.tf
+++ b/terraform/github.tf
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
- locals {
+locals {
   repositories = toset([
     var.github_repository,
     "${var.github_repository}-internal",

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -15,6 +15,10 @@ terraform {
       source  = "integrations/github"
       version = ">= 6.12.0"
     }
+    vercel = {
+      source  = "vercel/vercel"
+      version = ">= 2.0.0"
+    }
   }
 
   backend "remote" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -48,3 +48,16 @@ variable "github_repository" {
   description = "Canonical name of the GitHub repository to manage."
   type        = string
 }
+
+# -------------------------
+# Vercel
+# -------------------------
+variable "vercel_team_slug" {
+  description = "Vercel team slug (the part after vercel.com/ in your team URL)."
+  type        = string
+}
+
+variable "vercel_project_id" {
+  description = "Vercel project ID. Find it in Project Settings → General."
+  type        = string
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -52,8 +52,8 @@ variable "github_repository" {
 # -------------------------
 # Vercel
 # -------------------------
-variable "vercel_team_slug" {
-  description = "Vercel team slug (the part after vercel.com/ in your team URL)."
+variable "vercel_team_id" {
+  description = "Team ID of the \"hashicorp\" team"
   type        = string
 }
 

--- a/terraform/vercel.tf
+++ b/terraform/vercel.tf
@@ -22,7 +22,7 @@ resource "vercel_project_environment_variable" "this" {
   for_each = local.environment
 
   project_id = var.vercel_project_id
-  team_id    = var.vercel_team_slug
+  team_id    = var.vercel_team_id
   key        = each.value.client_visible && !startswith(each.key, "NEXT_PUBLIC_") ? format("NEXT_PUBLIC_%s", each.key) : each.key
   value      = each.value.value
   target     = coalesce(try(each.value.targets, null), ["production"])

--- a/terraform/vercel.tf
+++ b/terraform/vercel.tf
@@ -1,0 +1,31 @@
+locals {
+  environment = {
+    INSTANA_OTLP_AGENT_TOKEN = {
+        value          = var.instana_agent_key
+        sensitive      = true
+        comment        = "Instana OTel agent key. Used to submit build metrics to Instana for tracking build times"
+        client_visible = false
+        targets        = ["production", "preview"]
+    },
+    INSTANA_OTLP_ENDPOINT = {
+        value          = var.instana_otlp_endpoint
+        sensitive      = false
+        comment        = "Instana OTel endpoint for build metrics to Instana"
+        client_visible = false
+        targets        = ["production", "preview"]
+    },
+  }
+}
+
+# Vercel Project Environment Variables
+resource "vercel_project_environment_variable" "this" {
+  for_each = local.environment
+
+  project_id = var.vercel_project_id
+  team_id    = var.vercel_team_slug
+  key        = each.value.client_visible && !startswith(each.key, "NEXT_PUBLIC_") ? format("NEXT_PUBLIC_%s", each.key) : each.key
+  value      = each.value.value
+  target     = coalesce(try(each.value.targets, null), ["production"])
+  sensitive  = each.value.sensitive != null ? each.value.sensitive : true
+  comment    = "${try(each.value.comment, "")} ${format(" - Managed by Terraform workspace %s. Do not edit manually.", terraform.workspace)}"
+}

--- a/terraform/vercel.tf
+++ b/terraform/vercel.tf
@@ -1,31 +1,48 @@
 locals {
-  environment = {
-    INSTANA_OTLP_AGENT_TOKEN = {
-        value          = var.instana_agent_key
-        sensitive      = true
-        comment        = "Instana OTel agent key. Used to submit build metrics to Instana for tracking build times"
+  vercel_variables = {
+    INSTANA_OTLP_ENDPOINT = {
+        value          = var.instana_otlp_endpoint
+        comment        = "Instana OTel endpoint for build metrics to Instana"
         client_visible = false
         targets        = ["production", "preview"]
     },
-    INSTANA_OTLP_ENDPOINT = {
-        value          = var.instana_otlp_endpoint
-        sensitive      = false
-        comment        = "Instana OTel endpoint for build metrics to Instana"
+  }
+
+  vercel_secrets = {
+    INSTANA_OTLP_AGENT_TOKEN = {
+        value          = var.instana_agent_key
+        comment        = "Instana OTel agent key. Used to submit build metrics to Instana for tracking build times"
         client_visible = false
         targets        = ["production", "preview"]
     },
   }
 }
 
-# Vercel Project Environment Variables
-resource "vercel_project_environment_variable" "this" {
-  for_each = local.environment
+# The sensitive and non-sensitive env vars have to be split up otherwise terraform
+# just makes everything as sensitive. Which is irritating for API URLs etc.
+
+# Sensitive env vars
+resource "vercel_project_environment_variable" "sensitive" {
+  for_each = local.vercel_secrets
 
   project_id = var.vercel_project_id
   team_id    = var.vercel_team_id
   key        = each.value.client_visible && !startswith(each.key, "NEXT_PUBLIC_") ? format("NEXT_PUBLIC_%s", each.key) : each.key
   value      = each.value.value
   target     = coalesce(try(each.value.targets, null), ["production"])
-  sensitive  = each.value.sensitive != null ? each.value.sensitive : true
+  sensitive  = true
+  comment    = "${try(each.value.comment, "")} ${format(" - Managed by Terraform workspace %s. Do not edit manually.", terraform.workspace)}"
+}
+
+# Non-sensitive env vars
+resource "vercel_project_environment_variable" "non-sensitive" {
+  for_each = local.vercel_variables
+
+  project_id = var.vercel_project_id
+  team_id    = var.vercel_team_id
+  key        = each.value.client_visible && !startswith(each.key, "NEXT_PUBLIC_") ? format("NEXT_PUBLIC_%s", each.key) : each.key
+  value      = each.value.value
+  target     = coalesce(try(each.value.targets, null), ["production"])
+  sensitive  = false
   comment    = "${try(each.value.comment, "")} ${format(" - Managed by Terraform workspace %s. Do not edit manually.", terraform.workspace)}"
 }

--- a/terraform/vercel.tf
+++ b/terraform/vercel.tf
@@ -24,7 +24,7 @@ locals {
 # add the env vars we want to manage, while the latter would completely replace
 # anything not included in the array specified in the configuration.
 resource "vercel_project_environment_variable" "sensitive" {
-  for_each = local.vercel_env
+  for_each   = local.vercel_env
   project_id = var.vercel_project_id
   team_id    = var.vercel_team_id
   key        = each.value.client_visible && !startswith(each.key, "NEXT_PUBLIC_") ? format("NEXT_PUBLIC_%s", each.key) : each.key

--- a/terraform/vercel.tf
+++ b/terraform/vercel.tf
@@ -1,48 +1,35 @@
 locals {
-  vercel_variables = {
+  vercel_env = {
     INSTANA_OTLP_ENDPOINT = {
-        value          = var.instana_otlp_endpoint
-        comment        = "Instana OTel endpoint for build metrics to Instana"
-        client_visible = false
-        targets        = ["production", "preview"]
+      value          = var.instana_otlp_endpoint
+      comment        = "Instana OTel endpoint for build metrics to Instana."
+      client_visible = false
+      sensitive      = false
+      targets        = ["production", "preview"]
     },
-  }
-
-  vercel_secrets = {
     INSTANA_OTLP_AGENT_TOKEN = {
-        value          = var.instana_agent_key
-        comment        = "Instana OTel agent key. Used to submit build metrics to Instana for tracking build times"
-        client_visible = false
-        targets        = ["production", "preview"]
+      value          = var.instana_agent_key
+      comment        = "Instana OTel agent key. Used to submit build metrics to Instana for tracking build times."
+      client_visible = false
+      sensitive      = true
+      targets        = ["production", "preview"]
     },
   }
 }
 
-# The sensitive and non-sensitive env vars have to be split up otherwise terraform
-# just makes everything as sensitive. Which is irritating for API URLs etc.
-
-# Sensitive env vars
+# Enviornment variables
+#
+# The `vercel_project_environment_variable` resource is used here isntead of
+# `vercel_project_environment_variables` because the former allows us to just
+# add the env vars we want to manage, while the latter would completely replace
+# anything not included in the array specified in the configuration.
 resource "vercel_project_environment_variable" "sensitive" {
-  for_each = local.vercel_secrets
-
+  for_each = local.vercel_env
   project_id = var.vercel_project_id
   team_id    = var.vercel_team_id
   key        = each.value.client_visible && !startswith(each.key, "NEXT_PUBLIC_") ? format("NEXT_PUBLIC_%s", each.key) : each.key
   value      = each.value.value
   target     = coalesce(try(each.value.targets, null), ["production"])
-  sensitive  = true
-  comment    = "${try(each.value.comment, "")} ${format(" - Managed by Terraform workspace %s. Do not edit manually.", terraform.workspace)}"
-}
-
-# Non-sensitive env vars
-resource "vercel_project_environment_variable" "non-sensitive" {
-  for_each = local.vercel_variables
-
-  project_id = var.vercel_project_id
-  team_id    = var.vercel_team_id
-  key        = each.value.client_visible && !startswith(each.key, "NEXT_PUBLIC_") ? format("NEXT_PUBLIC_%s", each.key) : each.key
-  value      = each.value.value
-  target     = coalesce(try(each.value.targets, null), ["production"])
-  sensitive  = false
-  comment    = "${try(each.value.comment, "")} ${format(" - Managed by Terraform workspace %s. Do not edit manually.", terraform.workspace)}"
+  sensitive  = each.value.sensitive
+  comment    = trimspace("${try(each.value.comment, "")} ${format("Managed by Terraform workspace %s. Do not edit manually.", terraform.workspace)}")
 }


### PR DESCRIPTION
A build was failing on Vercel due to missing OTel endpoint info. This info exists already in HCP Terraform, so it probably makes sense to just push it to Vercel to keep everything in sync