### PR TITLE
docs: Client Agent behavior changes

### DIFF
--- a/content/boundary/v1.0.x/content/docs/client-agent/index.mdx
+++ b/content/boundary/v1.0.x/content/docs/client-agent/index.mdx
@@ -4,8 +4,8 @@ page_title: Client Agent overview
 description: >-
   Learn how the Boundary Client Agent intercepts DNS requests as the primary resolver on the system, allowing Boundary to proxy connections transparently.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-11-18T17:04:41-05:00
-last_modified: 2026-01-26T13:07:13-05:00
+created_at: 2026-05-11T10:18:43-04:00
+last_modified: 2026-07-23T21:02:45.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -16,6 +16,12 @@ When the Boundary Client Agent runs alongside an authenticated Boundary client, 
 
 If you enter a hostname that matches a Boundary alias that the client is authorized to establish a session to, Boundary automatically generates the session and transparently proxies the connection on your behalf.
 If the Boundary Client Agent cannot find an alias, or if there are any issues with authentication, network connectivity, or latency, the Client Agent defers DNS resolution to the previously configured DNS resolvers.
+
+The Client Agent proxy operates over TCP only.
+The agent does not capture or forward UDP-based traffic, including QUIC-based HTTP/3, RTP, RTSP, or other UDP protocols.
+For a target that serves UDP traffic, the alias resolves via DNS to the local proxy IP, but UDP packets have nowhere to go and fail.
+Many protocols that prefer UDP, such as HTTP/3, automatically fall back to TCP and continue to work through the agent.
+Targets that rely on UDP with no TCP fallback do not work with transparent sessions.
 
 Currently HashiCorp tests the Client Agent on the following operating systems:
 

--- a/content/boundary/v1.0.x/content/docs/client-agent/index.mdx
+++ b/content/boundary/v1.0.x/content/docs/client-agent/index.mdx
@@ -5,7 +5,7 @@ description: >-
   Learn how the Boundary Client Agent intercepts DNS requests as the primary resolver on the system, allowing Boundary to proxy connections transparently.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2026-05-11T10:18:43-04:00
-last_modified: 2026-07-27T14:47:44.000Z
+last_modified: 2026-07-27T15:02:33.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -26,6 +26,16 @@ Currently HashiCorp tests the Client Agent on the following operating systems:
 The Client Agent does not have a standalone binary, so you must use the Boundary installer to [install or update](/boundary/docs/deploy/install-clients) it.
 
 Refer to the [Transparent sessions interoperability matrix](/boundary/docs/interoperability-matrix) for a list of third-party products that have been tested and confirmed to work with the Client Agent to provide transparent sessions.
+
+## Proxy traffic
+
+The Client Agent proxy supports TCP only.
+It does not capture or forward UDP traffic, including QUIC-based HTTP/3, RTP, RTSP, or other UDP protocols.
+If a target serves UDP traffic, the alias resolves via DNS to the local proxy IP.
+UDP packets have nowhere to go, so the connection fails.
+
+Many UDP-based protocols automatically fall back to TCP and successfully connect.
+Targets that rely on UDP without a TCP fallback do not work with transparent sessions.
 
 ## Security
 
@@ -85,15 +95,6 @@ You can use the following grant string to grant the permission to list resolvabl
 ```
 type=user;ids=*;actions=list-resolvable-aliases
 ```
-
-## Proxy traffic
-
-The Client Agent proxy supports TCP only.
-It does not capture or forward UDP traffic, including QUIC-based HTTP/3, RTP, RTSP, and other UDP protocols.
-If a target serves UDP traffic, the alias resolves via DNS to the local proxy IP. However, UDP packets have nowhere to go, so the connection fails.
-
-Many UDP-based protocols automatically fall back to TCP and continue to work.
-Targets that rely on UDP without a TCP fallback do not work with transparent sessions.
 
 ## Configuration changes and active sessions
 

--- a/content/boundary/v1.0.x/content/docs/client-agent/index.mdx
+++ b/content/boundary/v1.0.x/content/docs/client-agent/index.mdx
@@ -5,7 +5,7 @@ description: >-
   Learn how the Boundary Client Agent intercepts DNS requests as the primary resolver on the system, allowing Boundary to proxy connections transparently.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2026-05-11T10:18:43-04:00
-last_modified: 2026-07-23T21:02:45.000Z
+last_modified: 2026-07-27T14:47:44.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -16,12 +16,6 @@ When the Boundary Client Agent runs alongside an authenticated Boundary client, 
 
 If you enter a hostname that matches a Boundary alias that the client is authorized to establish a session to, Boundary automatically generates the session and transparently proxies the connection on your behalf.
 If the Boundary Client Agent cannot find an alias, or if there are any issues with authentication, network connectivity, or latency, the Client Agent defers DNS resolution to the previously configured DNS resolvers.
-
-The Client Agent proxy operates over TCP only.
-The agent does not capture or forward UDP-based traffic, including QUIC-based HTTP/3, RTP, RTSP, or other UDP protocols.
-For a target that serves UDP traffic, the alias resolves via DNS to the local proxy IP, but UDP packets have nowhere to go and fail.
-Many protocols that prefer UDP, such as HTTP/3, automatically fall back to TCP and continue to work through the agent.
-Targets that rely on UDP with no TCP fallback do not work with transparent sessions.
 
 Currently HashiCorp tests the Client Agent on the following operating systems:
 
@@ -91,6 +85,19 @@ You can use the following grant string to grant the permission to list resolvabl
 ```
 type=user;ids=*;actions=list-resolvable-aliases
 ```
+
+## Proxy traffic
+
+The Client Agent proxy supports TCP only.
+It does not capture or forward UDP traffic, including QUIC-based HTTP/3, RTP, RTSP, and other UDP protocols.
+If a target serves UDP traffic, the alias resolves via DNS to the local proxy IP. However, UDP packets have nowhere to go, so the connection fails.
+
+Many UDP-based protocols automatically fall back to TCP and continue to work.
+Targets that rely on UDP without a TCP fallback do not work with transparent sessions.
+
+## Configuration changes and active sessions
+
+@include '/client-agent/configuration-changes.mdx'
 
 ## More information
 

--- a/content/boundary/v1.0.x/content/docs/client-agent/troubleshoot.mdx
+++ b/content/boundary/v1.0.x/content/docs/client-agent/troubleshoot.mdx
@@ -4,8 +4,8 @@ page_title: Troubleshoot the Client Agent
 description: >-
   Troubleshoot issues with the Boundary Client Agent to ensure it is functioning properly.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-11-18T17:04:41-05:00
-last_modified: 2026-01-26T13:07:13-05:00
+created_at: 2026-05-11T10:18:43-04:00
+last_modified: 2026-07-23T20:28:24.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -284,3 +284,4 @@ Refer to the following table for known issues with the Client Agent that may aff
 | Windows installer does not support partial installations | The Windows installer fails to start the Client Agent if the Desktop client is not installed at the same time. |
 | Alias connection failures inside containers/VMs | Using transparent sessions rely on network access to the local network of the computer the Client Agent is running on. Network enclaves such as those created by Docker containers and VMs cannot reach this network. |
 | DNS lookup is broken on MacOS 15.1 and 15.2 | MacOS 15.1 and 15.2 may incorrectly block DNS lookups for the Client Agent. This issue is resolved in MacOS 15.3 and later. |
+| UDP traffic is not supported | The Client Agent proxy operates over TCP only. The agent does not capture or forward UDP-based traffic, including QUIC-based HTTP/3, RTP, RTSP, or other UDP protocols.<br /><br />For a target that serves UDP traffic, the alias resolves via DNS to the local proxy IP, but UDP packets have nowhere to go and fail. Many protocols that prefer UDP, such as HTTP/3, automatically fall back to TCP and continue to work through the agent. Targets that rely on UDP with no TCP fallback do not work with transparent sessions. |

--- a/content/boundary/v1.0.x/content/docs/client-agent/troubleshoot.mdx
+++ b/content/boundary/v1.0.x/content/docs/client-agent/troubleshoot.mdx
@@ -5,7 +5,7 @@ description: >-
   Troubleshoot issues with the Boundary Client Agent to ensure it is functioning properly.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2026-05-11T10:18:43-04:00
-last_modified: 2026-07-23T20:28:24.000Z
+last_modified: 2026-07-27T14:47:46.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -284,4 +284,4 @@ Refer to the following table for known issues with the Client Agent that may aff
 | Windows installer does not support partial installations | The Windows installer fails to start the Client Agent if the Desktop client is not installed at the same time. |
 | Alias connection failures inside containers/VMs | Using transparent sessions rely on network access to the local network of the computer the Client Agent is running on. Network enclaves such as those created by Docker containers and VMs cannot reach this network. |
 | DNS lookup is broken on MacOS 15.1 and 15.2 | MacOS 15.1 and 15.2 may incorrectly block DNS lookups for the Client Agent. This issue is resolved in MacOS 15.3 and later. |
-| UDP traffic is not supported | The Client Agent proxy operates over TCP only. The agent does not capture or forward UDP-based traffic, including QUIC-based HTTP/3, RTP, RTSP, or other UDP protocols.<br /><br />For a target that serves UDP traffic, the alias resolves via DNS to the local proxy IP, but UDP packets have nowhere to go and fail. Many protocols that prefer UDP, such as HTTP/3, automatically fall back to TCP and continue to work through the agent. Targets that rely on UDP with no TCP fallback do not work with transparent sessions. |
+| UDP traffic is not supported | The Client Agent proxy supports TCP only. It does not capture or forward UDP traffic, including QUIC-based HTTP/3, RTP, RTSP, and other UDP protocols. If a target serves UDP traffic, the alias resolves via DNS to the local proxy IP. However, UDP packets have nowhere to go, so the connection fails.<br /><br />Many UDP-based protocols automatically fall back to TCP and continue to work. Targets that rely on UDP without a TCP fallback do not work with transparent sessions. |

--- a/content/boundary/v1.0.x/content/docs/client-agent/troubleshoot.mdx
+++ b/content/boundary/v1.0.x/content/docs/client-agent/troubleshoot.mdx
@@ -5,7 +5,7 @@ description: >-
   Troubleshoot issues with the Boundary Client Agent to ensure it is functioning properly.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2026-05-11T10:18:43-04:00
-last_modified: 2026-07-27T14:47:46.000Z
+last_modified: 2026-07-27T15:02:33.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -284,4 +284,4 @@ Refer to the following table for known issues with the Client Agent that may aff
 | Windows installer does not support partial installations | The Windows installer fails to start the Client Agent if the Desktop client is not installed at the same time. |
 | Alias connection failures inside containers/VMs | Using transparent sessions rely on network access to the local network of the computer the Client Agent is running on. Network enclaves such as those created by Docker containers and VMs cannot reach this network. |
 | DNS lookup is broken on MacOS 15.1 and 15.2 | MacOS 15.1 and 15.2 may incorrectly block DNS lookups for the Client Agent. This issue is resolved in MacOS 15.3 and later. |
-| UDP traffic is not supported | The Client Agent proxy supports TCP only. It does not capture or forward UDP traffic, including QUIC-based HTTP/3, RTP, RTSP, and other UDP protocols. If a target serves UDP traffic, the alias resolves via DNS to the local proxy IP. However, UDP packets have nowhere to go, so the connection fails.<br /><br />Many UDP-based protocols automatically fall back to TCP and continue to work. Targets that rely on UDP without a TCP fallback do not work with transparent sessions. |
+| UDP traffic is not supported | The Client Agent proxy supports TCP only. It does not capture or forward UDP traffic, including QUIC-based HTTP/3, RTP, RTSP, or other UDP protocols. If a target serves UDP traffic, the alias resolves via DNS to the local proxy IP. UDP packets have nowhere to go, so the connection fails.<br /><br />Many UDP-based protocols automatically fall back to TCP and successfully connect. Targets that rely on UDP without a TCP fallback do not work with transparent sessions. |

--- a/content/boundary/v1.0.x/content/docs/commands/targets/update.mdx
+++ b/content/boundary/v1.0.x/content/docs/commands/targets/update.mdx
@@ -5,7 +5,7 @@ description: >-
   The "targets update" command updates an existing target resource.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2026-05-11T10:18:43-04:00
-last_modified: 2026-07-27T16:17:01.000Z
+last_modified: 2026-07-27T16:19:55.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -60,10 +60,10 @@ The `targets update rdp` command lets you update existing RDP targets.
 
 #### Example
 
-This example updates an RDP target with the id `rdp_1234567890` to add the name `devops` and the description `RDP target for DevOps`:
+This example updates an RDP target with the id `trdp_1234567890` to add the name `devops` and the description `RDP target for DevOps`:
 
 ```shell-session
-$ boundary targets update rdp -id rdp_1234567890 -name "devops" -description "RDP target for DevOps"
+$ boundary targets update rdp -id trdp_1234567890 -name "devops" -description "RDP target for DevOps"
 ```
 
 #### Usage

--- a/content/boundary/v1.0.x/content/docs/commands/targets/update.mdx
+++ b/content/boundary/v1.0.x/content/docs/commands/targets/update.mdx
@@ -4,8 +4,8 @@ page_title: targets update - Command
 description: >-
   The "targets update" command updates an existing target resource.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-11-18T17:04:41-05:00
-last_modified: 2025-12-10T14:31:06-05:00
+created_at: 2026-05-11T10:18:43-04:00
+last_modified: 2026-07-27T16:03:54.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -78,37 +78,7 @@ $ boundary targets update rdp [options] [args]
 
 #### RDP target options
 
-- `-address=<string>` - An optional valid network address for the target to connect to.
-You cannot use an address alongside host sources.
-
-  If you set a target address for RDP targets that use Kerberos authentication, use the target's hostname and append the domain to it, for example `target-hostname.mydomain.com`. For RDP targets that use NTLM authentication, set the target address to the target's IP address.
-- `-default-client-port=<string>` - The default client port on the target.
-- `-default-port=<string>` - The default port on the target.
-For Client Agent versions prior to 0.21.2, you must configure a custom port to use transparent sessions with RDP targets.
-
-  Refer to [RDP targets](/boundary/docs/targets/configuration/configure-transparent-sessions#rdp-targets) for more information about configuring a custom port for transparent sessions.
-- `-egress-worker-filter=<string>` - A Boolean expression that filters which egress workers can process sessions for the target.
-- `-ingress-worker-filter=<string>` - A Boolean expression that filters which ingress workers can process sessions for the target.
-- `-session-connection-limit=<string>` - The maximum number of connections allowed for a session.
-A value of `-1` means the connections are unlimited.
-
-  The Windows Remote Desktop Connection application consumes multiple connections when initiating a session.
-  If you set the `session-connection-limit` to `1` for RDP targets it will cause all RDP connections using this client to fail.
-  You can leave the connection limit unset or configure a limit of `2` or higher to account for the multiple connections used by the RDP client.
-
-  Refer to [RDP target attributes](/boundary/docs/domain-model/targets#rdp-target-attributes) for more information.
-- `-session-max-seconds=<string>` - The maximum lifetime of the session, including all connections.
-You can specify an integer number of seconds or a duration string.
-If you do not specify a maximum duration, Boundary uses the default value of 8 hours (28800 seconds).
-- `-with-alias-authorize-session-host-id=<string>` - The host ID that an alias uses to authorize sessions for the target.
-- `-with-alias-scope-id=<string>` - The scope ID that you want to create the target and alias in.
-The default is `global`.
-You can create aliases in the `global` and project scopes.
-
-  You must create org and project suffixes before you can create an alias in the target's project scope. Otherwise, you can only create the alias in the `global` scope. Refer to [Create a suffix for a scope](/boundary/docs/targets/configuration/create-suffix) for more information.
-- `-with-alias-value=<string>` - The value of the alias that you want to use to represent the target.
-Use this parameter to create the alias and target, and associate them with each other, at the same time.
-
+@include 'targets/targets-update-rdp.mdx'
 
 </Tab>
 <Tab heading="SSH">
@@ -135,20 +105,7 @@ $ boundary targets update ssh [options] [args]
 
 #### SSH target options
 
-- `-address=<string>` - An optional valid network address for the target to connect to.
-You cannot use an address alongside host sources.
-- `-default-client-port=<string>` - The default client port on the target, if set.
-- `-default-port=<string>` - The default port on the target, if set.
-If you do not specify a default port, Boundary uses port 22.
-- `-egress-worker-filter=<string>` - A Boolean expression that filters which egress workers can process sessions for the target.
-- `-enable-session-recording=<string>` - A Boolean expression you can use to enable session recording for the target.
-- `-ingress-worker-filter=<string>` - A Boolean expression that filters which ingress workers can process sessions for the target.
-- `-session-connection-limit=<string>` - The maximum number of connections allowed for a session.
-A value of `-1` means the connections are unlimited.
-- `-session-max-seconds=<string>` - The maximum lifetime of the session, including all connections.
-You can specify an integer number of seconds or a duration string.
-If you do not specify a maximum duration, Boundary uses the default value of 8 hours (28800 seconds).
-- `-storage-bucket-id=<string>` - The public ID of the storage bucket you want to associate with the target.
+@include 'targets/targets-update-ssh.mdx'
 
 
 </Tab>
@@ -176,20 +133,7 @@ $ boundary targets update tcp [options] [args]
 
 #### TCP target options
 
-- `-address=<string>` - An optional valid network address for the target to connect to.
-You cannot use an address alongside host sources.
-- `-default-client-port=<string>` - The default client port on the target, if set.
-- `-default-port=<string>` - The default port on the target, if set.
-If you do not specify a default port, Boundary uses port 22.
-- `-egress-worker-filter=<string>` - A Boolean expression that filters which egress workers can process sessions for the target.
-- `-ingress-worker-filter=<string>` - A Boolean expression that filters which ingress workers can process sessions for the target.
-- `-session-connection-limit=<string>` - The maximum number of connections allowed for a session.
-A value of `-1` means the connections are unlimited.
-- `-session-max-seconds=<string>` - The maximum lifetime of the session, including all connections.
-You can specify an integer number of seconds or a duration string.
-If you do not specify a maximum duration, Boundary uses the default value of 8 hours (28800 seconds).
-- `-worker-filter=<string>` - This option is deprecated.
-Use the egress or ingress filters instead.
+@include 'targets/targets-update-tcp.mdx'
 
 </Tab>
 </Tabs>

--- a/content/boundary/v1.0.x/content/docs/commands/targets/update.mdx
+++ b/content/boundary/v1.0.x/content/docs/commands/targets/update.mdx
@@ -5,7 +5,7 @@ description: >-
   The "targets update" command updates an existing target resource.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2026-05-11T10:18:43-04:00
-last_modified: 2026-07-27T16:03:54.000Z
+last_modified: 2026-07-27T16:17:01.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -63,7 +63,7 @@ The `targets update rdp` command lets you update existing RDP targets.
 This example updates an RDP target with the id `rdp_1234567890` to add the name `devops` and the description `RDP target for DevOps`:
 
 ```shell-session
-$ boundary targets update rdp -id trdp_1234567890 -name "devops" -description "RDP target for DevOps"
+$ boundary targets update rdp -id rdp_1234567890 -name "devops" -description "RDP target for DevOps"
 ```
 
 #### Usage
@@ -106,7 +106,6 @@ $ boundary targets update ssh [options] [args]
 #### SSH target options
 
 @include 'targets/targets-update-ssh.mdx'
-
 
 </Tab>
 <Tab heading="TCP">

--- a/content/boundary/v1.0.x/content/docs/domain-model/targets.mdx
+++ b/content/boundary/v1.0.x/content/docs/domain-model/targets.mdx
@@ -4,8 +4,8 @@ page_title: Target resource
 description: >-
   Learn about using the target resource to configure a networked service a user can connect to. Understand the TCP, SSH, and RDP target type requirements and attributes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-11-18T17:04:41-05:00
-last_modified: 2026-01-26T14:35:46-05:00
+created_at: 2026-05-11T10:18:43-04:00
+last_modified: 2026-07-23T20:28:24.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -51,7 +51,10 @@ A target has the following configurable attributes:
   If you set a target address for RDP targets that use Kerberos authentication, use the target's hostname and append the domain to it, for example `target-hostname.mydomain.com`. For RDP targets that use NTLM authentication, set the target address to the target's IP address.
 
 - `default_client_port` - (optional)
-  Represents a local port that you want Boundary to listen to by default when someone initiates a session on the client.
+  The port that the Client Agent binds its local proxy listener to when establishing a transparent session for this target.
+  This value must match the port that the client application dials by default. For example, SSH clients dial port 22, RDP clients dial port 3389, and HTTPS clients dial port 443.
+
+  Set `default_client_port` to match the intended client application. If you do not set this value, the Client Agent falls back to `default_port`. This fallback only works when the server port and the client application's port are the same, and you should not rely on it. If `default_client_port` does not match the client application, the application dials a port the proxy is not listening on and the transparent session fails.
 
 - `egress_worker_filter` - (optional)
   A boolean expression to [filter][] which egress workers can handle sessions

--- a/content/boundary/v1.0.x/content/docs/targets/connections/transparent-sessions.mdx
+++ b/content/boundary/v1.0.x/content/docs/targets/connections/transparent-sessions.mdx
@@ -4,8 +4,8 @@ page_title: Connect using transparent sessions
 description: >-
   Learn how to use transparent sessions to enhance end-user workflows and simplify target access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-11-18T17:04:41-05:00
-last_modified: 2026-01-26T13:07:13-05:00
+created_at: 2026-05-11T10:18:43-04:00
+last_modified: 2026-07-23T20:40:26.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -46,6 +46,15 @@ $ ssh my.alias.name
 ```
 
 Boundary starts the session as usual, and brokers or injects any credentials you have configured.
+
+## Configuration changes and active sessions
+
+The Client Agent refreshes target and alias metadata in the background.
+When you change a target's configuration, such as the target's default port or an alias reassignment, the updated configuration applies only to new sessions.
+Active sessions continue using the configuration in place when Boundary established them, and subsequent changes do not affect them.
+
+To apply updated configuration to an active connection, manually terminate the existing session and establish a new one.
+The new session uses the current configuration.
 
 ## Next steps
 

--- a/content/boundary/v1.0.x/content/docs/targets/connections/transparent-sessions.mdx
+++ b/content/boundary/v1.0.x/content/docs/targets/connections/transparent-sessions.mdx
@@ -5,7 +5,7 @@ description: >-
   Learn how to use transparent sessions to enhance end-user workflows and simplify target access.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2026-05-11T10:18:43-04:00
-last_modified: 2026-07-23T20:40:26.000Z
+last_modified: 2026-07-27T14:47:46.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -49,12 +49,7 @@ Boundary starts the session as usual, and brokers or injects any credentials you
 
 ## Configuration changes and active sessions
 
-The Client Agent refreshes target and alias metadata in the background.
-When you change a target's configuration, such as the target's default port or an alias reassignment, the updated configuration applies only to new sessions.
-Active sessions continue using the configuration in place when Boundary established them, and subsequent changes do not affect them.
-
-To apply updated configuration to an active connection, manually terminate the existing session and establish a new one.
-The new session uses the current configuration.
+@include '/client-agent/configuration-changes.mdx'
 
 ## Next steps
 

--- a/content/boundary/v1.0.x/content/partials/client-agent/configuration-changes.mdx
+++ b/content/boundary/v1.0.x/content/partials/client-agent/configuration-changes.mdx
@@ -1,7 +1,6 @@
 The Client Agent refreshes target and alias metadata in the background.
 When you change a target configuration, such as the default port or alias, the updated configuration applies only to new sessions.
 Active sessions continue to use the configuration that was in place when Boundary established them.
-Subsequent changes do not affect active sessions.
 
-To apply updated configuration changes to an active connection, terminate the existing session and establish a new one.
+To apply configuration changes to an active connection, terminate the existing session and establish a new one.
 The new session uses the current configuration.

--- a/content/boundary/v1.0.x/content/partials/client-agent/configuration-changes.mdx
+++ b/content/boundary/v1.0.x/content/partials/client-agent/configuration-changes.mdx
@@ -1,0 +1,7 @@
+The Client Agent refreshes target and alias metadata in the background.
+When you change a target configuration, such as the default port or alias, the updated configuration applies only to new sessions.
+Active sessions continue to use the configuration that was in place when Boundary established them.
+Subsequent changes do not affect active sessions.
+
+To apply updated configuration changes to an active connection, terminate the existing session and establish a new one.
+The new session uses the current configuration.

--- a/content/boundary/v1.0.x/content/partials/targets/targets-create-rdp.mdx
+++ b/content/boundary/v1.0.x/content/partials/targets/targets-create-rdp.mdx
@@ -3,7 +3,7 @@ You cannot use an address alongside host sources.
 
   If you set a target address for RDP targets that use Kerberos authentication, use the target's hostname and append the domain to it, for example `target-hostname.mydomain.com`. For RDP targets that use NTLM authentication, set the target address to the target's IP address.
 - `-default-client-port=<string>` - The port that the Client Agent binds its local proxy listener to when establishing a transparent session for this target.
-  Set this value to match the port that the client application dials by default — for example, SSH clients dial port 22, RDP clients dial port 3389, and HTTPS clients dial port 443.
+  Set this value to match the port that the client application dials by default. For example, SSH clients dial port 22, RDP clients dial port 3389, and HTTPS clients dial port 443.
   If you do not set this value, the Client Agent falls back to `-default-port`. If `-default-client-port` does not match the client application, the transparent session fails.
 - `-default-port=<string>` - The default port on the target.
 For Client Agent versions prior to 0.21.2, you must configure a custom port to use transparent sessions with RDP targets.

--- a/content/boundary/v1.0.x/content/partials/targets/targets-create-rdp.mdx
+++ b/content/boundary/v1.0.x/content/partials/targets/targets-create-rdp.mdx
@@ -2,7 +2,9 @@
 You cannot use an address alongside host sources.
 
   If you set a target address for RDP targets that use Kerberos authentication, use the target's hostname and append the domain to it, for example `target-hostname.mydomain.com`. For RDP targets that use NTLM authentication, set the target address to the target's IP address.
-- `-default-client-port=<string>` - The default client port on the target.
+- `-default-client-port=<string>` - The port that the Client Agent binds its local proxy listener to when establishing a transparent session for this target.
+  Set this value to match the port that the client application dials by default — for example, SSH clients dial port 22, RDP clients dial port 3389, and HTTPS clients dial port 443.
+  If you do not set this value, the Client Agent falls back to `-default-port`. If `-default-client-port` does not match the client application, the transparent session fails.
 - `-default-port=<string>` - The default port on the target.
 For Client Agent versions prior to 0.21.2, you must configure a custom port to use transparent sessions with RDP targets.
 

--- a/content/boundary/v1.0.x/content/partials/targets/targets-create-rdp.mdx
+++ b/content/boundary/v1.0.x/content/partials/targets/targets-create-rdp.mdx
@@ -5,7 +5,7 @@ You cannot use an address alongside host sources.
 - `-default-client-port=<string>` - The port that the Client Agent binds its local proxy listener to when establishing a transparent session for this target.
   Set this value to match the port that the client application dials by default. For example, SSH clients dial port 22, RDP clients dial port 3389, and HTTPS clients dial port 443.
   If you do not set this value, the Client Agent falls back to `-default-port`. If `-default-client-port` does not match the client application, the transparent session fails.
-- `-default-port=<string>` - The default port on the target.
+- `-default-port=<string>` - The default port on the target, if set.
 - `-egress-worker-filter=<string>` - A Boolean expression that filters which egress workers can process sessions for the target.
 - `-ingress-worker-filter=<string>` - A Boolean expression that filters which ingress workers can process sessions for the target.
 - `-session-connection-limit=<string>` - The maximum number of connections allowed for a session.

--- a/content/boundary/v1.0.x/content/partials/targets/targets-create-ssh.mdx
+++ b/content/boundary/v1.0.x/content/partials/targets/targets-create-ssh.mdx
@@ -1,7 +1,7 @@
 - `-address=<string>` - An optional valid network address for the target to connect to.
 You cannot use an address alongside host sources.
 - `-default-client-port=<string>` - The port that the Client Agent binds its local proxy listener to when establishing a transparent session for this target.
-  Set this value to match the port that the client application dials by default — for example, SSH clients dial port 22, RDP clients dial port 3389, and HTTPS clients dial port 443.
+  Set this value to match the port that the client application dials by default. For example, SSH clients dial port 22, RDP clients dial port 3389, and HTTPS clients dial port 443.
   If you do not set this value, the Client Agent falls back to `-default-port`. If `-default-client-port` does not match the client application, the transparent session fails.
 - `-default-port=<string>` - The default port on the target.
 If you do not specify a default port, Boundary uses port 22.

--- a/content/boundary/v1.0.x/content/partials/targets/targets-create-ssh.mdx
+++ b/content/boundary/v1.0.x/content/partials/targets/targets-create-ssh.mdx
@@ -1,6 +1,8 @@
 - `-address=<string>` - An optional valid network address for the target to connect to.
 You cannot use an address alongside host sources.
-- `-default-client-port=<string>` - The default client port on the target.
+- `-default-client-port=<string>` - The port that the Client Agent binds its local proxy listener to when establishing a transparent session for this target.
+  Set this value to match the port that the client application dials by default — for example, SSH clients dial port 22, RDP clients dial port 3389, and HTTPS clients dial port 443.
+  If you do not set this value, the Client Agent falls back to `-default-port`. If `-default-client-port` does not match the client application, the transparent session fails.
 - `-default-port=<string>` - The default port on the target.
 If you do not specify a default port, Boundary uses port 22.
 - `-egress-worker-filter=<string>` - A Boolean expression that filters which egress workers can process sessions for the target.

--- a/content/boundary/v1.0.x/content/partials/targets/targets-create-ssh.mdx
+++ b/content/boundary/v1.0.x/content/partials/targets/targets-create-ssh.mdx
@@ -3,7 +3,7 @@ You cannot use an address alongside host sources.
 - `-default-client-port=<string>` - The port that the Client Agent binds its local proxy listener to when establishing a transparent session for this target.
   Set this value to match the port that the client application dials by default. For example, SSH clients dial port 22, RDP clients dial port 3389, and HTTPS clients dial port 443.
   If you do not set this value, the Client Agent falls back to `-default-port`. If `-default-client-port` does not match the client application, the transparent session fails.
-- `-default-port=<string>` - The default port on the target.
+- `-default-port=<string>` - The default port on the target, if set.
 If you do not specify a default port, Boundary uses port 22.
 - `-egress-worker-filter=<string>` - A Boolean expression that filters which egress workers can process sessions for the target.
 - `-enable-session-recording=<string>` - A Boolean expression you can use to enable session recording for the target.

--- a/content/boundary/v1.0.x/content/partials/targets/targets-create-tcp.mdx
+++ b/content/boundary/v1.0.x/content/partials/targets/targets-create-tcp.mdx
@@ -1,7 +1,7 @@
 - `-address=<string>` - An optional valid network address for the target to connect to.
 You cannot use an address alongside host sources.
 - `-default-client-port=<string>` - The port that the Client Agent binds its local proxy listener to when establishing a transparent session for this target.
-  Set this value to match the port that the client application dials by default — for example, SSH clients dial port 22, RDP clients dial port 3389, and HTTPS clients dial port 443.
+  Set this value to match the port that the client application dials by default. For example, SSH clients dial port 22, RDP clients dial port 3389, and HTTPS clients dial port 443.
   If you do not set this value, the Client Agent falls back to `-default-port`. If `-default-client-port` does not match the client application, the transparent session fails.
 - `-default-port=<string>` - The default port on the target.
 If you do not specify a default port, Boundary uses port 22.

--- a/content/boundary/v1.0.x/content/partials/targets/targets-create-tcp.mdx
+++ b/content/boundary/v1.0.x/content/partials/targets/targets-create-tcp.mdx
@@ -1,6 +1,8 @@
 - `-address=<string>` - An optional valid network address for the target to connect to.
 You cannot use an address alongside host sources.
-- `-default-client-port=<string>` - The default client port on the target.
+- `-default-client-port=<string>` - The port that the Client Agent binds its local proxy listener to when establishing a transparent session for this target.
+  Set this value to match the port that the client application dials by default — for example, SSH clients dial port 22, RDP clients dial port 3389, and HTTPS clients dial port 443.
+  If you do not set this value, the Client Agent falls back to `-default-port`. If `-default-client-port` does not match the client application, the transparent session fails.
 - `-default-port=<string>` - The default port on the target.
 If you do not specify a default port, Boundary uses port 22.
 - `-egress-worker-filter=<string>` - A Boolean expression that filters which egress workers can process sessions for the target.

--- a/content/boundary/v1.0.x/content/partials/targets/targets-create-tcp.mdx
+++ b/content/boundary/v1.0.x/content/partials/targets/targets-create-tcp.mdx
@@ -3,8 +3,7 @@ You cannot use an address alongside host sources.
 - `-default-client-port=<string>` - The port that the Client Agent binds its local proxy listener to when establishing a transparent session for this target.
   Set this value to match the port that the client application dials by default. For example, SSH clients dial port 22, RDP clients dial port 3389, and HTTPS clients dial port 443.
   If you do not set this value, the Client Agent falls back to `-default-port`. If `-default-client-port` does not match the client application, the transparent session fails.
-- `-default-port=<string>` - The default port on the target.
-If you do not specify a default port, Boundary uses port 22.
+- `-default-port=<string>` - The default port on the target, if set.
 - `-egress-worker-filter=<string>` - A Boolean expression that filters which egress workers can process sessions for the target.
 - `-ingress-worker-filter=<string>` - A Boolean expression that filters which ingress workers can process sessions for the target.
 - `-session-connection-limit=<string>` - The maximum number of connections allowed for a session.

--- a/content/boundary/v1.0.x/content/partials/targets/targets-update-rdp.mdx
+++ b/content/boundary/v1.0.x/content/partials/targets/targets-update-rdp.mdx
@@ -19,11 +19,3 @@ A value of `-1` means the connections are unlimited.
 - `-session-max-seconds=<string>` - The maximum lifetime of the session, including all connections.
 You can specify an integer number of seconds or a duration string.
 If you do not specify a maximum duration, Boundary uses the default value of 8 hours (28800 seconds).
-- `-with-alias-authorize-session-host-id=<string>` - The host ID that an alias uses to authorize sessions for the target.
-- `-with-alias-scope-id=<string>` - The scope ID that you want to create the target and alias in.
-The default is `global`.
-You can create aliases in the `global` and project scopes.
-
-  You must create org and project suffixes before you can create an alias in the target's project scope. Otherwise, you can only create the alias in the `global` scope. Refer to [Create a suffix for a scope](/boundary/docs/targets/configuration/create-suffix) for more information.
-- `-with-alias-value=<string>` - The value of the alias that you want to use to represent the target.
-Use this parameter to create the alias and target, and associate them with each other, at the same time.

--- a/content/boundary/v1.0.x/content/partials/targets/targets-update-rdp.mdx
+++ b/content/boundary/v1.0.x/content/partials/targets/targets-update-rdp.mdx
@@ -27,5 +27,3 @@ You can create aliases in the `global` and project scopes.
   You must create org and project suffixes before you can create an alias in the target's project scope. Otherwise, you can only create the alias in the `global` scope. Refer to [Create a suffix for a scope](/boundary/docs/targets/configuration/create-suffix) for more information.
 - `-with-alias-value=<string>` - The value of the alias that you want to use to represent the target.
 Use this parameter to create the alias and target, and associate them with each other, at the same time.
-
-  If you are creating an alias for a target that resides in a project scope, you must append the org and project suffixes to the value using the format `alias.projectsuffix.orgsuffix`. The `value` must comply with DNS naming rules.

--- a/content/boundary/v1.0.x/content/partials/targets/targets-update-ssh.mdx
+++ b/content/boundary/v1.0.x/content/partials/targets/targets-update-ssh.mdx
@@ -13,4 +13,4 @@ A value of `-1` means the connections are unlimited.
 - `-session-max-seconds=<string>` - The maximum lifetime of the session, including all connections.
 You can specify an integer number of seconds or a duration string.
 If you do not specify a maximum duration, Boundary uses the default value of 8 hours (28800 seconds).
-- `-storage-bucket-id=<string>` - The public ID of the storage bucket you want to associate with the target.
+- `-storage-bucket-id=<string>` - The public ID of the storage bucket to associate with the target.

--- a/content/boundary/v1.0.x/content/partials/targets/targets-update-ssh.mdx
+++ b/content/boundary/v1.0.x/content/partials/targets/targets-update-ssh.mdx
@@ -1,0 +1,16 @@
+- `-address=<string>` - An optional valid network address for the target to connect to.
+You cannot use an address alongside host sources.
+- `-default-client-port=<string>` - The port that the Client Agent binds its local proxy listener to when establishing a transparent session for this target.
+  Set this value to match the port that the client application dials by default. For example, SSH clients dial port 22, RDP clients dial port 3389, and HTTPS clients dial port 443.
+  If you do not set this value, the Client Agent falls back to `-default-port`. If `-default-client-port` does not match the client application, the transparent session fails.
+- `-default-port=<string>` - The default port on the target, if set.
+If you do not specify a default port, Boundary uses port 22.
+- `-egress-worker-filter=<string>` - A Boolean expression that filters which egress workers can process sessions for the target.
+- `-enable-session-recording=<string>` - A Boolean expression you can use to enable session recording for the target.
+- `-ingress-worker-filter=<string>` - A Boolean expression that filters which ingress workers can process sessions for the target.
+- `-session-connection-limit=<string>` - The maximum number of connections allowed for a session.
+A value of `-1` means the connections are unlimited.
+- `-session-max-seconds=<string>` - The maximum lifetime of the session, including all connections.
+You can specify an integer number of seconds or a duration string.
+If you do not specify a maximum duration, Boundary uses the default value of 8 hours (28800 seconds).
+- `-storage-bucket-id=<string>` - The public ID of the storage bucket you want to associate with the target.

--- a/content/boundary/v1.0.x/content/partials/targets/targets-update-tcp.mdx
+++ b/content/boundary/v1.0.x/content/partials/targets/targets-update-tcp.mdx
@@ -1,0 +1,16 @@
+- `-address=<string>` - An optional valid network address for the target to connect to.
+You cannot use an address alongside host sources.
+- `-default-client-port=<string>` - The port that the Client Agent binds its local proxy listener to when establishing a transparent session for this target.
+  Set this value to match the port that the client application dials by default. For example, SSH clients dial port 22, RDP clients dial port 3389, and HTTPS clients dial port 443.
+  If you do not set this value, the Client Agent falls back to `-default-port`. If `-default-client-port` does not match the client application, the transparent session fails.
+- `-default-port=<string>` - The default port on the target, if set.
+If you do not specify a default port, Boundary uses port 22.
+- `-egress-worker-filter=<string>` - A Boolean expression that filters which egress workers can process sessions for the target.
+- `-ingress-worker-filter=<string>` - A Boolean expression that filters which ingress workers can process sessions for the target.
+- `-session-connection-limit=<string>` - The maximum number of connections allowed for a session.
+A value of `-1` means the connections are unlimited.
+- `-session-max-seconds=<string>` - The maximum lifetime of the session, including all connections.
+You can specify an integer number of seconds or a duration string.
+If you do not specify a maximum duration, Boundary uses the default value of 8 hours (28800 seconds).
+- `-worker-filter=<string>` - This option is deprecated.
+Use the egress or ingress filters instead.

--- a/content/boundary/v1.0.x/content/partials/targets/targets-update-tcp.mdx
+++ b/content/boundary/v1.0.x/content/partials/targets/targets-update-tcp.mdx
@@ -4,7 +4,6 @@ You cannot use an address alongside host sources.
   Set this value to match the port that the client application dials by default. For example, SSH clients dial port 22, RDP clients dial port 3389, and HTTPS clients dial port 443.
   If you do not set this value, the Client Agent falls back to `-default-port`. If `-default-client-port` does not match the client application, the transparent session fails.
 - `-default-port=<string>` - The default port on the target, if set.
-If you do not specify a default port, Boundary uses port 22.
 - `-egress-worker-filter=<string>` - A Boolean expression that filters which egress workers can process sessions for the target.
 - `-ingress-worker-filter=<string>` - A Boolean expression that filters which ingress workers can process sessions for the target.
 - `-session-connection-limit=<string>` - The maximum number of connections allowed for a session.


### PR DESCRIPTION
<!--
**Merge branch**

Make sure your PR uses the correct **base** branch for the merge destination.

For more information, refer to **Change the branch range and destination repository** (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request).

To update:

- Existing content

  Choose **base: main** to update existing documentation.
  Your content will be published when the PR is merged.

- Content for an upcoming Boundary release

  Choose the branch for the relevant upcoming Boundary release.
  Boundary release branches use the `boundary/<exact-release-number>` format.
  Your content will be published when the upcoming release goes live.

If you are not sure which base branch to use, or you cannot find the release branch you are looking for:

  - Choose the `main` branch.
  - Add the "do not merge" label.
  - Convert the PR to a DRAFT.
  - Explain the update in the **Description**.

**Back porting to older versions**

This repo stores versioned documentation in folders instead of branches.
There are no backport labels.
If your update applies to multiple versions, you must update the content in each of the corresponding version folders.

For example, you make an update to the Boundary code in the current release, 0.21.0, and back port it to versions 0.20.x and 0.19.x.
To document the update for each of the relevant versions, you would update the documentation in the v0.21.x, v0.20.x, and v0.19.x folders.
-->

## Description

This PR documents behavior changes in the Client Agent that will be implemented as part of the Windows multi-user session isolation fix ([ICU-18674](https://hashicorp.atlassian.net/browse/ICU-18674)).

View the updates in the preview deployment:

- Boundary Client Agent > [Proxy traffic](https://unified-docs-frontend-preview-2hvqegsmu-hashicorp.vercel.app/boundary/docs/client-agent#proxy-traffic)
- Boundary Client Agent > [Configuration changes and active traffic](https://unified-docs-frontend-preview-2hvqegsmu-hashicorp.vercel.app/boundary/docs/client-agent#configuration-changes-and-active-sessions)
- Troubleshoot issues with the Client Agent > [Transparent sessions known issues](https://unified-docs-frontend-preview-2hvqegsmu-hashicorp.vercel.app/boundary/docs/client-agent/troubleshoot#transparent-sessions-known-issues)
- Domain model > Targets > [`default_client_port`](https://unified-docs-frontend-preview-2hvqegsmu-hashicorp.vercel.app/boundary/docs/domain-model/targets#default_client_port)
- Connect using transparent sessions > [Configuration changes and active traffic](https://unified-docs-frontend-preview-2hvqegsmu-hashicorp.vercel.app/boundary/docs/targets/connections/transparent-sessions#configuration-changes-and-active-sessions)
- CLI > targets > targets create > [Usages by type](https://unified-docs-frontend-preview-2hvqegsmu-hashicorp.vercel.app/boundary/docs/commands/targets/create#usages-by-type)
- CLI > targets > targets update > [Usages by type](https://unified-docs-frontend-preview-2hvqegsmu-hashicorp.vercel.app/boundary/docs/commands/targets/update#usages-by-type)


## Links
<!--
Include links to any associated pull requests, GitHub issues, or documentation that is relevant to this update.

// GH-Jira integration generates the link and updates the Jira ticket.
Jira: [<jira-ticket-number>]  // for example, Jira: [ICU-1234]

GitHub Issue: <issue-link>
-->

Code PR:
Jira: [ICU-19105](https://hashicorp.atlassian.net/browse/ICU-19105)
GitHub issue:
RFC/PRD:

## Contributor checklists

<!--
Help your reviewer understand the type of review you need by selecting the scope and urgency.
-->

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [x] 3 days: Small changes, easy reviews
- [ ] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [x] Verify that all status checks passed
- [x] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [ ] I added redirects for any moved or removed pages
- [x] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [x] I looked at the local or Vercel build to make sure the content rendered correctly


[ICU-1234]: https://hashicorp.atlassian.net/browse/ICU-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ICU-18674]: https://hashicorp.atlassian.net/browse/ICU-18674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ