### PR TITLE
docs: remove beta label from plugin download flag

### DIFF
--- a/content/vault/v2.x/content/docs/commands/plugin/register.mdx
+++ b/content/vault/v2.x/content/docs/commands/plugin/register.mdx
@@ -122,7 +122,7 @@ flags](/vault/docs/commands) included on all commands.
    You can omit version to register a plugin binary, but you must provide
    an explicit version to register an extracted `.zip` file.
 
-- `-download` `(bool: false)` - <EnterpriseAlert inline="true" /> **( BETA )**
+- `-download` `(bool: false)` - <EnterpriseAlert inline="true" />
   Tells Vault to download the specified plugin from the
   [HashiCorp releases page](https://releases.hashicorp.com/). Automatic
   downloads only support secret and auth plugins with artifacts containing


### PR DESCRIPTION
## Summary 

Removes the incorrect **(BETA)** label from the `-download` flag in the Vault plugin register documentation.

## Changes

-Updated `content/vault/v2.x/content/docs/commands/plugin/register.mdx`

-Removed only the **(BETA)** label

-No code changes

## Related issue

VAULT-45641