### PR TITLE
API gw scaling docs update and sync consul-k8s helm values description with consul public docs

### DIFF
--- a/content/consul/v2.0.x/content/docs/north-south/api-gateway/k8s/scale.mdx
+++ b/content/consul/v2.0.x/content/docs/north-south/api-gateway/k8s/scale.mdx
@@ -122,7 +122,7 @@ If a user-managed HPA already targets the gateway deployment, Consul does not cr
 
 **Case 1: User-managed HPA wins over Gateway annotations**
 
-If you create your own `HorizontalPodAutoscaler` that targets the gateway deployment and the `Gateway` resource also has scaling annotations, Consul uses the user-managed HPA and ignores the annotations entirely. Consul will not create or overwrite the existing HPA.
+If you create your own `HorizontalPodAutoscaler` that targets the gateway deployment and the `Gateway` resource also has scaling annotations, Consul uses the user-managed HPA and ignores the annotations entirely. Consul does not create or overwrite the existing HPA.
 
 ```yaml
 # User-managed HPA — this takes priority
@@ -146,7 +146,7 @@ spec:
           averageUtilization: 60
 ```
 
-Even if the `Gateway` resource below has `hpa-enabled: "true"`, Consul defers to `my-hpa` above and does not create a second HPA.
+Even if the following `Gateway` resource has `hpa-enabled: "true"`, Consul defers to `my-hpa` in the previous example and does not create a second HPA.
 
 ```yaml
 # Gateway annotations are ignored when a user-managed HPA already exists
@@ -168,7 +168,7 @@ spec:
 
 **Case 2: Gateway annotations win over deprecated Helm values**
 
-If the `Gateway` resource has a `default-replicas` annotation and the Helm chart still has a `deployment.defaultInstances` value set, the annotation takes effect and the Helm value is ignored. Note that `scaling.enabled` must be `true` for annotations to be evaluated at all.
+If the `Gateway` resource has a `default-replicas` annotation and the Helm chart still has a `deployment.defaultInstances` value set, Consul uses the annotation and ignores the Helm value. Note that `scaling.enabled` must be `true` for annotations to be evaluated at all.
 
 ```yaml
 # values.yaml — scaling must be enabled; the deprecated defaultInstances is ignored
@@ -199,7 +199,7 @@ spec:
 
 **Case 3: Deprecated Helm values are the only source**
 
-If there are no Gateway annotations and no user-managed HPA, Consul falls back to the deprecated `deployment.*` Helm values. The gateway deployment is created with `defaultInstances` replicas, and the controller enforces `minInstances` and `maxInstances` as bounds.
+If there are no Gateway annotations and no user-managed HPA, Consul falls back to the deprecated `deployment.*` Helm values. Consul creates the gateway deployment with `defaultInstances` replicas, and the controller enforces `minInstances` and `maxInstances` as bounds.
 
 ```yaml
 # values.yaml — used only as a fallback when no annotations exist

--- a/content/consul/v2.0.x/content/docs/north-south/api-gateway/k8s/scale.mdx
+++ b/content/consul/v2.0.x/content/docs/north-south/api-gateway/k8s/scale.mdx
@@ -114,11 +114,184 @@ Consul resolves gateway scaling in the following order:
 
 1. A user-managed HPA that targets the gateway deployment
 1. Gateway scaling annotations
-1. Deprecated `GatewayClassConfig.spec.deployment` fields
+1. Deprecated Helm chart `connectInject.apiGateway.managedGatewayClass.deployment` fields
 
 If a user-managed HPA already targets the gateway deployment, Consul does not create or manage its own HPA for that gateway.
 
-`GatewayClassConfig.spec.deployment.defaultInstances`, `minInstances`, and `maxInstances` are deprecated. Keep using gateway annotations for new configurations and migrations. Refer to the [`GatewayClassConfig` reference](/consul/docs/reference/k8s/api-gateway/gatewayclassconfig) for the full resource schema.
+### Precedence examples
+
+**Case 1: User-managed HPA wins over Gateway annotations**
+
+If you create your own `HorizontalPodAutoscaler` that targets the gateway deployment and the `Gateway` resource also has scaling annotations, Consul uses the user-managed HPA and ignores the annotations entirely. Consul will not create or overwrite the existing HPA.
+
+```yaml
+# User-managed HPA — this takes priority
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: my-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: api-gateway
+  minReplicas: 2
+  maxReplicas: 8
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 60
+```
+
+Even if the `Gateway` resource below has `hpa-enabled: "true"`, Consul defers to `my-hpa` above and does not create a second HPA.
+
+```yaml
+# Gateway annotations are ignored when a user-managed HPA already exists
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: api-gateway
+  annotations:
+    consul.hashicorp.com/hpa-enabled: "true"
+    consul.hashicorp.com/hpa-minimum-replicas: "3"
+    consul.hashicorp.com/hpa-maximum-replicas: "25"
+spec:
+  gatewayClassName: consul
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 8080
+```
+
+**Case 2: Gateway annotations win over deprecated Helm values**
+
+If the `Gateway` resource has a `default-replicas` annotation and the Helm chart still has a `deployment.defaultInstances` value set, the annotation takes effect and the Helm value is ignored. Note that `scaling.enabled` must be `true` for annotations to be evaluated at all.
+
+```yaml
+# values.yaml — scaling must be enabled; the deprecated defaultInstances is ignored
+connectInject:
+  apiGateway:
+    managedGatewayClass:
+      scaling:
+        enabled: true       # required for annotations to take effect
+      deployment:
+        defaultInstances: 2   # ignored because the annotation below is present
+```
+
+```yaml
+# gateway.yaml — annotation wins
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: api-gateway
+  annotations:
+    consul.hashicorp.com/default-replicas: "4"   # this value is used
+spec:
+  gatewayClassName: consul
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 8080
+```
+
+**Case 3: Deprecated Helm values are the only source**
+
+If there are no Gateway annotations and no user-managed HPA, Consul falls back to the deprecated `deployment.*` Helm values. The gateway deployment is created with `defaultInstances` replicas, and the controller enforces `minInstances` and `maxInstances` as bounds.
+
+```yaml
+# values.yaml — used only as a fallback when no annotations exist
+connectInject:
+  apiGateway:
+    managedGatewayClass:
+      deployment:
+        defaultInstances: 3
+        minInstances: 1
+        maxInstances: 5
+```
+
+The following Helm values under `connectInject.apiGateway.managedGatewayClass.deployment` are deprecated and will be removed in a future release. Migrate each one to the equivalent Gateway annotation.
+
+### Migrate `deployment.defaultInstances`
+
+**Before (deprecated):**
+
+<CodeBlockConfig filename="values.yaml">
+
+```yaml
+connectInject:
+  apiGateway:
+    managedGatewayClass:
+      deployment:
+        defaultInstances: 4
+```
+
+</CodeBlockConfig>
+
+**After:**
+
+<CodeBlockConfig filename="gateway.yaml">
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: api-gateway
+  annotations:
+    consul.hashicorp.com/default-replicas: "4"
+spec:
+  gatewayClassName: consul
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 8080
+```
+
+</CodeBlockConfig>
+
+### Migrate `deployment.minInstances` and `deployment.maxInstances`
+
+**Before (deprecated):**
+
+<CodeBlockConfig filename="values.yaml">
+
+```yaml
+connectInject:
+  apiGateway:
+    managedGatewayClass:
+      deployment:
+        minInstances: 2
+        maxInstances: 10
+```
+
+</CodeBlockConfig>
+
+**After:**
+
+<CodeBlockConfig filename="gateway.yaml">
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: api-gateway
+  annotations:
+    consul.hashicorp.com/hpa-enabled: "true"
+    consul.hashicorp.com/hpa-minimum-replicas: "2"
+    consul.hashicorp.com/hpa-maximum-replicas: "10"
+spec:
+  gatewayClassName: consul
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 8080
+```
+
+</CodeBlockConfig>
+
+Refer to the [Helm chart reference for `connectInject.apiGateway`](/consul/docs/reference/k8s/helm#v-connectinject-apigateway-managedgatewayclass-deployment) for the full list of deprecated fields.
 
 ## Manual scaling behavior
 

--- a/content/consul/v2.0.x/content/docs/reference/k8s/helm.mdx
+++ b/content/consul/v2.0.x/content/docs/reference/k8s/helm.mdx
@@ -4,8 +4,8 @@ page_title: Helm Chart Reference
 description: >-
   The Helm Chart allows you to schedule Kubernetes clusters with injected Consul sidecars by defining custom values in a YAML configuration. Find stanza hierarchy, the parameters you can set, and their default values in this k8s reference guide.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2026-03-31T20:45:52.000Z
-last_modified: 2026-03-31T20:45:52.000Z
+created_at: 2026-03-31T13:43:36-07:00
+last_modified: 2026-07-24T05:00:37.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -45,6 +45,8 @@ Use these links to navigate to a particular top-level stanza.
 ### global ((#h-global))
 
 - `global` ((#v-global)) - Holds values that affect multiple components of the chart.
+
+  - `installK8sNetworkingCRDs` ((#v-global-installk8snetworkingcrds)) (`boolean: true`)
 
   - `enabled` ((#v-global-enabled)) (`boolean: true`) - The main enabled/disabled setting. If true, servers,
     clients, Consul DNS and the Consul UI will be enabled. Each component can override
@@ -684,14 +686,75 @@ Use these links to navigate to a particular top-level stanza.
   - `imageConsulDataplane` ((#v-global-imageconsuldataplane)) (`string: hashicorp/consul-dataplane:<latest supported version>`) - The name (and tag) of the consul-dataplane Docker image used for the
     connect-injected sidecar proxies and mesh, terminating, and ingress gateways.
 
+  - `generateManifests` ((#v-global-generatemanifests)) (`boolean: false`) - Disable this once the manifests are generated and subsequent helm upgrades
+
+  - `generateManifestsStorageClassName` ((#v-global-generatemanifestsstorageclassname)) (`string: ""`) - Uses the provided storage class name for the generated manifests - recommended to create SC with volumebinding as Immediate. If not provided, the default storage class will be used.
+
+  - `generateManifestsStorage` ((#v-global-generatemanifestsstorage)) (`string: 1Gi`) - Storage requirement for generateManifests pvc
+
+  - `crds` ((#v-global-crds)) - During the install:
+    custom crds and gateway TCP crd enabling
+    enableTcpRoute installs the TCP GVK under gateway.networking.k8s.io and enables the stable gatewaycontroller to watch for the resources.
+    crds.consulapi.enabled install the CRDs under consul.hashicorp.com API group and enables the new custom gateway controller to watch for the resources.
+
+    During the upgrade - manifests are generated.
+    if consulapi.enabled is set to false; no manifests will be generated under consul.hashicorp.com API group
+    if consulapi.enables is set to true; manifests will be generated and applied under consul.hashicorp.com API group
+
+    - `enableTcpRoute` ((#v-global-crds-enabletcproute)) (`boolean: true`)
+
+    - `consulapi` ((#v-global-crds-consulapi))
+
+      - `enabled` ((#v-global-crds-consulapi-enabled)) (`boolean: false`)
+
+  - `podSecurityContext` ((#v-global-podsecuritycontext)) - Add additional pod-level securityContext for the generate-manifests Job when volume permissions require it.
+
+    - `enabled` ((#v-global-podsecuritycontext-enabled)) (`boolean: false`)
+
   - `openshift` ((#v-global-openshift)) - Configuration for running this Helm chart on the Red Hat OpenShift platform.
     This Helm chart currently supports OpenShift v4.x+.
 
     - `enabled` ((#v-global-openshift-enabled)) (`boolean: false`) - If true, the Helm chart will create necessary configuration for running
       its components on OpenShift.
 
-    - `upgradeTo419From418` ((#v-global-openshift-upgradeto419from418)) (`boolean: false`) - If true, the Helm chart upgrades existing resources to be compatible with OpenShift v4.19+.
-      Only set to true if you are currently running on OpenShift v4.18 and plan to upgrade to v4.19 imminently.
+    - `upgradeTo419From418` ((#v-global-openshift-upgradeto419from418)) (`boolean: false`) - During the install:
+      in this case ideally customer deploys the consul directly on the 4.19+ and thus is void.
+
+      During the upgrade:
+      This should be enabled when the customer plans to upgrade the OCP from 4.18 to 4.19+ versions.
+      This will generate the manifests inaccordance to 2 cases along with enableTcpRoute:
+      case 1: when upgradeTo419From418 is true and enableTcpRoute is false:
+      generate the manifests only for gateway.networking.k8s.io and ignores the TCP watch
+      case 2: when upgradeTo419From418 is true and enableTcpRoute is true:
+      generate the manifests for both consul.hashicorp.com and gateway.networking.k8s.io ( the deleteion of TCP GVK is manual )
+
+    - `isOcpGreaterthan4_18` ((#v-global-openshift-isocpgreaterthan4_18)) (`boolean: false`) - During the install:
+      for isOcpGreaterthan4_18: n this case ideally customer deploys the consul directly on the 4.19+ and thus is void.
+
+      for crds.enableTcpRoute set to true; controller watches for the TCP
+      for crds.enableTcpRoute set to false; controller does not watch for the TCp.
+
+      for crds.consulapi.enabled set to true; controller watches for resources under the API group - consul.hashicorp.com
+
+      During the upgrade:
+      If isOcpGreaterthan4_18 is false and enableTcpRoute is false:
+      generate the manifests only for gateway.networking.k8s.io and ignores the TCP watch
+      If isOcpGreaterthan4_18 is false and enableTcpRoute is true:
+      generate the manifests only for gateway.networking.k8s.io and watches for the TCP
+      If isOcpGreaterthan4_18 is true and enableTcpRoute is false:
+      generate the manifests only for gateway.networking.k8s.io and ignores the TCP watch
+      If isOcpGreaterthan4_18 is true and enableTcpRoute is true:
+      generate the manifests for both consul.hashicorp.com ( all current GVK ) and gateway.networking.k8s.io ( no TCP )
+
+      in any case, crds.consulapi.enabled install the CRDs under consul.hashicorp.com API group and enables the new custom gateway controller to watch for the resources.
+
+    - `crds` ((#v-global-openshift-crds))
+
+      - `enableTcpRoute` ((#v-global-openshift-crds-enabletcproute)) (`boolean: false`)
+
+      - `consulapi` ((#v-global-openshift-crds-consulapi))
+
+        - `enabled` ((#v-global-openshift-crds-consulapi-enabled)) (`boolean: false`)
 
   - `consulAPITimeout` ((#v-global-consulapitimeout)) (`string: 5s`) - The time in seconds that the consul API client will wait for a response from
     the API before cancelling the request.
@@ -2019,13 +2082,28 @@ Use these links to navigate to a particular top-level stanza.
 
       - `resources` ((#v-connectinject-apigateway-managedgatewayclass-resources)) (`map`) - The resource settings for Pods handling traffic for Gateway API.
 
-      - `deployment` ((#v-connectinject-apigateway-managedgatewayclass-deployment)) - This value defines the number of pods to deploy for each Gateway as well as a min and max number of pods for all Gateways
+      - `scaling` ((#v-connectinject-apigateway-managedgatewayclass-scaling)) - <EnterpriseAlert inline /> These settings enable per-Gateway scaling behavior for
+        the managed GatewayClass, including Gateway annotations for static
+        replicas, controller-managed HPA resources, and preserving manual scale.
+        Requires Consul Enterprise with a valid license.
 
-        - `defaultInstances` ((#v-connectinject-apigateway-managedgatewayclass-deployment-defaultinstances)) (`integer: 1`)
+        - `enabled` ((#v-connectinject-apigateway-managedgatewayclass-scaling-enabled)) (`boolean: false`)
 
-        - `maxInstances` ((#v-connectinject-apigateway-managedgatewayclass-deployment-maxinstances)) (`integer: 1`)
+      - `deployment` ((#v-connectinject-apigateway-managedgatewayclass-deployment)) - DEPRECATED: These values are deprecated and will be removed in a future release.
+        Use Gateway annotations instead for per-gateway scaling configuration.
+        See: [API Gateway Scaling](/consul/docs/north-south/api-gateway/k8s/scale)
 
-        - `minInstances` ((#v-connectinject-apigateway-managedgatewayclass-deployment-mininstances)) (`integer: 1`)
+        For static replica count, use: `consul.hashicorp.com/default-replicas: "<N>"`.
+        For HPA, use: `consul.hashicorp.com/hpa-enabled: "true"` with min/max replicas annotations.
+
+        - `defaultInstances` ((#v-connectinject-apigateway-managedgatewayclass-deployment-defaultinstances)) (`integer: 1`) - Default number of gateway instances.
+          _DEPRECATED: Use consul.hashicorp.com/default-replicas annotation on Gateway resource_
+
+        - `maxInstances` ((#v-connectinject-apigateway-managedgatewayclass-deployment-maxinstances)) (`integer: 1`) - Maximum number of gateway instances.
+          _DEPRECATED: No longer enforced. Use HPA maxReplicas via annotations instead_
+
+        - `minInstances` ((#v-connectinject-apigateway-managedgatewayclass-deployment-mininstances)) (`integer: 1`) - Minimum number of gateway instances.
+          _DEPRECATED: Use HPA minReplicas via annotations instead_
 
       - `openshiftSCCName` ((#v-connectinject-apigateway-managedgatewayclass-openshiftsccname)) (`string: restricted-v2`) - The name of the OpenShift SecurityContextConstraints resource to use for Gateways.
         Only applicable if `global.openshift.enabled` is true.
@@ -2234,6 +2312,7 @@ Use these links to navigate to a particular top-level stanza.
     want those pods injected and local-path-storage and openebs so that
     Kind (Kubernetes In Docker) and [OpenEBS](https://openebs.io/) respectively can provision Pods used to create PVCs.
     We also exclude gmp-system and gke-managed-cim namespaces that are used by GKE for managing the cluster.
+    We also exclude any namespaces with the label `openshift.io/cluster-monitoring` since those are used by OpenShift for cluster monitoring and typically should not be injected.
     Note that this exclusion is only supported in Kubernetes v1.21.1+.
 
     Example:
@@ -2334,6 +2413,18 @@ Use these links to navigate to a particular top-level stanza.
     - `secretName` ((#v-connectinject-aclinjecttoken-secretname)) (`string: null`) - The name of the Vault secret that holds the ACL inject token.
 
     - `secretKey` ((#v-connectinject-aclinjecttoken-secretkey)) (`string: null`) - The key within the Vault secret that holds the ACL inject token.
+
+  - `globalConfigACLToken` ((#v-connectinject-globalconfigacltoken)) - Refers to a Kubernetes secret that contains an ACL token with operator privileges
+    for global config entry writes reconciled by connect-inject (for example, for writing
+    RateLimit).
+
+    This token is optional and only used when both secretName and secretKey
+    are provided. When set, connect-inject passes only the secret name/key
+    and reads the token from the Kubernetes Secret in code.
+
+    - `secretName` ((#v-connectinject-globalconfigacltoken-secretname)) (`string: null`) - The name of the Kubernetes secret that holds the global config ACL token.
+
+    - `secretKey` ((#v-connectinject-globalconfigacltoken-secretkey)) (`string: null`) - The key within the Kubernetes secret that holds the global config ACL token.
 
   - `sidecarProxy` ((#v-connectinject-sidecarproxy))
 


### PR DESCRIPTION
Changes:
- sync consul-k8s helm values description with consul public docs
- add precedence examples and migration guide for deprecated Helm scaling fields of API GW.

Affected pages: 
- https://developer.hashicorp.com/consul/docs/reference/k8s/helm
- https://developer.hashicorp.com/consul/docs/north-south/api-gateway/k8s/scale

Please note: Consul Helm documentation changes is updated/fetched from consul-k8s repo as [mentioned](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#helm-reference-docs).