### PR TITLE
Terraform housekeeping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,5 +73,5 @@ cache-key.txt
 
 #IDE
 .idea
-.terraform*
+.terraform
 terraform.tfvars

--- a/.terraformignore
+++ b/.terraformignore
@@ -1,0 +1,4 @@
+**
+!*.tf
+!*.tf.json
+!.terraform.lock.hcl

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,60 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/instana/instana" {
+  version     = "7.3.1"
+  constraints = ">= 7.3.1"
+  hashes = [
+    "h1:5nDs6uTpO90p/NROKVYx8cobsDxAfvhUJ/CINsQinz4=",
+    "zh:1e2b6a67cebcc6775b32c950bc6f3eea95d9ee1b3a319d501996cb0a47841476",
+    "zh:2549a953c0652b607ee2b0c80e5bbb1940bbfd0ff4a041c67560b6d5ee97df91",
+    "zh:4d34bf2654507268e2b7eb79fc96cfe096882f00befe3d1f2556598aafd0b004",
+    "zh:4e449f742fe339877d9ea38046f2f99d341116299f81807aaafb441066213318",
+    "zh:a8a248e5111c12179761ebdacd13514fb49a3cc54a42db214283fa14cf05f517",
+    "zh:da8e915f4bd3aaeda7cf0c8c07a0d35bf8c8729260dbfdf9435f026831165bf7",
+  ]
+}
+
+provider "registry.terraform.io/integrations/github" {
+  version     = "6.12.1"
+  constraints = ">= 6.12.0"
+  hashes = [
+    "h1:bGz4LIep/7PVrqy6P8cTYbAJpdxXGrupUJjkCczlzIs=",
+    "zh:3e1a4081ecb9518fdf0074db83c16ad00dc81ffe8249a6e3cf1894e947e28df6",
+    "zh:4cb8224b7f530795b674ac044675f6b22a7c9154f55eb9f76c5af6c7534056a4",
+    "zh:560bc08637926191f6871a89e986022ca67c70afda5bebca34b5216e6fac69c9",
+    "zh:5a70b5d2ac650c5c9819a1875411ebda229d0fcc6c9f57f9d751852ca3cd77ac",
+    "zh:8668d93bd4dc2ffa2545e1473af600a925d479b16033a71a4498a16f3b683c0c",
+    "zh:86eacc6059fd057948e178b665ba5cce74bd5488a9e1035734e60ff5ef1b6f8f",
+    "zh:a329fac98881d8dfc211a9bdc0ec6f2948f0b0c2704d1b6cbe5307403c7ad1b2",
+    "zh:dadd44abab3c52b9d572955afaef1658790e17ea355ee22b58996d81d28e02d8",
+    "zh:de9f455ef342cc38fb76bce844bfcd376fb81a4b9f9bc2fae023ff99efdf1338",
+    "zh:f8c6d2e8351b334491790358574e0a30a7c6d7f5b80f7daf32a7c0f3e9b1ab19",
+    "zh:fab41971a3edee04ab6eceaeab4eeb9a2b2f38a2af3b06eda93e2117b64994be",
+    "zh:fb1279b566dd9c8c117b2e4e0cc8344413b8fc8f2a3e24be22a9b2610551777b",
+    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
+    "zh:fe79d2a861fb9af420fa5bd7f02c031b2a0a3edf5dbc46022c8ecc7a33cf2b6d",
+  ]
+}
+
+provider "registry.terraform.io/vercel/vercel" {
+  version     = "5.5.0"
+  constraints = ">= 2.0.0"
+  hashes = [
+    "h1:6v3XXAb3saACELAFz9JwRoK2w7dmHc7ovBoTlvjSafM=",
+    "zh:29714ce971c08b3351e90bc9d723bff6b78518e63ab9cc3bd374728ddf5836f5",
+    "zh:2e5524e130fa1314f67a165e3672404f8444a8ccb2368322554f6d19c0b787a2",
+    "zh:4d0e8e60797db77b6ffd1fe5ad5d2d967fa145be9b8e9ff55c8ae0ebb0ff94bd",
+    "zh:55c48474b3817941c5267cb95b2a4e64e85203d2c0d38293a788d6b3e9aa3440",
+    "zh:599934b674cb28f829b31eeb02b70c0e60dd06d52394f66280e91dbccf814bd0",
+    "zh:77f882ad6455ce1be520a6c8660e6344fbf25f9b9ac4dce1542c29248bb79400",
+    "zh:9db5c14d1a7f9824e067f07665eb76aebddc60a01c36be96715b5b8bb39f34ac",
+    "zh:a2b2df289a954c2e27539313cb662759de194741c7ace7b2a60dbe454e0757bb",
+    "zh:abe68c88928a3051dff452556cb0b9c937bbbb5056685f7da2cfe49f45e80c33",
+    "zh:bca31cfa9b510d5e150c0c31def952690905b58c35e6d22c8f6a62d5e04caf11",
+    "zh:e093e841269ef5cf94c8e7a89424ea51f09ae758328a5f95c0cab39eb622f068",
+    "zh:e1fa1bf66e392133c6bd5feffd0dd8d1b39fa6bac7a4f674922e94b38f2f0aad",
+    "zh:e5de43a01d0f0c1dbf887c926eecfe07550986736b24883aa4be8ae835206f8e",
+    "zh:f26e0763dbe6a6b2195c94b44696f2110f7f55433dc142839be16b9697fa5597",
+  ]
+}

--- a/terraform/github.tf
+++ b/terraform/github.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2024, 2026
+ * Copyright IBM Corp. 2025, 2026
  * SPDX-License-Identifier: BUSL-1.1
  */
 

--- a/terraform/instana.tf
+++ b/terraform/instana.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2024, 2026
+ * Copyright IBM Corp. 2025, 2026
  * SPDX-License-Identifier: BUSL-1.1
  */
 

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -42,3 +42,8 @@ provider "github" {
   # PAT comes from env var in HCP:
   # GITHUB_TOKEN
 }
+
+provider "vercel" {
+  # PAT comes from env var in HCP:
+  # VERCEL_TOKEN
+}

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2024, 2026
+ * Copyright IBM Corp. 2025, 2026
  * SPDX-License-Identifier: BUSL-1.1
  */
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2024, 2026
+ * Copyright IBM Corp. 2025, 2026
  * SPDX-License-Identifier: BUSL-1.1
  */
 

--- a/terraform/vercel.tf
+++ b/terraform/vercel.tf
@@ -1,3 +1,9 @@
+/**
+ * Copyright IBM Corp. 2025, 2026
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+
 locals {
   vercel_env = {
     INSTANA_OTLP_ENDPOINT = {


### PR DESCRIPTION
A little bit of housekeeping on our terraform setup for this repo. Most notably:

1. Reduce terraform plan execution times by only uploading the files that HCP actually needs (i.e: the `/terraform`) directory
2. Add provider lockfile to prevent workflow breakages by automatic version bumps to providers