### PR TITLE
Error in Terraform Docs example for terraform query

### DIFF
--- a/content/terraform/v1.14.x/docs/cli/commands/query.mdx
+++ b/content/terraform/v1.14.x/docs/cli/commands/query.mdx
@@ -80,11 +80,11 @@ $ terraform query -var-file=my-vars.tfvars
 The following command generates `import` and `resource` blocks for the query results to a file in the `to-import` directory:
 
 ```shell-session
-$ terraform query -generate-config=to-import/file.tf
+$ terraform query -generate-config-out=to-import/file.tf
 ```
 
 The following command prints `import` and `resource` blocks for the query results as JSON:
 
 ```shell-session
-$ terraform query -generate-config=file.tf -json
+$ terraform query -generate-config-out=file.tf -json
 ```

--- a/content/terraform/v1.15.x/docs/cli/commands/query.mdx
+++ b/content/terraform/v1.15.x/docs/cli/commands/query.mdx
@@ -80,11 +80,11 @@ $ terraform query -var-file=my-vars.tfvars
 The following command generates `import` and `resource` blocks for the query results to a file in the `to-import` directory:
 
 ```shell-session
-$ terraform query -generate-config=to-import/file.tf
+$ terraform query -generate-config-out=to-import/file.tf
 ```
 
 The following command prints `import` and `resource` blocks for the query results as JSON:
 
 ```shell-session
-$ terraform query -generate-config=file.tf -json
+$ terraform query -generate-config-out=file.tf -json
 ```


### PR DESCRIPTION
the command option for `terraform query` is `generate-config-out=<PATH/TO/OUTPUT>` however the example in the documentation shows `terraform query -generate-config=file.tf`

### What
Updated the two examples to include the "-out" in the `terraform-query -generate-config-out=...` command examples 

### Why
`generate-config=` is incomplete and does not work

### Screenshots
n/a
----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] You added redirects to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages **across all affected versions**. Refer to [Redirects](https://github.com/hashicorp/web-unified-docs/blob/main/docs/content-guide/redirects.md#example-redirects) for examples and guidance. 
- [ ] Links to related content where appropriate (e.g., CLI, language, API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
