### PR TITLE
Backport 202608: PKI External CA DNS feature updates (#2656)

### DIFF
--- a/content/vault/v2.x/content/api-docs/secret/pki-external-ca.mdx
+++ b/content/vault/v2.x/content/api-docs/secret/pki-external-ca.mdx
@@ -672,7 +672,7 @@ $ curl                                        \
     "hosted_zone_id": "Z3M3LMPEXAMPLE",
     "ttl": 60,
     "creation_date": "2026-02-24T20:00:00Z",
-    "last_update_date": "2026-02-24T20:00:00Z"
+    "last_updated_date": "2026-02-24T20:00:00Z"
   }
 }
 ```
@@ -707,7 +707,7 @@ $ curl                                        \
     "hosted_zone_id": "Z3M3LMPEXAMPLE",
     "ttl": 60,
     "creation_date": "2026-02-24T20:00:00Z",
-    "last_update_date": "2026-02-24T20:00:00Z"
+    "last_updated_date": "2026-02-24T20:00:00Z"
   }
 }
 ```
@@ -836,7 +836,7 @@ $ curl                                        \
     "environment": "AzurePublic",
     "ttl": 60,
     "creation_date": "2026-02-24T20:00:00Z",
-    "last_update_date": "2026-02-24T20:00:00Z"
+    "last_updated_date": "2026-02-24T20:00:00Z"
   }
 }
 ```
@@ -874,7 +874,7 @@ $ curl                                        \
     "environment": "AzurePublic",
     "ttl": 60,
     "creation_date": "2026-02-24T20:00:00Z",
-    "last_update_date": "2026-02-24T20:00:00Z"
+    "last_updated_date": "2026-02-24T20:00:00Z"
   }
 }
 ```
@@ -985,7 +985,7 @@ $ curl                                        \
     "zone_name": "example-com",
     "ttl": 10,
     "creation_date": "2026-02-24T20:00:00Z",
-    "last_update_date": "2026-02-24T20:00:00Z"
+    "last_updated_date": "2026-02-24T20:00:00Z"
   }
 }
 ```
@@ -1020,7 +1020,7 @@ $ curl                                        \
     "zone_name": "example-com",
     "ttl": 10,
     "creation_date": "2026-02-24T20:00:00Z",
-    "last_update_date": "2026-02-24T20:00:00Z"
+    "last_updated_date": "2026-02-24T20:00:00Z"
   }
 }
 ```
@@ -1136,7 +1136,7 @@ $ curl                                        \
     "tsig_algorithm": "hmac-sha256",
     "ttl": 60,
     "creation_date": "2026-02-24T20:00:00Z",
-    "last_update_date": "2026-02-24T20:00:00Z"
+    "last_updated_date": "2026-02-24T20:00:00Z"
   }
 }
 ```
@@ -1172,7 +1172,7 @@ $ curl                                        \
     "tsig_algorithm": "hmac-sha256",
     "ttl": 60,
     "creation_date": "2026-02-24T20:00:00Z",
-    "last_update_date": "2026-02-24T20:00:00Z"
+    "last_updated_date": "2026-02-24T20:00:00Z"
   }
 }
 ```

--- a/content/vault/v2.x/content/api-docs/secret/pki-external-ca.mdx
+++ b/content/vault/v2.x/content/api-docs/secret/pki-external-ca.mdx
@@ -384,8 +384,9 @@ $ curl                                        \
     "rotated_at": "2026-02-24T20:45:00Z"
   }
 }
-```
 
+
+```
 ## Role management
 
 Roles define policies for certificate issuance, including which domains you can request and what challenge types you can use.
@@ -555,6 +556,751 @@ $ curl                                        \
 {
   "data": {
     "keys": ["web-server", "api-server", "internal-services"]
+  }
+}
+```
+
+## DNS provider configuration
+
+DNS provider configurations enable automated DNS-01 challenge fulfillment for ACME certificate orders.
+Configure DNS providers to allow Vault to automatically create and delete DNS TXT records required for DNS-01 challenges.
+
+### List all DNS configurations
+
+List all configured DNS providers across all provider types.
+
+| Method | Path                                  |
+|:-------|:--------------------------------------|
+| `LIST` | `/{plugin_mount_path}/config/dns`     |
+
+#### Sample request
+
+```shell-session
+$ curl                                        \
+    --header "X-Vault-Token: ${VAULT_TOKEN}"  \
+    --request LIST                            \
+    ${VAULT_ADDR}/v1/pki-external-ca/config/dns
+```
+
+#### Sample response
+
+```json
+{
+  "data": {
+    "keys": [
+      "aws-route53/production",
+      "azure-dns/staging"
+    ],
+    "key_info": {
+      "aws-route53/production": {
+        "name": "production",
+        "type": "aws-route53"
+      },
+      "azure-dns/staging": {
+        "name": "staging",
+        "type": "azure-dns"
+      }
+    }
+  }
+}
+```
+
+### AWS Route53 DNS provider
+
+Configure AWS Route53 as a DNS provider for DNS-01 ACME challenges.
+
+#### Create/update AWS Route53 configuration
+
+| Method | Path                                                      |
+|:-------|:----------------------------------------------------------|
+| `POST` | `/{plugin_mount_path}/config/dns/aws-route53/:name`       |
+
+##### Parameters
+
+- `name` `(string: <required>)` - Unique name for the DNS provider configuration.
+
+- `identifiers` `(array<string>: <required>)` - List of DNS identifiers (domain names) the provider can manage. Supports wildcard patterns with leftmost asterisk (e.g., `*.example.com`).
+
+- `access_key_id` `(string: "")` - AWS access key ID for Route53 API access.
+  The access key ID is optional if you use IAM role assumption or instance profiles.
+
+- `secret_access_key` `(string: "")` - AWS secret access key for Route53 API access.
+  The secret access key is optional if you use IAM role assumption or instance profiles.
+
+- `region` `(string: "us-east-1")` - AWS region for Route53 operations.
+
+- `hosted_zone_id` `(string: "")` - AWS Route53 hosted zone ID.
+
+- `external_id` `(string: "")` - External ID for AWS STS AssumeRole.
+
+- `assume_role_arn` `(string: "")` - AWS IAM role ARN to assume for Route53 operations.
+
+- `ttl` `(duration: "60s")` - TTL for DNS TXT records used in DNS-01 challenges.
+
+##### Sample payload
+
+```json
+{
+  "identifiers": ["*.example.com", "example.com"],
+  "access_key_id": "AKIAIOSFODNN7EXAMPLE",
+  "secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+  "region": "us-east-1",
+  "hosted_zone_id": "Z3M3LMPEXAMPLE",
+  "ttl": "60s"
+}
+```
+
+##### Sample request
+
+```shell-session
+$ curl                                        \
+    --header "X-Vault-Token: ${VAULT_TOKEN}"  \
+    --request POST                            \
+    --data @payload.json                      \
+    ${VAULT_ADDR}/v1/pki-external-ca/config/dns/aws-route53/production
+```
+
+##### Sample response
+
+```json
+{
+  "data": {
+    "name": "production",
+    "type": "aws-route53",
+    "identifiers": ["*.example.com", "example.com"],
+    "region": "us-east-1",
+    "hosted_zone_id": "Z3M3LMPEXAMPLE",
+    "ttl": 60,
+    "creation_date": "2026-02-24T20:00:00Z",
+    "last_update_date": "2026-02-24T20:00:00Z"
+  }
+}
+```
+
+#### Read AWS Route53 configuration
+
+| Method | Path                                                      |
+|:-------|:----------------------------------------------------------|
+| `GET`  | `/{plugin_mount_path}/config/dns/aws-route53/:name`       |
+
+##### Parameters
+
+- `name` `(string: <required>)` - Name of the DNS provider configuration to read.
+
+##### Sample request
+
+```shell-session
+$ curl                                        \
+    --header "X-Vault-Token: ${VAULT_TOKEN}"  \
+    ${VAULT_ADDR}/v1/pki-external-ca/config/dns/aws-route53/production
+```
+
+##### Sample response
+
+```json
+{
+  "data": {
+    "name": "production",
+    "type": "aws-route53",
+    "identifiers": ["*.example.com", "example.com"],
+    "region": "us-east-1",
+    "hosted_zone_id": "Z3M3LMPEXAMPLE",
+    "ttl": 60,
+    "creation_date": "2026-02-24T20:00:00Z",
+    "last_update_date": "2026-02-24T20:00:00Z"
+  }
+}
+```
+
+#### Delete AWS Route53 configuration
+
+Delete a DNS provider configuration. You cannot delete a configuration if any roles reference it.
+
+| Method   | Path                                                      |
+|:---------|:----------------------------------------------------------|
+| `DELETE` | `/{plugin_mount_path}/config/dns/aws-route53/:name`       |
+
+##### Parameters
+
+- `name` `(string: <required>)` - Name of the DNS provider configuration to delete.
+
+##### Sample request
+
+```shell-session
+$ curl                                        \
+    --header "X-Vault-Token: ${VAULT_TOKEN}"  \
+    --request DELETE                          \
+    ${VAULT_ADDR}/v1/pki-external-ca/config/dns/aws-route53/production
+```
+
+#### List AWS Route53 configurations
+
+| Method | Path                                              |
+|:-------|:--------------------------------------------------|
+| `LIST` | `/{plugin_mount_path}/config/dns/aws-route53`     |
+
+##### Sample request
+
+```shell-session
+$ curl                                        \
+    --header "X-Vault-Token: ${VAULT_TOKEN}"  \
+    --request LIST                            \
+    ${VAULT_ADDR}/v1/pki-external-ca/config/dns/aws-route53
+```
+
+##### Sample response
+
+```json
+{
+  "data": {
+    "keys": ["production", "staging", "development"]
+  }
+}
+```
+
+### Azure DNS provider
+
+Configure Azure DNS as a DNS provider for DNS-01 ACME challenges.
+
+#### Create/update Azure DNS configuration
+
+| Method | Path                                                  |
+|:-------|:------------------------------------------------------|
+| `POST` | `/{plugin_mount_path}/config/dns/azure-dns/:name`     |
+
+##### Parameters
+
+- `name` `(string: <required>)` - Unique name for the DNS provider configuration.
+
+- `identifiers` `(array<string>: <required>)` - List of DNS identifiers (domain names) the provider can manage. Supports wildcard patterns with leftmost asterisk (e.g., `*.example.com`).
+
+- `zone_name` `(string: "")` - Azure DNS zone name.
+
+- `client_id` `(string: "")` - Azure service principal client ID.
+  Optional for managed identities.
+
+- `client_secret` `(string: "")` - Azure service principal client secret.
+  Optional for managed identities.
+
+- `tenant_id` `(string: "")` - Azure tenant ID. Optional for managed identities.
+
+- `subscription_id` `(string: "")` - Azure subscription ID. Optional for managed identities.
+
+- `resource_group_name` `(string: "")` - Azure resource group name containing the DNS zone.
+
+- `environment` `(string: "AzurePublic")` - Azure cloud environment. Must be one of:
+  - `AzurePublic`
+  - `AzureChina`
+  - `AzureGovernment`
+
+- `ttl` `(duration: "60s")` - TTL for DNS TXT records used in DNS-01 challenges.
+
+##### Sample payload
+
+```json
+{
+  "identifiers": ["*.example.com", "example.com"],
+  "zone_name": "example.com",
+  "client_id": "12345678-1234-1234-1234-123456789abc",
+  "client_secret": "your-client-secret",
+  "tenant_id": "87654321-4321-4321-4321-cba987654321",
+  "subscription_id": "abcdef01-2345-6789-abcd-ef0123456789",
+  "resource_group_name": "dns-resources",
+  "environment": "AzurePublic",
+  "ttl": "60s"
+}
+```
+
+##### Sample request
+
+```shell-session
+$ curl                                        \
+    --header "X-Vault-Token: ${VAULT_TOKEN}"  \
+    --request POST                            \
+    --data @payload.json                      \
+    ${VAULT_ADDR}/v1/pki-external-ca/config/dns/azure-dns/production
+```
+
+##### Sample response
+
+```json
+{
+  "data": {
+    "name": "production",
+    "type": "azure-dns",
+    "identifiers": ["*.example.com", "example.com"],
+    "zone_name": "example.com",
+    "tenant_id": "87654321-4321-4321-4321-cba987654321",
+    "subscription_id": "abcdef01-2345-6789-abcd-ef0123456789",
+    "resource_group_name": "dns-resources",
+    "environment": "AzurePublic",
+    "ttl": 60,
+    "creation_date": "2026-02-24T20:00:00Z",
+    "last_update_date": "2026-02-24T20:00:00Z"
+  }
+}
+```
+
+#### Read Azure DNS configuration
+
+| Method | Path                                                  |
+|:-------|:------------------------------------------------------|
+| `GET`  | `/{plugin_mount_path}/config/dns/azure-dns/:name`     |
+
+##### Parameters
+
+- `name` `(string: <required>)` - Name of the DNS provider configuration to read.
+
+##### Sample request
+
+```shell-session
+$ curl                                        \
+    --header "X-Vault-Token: ${VAULT_TOKEN}"  \
+    ${VAULT_ADDR}/v1/pki-external-ca/config/dns/azure-dns/production
+```
+
+##### Sample response
+
+```json
+{
+  "data": {
+    "name": "production",
+    "type": "azure-dns",
+    "identifiers": ["*.example.com", "example.com"],
+    "zone_name": "example.com",
+    "tenant_id": "87654321-4321-4321-4321-cba987654321",
+    "subscription_id": "abcdef01-2345-6789-abcd-ef0123456789",
+    "resource_group_name": "dns-resources",
+    "environment": "AzurePublic",
+    "ttl": 60,
+    "creation_date": "2026-02-24T20:00:00Z",
+    "last_update_date": "2026-02-24T20:00:00Z"
+  }
+}
+```
+
+#### Delete Azure DNS configuration
+
+| Method   | Path                                                  |
+|:---------|:------------------------------------------------------|
+| `DELETE` | `/{plugin_mount_path}/config/dns/azure-dns/:name`     |
+
+##### Parameters
+
+- `name` `(string: <required>)` - Name of the DNS provider configuration to delete.
+
+##### Sample request
+
+```shell-session
+$ curl                                        \
+    --header "X-Vault-Token: ${VAULT_TOKEN}"  \
+    --request DELETE                          \
+    ${VAULT_ADDR}/v1/pki-external-ca/config/dns/azure-dns/production
+```
+
+#### List Azure DNS configurations
+
+| Method | Path                                          |
+|:-------|:----------------------------------------------|
+| `LIST` | `/{plugin_mount_path}/config/dns/azure-dns`   |
+
+##### Sample request
+
+```shell-session
+$ curl                                        \
+    --header "X-Vault-Token: ${VAULT_TOKEN}"  \
+    --request LIST                            \
+    ${VAULT_ADDR}/v1/pki-external-ca/config/dns/azure-dns
+```
+
+##### Sample response
+
+```json
+{
+  "data": {
+    "keys": ["production", "staging"]
+  }
+}
+```
+
+### Google Cloud DNS provider
+
+Configure Google Cloud DNS as a DNS provider for DNS-01 ACME challenges.
+
+#### Create/update Google Cloud DNS configuration
+
+| Method | Path                                                          |
+|:-------|:--------------------------------------------------------------|
+| `POST` | `/{plugin_mount_path}/config/dns/google-cloud-dns/:name`      |
+
+##### Parameters
+
+- `name` `(string: <required>)` - Unique name for the DNS provider configuration.
+
+- `identifiers` `(array<string>: <required>)` - List of DNS identifiers (domain names) the provider can manage. Supports wildcard patterns with leftmost asterisk (e.g., `*.example.com`).
+
+- `credentials` `(string: "")` - GCP service account credentials as a
+  JSON object. Credentials are optional if you use application default
+  credentials or workload identity.
+
+- `project` `(string: "")` - GCP project name.
+
+- `zone_name` `(string: "")` - GCP DNS zone name.
+
+- `impersonate_service_account` `(string: "")` - Service account email to impersonate.
+
+- `ttl` `(duration: "10s")` - TTL for DNS TXT records used in DNS-01 challenges.
+
+##### Sample payload
+
+```json
+{
+  "identifiers": ["*.example.com", "example.com"],
+  "credentials": "<GCP service account file contents>",
+  "project": "my-project",
+  "zone_name": "example-com",
+  "ttl": "10s"
+}
+```
+
+##### Sample request
+
+```shell-session
+$ curl                                        \
+    --header "X-Vault-Token: ${VAULT_TOKEN}"  \
+    --request POST                            \
+    --data @payload.json                      \
+    ${VAULT_ADDR}/v1/pki-external-ca/config/dns/google-cloud-dns/production
+```
+
+##### Sample response
+
+```json
+{
+  "data": {
+    "name": "production",
+    "type": "google-cloud-dns",
+    "identifiers": ["*.example.com", "example.com"],
+    "project": "my-project",
+    "zone_name": "example-com",
+    "ttl": 10,
+    "creation_date": "2026-02-24T20:00:00Z",
+    "last_update_date": "2026-02-24T20:00:00Z"
+  }
+}
+```
+
+#### Read Google Cloud DNS configuration
+
+| Method | Path                                                          |
+|:-------|:--------------------------------------------------------------|
+| `GET`  | `/{plugin_mount_path}/config/dns/google-cloud-dns/:name`      |
+
+##### Parameters
+
+- `name` `(string: <required>)` - Name of the DNS provider configuration to read.
+
+##### Sample request
+
+```shell-session
+$ curl                                        \
+    --header "X-Vault-Token: ${VAULT_TOKEN}"  \
+    ${VAULT_ADDR}/v1/pki-external-ca/config/dns/google-cloud-dns/production
+```
+
+##### Sample response
+
+```json
+{
+  "data": {
+    "name": "production",
+    "type": "google-cloud-dns",
+    "identifiers": ["*.example.com", "example.com"],
+    "project": "my-project",
+    "zone_name": "example-com",
+    "ttl": 10,
+    "creation_date": "2026-02-24T20:00:00Z",
+    "last_update_date": "2026-02-24T20:00:00Z"
+  }
+}
+```
+
+#### Delete Google Cloud DNS configuration
+
+| Method   | Path                                                          |
+|:---------|:--------------------------------------------------------------|
+| `DELETE` | `/{plugin_mount_path}/config/dns/google-cloud-dns/:name`      |
+
+##### Parameters
+
+- `name` `(string: <required>)` - Name of the DNS provider configuration to delete.
+
+##### Sample request
+
+```shell-session
+$ curl                                        \
+    --header "X-Vault-Token: ${VAULT_TOKEN}"  \
+    --request DELETE                          \
+    ${VAULT_ADDR}/v1/pki-external-ca/config/dns/google-cloud-dns/production
+```
+
+#### List Google Cloud DNS configurations
+
+| Method | Path                                                  |
+|:-------|:------------------------------------------------------|
+| `LIST` | `/{plugin_mount_path}/config/dns/google-cloud-dns`    |
+
+##### Sample request
+
+```shell-session
+$ curl                                        \
+    --header "X-Vault-Token: ${VAULT_TOKEN}"  \
+    --request LIST                            \
+    ${VAULT_ADDR}/v1/pki-external-ca/config/dns/google-cloud-dns
+```
+
+##### Sample response
+
+```json
+{
+  "data": {
+    "keys": ["production", "staging"]
+  }
+}
+```
+
+### RFC2136 DNS provider
+
+Configure RFC2136 (Dynamic DNS Update) as a DNS provider for DNS-01 ACME challenges. RFC2136 enables dynamic DNS updates using TSIG authentication.
+
+#### Create/update RFC2136 configuration
+
+| Method | Path                                              |
+|:-------|:--------------------------------------------------|
+| `POST` | `/{plugin_mount_path}/config/dns/rfc2136/:name`   |
+
+##### Parameters
+
+- `name` `(string: <required>)` - Unique name for the DNS provider configuration.
+
+- `identifiers` `(array<string>: <required>)` - List of DNS identifiers (domain names) the provider can manage. Supports wildcard patterns with leftmost asterisk (e.g., `*.example.com`).
+
+- `nameserver` `(string: "<required>")` - DNS server address in `IP:port` format (e.g., `192.168.1.1:53`).
+
+- `tsig_key_name` `(string: "<required>")` - TSIG key name for authenticated DNS updates.
+
+- `tsig_secret` `(string: "<required>")` - TSIG secret (base64 encoded) for authenticated DNS updates.
+
+- `tsig_algorithm` `(string: "hmac-sha1")` - TSIG algorithm. Must be one of:
+  - `hmac-sha1`,
+  - `hmac-sha224`
+  - `hmac-sha256`
+  - `hmac-sha384`
+  - `hmac-sha512`
+
+- `ttl` `(duration: "60s")` - TTL for DNS TXT records used in DNS-01 challenges.
+
+##### Sample payload
+
+```json
+{
+  "identifiers": ["*.internal.example.com", "internal.example.com"],
+  "nameserver": "192.168.1.53:53",
+  "tsig_key_name": "vault-dns-update",
+  "tsig_secret": "c29tZS1iYXNlNjQtZW5jb2RlZC1zZWNyZXQ=",
+  "tsig_algorithm": "hmac-sha256",
+  "ttl": "60s"
+}
+```
+
+##### Sample request
+
+```shell-session
+$ curl                                        \
+    --header "X-Vault-Token: ${VAULT_TOKEN}"  \
+    --request POST                            \
+    --data @payload.json                      \
+    ${VAULT_ADDR}/v1/pki-external-ca/config/dns/rfc2136/internal-dns
+```
+
+##### Sample response
+
+```json
+{
+  "data": {
+    "name": "internal-dns",
+    "type": "rfc2136",
+    "identifiers": ["*.internal.example.com", "internal.example.com"],
+    "nameserver": "192.168.1.53:53",
+    "tsig_key_name": "vault-dns-update",
+    "tsig_algorithm": "hmac-sha256",
+    "ttl": 60,
+    "creation_date": "2026-02-24T20:00:00Z",
+    "last_update_date": "2026-02-24T20:00:00Z"
+  }
+}
+```
+
+#### Read RFC2136 configuration
+
+| Method | Path                                              |
+|:-------|:--------------------------------------------------|
+| `GET`  | `/{plugin_mount_path}/config/dns/rfc2136/:name`   |
+
+##### Parameters
+
+- `name` `(string: <required>)` - Name of the DNS provider configuration to read.
+
+##### Sample request
+
+```shell-session
+$ curl                                        \
+    --header "X-Vault-Token: ${VAULT_TOKEN}"  \
+    ${VAULT_ADDR}/v1/pki-external-ca/config/dns/rfc2136/internal-dns
+```
+
+##### Sample response
+
+```json
+{
+  "data": {
+    "name": "internal-dns",
+    "type": "rfc2136",
+    "identifiers": ["*.internal.example.com", "internal.example.com"],
+    "nameserver": "192.168.1.53:53",
+    "tsig_key_name": "vault-dns-update",
+    "tsig_algorithm": "hmac-sha256",
+    "ttl": 60,
+    "creation_date": "2026-02-24T20:00:00Z",
+    "last_update_date": "2026-02-24T20:00:00Z"
+  }
+}
+```
+
+#### Delete RFC2136 configuration
+
+| Method   | Path                                              |
+|:---------|:--------------------------------------------------|
+| `DELETE` | `/{plugin_mount_path}/config/dns/rfc2136/:name`   |
+
+##### Parameters
+
+- `name` `(string: <required>)` - Name of the DNS provider configuration to delete.
+
+##### Sample request
+
+```shell-session
+$ curl                                        \
+    --header "X-Vault-Token: ${VAULT_TOKEN}"  \
+    --request DELETE                          \
+    ${VAULT_ADDR}/v1/pki-external-ca/config/dns/rfc2136/internal-dns
+```
+
+#### List RFC2136 configurations
+
+| Method | Path                                      |
+|:-------|:------------------------------------------|
+| `LIST` | `/{plugin_mount_path}/config/dns/rfc2136` |
+
+##### Sample request
+
+```shell-session
+$ curl                                        \
+    --header "X-Vault-Token: ${VAULT_TOKEN}"  \
+    --request LIST                            \
+    ${VAULT_ADDR}/v1/pki-external-ca/config/dns/rfc2136
+```
+
+##### Sample response
+
+```json
+{
+  "data": {
+    "keys": ["internal-dns", "backup-dns"]
+  }
+}
+```
+
+## DNS provider testing
+
+### Test DNS provider workflow
+
+Test a DNS provider configuration by creating a test TXT record and optionally cleaning it up.
+The testing endpoint validates that the DNS provider credentials and configuration are correct
+before using them in production certificate workflows.
+
+| Method | Path                                     |
+|:-------|:-----------------------------------------|
+| `POST` | `/{plugin_mount_path}/dns/test/workflow` |
+
+#### Parameters
+
+- `identifier` `(string: <required>)` - The DNS identifier (domain name) to test with. Must be a domain
+that the DNS provider configuration is authorized to manage.
+
+- `provider_type` `(string: <required>)` - The DNS provider type. Must be one of:
+  - `aws-route53` - AWS Route53
+  - `azure-dns` - Azure DNS
+  - `google-cloud-dns` - Google Cloud DNS
+  - `rfc2136` - RFC2136 (Dynamic DNS Update)
+
+- `provider_name` `(string: <required>)` - The name of the DNS provider configuration to test.
+
+- `omit_cleanup` `(bool: false)` - If `true`, skip cleanup of the test
+  DNS record. Skipping cleanup is useful for manually validating record
+  creation. If you skip automatic cleanup, you must manually delete the
+  record or re-run the test with `omit_cleanup` set to `false` to clean
+  it up.
+
+#### Sample payload
+
+```json
+{
+  "identifier": "test.example.com",
+  "provider_type": "aws-route53",
+  "provider_name": "production"
+}
+```
+
+#### Sample request
+
+```shell-session
+$ curl                                        \
+    --header "X-Vault-Token: ${VAULT_TOKEN}"  \
+    --request POST                            \
+    --data @payload.json                      \
+    ${VAULT_ADDR}/v1/pki-external-ca/dns/test/workflow
+```
+
+#### Sample response (success)
+
+```json
+{
+  "data": {
+    "success": true,
+    "message": "DNS provider test successful: TXT record was created and cleaned up successfully",
+    "identifier": "test.example.com",
+    "provider_type": "aws-route53",
+    "provider_name": "production",
+    "record_name": "_acme-challenge.test.example.com."
+  }
+}
+```
+
+#### Sample response (failure)
+
+```json
+{
+  "errors": [
+    "Failed to create DNS TXT record: authentication failed"
+  ],
+  "data": {
+    "success": false,
+    "message": "Failed to create DNS TXT record: authentication failed",
+    "identifier": "test.example.com",
+    "provider_type": "aws-route53",
+    "provider_name": "production",
+    "record_name": "_acme-challenge.test.example.com."
   }
 }
 ```
@@ -731,7 +1477,7 @@ $ curl                                        \
 
 ### Mark challenge as fulfilled
 
-Tell This Vault that a challenge is fulfilled and ready for validation by the ACME server.
+Tell Vault that a challenge is fulfilled and ready for validation by the ACME server.
 
 | Method | Path                                                                  |
 |:-------|:----------------------------------------------------------------------|

--- a/content/vault/v2.x/content/docs/secrets/pki-external-ca/index.mdx
+++ b/content/vault/v2.x/content/docs/secrets/pki-external-ca/index.mdx
@@ -148,6 +148,133 @@ The PKI External CA secrets engine is verified to work with
 $ vault write pki-external-ca/role/web-servers @role.json
 ```
 
+## DNS providers for automatic challenge fulfillment
+
+The PKI External CA secrets engine integrates with certain DNS providers to enable automatic
+DNS-01 challenge fulfillment. You configure DNS providers globally and share them across all ACME accounts,
+allowing you to automate certificate issuance without manual intervention or external systems.
+
+### Challenge fulfillment modes
+
+The plugin supports three challenge fulfillment modes:
+
+1. **Manual/External Fulfillment** (default behavior): The plugin exposes challenges via API endpoints for
+external systems to fulfill. The external systems retrieve challenge tokens from Vault and manually create DNS records or HTTP tokens.
+
+1. **Automatic DNS Fulfillment**: Vault automatically manages DNS records
+   using configured provider credentials. Vault handles the entire ACME
+   certificate request process when it receives an order that matches all
+   the requested identifiers for a configured DNS provider.
+
+1. **Hybrid Fulfillment**: You can configure Vault to fulfill some of
+   the challenges automatically while others require manual fulfillment.
+   Hybrid fulfillment is useful when you have DNS providers configured
+   for some domains but not others.
+
+### DNS provider configuration
+
+You manage DNS providers independently with the
+`config/dns/<provider-type>/<name>` endpoint and specify the supported
+identifiers using glob patterns. During ACME challenge evaluation for
+any order from any ACME account, Vault:
+
+1. Selects one or more matching DNS providers based on the identifiers
+   in the order.
+1. Requires manual fulfillment for challenges with no matching provider.
+1. Identifies challenges for automatic fulfillment using the DNS provider.
+1. Waits for manual challenge fulfillment then performs automatic DNS
+   updates for challenges that qualify for automatic fulfillment.
+
+### Supported DNS providers
+
+The plugin supports multiple DNS providers, including:
+
+- **AWS Route53** - Amazon DNS service
+- **Azure DNS** - Microsoft Azure DNS service
+- **Google Cloud DNS** - Google Cloud Platform DNS service
+- **RFC2136** - Dynamic DNS updates for BIND and other RFC2136-compliant servers
+
+### Configure DNS providers
+
+For additional details on supported arguments for DNS providers, see the [API-docs](/vault/api-docs/secret/pki-external-ca) page.
+
+<Tabs>
+
+<Tab heading="AWS Route53">
+
+Configure AWS Route53 as a DNS provider:
+
+```shell-session
+$ vault write pki-external-ca/config/dns/aws-route53/production \
+    identifiers="*.example.com,*.prod.example.com" \
+    access_key_id="AKIAIOSFODNN7EXAMPLE" \
+    secret_access_key="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" \
+    region="us-east-1"
+```
+
+</Tab>
+
+<Tab heading="Azure DNS">
+
+Configure Azure DNS as a DNS provider:
+
+```shell-session
+$ vault write pki-external-ca/config/dns/azure-dns/production \
+    identifiers="*.example.com" \
+    zone_name="my-zone-id" \
+    client_id="00000000-0000-0000-0000-000000000000" \
+    client_secret="your-client-secret"
+```
+
+</Tab>
+
+<Tab heading="Google Cloud DNS">
+
+Configure Google Cloud DNS as a DNS provider:
+
+```shell-session
+$ vault write pki-external-ca/config/dns/google-cloud-dns/production \
+    identifiers="*.example.com" \
+    credentials=@gcp-service-account.json
+```
+
+</Tab>
+
+<Tab heading="RFC2136">
+
+Configure RFC2136 for dynamic DNS updates:
+
+```shell-session
+$ vault write pki-external-ca/config/dns/rfc2136/bind-dns \
+    identifiers="*.example.com" \
+    nameserver="ns1.example.com:53" \
+    tsig_key_name="my-key" \
+    tsig_secret="base64-encoded-secret" \
+    tsig_algorithm="hmac-sha256"
+```
+
+</Tab>
+
+</Tabs>
+
+### Testing DNS providers
+
+You can use the test API endpoint before using a DNS provider within
+an ACME workflow to confirm the DNS provider configuration works
+without requesting any certificates.
+
+For example, the following command confirms that:
+ - The DNS provider credentials are correct.
+ - Vault can create and delete DNS records.
+ - The DNS provider can service the specified identifier.
+
+```shell-session
+$ vault write pki-external-ca/dns/test/workflow \
+    provider_type="aws-route53" \
+    provider_name="production" \
+    identifier="test.example.com"
+```
+
 ## Certificate workflows
 
 The PKI External CA secrets engine supports two distinct workflows for requesting certificates,
@@ -204,7 +331,12 @@ the private key with the certificate so you can retrieve the key later if needed
    $ vault read pki-external-ca/role/web-servers/order/01936d8e-7c3a-7890-b123-456789abcdef/status
    ```
 
-1. Fetch the challenge token and auth key for each identifier from Vault:
+1. **If you have DNS providers configured**, Vault automatically handles
+   DNS-01 challenges for matching identifiers. Skip to step 5.
+
+1. **If you do not have a DNS provider configured or the identifiers
+   do not match**, fetch the challenge token and auth key for each
+   identifier from Vault:
 
    ```shell-session
    $ vault read pki-external-ca/role/web-servers/order/01936d8e-7c3a-7890-b123-456789abcdef/challenge \
@@ -212,9 +344,7 @@ the private key with the certificate so you can retrieve the key later if needed
        challenge_type="http-01"
    ```
 
-1. Fulfill challenges (place HTTP token or DNS records) as ACME server expects.
-
-1. Notify Vault that challenges are ready:
+   Fulfill challenges (place HTTP token or DNS records) as ACME server expects, then notify Vault:
 
    ```shell-session
    $ vault write pki-external-ca/role/web-servers/order/01936d8e-7c3a-7890-b123-456789abcdef/fulfilled-challenge \
@@ -265,7 +395,12 @@ a signed certificate.
    $ vault read pki-external-ca/role/web-servers/order/01936d8e-7c3a-7890-b123-456789abcdef/status
    ```
 
-1. Fetch the challenge token and auth key for each identifier from Vault:
+1. **If you have DNS providers configured**, Vault automatically handles
+   DNS-01 challenges for matching identifiers. Skip to step 5.
+
+1. **If you do not have a DNS provider configured or the identifiers
+   do not match**, fetch the challenge token and auth key for each
+   identifier from Vault:
 
    ```shell-session
    $ vault read pki-external-ca/role/web-servers/order/01936d8e-7c3a-7890-b123-456789abcdef/challenge \
@@ -273,9 +408,7 @@ a signed certificate.
        challenge_type="http-01"
    ```
 
-1. Fulfill challenges (place HTTP token or DNS records) as ACME server expects.
-
-1. Notify Vault that challenges are ready:
+   Fulfill challenges (place HTTP token or DNS records) as ACME server expects, then notify Vault:
 
    ```shell-session
    $ vault write pki-external-ca/role/web-servers/order/01936d8e-7c3a-7890-b123-456789abcdef/fulfilled-challenge \
@@ -424,9 +557,11 @@ Order statuses:
 - `new` - Order created, not yet submitted to ACME server
 - `submitted` - Submitted to ACME server
 - `awaiting-challenge-fulfillment` - Waiting for client to fulfill challenges
+- `vault-challenge-fulfillment` - Vault is fulfilling DNS challenges
+- `vault-challenge-propogating` - Vault waits for internal validation of the DNS challenges it made in vault_challenge_fulfillment
 - `notify-acme-server-challenges-completed` - Ready to notify ACME server
 - `processing-challenge` - ACME server is validating challenges
-- `fetching-certificate` - Retrieving issued certificate
+- `fetching-certificate` - Retrieving issued certificate, the ACME server has accepted the challenges
 - `completed` - Certificate issued successfully
 - `expired` - Order expired before completion
 - `revoked` - Vault revoked the certificate


### PR DESCRIPTION
Backport of https://github.com/hashicorp/web-unified-docs/pull/2656: Update the existing PKI external CA docs around the Vault 2.1.x Automatic DNS resolution of ACME challenges.

There is are a couple minor difference from the original PR. 
- #2743 (to main) made some updates to the order statuses. This PR preserves the dasherized syntax, **and** adds the DNS-related statuses (dasherized, instead of underscored which is the correct syntax)
- The `last_updated_date` param was renamed for consistency to match the other params in this API via:  https://github.com/hashicorp/vault-plugin-secrets-pki-external-ca/pull/122. 
 
Please go to the `Preview` tab and select the appropriate template:

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
