### PR TITLE
vault/202610: Update PKI CA DNS Params

### DIFF
--- a/content/vault/v2.x/content/api-docs/secret/pki-external-ca.mdx
+++ b/content/vault/v2.x/content/api-docs/secret/pki-external-ca.mdx
@@ -672,7 +672,7 @@ $ curl                                        \
     "hosted_zone_id": "Z3M3LMPEXAMPLE",
     "ttl": 60,
     "creation_date": "2026-02-24T20:00:00Z",
-    "last_update_date": "2026-02-24T20:00:00Z"
+    "last_updated_date": "2026-02-24T20:00:00Z"
   }
 }
 ```
@@ -707,7 +707,7 @@ $ curl                                        \
     "hosted_zone_id": "Z3M3LMPEXAMPLE",
     "ttl": 60,
     "creation_date": "2026-02-24T20:00:00Z",
-    "last_update_date": "2026-02-24T20:00:00Z"
+    "last_updated_date": "2026-02-24T20:00:00Z"
   }
 }
 ```
@@ -836,7 +836,7 @@ $ curl                                        \
     "environment": "AzurePublic",
     "ttl": 60,
     "creation_date": "2026-02-24T20:00:00Z",
-    "last_update_date": "2026-02-24T20:00:00Z"
+    "last_updated_date": "2026-02-24T20:00:00Z"
   }
 }
 ```
@@ -874,7 +874,7 @@ $ curl                                        \
     "environment": "AzurePublic",
     "ttl": 60,
     "creation_date": "2026-02-24T20:00:00Z",
-    "last_update_date": "2026-02-24T20:00:00Z"
+    "last_updated_date": "2026-02-24T20:00:00Z"
   }
 }
 ```
@@ -985,7 +985,7 @@ $ curl                                        \
     "zone_name": "example-com",
     "ttl": 10,
     "creation_date": "2026-02-24T20:00:00Z",
-    "last_update_date": "2026-02-24T20:00:00Z"
+    "last_updated_date": "2026-02-24T20:00:00Z"
   }
 }
 ```
@@ -1020,7 +1020,7 @@ $ curl                                        \
     "zone_name": "example-com",
     "ttl": 10,
     "creation_date": "2026-02-24T20:00:00Z",
-    "last_update_date": "2026-02-24T20:00:00Z"
+    "last_updated_date": "2026-02-24T20:00:00Z"
   }
 }
 ```
@@ -1136,7 +1136,7 @@ $ curl                                        \
     "tsig_algorithm": "hmac-sha256",
     "ttl": 60,
     "creation_date": "2026-02-24T20:00:00Z",
-    "last_update_date": "2026-02-24T20:00:00Z"
+    "last_updated_date": "2026-02-24T20:00:00Z"
   }
 }
 ```
@@ -1172,7 +1172,7 @@ $ curl                                        \
     "tsig_algorithm": "hmac-sha256",
     "ttl": 60,
     "creation_date": "2026-02-24T20:00:00Z",
-    "last_update_date": "2026-02-24T20:00:00Z"
+    "last_updated_date": "2026-02-24T20:00:00Z"
   }
 }
 ```

--- a/content/vault/v2.x/content/docs/secrets/pki-external-ca/index.mdx
+++ b/content/vault/v2.x/content/docs/secrets/pki-external-ca/index.mdx
@@ -555,18 +555,18 @@ $ vault read pki-external-ca/role/web-servers/order/01936d8e-7c3a-7890-b123-4567
 
 Order statuses:
 
-- `awaiting-challenge-fulfillment` - Waiting for client to fulfill challenges
-- `completed` - Certificate issued successfully
-- `error` - An error occurred
-- `expired` - Order expired before completion
-- `fetching-certificate` - Retrieving issued certificate
 - `new` - Order created, not yet submitted to ACME server
+- `submitted` - Submitted to ACME server
+- `awaiting-challenge-fulfillment` - Waiting for client to fulfill challenges
+- `vault-challenge-fulfillment` - Vault is fulfilling DNS challenges
+- `vault-challenge-propogating` - Vault waits for internal validation of the DNS challenges it made in vault_challenge_fulfillment
 - `notify-acme-server-challenges-completed` - Ready to notify ACME server
 - `processing-challenge` - ACME server is validating challenges
+- `fetching-certificate` - Retrieving issued certificate, the ACME server has accepted the challenges
+- `completed` - Certificate issued successfully
+- `expired` - Order expired before completion
 - `revoked` - Vault revoked the certificate
-- `submitted` - Submitted to ACME server
-- `vault_challenge_fulfillment` - Vault is fulfilling DNS challenges
-- `vault_challenge_propogating` - Vault waits for internal validation of the DNS challenges it made in vault_challenge_fulfillment
+- `error` - An error occurred
 
 ### List active orders
 


### PR DESCRIPTION
This updates the order status syntaxes to use dashes instead of hyphens (see https://github.com/hashicorp/web-unified-docs/pull/2743) and fixes their order which were rearranged by https://github.com/hashicorp/web-unified-docs/commit/2bc0da29b01c1659b9e4e795ed80da29ba268154#diff-fc45a89ed16748374e03ac48d9e28144820212e06b8b7c0e4dd373875159ce90. I'm not entirely sure how that happened because the [statuses in main](https://github.com/hashicorp/web-unified-docs/blob/main/content/vault/v2.x/content/docs/secrets/pki-external-ca/index.mdx#monitoring-and-troubleshooting) are currently in the correct order (that matches this PR) 

The `last_updated_date` param was renamed for consistency to match the other last update params in this API via:  https://github.com/hashicorp/vault-plugin-secrets-pki-external-ca/pull/122. 

Please go to the `Preview` tab and select the appropriate template:

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
