### PR TITLE
nomad: Add note about draining the client before node pool change.

### DIFF
--- a/content/nomad/v1.10.x/content/docs/configuration/client.mdx
+++ b/content/nomad/v1.10.x/content/docs/configuration/client.mdx
@@ -126,6 +126,10 @@ client {
   non-authoritative regions, the node is kept in the `initializing` status
   until the node pool is created and replicated.
 
+  When changing this option on a client that is already running allocations,
+  drain all allocations not targeting the `all` node pool before making the
+  change and restarting the client.
+
 - `options` <code>([Options](#options-parameters): nil)</code> - Specifies a
   key-value mapping of internal configuration for clients, such as for driver
   configuration.

--- a/content/nomad/v1.11.x/content/docs/configuration/client.mdx
+++ b/content/nomad/v1.11.x/content/docs/configuration/client.mdx
@@ -129,6 +129,10 @@ client {
   non-authoritative regions, the node is kept in the `initializing` status
   until the node pool is created and replicated.
 
+  When changing this option on a client that is already running allocations,
+  drain all allocations not targeting the `all` node pool before making the
+  change and restarting the client.
+
 - `options` <code>([Options](#options-parameters): nil)</code> - Specifies a
   key-value mapping of internal configuration for clients, such as for driver
   configuration.

--- a/content/nomad/v1.6.x/content/docs/configuration/client.mdx
+++ b/content/nomad/v1.6.x/content/docs/configuration/client.mdx
@@ -98,6 +98,10 @@ client {
   non-authoritative regions, the node is kept in the `initializing` status
   until the node pool is created and replicated.
 
+  When changing this option on a client that is already running allocations,
+  drain all allocations not targeting the `all` node pool before making the
+  change and restarting the client.
+
 - `options` <code>([Options](#options-parameters): nil)</code> - Specifies a
   key-value mapping of internal configuration for clients, such as for driver
   configuration.

--- a/content/nomad/v1.7.x/content/docs/configuration/client.mdx
+++ b/content/nomad/v1.7.x/content/docs/configuration/client.mdx
@@ -98,6 +98,10 @@ client {
   non-authoritative regions, the node is kept in the `initializing` status
   until the node pool is created and replicated.
 
+  When changing this option on a client that is already running allocations,
+  drain all allocations not targeting the `all` node pool before making the
+  change and restarting the client.
+
 - `options` <code>([Options](#options-parameters): nil)</code> - Specifies a
   key-value mapping of internal configuration for clients, such as for driver
   configuration.

--- a/content/nomad/v1.8.x/content/docs/configuration/client.mdx
+++ b/content/nomad/v1.8.x/content/docs/configuration/client.mdx
@@ -113,6 +113,10 @@ client {
   non-authoritative regions, the node is kept in the `initializing` status
   until the node pool is created and replicated.
 
+  When changing this option on a client that is already running allocations,
+  drain all allocations not targeting the `all` node pool before making the
+  change and restarting the client.
+
 - `options` <code>([Options](#options-parameters): nil)</code> - Specifies a
   key-value mapping of internal configuration for clients, such as for driver
   configuration.

--- a/content/nomad/v1.9.x/content/docs/configuration/client.mdx
+++ b/content/nomad/v1.9.x/content/docs/configuration/client.mdx
@@ -122,6 +122,10 @@ client {
   non-authoritative regions, the node is kept in the `initializing` status
   until the node pool is created and replicated.
 
+  When changing this option on a client that is already running allocations,
+  drain all allocations not targeting the `all` node pool before making the
+  change and restarting the client.
+
 - `options` <code>([Options](#options-parameters): nil)</code> - Specifies a
   key-value mapping of internal configuration for clients, such as for driver
   configuration.

--- a/content/nomad/v2.0.x/content/docs/configuration/client.mdx
+++ b/content/nomad/v2.0.x/content/docs/configuration/client.mdx
@@ -129,6 +129,10 @@ client {
   non-authoritative regions, the node is kept in the `initializing` status
   until the node pool is created and replicated.
 
+  When changing this option on a client that is already running allocations,
+  drain all allocations not targeting the `all` node pool before making the
+  change and restarting the client.
+
 - `options` <code>([Options](#options-parameters): nil)</code> - Specifies a
   key-value mapping of internal configuration for clients, such as for driver
   configuration.


### PR DESCRIPTION
## Description
Changing the node pool parameter dramatically changes the scheduling conditions of a node and placed allocations will no longer be feasible. Adding this note for operators.

## Contributor checklists

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [x] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [x] Verify that all status checks passed
- [x] Verify that the preview environment deployed successfully
- [x] Add additional reviewers if they are not part of assigned groups

Content:

- [x] I added redirects for any moved or removed pages
- [x] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [x] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [ ] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.
