### PR TITLE
kak/vault/add tutorial links for OS-password and Kubernetes secrets engine 

### DIFF
--- a/content/vault/v2.x/content/docs/secrets/kubernetes.mdx
+++ b/content/vault/v2.x/content/docs/secrets/kubernetes.mdx
@@ -447,6 +447,9 @@ service_account_name         v-token-auto-man-1653002096-4imxf3ytjh5hbyro9s1oqdo
 service_account_namespace    test
 service_account_token        eyJHbGci0iJSUzI1Ni...
 ```
+## Tutorial
+
+Refer to [Manage Kubernetes service tokens](/vault/tutorials/kubernetes/kubernetes-secrets-engine) for a tep-by-step tutorial.
 
 ## API
 

--- a/content/vault/v2.x/content/docs/secrets/kubernetes.mdx
+++ b/content/vault/v2.x/content/docs/secrets/kubernetes.mdx
@@ -449,7 +449,7 @@ service_account_token        eyJHbGci0iJSUzI1Ni...
 ```
 ## Tutorial
 
-Refer to [Manage Kubernetes service tokens](/vault/tutorials/kubernetes/kubernetes-secrets-engine) for a tep-by-step tutorial.
+Refer to [Manage Kubernetes service tokens](/vault/tutorials/kubernetes/kubernetes-secrets-engine) for a step-by-step tutorial.
 
 ## API
 

--- a/content/vault/v2.x/content/docs/secrets/os.mdx
+++ b/content/vault/v2.x/content/docs/secrets/os.mdx
@@ -231,6 +231,9 @@ To delete an entire host, repeat these steps for each managed account, then dele
 $ vault delete os/hosts/my-box
 Success! Data deleted (if it existed) at: os/hosts/my-box
 ```
+## Tutorial
+
+Refer to [Automate Linux password rotation with Vault](/vault/tutorials/secrets-management/os-password-secrets) for a tep-by-step tutorial.
 
 ## API
 

--- a/content/vault/v2.x/content/docs/secrets/os.mdx
+++ b/content/vault/v2.x/content/docs/secrets/os.mdx
@@ -233,7 +233,7 @@ Success! Data deleted (if it existed) at: os/hosts/my-box
 ```
 ## Tutorial
 
-Refer to [Automate Linux password rotation with Vault](/vault/tutorials/secrets-management/os-password-secrets) for a tep-by-step tutorial.
+Refer to [Automate Linux password rotation with Vault](/vault/tutorials/secrets-management/os-password-secrets) for a step-by-step tutorial.
 
 ## API
 


### PR DESCRIPTION
* [Ticket](https://hashicorp.atlassian.net/browse/SPE-1462?atlOrigin=eyJpIjoiNGUyYTBhYzVmZGQ4NDRlMmE0MTg0NTU4YmZlY2ZlMTgiLCJwIjoiaiJ9)

Added the tutorial section to:

- [Link to OS secrets engine](http://unified-docs-frontend-preview-bvk2ttdtv-hashicorp.vercel.app/vault/docs/secrets/kubernetes#tutorial)
- [Link to Kubernetes secrets engine](https://unified-docs-frontend-preview-bvk2ttdtv-hashicorp.vercel.app/vault/docs/secrets/kubernetes#tutorial)