### PR TITLE
Remove team-docs-packer-and-terraform from codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -17,28 +17,28 @@
 /content/terraform-plugin-sdk @hashicorp/terraform-core-plugins @hashicorp/terraform-education @hashicorp/team-devrel-infrastructure-education
 /content/terraform-plugin-testing @hashicorp/terraform-core-plugins @hashicorp/terraform-education @hashicorp/team-devrel-infrastructure-education
 /content/terraform-docs-agents @hashicorp/team-hcpt-agent-engineering @hashicorp/team-devrel-infrastructure-education
-/content/terraform-mcp-server @hashicorp/team-docs-packer-and-terraform @hashicorp/team-devrel-infrastructure-education
-/content/terraform-migrate @hashicorp/team-docs-packer-and-terraform @hashicorp/team-devrel-infrastructure-education
-/content/terraform-policy @hashicorp/team-docs-packer-and-terraform @hashicorp/team-devrel-infrastructure-education
+/content/terraform-mcp-server @hashicorp/team-devrel-infrastructure-education
+/content/terraform-migrate @hashicorp/team-devrel-infrastructure-education
+/content/terraform-policy @hashicorp/team-devrel-infrastructure-education
 /content/terraform-cdk @hashicorp/cdktf @hashicorp/team-devrel-infrastructure-education
 
-/content/terraform @hashicorp/terraform-education @hashicorp/terraform-core @hashicorp/team-docs-packer-and-terraform @hashicorp/team-devrel-infrastructure-education
-/content/terraform/*/docs/language/backend/azurerm.mdx @hashicorp/terraform-education @hashicorp/terraform-core @hashicorp/team-docs-packer-and-terraform @hashicorp/terraform-azure @hashicorp/team-devrel-infrastructure-education
-/content/terraform/*/docs/language/backend/gcs.mdx  @hashicorp/terraform-education @hashicorp/terraform-core @hashicorp/team-docs-packer-and-terraform @hashicorp/tf-eco-hybrid-cloud @hashicorp/team-devrel-infrastructure-education
-/content/terraform/*/docs/language/backend/kubernetes.mdx  @hashicorp/terraform-education @hashicorp/terraform-core @hashicorp/team-docs-packer-and-terraform @hashicorp/tf-eco-hybrid-cloud @hashicorp/team-devrel-infrastructure-education
-/content/terraform/*/docs/language/backend/s3.mdx  @hashicorp/terraform-education @hashicorp/terraform-core @hashicorp/team-docs-packer-and-terraform @hashicorp/terraform-aws @hashicorp/team-devrel-infrastructure-education
+/content/terraform @hashicorp/terraform-education @hashicorp/terraform-core @hashicorp/team-devrel-infrastructure-education
+/content/terraform/*/docs/language/backend/azurerm.mdx @hashicorp/terraform-education @hashicorp/terraform-core @hashicorp/terraform-azure @hashicorp/team-devrel-infrastructure-education
+/content/terraform/*/docs/language/backend/gcs.mdx @hashicorp/terraform-education @hashicorp/terraform-core @hashicorp/tf-eco-hybrid-cloud @hashicorp/team-devrel-infrastructure-education
+/content/terraform/*/docs/language/backend/kubernetes.mdx @hashicorp/terraform-education @hashicorp/terraform-core @hashicorp/tf-eco-hybrid-cloud @hashicorp/team-devrel-infrastructure-education
+/content/terraform/*/docs/language/backend/s3.mdx @hashicorp/terraform-education @hashicorp/terraform-core @hashicorp/terraform-aws @hashicorp/team-devrel-infrastructure-education
 
-/content/terraform-docs-common/ @hashicorp/team-docs-packer-and-terraform @hashicorp/team-devrel-infrastructure-education
+/content/terraform-docs-common/ @hashicorp/team-devrel-infrastructure-education
 /content/terraform-docs-common/docs/plugin/ @hashicorp/terraform-core-plugins @hashicorp/team-devrel-infrastructure-education
 /content/terraform-docs-common/data/plugin-nav-data.json @hashicorp/terraform-core-plugins @hashicorp/team-devrel-infrastructure-education
 
-/content/terraform-enterprise @hashicorp/team-docs-packer-and-terraform @hashicorp/ptfe-review @hashicorp/team-devrel-infrastructure-education
+/content/terraform-enterprise @hashicorp/ptfe-review @hashicorp/team-devrel-infrastructure-education
 
 # Vault documentation ownership
 /content/vault/                                    @hashicorp/vault-education-approvers
 
 # Sentinel documentation ownership
-/content/sentinel/ @hashicorp/team-docs-packer-and-terraform @hashicorp/tf-compliance @hashicorp/team-devrel-infrastructure-education
+/content/sentinel/ @hashicorp/tf-compliance @hashicorp/team-devrel-infrastructure-education
 
 # Well-architected framework
 /content/well-architected-framework/ @hashicorp/well-architected-education-approvers
@@ -75,7 +75,7 @@
 /content/vagrant @hashicorp/Vagrant
 
 # Nomad
-/content/nomad/ @hashicorp/nomad-docs @hashicorp/nomad-eng  @hashicorp/team-devrel-infrastructure-education
+/content/nomad/ @hashicorp/nomad-docs @hashicorp/nomad-eng @hashicorp/team-devrel-infrastructure-education
 
 # Packer
-/content/packer @hashicorp/team-docs-packer-and-terraform @hashicorp/packer @hashicorp/team-devrel-infrastructure-education
+/content/packer @hashicorp/packer @hashicorp/team-devrel-infrastructure-education

--- a/docs/workflows/add-versioned-docs.md
+++ b/docs/workflows/add-versioned-docs.md
@@ -84,10 +84,10 @@ Before merging these changes, make changes to the `web-unified-docs` API. Refer 
       ]
    ```
 
-1. If you need a specific team to act as reviewers, add the group to the repository `CODEOWERS` file. The following example adds the `team-docs-packer-and-terraform ` team to the MCP server documentation: 
+1. If you need a specific team to act as reviewers, add the group to the repository `CODEOWERS` file. The following example adds the `team-devrel-infrastructure-education` team to the MCP server documentation:
 
    ```text
-   content/terraform-mcp-server @hashicorp/team-docs-packer-and-terraform
+   content/terraform-mcp-server @hashicorp/team-devrel-infrastructure-education
    ```
 
 1. Add an entry for your docs to the `productConfig.mjs` file. Use the following syntax:


### PR DESCRIPTION
This is a followup to PR #2822, to remove the old `team-docs-packer-and-terraform` team.