### PR TITLE
fix: add permissions to github actions

### DIFF
--- a/.github/workflows/force-rebuild-dev-portal.yml
+++ b/.github/workflows/force-rebuild-dev-portal.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   rebuild-dev-portal:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Rebuild Dev Portal
         shell: bash


### PR DESCRIPTION
### Description

This PR adds permissions to one of the github actions. All other actions already had permissions

### Testing

Make sure actions don't fail