### PR TITLE
chore: Sync changes to TF 1.15 docs from d4e2a51 into TF 1.16 docs

### DIFF
--- a/content/terraform/v1.16.x (beta)/docs/cli/commands/stacks/index.mdx
+++ b/content/terraform/v1.16.x (beta)/docs/cli/commands/stacks/index.mdx
@@ -2,8 +2,8 @@
 page_title: terraform stacks command
 description: The terraform stacks command manages Terraform Stacks configurations and deployments.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-11-19T19:11:19Z
-last_modified: 2026-01-13T10:56:42-08:00
+created_at: 2026-04-29T13:15:03Z
+last_modified: 2026-05-14T19:29:23.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -36,6 +36,7 @@ To use CLI commands with Stacks on Terraform Enterprise, set the `TF_STACKS_HOST
 - [`deployment-run`](/terraform/cli/commands/stacks/deployment-run) - Manage deployment runs for a Stack deployment.
 - [`deployment-group`](/terraform/cli/commands/stacks/deployment-group) - Manage deployment groups.
 - [`configuration`](/terraform/cli/commands/stacks/configuration) - Manage Stack configuration versions.
+- [`migrate`](/terraform/cli/commands/stacks/migrate) - Migrate traditional Terraform workflows to Terraform Stacks.
 
 ## Global flags
 

--- a/content/terraform/v1.16.x (beta)/docs/cli/commands/stacks/migrate/index.mdx
+++ b/content/terraform/v1.16.x (beta)/docs/cli/commands/stacks/migrate/index.mdx
@@ -1,0 +1,127 @@
+---
+page_title: terraform stacks migrate
+description: Use the terraform stacks migrate command group migrate existing HCP Terraform workspaces to Terraform Stacks.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-05-14T10:57:55-05:00
+last_modified: 2026-05-15T20:57:53.000Z
+# END AUTO GENERATED METADATA
+---
+
+# `terraform stacks migrate` reference
+
+Use the `terraform stacks migrate` commands to migrate traditional Terraform workspaces to Terraform Stacks.
+
+@include '@global/terraform-stacks-migrate-experiment.mdx'
+
+## Usage
+
+```shell-session
+$ TF_STACKS_MIGRATE_EXPERIMENTAL=true terraform stacks <global-stacks-flags> migrate <subcommand>
+```
+
+## Description
+
+The `terraform stacks migrate` command group lets you migrate
+HCP Terraform workspaces to Terraform Stacks. The commands use a migrate manifest
+to describe the source configuration, the translated stacks configuration, deployment
+inputs, and state artifact paths.
+
+The workflow supports local migration preparation. It does not create a Stack in HCP
+Terraform, upload configuration, or move remote state automatically.
+
+## Workflow
+
+Migrate commands use the following local workflow:
+
+1. Run
+   [`prepare-manifest`](/terraform/cli/commands/stacks/migrate/prepare-manifest) to
+   generate a migrate manifest from one or more HCP Terraform workspaces and download
+   each workspace's Terraform state file.
+1. Run
+   [`validate-manifest`](/terraform/cli/commands/stacks/migrate/validate-manifest) to
+   confirm the manifest and expected filesystem layout are valid.
+1. Run
+   [`translate-config`](/terraform/cli/commands/stacks/migrate/translate-config) to
+   generate the Stack configuration in the directory that the manifest references.
+1. Review the generated code and make the changes required to source-sensitive inputs.
+1. Run [`translate-state`](/terraform/cli/commands/stacks/migrate/translate-state)
+  to generate local `.tfstackstate` artifacts for the translated Stack
+   configuration.
+1. Upload the generated Stack configuration and complete the migration in the HCP
+   Terraform UI.
+
+Refer to [Migrate HCP Terraform workspaces to Terraform Stacks](/terraform/cloud-docs/stacks/migrate) for an end-to-end migration workflow.
+
+## Subcommands
+
+- [`prepare-manifest`](/terraform/cli/commands/stacks/migrate/prepare-manifest) -
+  Generate a migrate manifest from HCP Terraform workspaces.
+- [`translate-config`](/terraform/cli/commands/stacks/migrate/translate-config) -
+  Translate a traditional Terraform root module into Terraform Stack configuration.
+- [`translate-state`](/terraform/cli/commands/stacks/migrate/translate-state) - Convert
+  Terraform state files into Terraform Stack state artifacts.
+- [`validate-manifest`](/terraform/cli/commands/stacks/migrate/validate-manifest) -
+  Validate a migrate manifest and its expected filesystem layout.
+
+## Migrate manifest
+
+A migrate manifest is a JSON file that describes the local migration workspace. By
+default, commands read or write `migrate-manifest.json` in the working directory after
+applying the `-chdir` flag.
+
+The following example shows the manifest structure:
+
+```json
+{
+  "version": 1,
+  "source_configuration": "./source-config",
+  "stacks_configuration": "./stack-config",
+  "deployments": [
+    {
+      "name": "prod",
+      "workspace_id": "ws-prod",
+      "inputs": [
+        {
+          "key": "region",
+          "value": "us-east-1",
+          "hcl": false,
+          "sensitive": false,
+          "category": "terraform"
+        }
+      ],
+      "state": {
+        "tfstate": "./tfstates/prod.tfstate",
+        "tfstackstate": "./tfstackstates/prod.tfstackstate"
+      }
+    }
+  ]
+}
+```
+
+The manifest supports the following fields:
+
+| Field | Description |
+| --- | --- |
+| `version` | Manifest format version. The supported version is `1`. |
+| `source_configuration` | Path to the traditional Terraform root module. Relative paths resolve from the manifest location. |
+| `stacks_configuration` | Path to the translated Terraform Stack configuration. Relative paths resolve from the manifest location. |
+| `deployments[].name` | Deployment name. `prepare-manifest` uses the HCP Terraform workspace name. |
+| `deployments[].workspace_id` | HCP Terraform workspace ID. This field can be omitted for deployments that do not map to an HCP Terraform workspace. |
+| `deployments[].inputs` | Deployment inputs derived from workspace variables. |
+| `deployments[].inputs[].key` | Input name. `prepare-manifest` removes the `TF_VAR_` prefix from environment variables that HCP Terraform passes to Terraform as input variables. |
+| `deployments[].inputs[].value` | Input value. Sensitive variables omit `value` because HCP Terraform does not return sensitive values from the API. |
+| `deployments[].inputs[].hcl` | Indicates whether HCP Terraform interprets the value as HCL. |
+| `deployments[].inputs[].sensitive` | Indicates whether the value is sensitive. All deployments must use the same sensitivity setting for matching input keys. |
+| `deployments[].inputs[].category` | HCP Terraform variable category, such as `terraform` or `env`. |
+| `deployments[].state.tfstate` | Path to the traditional Terraform state file for the deployment. Relative paths resolve from the manifest location. |
+| `deployments[].state.tfstackstate` | Path where `translate-state` writes the translated local Terraform Stack state artifact. Relative paths resolve from the manifest location. |
+
+## Global flags
+
+Refer to [Global flags reference](/terraform/cli/commands/stacks/global-flags) for
+information about flags you can use with all commands.
+
+## Related
+
+- [Migrate HCP Terraform workspaces to Terraform Stacks](/terraform/cloud-docs/stacks/migrate-workspaces)
+- [Terraform Stacks CLI reference](/terraform/cli/commands/stacks)

--- a/content/terraform/v1.16.x (beta)/docs/cli/commands/stacks/migrate/prepare-manifest.mdx
+++ b/content/terraform/v1.16.x (beta)/docs/cli/commands/stacks/migrate/prepare-manifest.mdx
@@ -1,0 +1,112 @@
+---
+page_title: terraform stacks migrate prepare-manifest
+description: Use the terraform stacks migrate prepare-manifest command to prepare a migrate manifest from HCP Terraform workspaces.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-05-14T15:06:58.000Z
+last_modified: 2026-05-14T15:06:58.000Z
+# END AUTO GENERATED METADATA
+---
+
+# `terraform stacks migrate prepare-manifest` reference
+
+Use the `terraform stacks migrate prepare-manifest` command to generate a migrate
+manifest from HCP Terraform workspaces to a Stack.
+
+@include '@global/terraform-stacks-migrate-experiment.mdx'
+
+## Usage
+
+```shell-session
+$ TF_STACKS_MIGRATE_EXPERIMENTAL=true terraform stacks <global-stacks-flags> migrate prepare-manifest <options> <workspace-id>...
+```
+
+## Description
+
+The `terraform stacks migrate prepare-manifest` command reads one or more HCP Terraform
+workspaces, verifies that each workspace is ready for migration, downloads each
+workspace's Terraform state file, and writes a migrate manifest.
+
+Each workspace ID becomes a deployment entry in the manifest. The command uses the
+workspace name as the deployment name and writes the workspace state to
+`./tfstates/<workspace-name>.tfstate` relative to the manifest location. It also creates
+the source configuration, Stack configuration, and translated state output directories
+that the migrate workflow expects.
+
+Refer to [Migrate HCP Terraform workspaces to Terraform Stacks](/terraform/cloud-docs/stacks/migrate) for an end-to-end migration workflow.
+
+To use this command, you must authenticate your local Terraform CLI with HCP Terraform as a user that has permission to read the HCP Terraform workspace variables and state versions.
+
+The command copies workspace variables into deployment inputs. It preserves non-sensitive
+variable values in the manifest. HCP Terraform does not return sensitive variable values
+from the API, so the manifest records sensitive metadata without the value. The command
+also converts environment variables with names that start with `TF_VAR_` into Terraform
+input variables by removing the `TF_VAR_` prefix.
+
+## Command arguments
+
+- `workspace-id`: One or more HCP Terraform workspace IDs to include in the migration, separated by spaces 
+  - Required.
+  - String.
+
+## Options
+
+- `-migrate-manifest`: The path where the command writes the migrate manifest.
+    - Optional.
+    - String.
+    - Default: `migrate-manifest.json`.
+
+- `-source-config`: The directory the manifest references as the traditional Terraform
+  source configuration.
+    - Optional.
+    - String.
+    - Default: `./source-config`.
+
+- `-stack-config`: The directory the manifest references as the translated Terraform
+  Stacks configuration.
+    - Optional.
+    - String.
+    - Default: `./stack-config`.
+
+- `-json`: Output progress events and the success message in JSON format instead of the
+  default human-readable text format.
+    - Optional.
+    - Boolean flag.
+    - Default: false.
+
+## Examples
+
+The following command prepares a migrate manifest for two HCP Terraform workspaces:
+
+```shell-session
+$ TF_STACKS_MIGRATE_EXPERIMENTAL=true terraform stacks migrate prepare-manifest \
+  ws-abc123 ws-def456
+```
+
+The following command writes the manifest and generated directories to the `./migration` directory:
+
+```shell-session
+$ TF_STACKS_MIGRATE_EXPERIMENTAL=true terraform stacks migrate prepare-manifest \
+  -migrate-manifest=./migration/migrate-manifest.json \
+  -source-config=./source-config \
+  -stack-config=./stack-config \
+  ws-abc123
+```
+
+The following command returns progress events in JSON format:
+
+```shell-session
+$ TF_STACKS_MIGRATE_EXPERIMENTAL=true terraform stacks migrate prepare-manifest \
+  -json \
+  ws-abc123
+```
+
+## Global flags
+
+Refer to [Global flags reference](/terraform/cli/commands/stacks/global-flags) for
+information about flags you can use with all commands.
+
+## Related
+
+- [Migrate HCP Terraform workspaces to Terraform Stacks](/terraform/cloud-docs/stacks/migrate)
+- [terraform stacks migrate reference](/terraform/cli/commands/stacks/migrate)
+- [Terraform Stacks CLI reference](/terraform/cli/commands/stacks)

--- a/content/terraform/v1.16.x (beta)/docs/cli/commands/stacks/migrate/translate-config.mdx
+++ b/content/terraform/v1.16.x (beta)/docs/cli/commands/stacks/migrate/translate-config.mdx
@@ -1,0 +1,87 @@
+---
+page_title: terraform stacks migrate translate-config
+description: Use the terraform stacks migrate translate-config command to convert a traditional Terraform root module into Terraform Stacks configuration.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-05-14T10:57:55-05:00
+last_modified: 2026-05-15T20:57:56.000Z
+# END AUTO GENERATED METADATA
+---
+
+# `terraform stacks migrate translate-config` reference
+
+Use the `terraform stacks migrate translate-config` command to convert a traditional
+Terraform root module into Terraform Stacks configuration.
+
+@include '@global/terraform-stacks-migrate-experiment.mdx'
+
+## Usage
+
+```shell-session
+$ TF_STACKS_MIGRATE_EXPERIMENTAL=true terraform stacks <global-stacks-flags> migrate translate-config <options>
+```
+
+## Description
+
+The `terraform stacks migrate translate-config` command reads a migrate manifest,
+inspects the traditional Terraform root module, and writes a Terraform Stacks
+configuration layout to the manifest's `stacks_configuration` path.
+
+The generated layout contains component configuration, deployment configuration, and a
+copy of the source module. The command validates the manifest before conversion so it can
+report manifest or filesystem errors before writing files. Use `validate-manifest` when
+you only need to validate the manifest and expected filesystem layout.
+
+## Options
+
+- `-migrate-manifest`: The path to the migrate manifest.
+    - Optional.
+    - String.
+    - Default: `migrate-manifest.json`.
+
+- `-root-component-name`: The name to use for the root component in generated Terraform
+  Stacks configuration.
+    - Optional.
+    - String.
+    - Default: `workspace`.
+
+- `-json`: Output results in JSON format instead of the default human-readable text
+  format.
+    - Optional.
+    - Boolean flag.
+    - Default: false.
+
+## Examples
+
+The following command generates Terraform Stacks configuration from the default migrate
+manifest:
+
+```shell-session
+$ TF_STACKS_MIGRATE_EXPERIMENTAL=true terraform stacks migrate translate-config
+```
+
+The following command generates Terraform Stacks configuration from a manifest at a
+custom path:
+
+```shell-session
+$ TF_STACKS_MIGRATE_EXPERIMENTAL=true terraform stacks migrate translate-config \
+  -migrate-manifest=./migration/migrate-manifest.json
+```
+
+The following command uses a custom root component name in the generated configuration:
+
+```shell-session
+$ TF_STACKS_MIGRATE_EXPERIMENTAL=true terraform stacks migrate translate-config \
+  -root-component-name=application
+```
+
+## Global flags
+
+Refer to [Global flags reference](/terraform/cli/commands/stacks/global-flags) for
+information about flags you can use with all commands.
+
+## Related
+
+- [Migrate HCP Terraform workspaces to Terraform Stacks](/terraform/cloud-docs/stacks/migrate-workspaces)
+- [terraform stacks migrate validate-manifest reference](/terraform/cli/commands/stacks/migrate/validate-manifest)
+- [terraform stacks migrate reference](/terraform/cli/commands/stacks/migrate)
+- [Terraform Stacks CLI reference](/terraform/cli/commands/stacks)

--- a/content/terraform/v1.16.x (beta)/docs/cli/commands/stacks/migrate/translate-state.mdx
+++ b/content/terraform/v1.16.x (beta)/docs/cli/commands/stacks/migrate/translate-state.mdx
@@ -1,0 +1,143 @@
+---
+page_title: terraform stacks migrate translate-state
+description: Use the terraform stacks migrate translate-state command to convert Terraform state files into Terraform Stack state artifacts.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-05-14T10:57:55-05:00
+last_modified: 2026-05-15T20:57:57.000Z
+# END AUTO GENERATED METADATA
+---
+
+# `terraform stacks migrate translate-state` reference
+
+Use the `terraform stacks migrate translate-state` command to convert Terraform state
+files into Terraform Stack state artifacts.
+
+@include '@global/terraform-stacks-migrate-experiment.mdx'
+
+## Usage
+
+```shell-session
+$ TF_STACKS_MIGRATE_EXPERIMENTAL=true terraform stacks <global-stacks-flags> migrate translate-state <options>
+```
+
+Relative paths are resolved from the working directory after applying `-chdir`.
+
+## Description
+
+Use `terraform stacks migrate translate-state` after you translate your
+traditional configuration into a Stack configuration and you need state artifacts that
+match the translated configuration layout.
+
+The command accepts a migrate manifest to translate all deployments declared in the manifest or explicit paths to translate one Terraform state file. When you use
+explicit paths, the command reads the following files:
+
+- A traditional Terraform state file
+- The original Terraform root module that produced the original `.tfstate` file
+- A translated Stack configuration containing the target components and deployments
+
+This command writes `.tfstackstate` artifacts that you can use with the translated Stack
+configuration.
+
+This command works only with local files. It does not create a Stack, upload
+configuration, or move remote state automatically.
+
+Before you run the command, you must meet the following requirements:
+
+- Run `terraform init` in the original Terraform configuration directory so this command
+  can reuse the `.terraform.lock.hcl` dependency lock file and installed provider cache.
+- Your translated Stack configuration must already exist locally.
+- Run `terraform stacks init` in the translated Stack configuration directory so the
+  command can use the initialized local module bundle it needs for the translated
+  component sources.
+- The translated Stack configuration is self-contained under
+  `-stack-config`. Component sources and any nested local module sources must
+  resolve within that directory tree.
+- Each generated `.tfstackstate` output path points to an existing writable
+  directory and uses an unused filename.
+
+On success, human-readable output includes the output path, component count, resource
+count, and output value count. JSON output includes the same summary plus component
+addresses, resource type counts, provider addresses, and output names when present.
+
+## Options
+
+- `-migrate-manifest`: The path to the migrate manifest to translate all deployments
+  declared in the manifest. Mutually exclusive with `-tfstate`, `-source-config`, `-stack-config`, and `-output`.
+    - Optional.
+    - String.
+
+- `-tfstate`: The path to the traditional `.tfstate` file to translate.
+    - Required if you provide an explicit state file path.
+    - String.
+
+- `-source-config`: The directory containing the original Terraform root module that
+  produced the original `.tfstate` file.
+    - Required if you provide an explicit state file path.
+    - String.
+
+- `-stack-config`: The directory containing the translated Stack  configuration. The directory must contain component and deployment configuration files. All component sources and nested local module sources must resolve within this directory tree.
+    - Required if you provide an explicit state file path.
+    - String.
+
+- `-output`: The path to write the translated Stack state artifacts. The parent directory must already exist and be writable. The output file must not already exist. The command does not overwrite an  existing artifact.
+    - Required if you provide an explicit state file path.
+    - String.
+
+- `-json`: Output results in JSON format instead of the default human-readable text
+  format.
+    - Optional.
+    - Boolean flag.
+    - Default: false.
+
+## Examples
+
+The following command translates all state files declared in the default migrate
+manifest:
+
+```shell-session
+$ TF_STACKS_MIGRATE_EXPERIMENTAL=true terraform stacks migrate translate-state
+```
+
+The following command translates the state files declared in a specific migrate
+manifest:
+
+```shell-session
+$ TF_STACKS_MIGRATE_EXPERIMENTAL=true terraform stacks migrate translate-state \
+  -migrate-manifest=./migration/migrate-manifest.json
+```
+
+The following command translates one Terraform state file into a Terraform Stack state
+artifact:
+
+```shell-session
+$ TF_STACKS_MIGRATE_EXPERIMENTAL=true terraform stacks migrate translate-state \
+  -tfstate=./workspace.tfstate \
+  -source-config=./terraform \
+  -stack-config=./stack \
+  -output=./out/workspace.tfstackstate
+```
+
+The following command translates the state file and returns the result summary in JSON
+format:
+
+```shell-session
+$ TF_STACKS_MIGRATE_EXPERIMENTAL=true terraform stacks migrate translate-state \
+  -tfstate=./workspace.tfstate \
+  -source-config=./terraform \
+  -stack-config=./stack \
+  -output=./out/workspace.tfstackstate \
+  -json
+```
+
+## Global flags
+
+Refer to [Global flags reference](/terraform/cli/commands/stacks/global-flags) for
+information about flags you can use with all commands.
+
+## Related
+
+- [Migrate HCP Terraform workspaces to Terraform Stacks](/terraform/cloud-docs/stacks/migrate-workspaces)
+- [terraform stacks migrate prepare-manifest reference](/terraform/cli/commands/stacks/migrate/prepare-manifest)
+- [terraform stacks migrate validate-manifest reference](/terraform/cli/commands/stacks/migrate/validate-manifest)
+- [terraform stacks migrate reference](/terraform/cli/commands/stacks/migrate)
+- [Terraform Stacks CLI reference](/terraform/cli/commands/stacks)

--- a/content/terraform/v1.16.x (beta)/docs/cli/commands/stacks/migrate/validate-manifest.mdx
+++ b/content/terraform/v1.16.x (beta)/docs/cli/commands/stacks/migrate/validate-manifest.mdx
@@ -1,0 +1,92 @@
+---
+page_title: terraform stacks migrate validate-manifest
+description: Use the terraform stacks migrate validate-manifest command to validate a migrate manifest and its expected filesystem layout.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-05-14T15:06:59.000Z
+last_modified: 2026-05-14T15:06:59.000Z
+# END AUTO GENERATED METADATA
+---
+
+# `terraform stacks migrate validate-manifest` reference
+
+Use the `terraform stacks migrate validate-manifest` command to validate a migrate
+manifest and its expected filesystem layout.
+
+@include '@global/terraform-stacks-migrate-experiment.mdx'
+
+## Usage
+
+```shell-session
+$ TF_STACKS_MIGRATE_EXPERIMENTAL=true terraform stacks <global-stacks-flags> migrate validate-manifest <options>
+```
+
+## Description
+
+The `terraform stacks migrate validate-manifest` command reads a migrate manifest,
+validates its schema, and checks the files and directories the manifest references. Use
+this command after you prepare a manifest and before you translate the state.
+
+Manifest paths resolve relative to the directory that contains the manifest unless the
+path is absolute.
+
+The command validates that the following conditions are true:
+
+- The manifest uses version `1`.
+- The manifest contains at least one deployment.
+- The manifest sets the top-level `source_configuration` and `stacks_configuration` values.
+- Each deployment has a name, an inputs array, a `state.tfstate` path, and a
+  `state.tfstackstate` path.
+- Each deployment name is unique.
+- Workspace IDs are unique if they are present.
+- Each deployment input key appears only once per deployment.
+- All deployments use the same input keys with the same sensitivity settings.
+- The source configuration directory exists and is not empty.
+- The Stack configuration directory and state artifact directories exist and are writable.
+- Each `state.tfstate` path points to a readable Terraform state file created with Terraform v0.12+.
+
+## Options
+
+- `-migrate-manifest`: The path to the migrate manifest to validate.
+    - Optional.
+    - String.
+    - Default: `migrate-manifest.json`.
+
+- `-json`: Output results and diagnostics in JSON format instead of the default
+  human-readable text format.
+    - Optional.
+    - Boolean flag.
+    - Default: `false`.
+
+## Examples
+
+The following command validates the default migrate manifest:
+
+```shell-session
+$ TF_STACKS_MIGRATE_EXPERIMENTAL=true terraform stacks migrate validate-manifest
+```
+
+The following command validates a manifest at a custom path:
+
+```shell-session
+$ TF_STACKS_MIGRATE_EXPERIMENTAL=true terraform stacks migrate validate-manifest \
+  -migrate-manifest=./migration/migrate-manifest.json
+```
+
+The following command validates the manifest and returns the result in JSON format:
+
+```shell-session
+$ TF_STACKS_MIGRATE_EXPERIMENTAL=true terraform stacks migrate validate-manifest \
+  -migrate-manifest=./migration/migrate-manifest.json \
+  -json
+```
+
+## Global flags
+
+Refer to [Global flags reference](/terraform/cli/commands/stacks/global-flags) for
+information about flags you can use with all commands.
+
+## Related
+
+- [Migrate HCP Terraform workspaces to Terraform Stacks](/terraform/cloud-docs/stacks/migrate-workspaces)
+- [terraform stacks migrate reference](/terraform/cli/commands/stacks/migrate)
+- [Terraform Stacks CLI reference](/terraform/cli/commands/stacks)


### PR DESCRIPTION
See this comment for context. https://github.com/hashicorp/web-unified-docs/pull/2915#pullrequestreview-4806044756

This makes sure that recent changes to the v1.15 docs are reflected in the new docs for v1.16 betra