### PR TITLE
docs(terraform): Update docs to describe JSON output from `terraform workspace list -json`

### DIFF
--- a/content/terraform/v1.16.x (beta)/docs/cli/commands/workspace/list.mdx
+++ b/content/terraform/v1.16.x (beta)/docs/cli/commands/workspace/list.mdx
@@ -13,10 +13,20 @@ The `terraform workspace list` command lists all existing workspaces.
 
 ## Usage
 
-Usage: `terraform workspace list`
+Usage: `terraform workspace list [options]`
 
 The command will list all existing workspaces. The current workspace is
 indicated using an asterisk (`*`) marker.
+
+The command-line flags are all optional. The following flags are available:
+
+* `-json` - Produce output in a machine-readable JSON format, suitable for
+  use in text editor integrations and other automated systems. Always disables
+  color.
+
+* `-no-color` - If specified, output won't contain any color. Currently, this is
+  only relevant to diagnostics returned from this command.
+
 
 ## Example
 
@@ -25,4 +35,26 @@ $ terraform workspace list
   default
 * development
   jsmith-test
+```
+
+```
+$ terraform workspace list -json
+{
+  "format_version": "1.0",
+  "workspaces": [
+    {
+      "name": "default",
+      "is_current": false
+    },
+    {
+      "name": "development",
+      "is_current": true
+    },
+    {
+      "name": "jsmith-test",
+      "is_current": false
+    }
+  ],
+  "diagnostics": []
+}
 ```


### PR DESCRIPTION
### What
Updated docs for `workspace list` command in TF v1,16 to describe new support for `-json` flag and JSON formatted output.
* `content/terraform/v1.16.x (beta)/docs/cli/commands/workspace/list.mdx`

### Why
Users need to know what flags exist.

Reference: Adding `-json` : https://github.com/hashicorp/terraform/pull/38397
Reference: Why -no-color is now relevant to human output: https://github.com/hashicorp/terraform/pull/38900

### Screenshots
N/A

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [x] (N/A) You added redirects to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages **across all affected versions**. Refer to [Redirects](https://github.com/hashicorp/web-unified-docs/blob/main/docs/content-guide/redirects.md#example-redirects) for examples and guidance. 
- [x] (N/A) Links to related content where appropriate (e.g., CLI, language, API endpoints, permissions, etc.).
- [x] (N/A)  Pages with related content are updated and link to this content when appropriate.
- [x] (N/A) Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] (N/A)  New pages have metadata (page name and description) at the top.
- [x] (N/A) New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] (N/A) New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] (N/A) UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
