### PR TITLE
docs(terraform): Add documentation about evaluation scopes for `terraform console`

### DIFF
--- a/content/terraform/v1.16.x (beta)/docs/cli/commands/console.mdx
+++ b/content/terraform/v1.16.x (beta)/docs/cli/commands/console.mdx
@@ -5,7 +5,7 @@ description: >-
   expressions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2026-07-29T10:58:49+02:00
-last_modified: 2026-07-29T14:38:04.000Z
+last_modified: 2026-07-29T18:40:59.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -35,8 +35,11 @@ For configurations using
 
 ## Evaluation Scope
 
-By default, `terraform console` evaluates expressions using the [root module](/terraform/language/modules#hierarchy) as the scope.
-Expressions can also be evaluated using a child module as the scope by providing the `-scope` flag with the module address, for example:
+By default, `terraform console` evaluates expressions using the [root module](/terraform/language/modules#hierarchy) as the scope, which means
+the expressions can contain any variables, locals, resources, or other types that are defined in the root module exclusively.
+
+Expressions can be evaluated using variables, locals, resources, or other types that are defined in child modules by changing the evaluation scope;
+providing the `-scope` flag with the desired child module address, for example:
 
 ```shell
 terraform console -scope='module.child'

--- a/content/terraform/v1.16.x (beta)/docs/cli/commands/console.mdx
+++ b/content/terraform/v1.16.x (beta)/docs/cli/commands/console.mdx
@@ -4,8 +4,8 @@ description: >-
   The `terraform console` command opens an interactive console for evaluating
   expressions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-11-19T19:11:19Z
-last_modified: 2025-11-19T19:11:19Z
+created_at: 2026-07-29T10:58:49+02:00
+last_modified: 2026-07-29T14:25:58.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -32,6 +32,25 @@ For configurations using
 [the `local` backend](/terraform/language/backend/local) only,
 `terraform console` accepts the legacy command line option
 [`-state`](/terraform/language/backend/local#command-line-arguments).
+
+## Evaluation Scope
+
+By default, `terraform console` evaluates expressions using the [root module](/terraform/language/modules#hierarchy) as the scope.
+Expressions can also be evaluated using a child module as the scope by providing the `-scope` flag with the module address, for example:
+
+```shell
+terraform console -scope='module.child'
+```
+
+Child modules that have [multiple instances](/terraform/language/block/module#create-multiple-instances-of-module-resources) using the `count` or `for_each`
+argument can also be used as the evaluation scope, for example:
+```shell
+# If the module uses count, an index is provided
+terraform console -scope='module.child[0]'
+
+# If the module uses for_each, a key is provided
+terraform console -scope='module.child["key"]'
+```
 
 ## Scripting
 
@@ -80,6 +99,7 @@ means it would be run by `terraform console -plan` too.
 We don't recommend that you write configurations that make changes during the
 plan phase. If you do write such a configuration despite that recommendation,
 take care when using the console in plan mode against that configuration.
+
 
 ## Examples
 

--- a/content/terraform/v1.16.x (beta)/docs/cli/commands/console.mdx
+++ b/content/terraform/v1.16.x (beta)/docs/cli/commands/console.mdx
@@ -5,7 +5,7 @@ description: >-
   expressions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2026-07-29T10:58:49+02:00
-last_modified: 2026-07-29T14:25:58.000Z
+last_modified: 2026-07-29T14:38:04.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -99,7 +99,6 @@ means it would be run by `terraform console -plan` too.
 We don't recommend that you write configurations that make changes during the
 plan phase. If you do write such a configuration despite that recommendation,
 take care when using the console in plan mode against that configuration.
-
 
 ## Examples
 

--- a/content/terraform/v1.16.x (beta)/docs/cli/commands/console.mdx
+++ b/content/terraform/v1.16.x (beta)/docs/cli/commands/console.mdx
@@ -5,7 +5,7 @@ description: >-
   expressions.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2026-07-29T10:58:49+02:00
-last_modified: 2026-07-29T18:40:59.000Z
+last_modified: 2026-07-29T18:42:08.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -36,7 +36,7 @@ For configurations using
 ## Evaluation Scope
 
 By default, `terraform console` evaluates expressions using the [root module](/terraform/language/modules#hierarchy) as the scope, which means
-the expressions can contain any variables, locals, resources, or other types that are defined in the root module exclusively.
+the expression can contain any variables, locals, resources, or other types that are defined in the root module exclusively.
 
 Expressions can be evaluated using variables, locals, resources, or other types that are defined in child modules by changing the evaluation scope;
 providing the `-scope` flag with the desired child module address, for example:


### PR DESCRIPTION
### What
Ref: https://github.com/hashicorp/terraform/pull/38820

Updated the `terraform console` CLI documentation to describe the new `-scope` flag that will be introduced in Terraform 1.16 with a couple examples.

### Why
Tis a new flag! The practitioners yearn for evaluation scope control 😅 

### Screenshots
N/A

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] You added redirects to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages **across all affected versions**. Refer to [Redirects](https://github.com/hashicorp/web-unified-docs/blob/main/docs/content-guide/redirects.md#example-redirects) for examples and guidance. 
- [x] Links to related content where appropriate (e.g., CLI, language, API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] New pages have metadata (page name and description) at the top.
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
