### PR TITLE
Fix typo that's been corrected in v1.14 & v1.15 separately

### DIFF
--- a/content/terraform/v1.16.x (beta)/docs/language/import/bulk.mdx
+++ b/content/terraform/v1.16.x (beta)/docs/language/import/bulk.mdx
@@ -66,7 +66,7 @@ Add the following arguments to your `list` block:
 
 The `list` block also supports several Terraform **meta-arguments**, which are arguments built into Terraform configuration language that configure how Terraform creates and manages infrastructure objects. For example, you can use the `count` meta-argument to create multiple instances of the resource list returned by the query. Refer to [Meta-arguments](/terraform/language/meta-arguments) for more information.
 
-In the following example, Terraform applies provder arguments to query for `aws_instance` resources in the `us-east-2` region. The query also filters results prefixed with `prod-` and `stage-` and that are in a `running` state. The `limit` argument, which is not a provider-specific argument, instructs Terraform to return the first 50 results:
+In the following example, Terraform applies provider arguments to query for `aws_instance` resources in the `us-east-2` region. The query also filters results prefixed with `prod-` and `stage-` and that are in a `running` state. The `limit` argument, which is not a provider-specific argument, instructs Terraform to return the first 50 results:
 
 ```hcl
 list "aws_instance" "prod" {


### PR DESCRIPTION
### What
Fixes a typo that was being fixed in  https://github.com/hashicorp/web-unified-docs/pull/2958 but then we created a new instance of it in the v1.16 docs.

### Why
Typos bad, me no like read them. Me no like drift between doc versions.


### Screenshots
Nah

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] N/A You added redirects to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages **across all affected versions**. Refer to [Redirects](https://github.com/hashicorp/web-unified-docs/blob/main/docs/content-guide/redirects.md#example-redirects) for examples and guidance. 
- [x] N/A  Links to related content where appropriate (e.g., CLI, language, API endpoints, permissions, etc.).
- [x] N/A Pages with related content are updated and link to this content when appropriate.
- [x] N/A  Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] N/A New pages have metadata (page name and description) at the top.
- [x] N/A New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] N/A New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] N/A UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
