### PR TITLE
Update project.mdx

### DIFF
--- a/content/terraform-docs-common/docs/cloud-docs/users-teams-organizations/permissions/project.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/users-teams-organizations/permissions/project.mdx
@@ -51,8 +51,8 @@ The following table shows the permissions granted by each project role. Each rol
 | | [Read runs](#run-read) | ✅ | ✅ | ✅ | ✅ |
 | [Variable access](#variable-access) | [Read and write variables](#variable-read-write) | ✅ | ✅ | ✅ | ❌ |
 | | [Read variables](#variable-read) | ✅ | ✅ | ✅ | ✅ |
-| [Variable set access](#variable-set-access) | [Manage variable sets](#variable-set-manage) | ✅ | ❌ | ❌ | ❌ |
-| | [Read variable sets](#variable-set-read) | ✅ | ❌ | ❌ | ❌ |
+| [Variable set access](#variable-set-access) | [Manage variable sets](#variable-set-manage) | ✅ | ✅ | ✅ | ❌ |
+| | [Read variable sets](#variable-set-read) | ✅ | ✅ | ✅ | ❌ |
 | [State access](#state-access) | [Read and write state](#state-read-write) | ✅ | ✅ | ✅ | ❌ |
 | | [Read state](#state-read) | ✅ | ✅ | ✅ | ✅ |
 | | [Read outputs only](#state-read-outputs) | ✅ | ✅ | ✅ | ✅ |


### PR DESCRIPTION
Summary

Updated the Project Roles and Permissions table to correct inaccurate permission mappings.

Changes
Corrected the permissions associated with the Write and Maintain role. Updated the table to reflect that Write and Maintain grants Manage access for variable set permissions. Details

Users with the Write and Maintain role can:

Create variable sets owned by the project
Read variable sets owned by the project
Edit variable sets owned by the project
Delete variable sets owned by the project

This update aligns the documentation/UI with the actual behavior of project-scoped variable set access permissions.

Why

The previous table incorrectly represented the permissions granted by the Write and Maintain role, which could lead to confusion when assigning project roles and managing variable set access.

Please go to the `Preview` tab and select the appropriate template:

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
