### PR TITLE
Updating deployment-group list docs with guidance information

### DIFF
--- a/content/terraform/v1.15.x/docs/cli/commands/stacks/deployment-group/list.mdx
+++ b/content/terraform/v1.15.x/docs/cli/commands/stacks/deployment-group/list.mdx
@@ -1,6 +1,6 @@
 ---
 page_title: terraform stacks deployment-group list
-description: The terraform stacks deployment-group list command lists the deployment groups of a configuration.
+description: The terraform stacks deployment-group list command lists the deployment groups of a configuration, with guidance for investigating failed or abandoned groups and bad configuration status.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-11-19T19:11:19Z
 last_modified: 2025-11-19T19:11:19Z
@@ -21,6 +21,21 @@ $ terraform stacks <global-stacks-flags> deployment-group list <options>
 
 List the deployment groups of a configuration. Either `-configuration-id` must be provided, or `-organization-name`, `-project-name`, and `-stack-name` must be provided. If name arguments are used, the latest configuration for the specified stack will be used.
 
+When relevant, the command appends two conditional footer sections to the human-readable output:
+
+- **Configuration diagnostics** — shown when the configuration's status is bad (for example, `errored`). There are two variants:
+  - When diagnostics are available: `Configuration has N preparation diagnostics (X errors, Y warnings).`
+  - When diagnostics could not be fetched: `Configuration status is <status> and diagnostics could not be fetched.`
+
+  Both variants include a `terraform stacks diagnostics` command to investigate further.
+
+- **Failed deployment groups** — shown when one or more deployment groups have a `failed` or `abandoned` status. Lists each affected group with a `terraform stacks deployment-run list` command to investigate its runs:
+
+  ```
+  Failed deployment groups detected. Investigate further with:
+    <group-name> (<group-id>): terraform stacks deployment-run list -deployment-group-id=<group-id>
+  ```
+
 ## Options
 
 - `-organization-name`: The name of the organization to target.
@@ -36,7 +51,7 @@ List the deployment groups of a configuration. Either `-configuration-id` must b
     - String data type.
     - Overrides the ENV VAR `TF_STACKS_STACK_NAME` if provided.
 - `-configuration-id`: The id of the configuration to list the deployment groups of.
-    - Optional (but required if not using `-stack-name`)
+    - Optional (but required if not using `-stack-name`).
     - String data type.
     - Has precedence over the latest configuration of the stack provided in named arguments.
 - `-json`: Output results in JSON format instead of the default human-readable text format.
@@ -64,6 +79,18 @@ The following command lists deployment groups in JSON format:
 $ terraform stacks deployment-group list -configuration-id config-abc123 -json
 ```
 
+When the output shows a **Failed deployment groups detected** section, use the suggested command to inspect a group's runs:
+
+```shell-session
+$ terraform stacks deployment-run list -deployment-group-id=<group-id>
+```
+
+When the output shows a configuration diagnostics notice, use the suggested command to view details:
+
+```shell-session
+$ terraform stacks diagnostics -id=<configuration-id>
+```
+
 ## Global flags
 
 Refer to [Global flags reference](/terraform/cli/commands/stacks/global-flags) for information about flags you can use with all commands.
@@ -71,4 +98,6 @@ Refer to [Global flags reference](/terraform/cli/commands/stacks/global-flags) f
 ## Related
 
 - [Terraform Stacks CLI reference](/terraform/cli/commands/stacks)
-- [terraform stacks deployment-group reference](terraform/cli/commands/stacks/deployment-group)
+- [`terraform stacks deployment-group` reference](/terraform/cli/commands/stacks/deployment-group)
+- [`terraform stacks deployment-run list` reference](/terraform/cli/commands/stacks/deployment-run/list)
+- [`terraform stacks diagnostics` reference](/terraform/cli/commands/stacks/diagnostics)


### PR DESCRIPTION
Updates the `terraform stacks deployment-group list` reference to document the two conditional footer sections added to human-readable output:

Configuration diagnostics - appears when the configuration's status is bad. Covers both the "diagnostics available" and "diagnostics could not be fetched" variants, both of which point to terraform stacks diagnostics -id=<id>.

Failed deployment groups - appears when one or more groups have failed or abandoned status, listing each group with a terraform stacks deployment-run list follow-up command.

Also fixes the related-links section (absolute paths, backtick formatting) and adds links to deployment-run list and terraform stacks diagnostics.


Please go to the `Preview` tab and select the appropriate template:

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
