### PR TITLE
Updating providers-lock reference to include -json flag option

### DIFF
--- a/content/terraform/v1.15.x/docs/cli/commands/stacks/providers-lock.mdx
+++ b/content/terraform/v1.15.x/docs/cli/commands/stacks/providers-lock.mdx
@@ -28,6 +28,10 @@ The `terraform stacks providers-lock` command creates or updates the dependency 
     - String data type in the format `os_arch` (e.g., `linux_amd64`, `darwin_amd64`).
     - By default, Terraform will request package checksums suitable for execution within HCP Terraform (`linux_amd64`) and your current machine.
     - Use this option multiple times to include checksums for multiple target systems.
+- `-json`: Output results in JSON format instead of the default human-readable text format.
+    - Optional.
+    - Boolean flag.
+    - Default is false (human-readable format).
 
 ## Examples
 
@@ -41,6 +45,12 @@ The following command creates or updates the lock file with checksums for multip
 
 ```shell-session
 $ terraform stacks providers-lock -platform=linux_amd64 -platform=darwin_amd64 -platform=windows_amd64
+```
+
+The following command creates or updates the lock file and outputs JSON:
+
+```shell-session
+$ terraform stacks providers-lock -json
 ```
 
 ## Global flags


### PR DESCRIPTION
Add `-json` flag to providers-lock command

Adds the `-json` option to the `terraform stacks providers-lock` reference, including an entry in the Options section and a corresponding example.

Please go to the `Preview` tab and select the appropriate template:

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
