### PR TITLE
Collapse per-auth-method customkey metrics into single per-provider metrics

### DIFF
--- a/content/vault/v2.x/content/docs/license/product-usage-reporting.mdx
+++ b/content/vault/v2.x/content/docs/license/product-usage-reporting.mdx
@@ -246,9 +246,8 @@ IBM collects the following product usage metrics as numerical data. Vault does n
 | `vault.secret.engine.transit.key.count` | Number of secret engine keys of type Transit across all namespaces and mounts. |
 | `vault.secretsync.destinations.aws-sm.count` | Total number of secret sync destinations to AWS-SM configured. |
 | `vault.secretsync.destinations.aws-sm.static.count` | Total number of secret sync destinations configured using static credentials for AWS. |
-| `vault.secretsync.destinations.aws-sm.static.customkey.count` | Total number of secret sync destinations configured using a custom encryption key for AWS static credentials. |
+| `vault.secretsync.destinations.aws-sm.customkey.count` | Total number of secret sync destinations configured using a custom encryption key for AWS. |
 | `vault.secretsync.destinations.aws-sm.wif.count` | Total number of secret sync destinations configured using WIF for AWS. |
-| `vault.secretsync.destinations.aws-sm.wif.customkey.count` | Total number of secret sync destinations configured using a custom encryption key for AWS WIF. |
 | `vault.secretsync.destinations.azure-kv.count` | Total number of secret sync destinations to Azure KV configured. |
 | `vault.secretsync.destinations.azure-kv.static.count` | Total number of secret sync destinations configured using static credentials for Azure. |
 | `vault.secretsync.destinations.azure-kv.wif.count` | Total number of secret sync destinations configured using WIF for Azure. |
@@ -256,16 +255,14 @@ IBM collects the following product usage metrics as numerical data. Vault does n
 | `vault.secretsync.destinations.customkey.count` | Total number of secret sync destinations configured using a custom encryption key. |
 | `vault.secretsync.destinations.gcp-sm.count` | Total number of secret sync destinations to GCP-SM configured. |
 | `vault.secretsync.destinations.gcp-sm.static.count` | Total number of secret sync destinations configured using static credentials for GCP. |
-| `vault.secretsync.destinations.gcp-sm.static.customkey.count` | Total number of secret sync destinations configured using a custom encryption key for GCP static credentials. |
+| `vault.secretsync.destinations.gcp-sm.customkey.count` | Total number of secret sync destinations configured using a custom encryption key for GCP. |
 | `vault.secretsync.destinations.gcp-sm.wif.count` | Total number of secret sync destinations configured using WIF for GCP. |
-| `vault.secretsync.destinations.gcp-sm.wif.customkey.count` | Total number of secret sync destinations configured using a custom encryption key for GCP WIF. |
 | `vault.secretsync.destinations.gh.count` | Total number of secret sync destinations to GitHub configured. |
 | `vault.secretsync.destinations.gitlab.count` | Total number of secret sync destinations to GitLab configured. |
 | `vault.secretsync.destinations.inmem.count` | Total number of secret sync destinations to InMem configured. |
+| `vault.secretsync.destinations.inmem.customkey.count` | Total number of secret sync destinations configured using a custom encryption key for InMem. |
 | `vault.secretsync.destinations.inmem.static.count` | Total number of secret sync destinations configured using static credentials for InMem. |
-| `vault.secretsync.destinations.inmem.static.customkey.count` | Total number of secret sync destinations configured using a custom encryption key for InMem static credentials. |
 | `vault.secretsync.destinations.inmem.wif.count` | Total number of secret sync destinations configured using WIF for InMem. |
-| `vault.secretsync.destinations.inmem.wif.customkey.count` | Total number of secret sync destinations configured using a custom encryption key for InMem WIF. |
 | `vault.secretsync.destinations.static.count` | Total number of secret sync destinations configured using static credentials. |
 | `vault.secretsync.destinations.terraform.count` | Total number of secret sync destinations to Terraform configured. |
 | `vault.secretsync.destinations.vercel-project.count` | Total number of secret sync destinations to Vercel Project configured. |


### PR DESCRIPTION
Updates the product usage reporting reference table to reflect the
simplified custom encryption key destination metrics for secrets sync.

The per-auth-method breakdowns (`wif` and `static`) are collapsed into a
single metric per provider, reducing six metrics to three.

Please go to the `Preview` tab and select the appropriate template:

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
