### PR TITLE
terraform: Document the `planned_action_invocation` JSON log entry type that was added in v1.14

### DIFF
--- a/content/terraform/v1.14.x/docs/internals/machine-readable-ui.mdx
+++ b/content/terraform/v1.14.x/docs/internals/machine-readable-ui.mdx
@@ -125,7 +125,7 @@ Messages with `init_output` type have an additional `message_code` documented be
 
 - `apply_start`, `apply_progress`, `apply_complete`, `apply_errored`: sequence of messages indicating progress of a single resource through apply
 - `provision_start`, `provision_progress`, `provision_complete`, `provision_errored`: sequence of messages indicating progress of a single provisioner step
-- `planned_action_invocation` : message indicating that an action has been invoked.
+- `planned_action_invocation` : message indicating that an action has been invoked
 - `refresh_start`, `refresh_complete`: sequence of messages indicating progress of a single resource through refresh
 
 ### Test Results

--- a/content/terraform/v1.14.x/docs/internals/machine-readable-ui.mdx
+++ b/content/terraform/v1.14.x/docs/internals/machine-readable-ui.mdx
@@ -586,7 +586,7 @@ The `planned_action_invocation` message object has the following keys:
 
 The `invocation` object has the following keys:
 
-- `action_addr`: a [`resource` object](#resource-object) identifying the action being invoked.
+- `action_addr`: an object identifying the action being invoked.
 - `action_trigger`: the trigger object containing details about what triggered the action invocation.
 - `lifecycle_trigger`: the trigger object containing details about the resource that triggered the action invocation through its lifecycle.
 

--- a/content/terraform/v1.14.x/docs/internals/machine-readable-ui.mdx
+++ b/content/terraform/v1.14.x/docs/internals/machine-readable-ui.mdx
@@ -125,6 +125,7 @@ Messages with `init_output` type have an additional `message_code` documented be
 
 - `apply_start`, `apply_progress`, `apply_complete`, `apply_errored`: sequence of messages indicating progress of a single resource through apply
 - `provision_start`, `provision_progress`, `provision_complete`, `provision_errored`: sequence of messages indicating progress of a single provisioner step
+- `planned_action_invocation` : message indicating that an action has been invoked.
 - `refresh_start`, `refresh_complete`: sequence of messages indicating progress of a single resource through refresh
 
 ### Test Results
@@ -574,6 +575,100 @@ The `provision_errored` message `hook` object has the following keys:
     "provisioner": "local-exec"
   },
   "type": "provision_errored"
+}
+```
+
+## Action Invocation
+
+The `planned_action_invocation` message object has the following keys:
+
+- `invocation`: the invocation object containing details about the planned action invocation
+
+The `invocation` object has the following keys:
+
+- `action_addr`: a [`resource` object](#resource-object) identifying the action being invoked.
+- `action_trigger`: the trigger object containing details about what triggered the action invocation.
+- `lifecycle_trigger`: the trigger object containing details about the resource that triggered the action invocation through its lifecycle.
+
+The `action_addr` object has the following keys:
+
+- `addr`: the address of the action
+- `module`: the module containing the action
+- `action`: the full action string
+- `implied_provider`: the provider implied by the action
+- `action_type`: the type of the action
+- `action_name`: the name of the action
+- `action_key`: the key of the action, if any
+
+The `action_trigger` object is an empty object, and is present when the action is invoked via the CLI using the `-invoke` flag.
+
+The `lifecycle_trigger` object has the following keys:
+
+- `triggering_resource`: a [`resource` object](#resource-object) identifying the resource that triggered the action
+- `triggering_event`: the event that triggered the action
+- `action_trigger_block_index`: the index of the block that triggered the action
+- `actions_list_index`: the index of the action in the list of actions
+- `on_failure`: the action to take on failure
+
+### Example: Action invoked via the CLI using the `-invoke` flag.
+
+```json
+{
+  "@level":"info",
+  "@message": "planned action invocation: action.aws_lambda_invoke.api_handler",
+  "@module": "terraform.ui",
+  "@timestamp": "2026-07-30T15:18:39.254843+01:00",
+  "invocation": {
+    "action_addr": {
+      "addr": "action.aws_lambda_invoke.api_handler",
+      "module": "",
+      "action": "action.aws_lambda_invoke.api_handler",
+      "implied_provider": "aws",
+      "action_type": "aws_lambda_invoke",
+      "action_name": "api_handler",
+      "action_key": null
+    },
+    "action_trigger": {}
+  },
+  "type": "planned_action_invocation"
+}
+```
+
+### Example: Action invoked through a lifecycle trigger.
+
+```json
+{
+  "@level":"info",
+  "@message":"planned action invocation: action.aws_lambda_invoke.api_handler",
+  "@module":"terraform.ui",
+  "@timestamp":"2026-07-30T15:23:15.862206+01:00",
+  "invocation":{
+    "action_addr":{
+      "addr":"action.aws_lambda_invoke.api_handler",
+      "module":"",
+      "action":"action.aws_lambda_invoke.api_handler",
+      "implied_provider":"aws",
+      "action_type":"aws_lambda_invoke",
+      "action_name":"api_handler",
+      "action_key":null
+    },
+    "lifecycle_trigger":{
+      "triggering_resource":{
+        "addr":"aws_lambda_function.api_handler",
+        "module":"",
+        "resource":"aws_lambda_function.api_handler",
+        "implied_provider":"aws",
+        "resource_type":"aws_lambda_function",
+        "resource_name":"api_handler",
+        "resource_key":null
+      },
+      "triggering_event":"AfterUpdate",
+      "action_trigger_block_index":0,
+      "actions_list_index":0,
+      "on_failure":"ActionOnFailureHalt"
+    }
+  },
+  "type":"planned_action_invocation"
 }
 ```
 

--- a/content/terraform/v1.15.x/docs/internals/machine-readable-ui.mdx
+++ b/content/terraform/v1.15.x/docs/internals/machine-readable-ui.mdx
@@ -592,7 +592,7 @@ The `planned_action_invocation` message object has the following keys:
 
 The `invocation` object has the following keys:
 
-- `action_addr`: a [`resource` object](#resource-object) identifying the action being invoked.
+- `action_addr`: an object identifying the action being invoked.
 - `action_trigger`: the trigger object containing details about what triggered the action invocation.
 - `lifecycle_trigger`: the trigger object containing details about the resource that triggered the action invocation through its lifecycle.
 

--- a/content/terraform/v1.15.x/docs/internals/machine-readable-ui.mdx
+++ b/content/terraform/v1.15.x/docs/internals/machine-readable-ui.mdx
@@ -131,6 +131,7 @@ Messages with `init_output` type have an additional `message_code` documented be
 
 - `apply_start`, `apply_progress`, `apply_complete`, `apply_errored`: sequence of messages indicating progress of a single resource through apply
 - `provision_start`, `provision_progress`, `provision_complete`, `provision_errored`: sequence of messages indicating progress of a single provisioner step
+- `planned_action_invocation` : message indicating that an action has been invoked.
 - `refresh_start`, `refresh_complete`: sequence of messages indicating progress of a single resource through refresh
 
 ### Test Results
@@ -580,6 +581,100 @@ The `provision_errored` message `hook` object has the following keys:
     "provisioner": "local-exec"
   },
   "type": "provision_errored"
+}
+```
+
+## Action Invocation
+
+The `planned_action_invocation` message object has the following keys:
+
+- `invocation`: the invocation object containing details about the planned action invocation
+
+The `invocation` object has the following keys:
+
+- `action_addr`: a [`resource` object](#resource-object) identifying the action being invoked.
+- `action_trigger`: the trigger object containing details about what triggered the action invocation.
+- `lifecycle_trigger`: the trigger object containing details about the resource that triggered the action invocation through its lifecycle.
+
+The `action_addr` object has the following keys:
+
+- `addr`: the address of the action
+- `module`: the module containing the action
+- `action`: the full action string
+- `implied_provider`: the provider implied by the action
+- `action_type`: the type of the action
+- `action_name`: the name of the action
+- `action_key`: the key of the action, if any
+
+The `action_trigger` object is an empty object, and is present when the action is invoked via the CLI using the `-invoke` flag.
+
+The `lifecycle_trigger` object has the following keys:
+
+- `triggering_resource`: a [`resource` object](#resource-object) identifying the resource that triggered the action
+- `triggering_event`: the event that triggered the action
+- `action_trigger_block_index`: the index of the block that triggered the action
+- `actions_list_index`: the index of the action in the list of actions
+- `on_failure`: the action to take on failure
+
+### Example: Action invoked via the CLI using the `-invoke` flag.
+
+```json
+{
+  "@level":"info",
+  "@message": "planned action invocation: action.aws_lambda_invoke.api_handler",
+  "@module": "terraform.ui",
+  "@timestamp": "2026-07-30T15:18:39.254843+01:00",
+  "invocation": {
+    "action_addr": {
+      "addr": "action.aws_lambda_invoke.api_handler",
+      "module": "",
+      "action": "action.aws_lambda_invoke.api_handler",
+      "implied_provider": "aws",
+      "action_type": "aws_lambda_invoke",
+      "action_name": "api_handler",
+      "action_key": null
+    },
+    "action_trigger": {}
+  },
+  "type": "planned_action_invocation"
+}
+```
+
+### Example: Action invoked through a lifecycle trigger.
+
+```json
+{
+  "@level":"info",
+  "@message":"planned action invocation: action.aws_lambda_invoke.api_handler",
+  "@module":"terraform.ui",
+  "@timestamp":"2026-07-30T15:23:15.862206+01:00",
+  "invocation":{
+    "action_addr":{
+      "addr":"action.aws_lambda_invoke.api_handler",
+      "module":"",
+      "action":"action.aws_lambda_invoke.api_handler",
+      "implied_provider":"aws",
+      "action_type":"aws_lambda_invoke",
+      "action_name":"api_handler",
+      "action_key":null
+    },
+    "lifecycle_trigger":{
+      "triggering_resource":{
+        "addr":"aws_lambda_function.api_handler",
+        "module":"",
+        "resource":"aws_lambda_function.api_handler",
+        "implied_provider":"aws",
+        "resource_type":"aws_lambda_function",
+        "resource_name":"api_handler",
+        "resource_key":null
+      },
+      "triggering_event":"AfterUpdate",
+      "action_trigger_block_index":0,
+      "actions_list_index":0,
+      "on_failure":"ActionOnFailureHalt"
+    }
+  },
+  "type":"planned_action_invocation"
 }
 ```
 

--- a/content/terraform/v1.15.x/docs/internals/machine-readable-ui.mdx
+++ b/content/terraform/v1.15.x/docs/internals/machine-readable-ui.mdx
@@ -131,7 +131,7 @@ Messages with `init_output` type have an additional `message_code` documented be
 
 - `apply_start`, `apply_progress`, `apply_complete`, `apply_errored`: sequence of messages indicating progress of a single resource through apply
 - `provision_start`, `provision_progress`, `provision_complete`, `provision_errored`: sequence of messages indicating progress of a single provisioner step
-- `planned_action_invocation` : message indicating that an action has been invoked.
+- `planned_action_invocation` : message indicating that an action has been invoked
 - `refresh_start`, `refresh_complete`: sequence of messages indicating progress of a single resource through refresh
 
 ### Test Results

--- a/content/terraform/v1.16.x (beta)/docs/internals/machine-readable-ui.mdx
+++ b/content/terraform/v1.16.x (beta)/docs/internals/machine-readable-ui.mdx
@@ -592,7 +592,7 @@ The `planned_action_invocation` message object has the following keys:
 
 The `invocation` object has the following keys:
 
-- `action_addr`: a [`resource` object](#resource-object) identifying the action being invoked.
+- `action_addr`: an object identifying the action being invoked.
 - `action_trigger`: the trigger object containing details about what triggered the action invocation.
 - `lifecycle_trigger`: the trigger object containing details about the resource that triggered the action invocation through its lifecycle.
 

--- a/content/terraform/v1.16.x (beta)/docs/internals/machine-readable-ui.mdx
+++ b/content/terraform/v1.16.x (beta)/docs/internals/machine-readable-ui.mdx
@@ -131,6 +131,7 @@ Messages with `init_output` type have an additional `message_code` documented be
 
 - `apply_start`, `apply_progress`, `apply_complete`, `apply_errored`: sequence of messages indicating progress of a single resource through apply
 - `provision_start`, `provision_progress`, `provision_complete`, `provision_errored`: sequence of messages indicating progress of a single provisioner step
+- `planned_action_invocation` : message indicating that an action has been invoked.
 - `refresh_start`, `refresh_complete`: sequence of messages indicating progress of a single resource through refresh
 
 ### Test Results
@@ -580,6 +581,100 @@ The `provision_errored` message `hook` object has the following keys:
     "provisioner": "local-exec"
   },
   "type": "provision_errored"
+}
+```
+
+## Action Invocation
+
+The `planned_action_invocation` message object has the following keys:
+
+- `invocation`: the invocation object containing details about the planned action invocation
+
+The `invocation` object has the following keys:
+
+- `action_addr`: a [`resource` object](#resource-object) identifying the action being invoked.
+- `action_trigger`: the trigger object containing details about what triggered the action invocation.
+- `lifecycle_trigger`: the trigger object containing details about the resource that triggered the action invocation through its lifecycle.
+
+The `action_addr` object has the following keys:
+
+- `addr`: the address of the action
+- `module`: the module containing the action
+- `action`: the full action string
+- `implied_provider`: the provider implied by the action
+- `action_type`: the type of the action
+- `action_name`: the name of the action
+- `action_key`: the key of the action, if any
+
+The `action_trigger` object is an empty object, and is present when the action is invoked via the CLI using the `-invoke` flag.
+
+The `lifecycle_trigger` object has the following keys:
+
+- `triggering_resource`: a [`resource` object](#resource-object) identifying the resource that triggered the action
+- `triggering_event`: the event that triggered the action
+- `action_trigger_block_index`: the index of the block that triggered the action
+- `actions_list_index`: the index of the action in the list of actions
+- `on_failure`: the action to take on failure
+
+### Example: Action invoked via the CLI using the `-invoke` flag.
+
+```json
+{
+  "@level":"info",
+  "@message": "planned action invocation: action.aws_lambda_invoke.api_handler",
+  "@module": "terraform.ui",
+  "@timestamp": "2026-07-30T15:18:39.254843+01:00",
+  "invocation": {
+    "action_addr": {
+      "addr": "action.aws_lambda_invoke.api_handler",
+      "module": "",
+      "action": "action.aws_lambda_invoke.api_handler",
+      "implied_provider": "aws",
+      "action_type": "aws_lambda_invoke",
+      "action_name": "api_handler",
+      "action_key": null
+    },
+    "action_trigger": {}
+  },
+  "type": "planned_action_invocation"
+}
+```
+
+### Example: Action invoked through a lifecycle trigger.
+
+```json
+{
+  "@level":"info",
+  "@message":"planned action invocation: action.aws_lambda_invoke.api_handler",
+  "@module":"terraform.ui",
+  "@timestamp":"2026-07-30T15:23:15.862206+01:00",
+  "invocation":{
+    "action_addr":{
+      "addr":"action.aws_lambda_invoke.api_handler",
+      "module":"",
+      "action":"action.aws_lambda_invoke.api_handler",
+      "implied_provider":"aws",
+      "action_type":"aws_lambda_invoke",
+      "action_name":"api_handler",
+      "action_key":null
+    },
+    "lifecycle_trigger":{
+      "triggering_resource":{
+        "addr":"aws_lambda_function.api_handler",
+        "module":"",
+        "resource":"aws_lambda_function.api_handler",
+        "implied_provider":"aws",
+        "resource_type":"aws_lambda_function",
+        "resource_name":"api_handler",
+        "resource_key":null
+      },
+      "triggering_event":"AfterUpdate",
+      "action_trigger_block_index":0,
+      "actions_list_index":0,
+      "on_failure":"ActionOnFailureHalt"
+    }
+  },
+  "type":"planned_action_invocation"
 }
 ```
 

--- a/content/terraform/v1.16.x (beta)/docs/internals/machine-readable-ui.mdx
+++ b/content/terraform/v1.16.x (beta)/docs/internals/machine-readable-ui.mdx
@@ -131,7 +131,7 @@ Messages with `init_output` type have an additional `message_code` documented be
 
 - `apply_start`, `apply_progress`, `apply_complete`, `apply_errored`: sequence of messages indicating progress of a single resource through apply
 - `provision_start`, `provision_progress`, `provision_complete`, `provision_errored`: sequence of messages indicating progress of a single provisioner step
-- `planned_action_invocation` : message indicating that an action has been invoked.
+- `planned_action_invocation` : message indicating that an action has been invoked
 - `refresh_start`, `refresh_complete`: sequence of messages indicating progress of a single resource through refresh
 
 ### Test Results


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform/pull/37467
Reference: https://github.com/hashicorp/terraform/pull/38936

The `planned_action_invocation` type of JSON log is produced by the Actions feature that was released in v1.14. This PR documents that log entry type for v1.14 and recent versions.

I used this tutorial (https://developer.hashicorp.com/terraform/tutorials/configuration-language/actions) to perform actions with the -json flag, so the examples are copied as-is from those manual experiments.