### PR TITLE
fix: update copyright headers

### DIFF
--- a/.github/workflows/copyright-headers-check.yml
+++ b/.github/workflows/copyright-headers-check.yml
@@ -11,6 +11,7 @@ on:
       - '**.ts'
       - '**.tsx'
       - '**.mjs'
+      - '**.tf'
   push:
     branches: ['main']
 

--- a/terraform/github.tf
+++ b/terraform/github.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2025, 2026
+ * Copyright IBM Corp. 2024, 2026
  * SPDX-License-Identifier: BUSL-1.1
  */
 

--- a/terraform/instana.tf
+++ b/terraform/instana.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2025, 2026
+ * Copyright IBM Corp. 2024, 2026
  * SPDX-License-Identifier: BUSL-1.1
  */
 

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2025, 2026
+ * Copyright IBM Corp. 2024, 2026
  * SPDX-License-Identifier: BUSL-1.1
  */
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2025, 2026
+ * Copyright IBM Corp. 2024, 2026
  * SPDX-License-Identifier: BUSL-1.1
  */
 

--- a/terraform/vercel.tf
+++ b/terraform/vercel.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2025, 2026
+ * Copyright IBM Corp. 2024, 2026
  * SPDX-License-Identifier: BUSL-1.1
  */
 


### PR DESCRIPTION
### Description

This PR fixes the copyright headers on these files to fix the Check copyright Headers error that has been failing. Also adds .tf files to the github action to prevent this from happening in the future. It looks like it did not run on the original PR since `.tf` files were not included in the GHA

### Testing

Make sure the Check Copyright Headers check passes on this PR: https://github.com/hashicorp/web-unified-docs/actions/runs/30657871963/job/91246668421?pr=2985
