### PR TITLE
fix: add page_title to docs that do not have it

### DIFF
--- a/content/consul/v1.8.x/content/docs/guides/acl-replication.mdx
+++ b/content/consul/v1.8.x/content/docs/guides/acl-replication.mdx
@@ -1,5 +1,5 @@
 ---
-name: ACL Replication for Multiple Datacenters
+page_title: ACL Replication for Multiple Datacenters
 content_length: 15
 id: acl-replication
 products_used:

--- a/content/consul/v1.8.x/content/docs/guides/connect-services.mdx
+++ b/content/consul/v1.8.x/content/docs/guides/connect-services.mdx
@@ -1,5 +1,5 @@
 ---
-name: Secure Service-to-Service Communication
+page_title: Secure Service-to-Service Communication
 content_length: 12
 id: connect-services
 products_used:

--- a/content/consul/v1.8.x/content/docs/guides/consul-splitting.mdx
+++ b/content/consul/v1.8.x/content/docs/guides/consul-splitting.mdx
@@ -1,5 +1,5 @@
 ---
-name: Traffic Splitting for Service Deployments
+page_title: Traffic Splitting for Service Deployments
 content_length: 15
 id: connect-splitting
 products_used:

--- a/content/consul/v1.8.x/content/docs/guides/containers-guide.mdx
+++ b/content/consul/v1.8.x/content/docs/guides/containers-guide.mdx
@@ -1,5 +1,5 @@
 ---
-name: Consul with Containers
+page_title: Consul with Containers
 content_length: 15
 id: containers-guide
 products_used:

--- a/content/consul/v1.8.x/content/docs/guides/discovery-namespaces.mdx
+++ b/content/consul/v1.8.x/content/docs/guides/discovery-namespaces.mdx
@@ -1,5 +1,5 @@
 ---
-name: '[Enterprise] Register and Discover Services within Namespaces'
+page_title: '[Enterprise] Register and Discover Services within Namespaces'
 content_length: 8
 id: discovery-namespaces
 products_used:

--- a/content/consul/v1.8.x/content/docs/guides/kubernetes-production-deploy.mdx
+++ b/content/consul/v1.8.x/content/docs/guides/kubernetes-production-deploy.mdx
@@ -1,5 +1,5 @@
 ---
-name: Consul-Kubernetes Deployment Guide
+page_title: Consul-Kubernetes Deployment Guide
 content_length: 14
 id: kubernetes-production-deploy
 products_used:

--- a/content/consul/v1.8.x/content/docs/guides/managing-acl-policies.mdx
+++ b/content/consul/v1.8.x/content/docs/guides/managing-acl-policies.mdx
@@ -1,5 +1,5 @@
 ---
-name: Managing ACL Policies
+page_title: Managing ACL Policies
 content_length: 15
 id: managing-acl-policies
 products_used:

--- a/content/consul/v1.8.x/content/docs/guides/secure-namespaces.mdx
+++ b/content/consul/v1.8.x/content/docs/guides/secure-namespaces.mdx
@@ -1,5 +1,5 @@
 ---
-name: '[Enterprise] Setup Secure Namespaces'
+page_title: '[Enterprise] Setup Secure Namespaces'
 content_length: 14
 id: secure-namespaces
 products_used:

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/_template.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/api-docs/_template.mdx
@@ -1,4 +1,5 @@
 ---
+page_title: Api-docs template
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2023-01-01T00:00:00.000Z

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/_template.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/api-docs/_template.mdx
@@ -1,4 +1,5 @@
 ---
+page_title: Api-docs template
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2023-01-01T00:00:00.000Z

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/_template.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/api-docs/_template.mdx
@@ -1,4 +1,5 @@
 ---
+page_title: Api-docs template
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2023-01-01T00:00:00.000Z

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/_template.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/api-docs/_template.mdx
@@ -1,4 +1,5 @@
 ---
+page_title: Api-docs template
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2023-01-01T00:00:00.000Z

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/_template.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/api-docs/_template.mdx
@@ -1,4 +1,5 @@
 ---
+page_title: Api-docs template
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2023-01-01T00:00:00.000Z

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/_template.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/api-docs/_template.mdx
@@ -1,4 +1,5 @@
 ---
+page_title: Api-docs template
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2023-01-01T00:00:00.000Z

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/_template.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/api-docs/_template.mdx
@@ -1,4 +1,5 @@
 ---
+page_title: Api-docs templates
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2023-01-01T00:00:00.000Z

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/_template.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/api-docs/_template.mdx
@@ -1,4 +1,5 @@
 ---
+page_title: Api-docs template
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2023-01-01T00:00:00.000Z

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/_template.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/_template.mdx
@@ -1,4 +1,5 @@
 ---
+page_title: Api-docs template
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2023-01-01T00:00:00.000Z

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/project-team-access.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/api-docs/project-team-access.mdx
@@ -1,4 +1,5 @@
 ---
+page_title: Project Team Access API
 source: terraform-docs-common
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2023-01-01T00:00:00.000Z

--- a/content/terraform-plugin-framework/v1.15.x/docs/plugin/framework/migrating/index.mdx
+++ b/content/terraform-plugin-framework/v1.15.x/docs/plugin/framework/migrating/index.mdx
@@ -1,6 +1,6 @@
 ---
-Page_title: Migrate provider code from SDKv2 to the plugin framework
-Description:
+page_title: Migrate provider code from SDKv2 to the plugin framework
+description:
   The Terraform plugin framework is an SDK that you can use to develop Terraform providers that offers several advantages over SDKv2. Learn how to migrate your SDKv2 provider to the framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-05-16T15:29:56-04:00

--- a/content/terraform-plugin-framework/v1.16.x/docs/plugin/framework/migrating/index.mdx
+++ b/content/terraform-plugin-framework/v1.16.x/docs/plugin/framework/migrating/index.mdx
@@ -1,6 +1,6 @@
 ---
-Page_title: Migrate provider code from SDKv2 to the plugin framework
-Description:
+page_title: Migrate provider code from SDKv2 to the plugin framework
+description:
   The Terraform plugin framework is an SDK that you can use to develop Terraform providers that offers several advantages over SDKv2. Learn how to migrate your SDKv2 provider to the framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-09-23T14:09:33-05:00

--- a/content/terraform-plugin-framework/v1.17.x/docs/plugin/framework/migrating/index.mdx
+++ b/content/terraform-plugin-framework/v1.17.x/docs/plugin/framework/migrating/index.mdx
@@ -1,6 +1,6 @@
 ---
-Page_title: Migrate provider code from SDKv2 to the plugin framework
-Description:
+page_title: Migrate provider code from SDKv2 to the plugin framework
+description:
   The Terraform plugin framework is an SDK that you can use to develop Terraform providers that offers several advantages over SDKv2. Learn how to migrate your SDKv2 provider to the framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2026-03-05T16:11:39.000Z

--- a/content/terraform-plugin-framework/v1.18.x/docs/plugin/framework/migrating/index.mdx
+++ b/content/terraform-plugin-framework/v1.18.x/docs/plugin/framework/migrating/index.mdx
@@ -1,6 +1,6 @@
 ---
-Page_title: Migrate provider code from SDKv2 to the plugin framework
-Description:
+page_title: Migrate provider code from SDKv2 to the plugin framework
+description:
   The Terraform plugin framework is an SDK that you can use to develop Terraform providers that offers several advantages over SDKv2. Learn how to migrate your SDKv2 provider to the framework.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2026-03-05T16:12:48.000Z

--- a/content/vagrant/v2.2.10/content/vagrant-cloud/organizations/index.mdx
+++ b/content/vagrant/v2.2.10/content/vagrant-cloud/organizations/index.mdx
@@ -1,6 +1,6 @@
 ---
 layout: vagrant-cloud
-page_page_title: Organizations in Vagrant Cloud
+page_title: Organizations in Vagrant Cloud
 sidebar_title: Organizations
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2023-01-01T00:00:00.000Z

--- a/content/vagrant/v2.2.11/content/vagrant-cloud/organizations/index.mdx
+++ b/content/vagrant/v2.2.11/content/vagrant-cloud/organizations/index.mdx
@@ -1,6 +1,6 @@
 ---
 layout: vagrant-cloud
-page_page_title: Organizations in Vagrant Cloud
+page_title: Organizations in Vagrant Cloud
 sidebar_title: Organizations
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2023-01-01T00:00:00.000Z

--- a/content/vagrant/v2.2.12/content/vagrant-cloud/organizations/index.mdx
+++ b/content/vagrant/v2.2.12/content/vagrant-cloud/organizations/index.mdx
@@ -1,6 +1,6 @@
 ---
 layout: vagrant-cloud
-page_page_title: Organizations in Vagrant Cloud
+page_title: Organizations in Vagrant Cloud
 sidebar_title: Organizations
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2023-01-01T00:00:00.000Z

--- a/content/vagrant/v2.2.13/content/vagrant-cloud/organizations/index.mdx
+++ b/content/vagrant/v2.2.13/content/vagrant-cloud/organizations/index.mdx
@@ -1,6 +1,6 @@
 ---
 layout: vagrant-cloud
-page_page_title: Organizations in Vagrant Cloud
+page_title: Organizations in Vagrant Cloud
 sidebar_title: Organizations
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2023-01-01T00:00:00.000Z

--- a/content/vagrant/v2.2.14/content/vagrant-cloud/organizations/index.mdx
+++ b/content/vagrant/v2.2.14/content/vagrant-cloud/organizations/index.mdx
@@ -1,6 +1,6 @@
 ---
 layout: vagrant-cloud
-page_page_title: Organizations in Vagrant Cloud
+page_title: Organizations in Vagrant Cloud
 sidebar_title: Organizations
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2023-01-01T00:00:00.000Z

--- a/content/vagrant/v2.2.15/content/vagrant-cloud/organizations/index.mdx
+++ b/content/vagrant/v2.2.15/content/vagrant-cloud/organizations/index.mdx
@@ -1,6 +1,6 @@
 ---
 layout: vagrant-cloud
-page_page_title: Organizations in Vagrant Cloud
+page_title: Organizations in Vagrant Cloud
 sidebar_title: Organizations
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2023-01-01T00:00:00.000Z

--- a/content/vagrant/v2.2.16/content/vagrant-cloud/organizations/index.mdx
+++ b/content/vagrant/v2.2.16/content/vagrant-cloud/organizations/index.mdx
@@ -1,6 +1,6 @@
 ---
 layout: vagrant-cloud
-page_page_title: Organizations in Vagrant Cloud
+page_title: Organizations in Vagrant Cloud
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2023-01-01T00:00:00.000Z
 last_modified: 2023-01-01T00:00:00.000Z

--- a/content/vagrant/v2.2.17/content/vagrant-cloud/organizations/index.mdx
+++ b/content/vagrant/v2.2.17/content/vagrant-cloud/organizations/index.mdx
@@ -1,6 +1,6 @@
 ---
 layout: vagrant-cloud
-page_page_title: Organizations in Vagrant Cloud
+page_title: Organizations in Vagrant Cloud
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2023-01-01T00:00:00.000Z
 last_modified: 2023-01-01T00:00:00.000Z

--- a/content/vagrant/v2.2.18/content/vagrant-cloud/organizations/index.mdx
+++ b/content/vagrant/v2.2.18/content/vagrant-cloud/organizations/index.mdx
@@ -1,6 +1,6 @@
 ---
 layout: vagrant-cloud
-page_page_title: Organizations in Vagrant Cloud
+page_title: Organizations in Vagrant Cloud
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2023-01-01T00:00:00.000Z
 last_modified: 2023-01-01T00:00:00.000Z

--- a/content/vagrant/v2.2.19/content/vagrant-cloud/organizations/index.mdx
+++ b/content/vagrant/v2.2.19/content/vagrant-cloud/organizations/index.mdx
@@ -1,6 +1,6 @@
 ---
 layout: vagrant-cloud
-page_page_title: Organizations in Vagrant Cloud
+page_title: Organizations in Vagrant Cloud
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2023-01-01T00:00:00.000Z
 last_modified: 2023-01-01T00:00:00.000Z

--- a/content/vagrant/v2.3.0/content/vagrant-cloud/organizations/index.mdx
+++ b/content/vagrant/v2.3.0/content/vagrant-cloud/organizations/index.mdx
@@ -1,6 +1,6 @@
 ---
 layout: vagrant-cloud
-page_page_title: Organizations in Vagrant Cloud
+page_title: Organizations in Vagrant Cloud
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2023-01-01T00:00:00.000Z
 last_modified: 2023-01-01T00:00:00.000Z

--- a/content/vagrant/v2.3.1/content/vagrant-cloud/organizations/index.mdx
+++ b/content/vagrant/v2.3.1/content/vagrant-cloud/organizations/index.mdx
@@ -1,6 +1,6 @@
 ---
 layout: vagrant-cloud
-page_page_title: Organizations in Vagrant Cloud
+page_title: Organizations in Vagrant Cloud
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2023-01-01T00:00:00.000Z
 last_modified: 2023-01-01T00:00:00.000Z

--- a/content/vagrant/v2.3.2/content/vagrant-cloud/organizations/index.mdx
+++ b/content/vagrant/v2.3.2/content/vagrant-cloud/organizations/index.mdx
@@ -1,6 +1,6 @@
 ---
 layout: vagrant-cloud
-page_page_title: Organizations in Vagrant Cloud
+page_title: Organizations in Vagrant Cloud
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2023-01-01T00:00:00.000Z
 last_modified: 2023-01-01T00:00:00.000Z

--- a/content/vagrant/v2.3.3/content/vagrant-cloud/organizations/index.mdx
+++ b/content/vagrant/v2.3.3/content/vagrant-cloud/organizations/index.mdx
@@ -1,6 +1,6 @@
 ---
 layout: vagrant-cloud
-page_page_title: Organizations in Vagrant Cloud
+page_title: Organizations in Vagrant Cloud
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2023-01-01T00:00:00.000Z
 last_modified: 2023-01-01T00:00:00.000Z

--- a/content/vault/v1.10.x/content/intro/index.mdx
+++ b/content/vault/v1.10.x/content/intro/index.mdx
@@ -1,4 +1,5 @@
 ---
+page_title: intro
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2023-09-27T00:00:00.000Z

--- a/content/vault/v1.4.x/content/intro/index.mdx
+++ b/content/vault/v1.4.x/content/intro/index.mdx
@@ -1,4 +1,5 @@
 ---
+page_title: intro
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2021-11-19T00:00:00.000Z

--- a/content/vault/v1.5.x/content/intro/index.mdx
+++ b/content/vault/v1.5.x/content/intro/index.mdx
@@ -1,4 +1,5 @@
 ---
+page_title: intro
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2021-11-19T00:00:00.000Z

--- a/content/vault/v1.6.x/content/intro/index.mdx
+++ b/content/vault/v1.6.x/content/intro/index.mdx
@@ -1,4 +1,5 @@
 ---
+page_title: intro
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2021-11-19T00:00:00.000Z

--- a/content/vault/v1.7.x/content/intro/index.mdx
+++ b/content/vault/v1.7.x/content/intro/index.mdx
@@ -1,4 +1,5 @@
 ---
+page_title: intro
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2021-11-19T00:00:00.000Z

--- a/content/vault/v1.8.x/content/intro/index.mdx
+++ b/content/vault/v1.8.x/content/intro/index.mdx
@@ -1,4 +1,5 @@
 ---
+page_title: intro
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2021-11-19T00:00:00.000Z

--- a/content/vault/v1.9.x/content/intro/index.mdx
+++ b/content/vault/v1.9.x/content/intro/index.mdx
@@ -1,4 +1,5 @@
 ---
+page_title: intro
 layout: intro
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2021-11-19T00:00:00.000Z

--- a/content/well-architected-framework/docs/docs/implementation-resources/implementation-resources-consul-reliability.mdx
+++ b/content/well-architected-framework/docs/docs/implementation-resources/implementation-resources-consul-reliability.mdx
@@ -1,5 +1,5 @@
 ---
-name: Run a reliable Consul cluster
+page_title: Run a reliable Consul cluster
 description: Learn how to run a reliable Consul cluster.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-07-31T15:19:57-05:00

--- a/content/well-architected-framework/docs/docs/implementation-resources/implementation-resources-nomad-reliability.mdx
+++ b/content/well-architected-framework/docs/docs/implementation-resources/implementation-resources-nomad-reliability.mdx
@@ -1,5 +1,5 @@
 ---
-name: Run a reliable Nomad cluster
+page_title: Run a reliable Nomad cluster
 description: "Learn how to run a reliable Nomad cluster."
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-07-31T15:19:57-05:00

--- a/content/well-architected-framework/docs/docs/implementation-resources/implementation-resources-packer-reliability.mdx
+++ b/content/well-architected-framework/docs/docs/implementation-resources/implementation-resources-packer-reliability.mdx
@@ -1,5 +1,5 @@
 ---
-name: Run a reliable Packer pipeline
+page_title: Run a reliable Packer pipeline
 description: "Learn how to run a reliable Packer pipeline."
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-07-31T15:19:57-05:00

--- a/content/well-architected-framework/docs/docs/implementation-resources/implementation-resources-terraform-reliability.mdx
+++ b/content/well-architected-framework/docs/docs/implementation-resources/implementation-resources-terraform-reliability.mdx
@@ -1,5 +1,5 @@
 ---
-name: Run a reliable Terraform Enterprise cluster
+page_title: Run a reliable Terraform Enterprise cluster
 description: "Learn how to run a reliable Terraform Enterprise cluster."
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-07-31T15:19:57-05:00

--- a/content/well-architected-framework/docs/docs/implementation-resources/implementation-resources-vault-reliability.mdx
+++ b/content/well-architected-framework/docs/docs/implementation-resources/implementation-resources-vault-reliability.mdx
@@ -1,5 +1,5 @@
 ---
-name: Run a reliable Vault cluster
+page_title: Run a reliable Vault cluster
 description: "Learn how to run a reliable Vault cluster."
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-07-31T15:19:57-05:00


### PR DESCRIPTION
### Description

[Monday task](https://ibm.monday.com/boards/18402251594/pulses/11241971567)

This PR adds page_title to all the docs that do not have it. There is a bug where if an item in the search bar results does not have a page_title, it will crash the site. I've added a [fix on dev-portal](https://github.com/hashicorp/dev-portal/pull/3072) that will remove any search results that do not have a title. However, that would result in these pages not showing up in search so I added a page_title to each doc so they still appear in search results. Going forward, if a doc does not have a page_title, it will not break dev-portal but it won't show up in the search results.

### Testing

Since this PR won't update the algolia index (where search results live) until after it merges, the search will still be broken in this preview link. You can test the other PR if you would like: https://dev-portal-git-leah-fixapp-crash-if-no-title-hashicorp.vercel.app/

Also, you can test any of the docs I updated in the preview link: https://unified-docs-frontend-preview-372pq7ik8-hashicorp.vercel.app/