### PR TITLE
docs(plugin-framework): complete truncated Create diagnostics example

### DIFF
--- a/content/terraform-plugin-framework/v0.11.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v0.11.x/docs/plugin/framework/diagnostics.mdx
@@ -33,7 +33,10 @@ functions or methods:
 
 ```go
 func (m myResource) Create(ctx context.Context,
-	req resource.CreateRequest, resp *resource.CreateResponse)
+	req resource.CreateRequest, resp *resource.CreateResponse) {
+	// resp.Diagnostics is a diag.Diagnostics slice used to return
+	// errors and warnings to practitioners.
+}
 ```
 
 This is the most common form for Diagnostics: a slice that has one or more

--- a/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v0.12.x/docs/plugin/framework/diagnostics.mdx
@@ -33,7 +33,10 @@ functions or methods:
 
 ```go
 func (m myResource) Create(ctx context.Context,
-	req resource.CreateRequest, resp *resource.CreateResponse)
+	req resource.CreateRequest, resp *resource.CreateResponse) {
+	// resp.Diagnostics is a diag.Diagnostics slice used to return
+	// errors and warnings to practitioners.
+}
 ```
 
 This is the most common form for Diagnostics: a slice that has one or more

--- a/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v0.13.x/docs/plugin/framework/diagnostics.mdx
@@ -33,7 +33,10 @@ functions or methods:
 
 ```go
 func (m myResource) Create(ctx context.Context,
-	req resource.CreateRequest, resp *resource.CreateResponse)
+	req resource.CreateRequest, resp *resource.CreateResponse) {
+	// resp.Diagnostics is a diag.Diagnostics slice used to return
+	// errors and warnings to practitioners.
+}
 ```
 
 This is the most common form for Diagnostics: a slice that has one or more

--- a/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v0.14.x/docs/plugin/framework/diagnostics.mdx
@@ -35,7 +35,10 @@ functions or methods:
 
 ```go
 func (m myResource) Create(ctx context.Context,
-	req resource.CreateRequest, resp *resource.CreateResponse)
+	req resource.CreateRequest, resp *resource.CreateResponse) {
+	// resp.Diagnostics is a diag.Diagnostics slice used to return
+	// errors and warnings to practitioners.
+}
 ```
 
 This is the most common form for Diagnostics: a slice that has one or more

--- a/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v0.15.x/docs/plugin/framework/diagnostics.mdx
@@ -35,7 +35,10 @@ functions or methods:
 
 ```go
 func (m myResource) Create(ctx context.Context,
-	req resource.CreateRequest, resp *resource.CreateResponse)
+	req resource.CreateRequest, resp *resource.CreateResponse) {
+	// resp.Diagnostics is a diag.Diagnostics slice used to return
+	// errors and warnings to practitioners.
+}
 ```
 
 This is the most common form for Diagnostics: a slice that has one or more

--- a/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v0.16.x/docs/plugin/framework/diagnostics.mdx
@@ -35,7 +35,10 @@ functions or methods:
 
 ```go
 func (m myResource) Create(ctx context.Context,
-	req resource.CreateRequest, resp *resource.CreateResponse)
+	req resource.CreateRequest, resp *resource.CreateResponse) {
+	// resp.Diagnostics is a diag.Diagnostics slice used to return
+	// errors and warnings to practitioners.
+}
 ```
 
 This is the most common form for Diagnostics: a slice that has one or more

--- a/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v0.17.x/docs/plugin/framework/diagnostics.mdx
@@ -35,7 +35,10 @@ functions or methods:
 
 ```go
 func (m myResource) Create(ctx context.Context,
-	req resource.CreateRequest, resp *resource.CreateResponse)
+	req resource.CreateRequest, resp *resource.CreateResponse) {
+	// resp.Diagnostics is a diag.Diagnostics slice used to return
+	// errors and warnings to practitioners.
+}
 ```
 
 This is the most common form for Diagnostics: a slice that has one or more

--- a/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v1.0.x/docs/plugin/framework/diagnostics.mdx
@@ -33,7 +33,10 @@ functions or methods:
 
 ```go
 func (m myResource) Create(ctx context.Context,
-	req resource.CreateRequest, resp *resource.CreateResponse)
+	req resource.CreateRequest, resp *resource.CreateResponse) {
+	// resp.Diagnostics is a diag.Diagnostics slice used to return
+	// errors and warnings to practitioners.
+}
 ```
 
 This is the most common form for Diagnostics: a slice that has one or more

--- a/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v1.1.x/docs/plugin/framework/diagnostics.mdx
@@ -33,7 +33,10 @@ functions or methods:
 
 ```go
 func (m myResource) Create(ctx context.Context,
-	req resource.CreateRequest, resp *resource.CreateResponse)
+	req resource.CreateRequest, resp *resource.CreateResponse) {
+	// resp.Diagnostics is a diag.Diagnostics slice used to return
+	// errors and warnings to practitioners.
+}
 ```
 
 This is the most common form for Diagnostics: a slice that has one or more

--- a/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v1.10.x/docs/plugin/framework/diagnostics.mdx
@@ -33,7 +33,10 @@ functions or methods:
 
 ```go
 func (m myResource) Create(ctx context.Context,
-	req resource.CreateRequest, resp *resource.CreateResponse)
+	req resource.CreateRequest, resp *resource.CreateResponse) {
+	// resp.Diagnostics is a diag.Diagnostics slice used to return
+	// errors and warnings to practitioners.
+}
 ```
 
 This is the most common form for Diagnostics: a slice that has one or more

--- a/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v1.11.x/docs/plugin/framework/diagnostics.mdx
@@ -33,7 +33,10 @@ functions or methods:
 
 ```go
 func (m myResource) Create(ctx context.Context,
-	req resource.CreateRequest, resp *resource.CreateResponse)
+	req resource.CreateRequest, resp *resource.CreateResponse) {
+	// resp.Diagnostics is a diag.Diagnostics slice used to return
+	// errors and warnings to practitioners.
+}
 ```
 
 This is the most common form for Diagnostics: a slice that has one or more

--- a/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v1.12.x/docs/plugin/framework/diagnostics.mdx
@@ -33,7 +33,10 @@ functions or methods:
 
 ```go
 func (m myResource) Create(ctx context.Context,
-	req resource.CreateRequest, resp *resource.CreateResponse)
+	req resource.CreateRequest, resp *resource.CreateResponse) {
+	// resp.Diagnostics is a diag.Diagnostics slice used to return
+	// errors and warnings to practitioners.
+}
 ```
 
 This is the most common form for Diagnostics: a slice that has one or more

--- a/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v1.13.x/docs/plugin/framework/diagnostics.mdx
@@ -33,7 +33,10 @@ functions or methods:
 
 ```go
 func (m myResource) Create(ctx context.Context,
-	req resource.CreateRequest, resp *resource.CreateResponse)
+	req resource.CreateRequest, resp *resource.CreateResponse) {
+	// resp.Diagnostics is a diag.Diagnostics slice used to return
+	// errors and warnings to practitioners.
+}
 ```
 
 This is the most common form for Diagnostics: a slice that has one or more

--- a/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v1.14.x/docs/plugin/framework/diagnostics.mdx
@@ -32,7 +32,10 @@ functions or methods:
 
 ```go
 func (m myResource) Create(ctx context.Context,
-	req resource.CreateRequest, resp *resource.CreateResponse)
+	req resource.CreateRequest, resp *resource.CreateResponse) {
+	// resp.Diagnostics is a diag.Diagnostics slice used to return
+	// errors and warnings to practitioners.
+}
 ```
 
 This is the most common form for Diagnostics: a slice that has one or more

--- a/content/terraform-plugin-framework/v1.15.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v1.15.x/docs/plugin/framework/diagnostics.mdx
@@ -32,7 +32,10 @@ functions or methods:
 
 ```go
 func (m myResource) Create(ctx context.Context,
-	req resource.CreateRequest, resp *resource.CreateResponse)
+	req resource.CreateRequest, resp *resource.CreateResponse) {
+	// resp.Diagnostics is a diag.Diagnostics slice used to return
+	// errors and warnings to practitioners.
+}
 ```
 
 This is the most common form for Diagnostics: a slice that has one or more

--- a/content/terraform-plugin-framework/v1.16.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v1.16.x/docs/plugin/framework/diagnostics.mdx
@@ -32,7 +32,10 @@ functions or methods:
 
 ```go
 func (m myResource) Create(ctx context.Context,
-	req resource.CreateRequest, resp *resource.CreateResponse)
+	req resource.CreateRequest, resp *resource.CreateResponse) {
+	// resp.Diagnostics is a diag.Diagnostics slice used to return
+	// errors and warnings to practitioners.
+}
 ```
 
 This is the most common form for Diagnostics: a slice that has one or more

--- a/content/terraform-plugin-framework/v1.17.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v1.17.x/docs/plugin/framework/diagnostics.mdx
@@ -32,7 +32,10 @@ functions or methods:
 
 ```go
 func (m myResource) Create(ctx context.Context,
-	req resource.CreateRequest, resp *resource.CreateResponse)
+	req resource.CreateRequest, resp *resource.CreateResponse) {
+	// resp.Diagnostics is a diag.Diagnostics slice used to return
+	// errors and warnings to practitioners.
+}
 ```
 
 This is the most common form for Diagnostics: a slice that has one or more

--- a/content/terraform-plugin-framework/v1.18.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v1.18.x/docs/plugin/framework/diagnostics.mdx
@@ -32,7 +32,10 @@ functions or methods:
 
 ```go
 func (m myResource) Create(ctx context.Context,
-	req resource.CreateRequest, resp *resource.CreateResponse)
+	req resource.CreateRequest, resp *resource.CreateResponse) {
+	// resp.Diagnostics is a diag.Diagnostics slice used to return
+	// errors and warnings to practitioners.
+}
 ```
 
 This is the most common form for Diagnostics: a slice that has one or more

--- a/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v1.2.x/docs/plugin/framework/diagnostics.mdx
@@ -33,7 +33,10 @@ functions or methods:
 
 ```go
 func (m myResource) Create(ctx context.Context,
-	req resource.CreateRequest, resp *resource.CreateResponse)
+	req resource.CreateRequest, resp *resource.CreateResponse) {
+	// resp.Diagnostics is a diag.Diagnostics slice used to return
+	// errors and warnings to practitioners.
+}
 ```
 
 This is the most common form for Diagnostics: a slice that has one or more

--- a/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v1.3.x/docs/plugin/framework/diagnostics.mdx
@@ -33,7 +33,10 @@ functions or methods:
 
 ```go
 func (m myResource) Create(ctx context.Context,
-	req resource.CreateRequest, resp *resource.CreateResponse)
+	req resource.CreateRequest, resp *resource.CreateResponse) {
+	// resp.Diagnostics is a diag.Diagnostics slice used to return
+	// errors and warnings to practitioners.
+}
 ```
 
 This is the most common form for Diagnostics: a slice that has one or more

--- a/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v1.4.x/docs/plugin/framework/diagnostics.mdx
@@ -33,7 +33,10 @@ functions or methods:
 
 ```go
 func (m myResource) Create(ctx context.Context,
-	req resource.CreateRequest, resp *resource.CreateResponse)
+	req resource.CreateRequest, resp *resource.CreateResponse) {
+	// resp.Diagnostics is a diag.Diagnostics slice used to return
+	// errors and warnings to practitioners.
+}
 ```
 
 This is the most common form for Diagnostics: a slice that has one or more

--- a/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v1.5.x/docs/plugin/framework/diagnostics.mdx
@@ -33,7 +33,10 @@ functions or methods:
 
 ```go
 func (m myResource) Create(ctx context.Context,
-	req resource.CreateRequest, resp *resource.CreateResponse)
+	req resource.CreateRequest, resp *resource.CreateResponse) {
+	// resp.Diagnostics is a diag.Diagnostics slice used to return
+	// errors and warnings to practitioners.
+}
 ```
 
 This is the most common form for Diagnostics: a slice that has one or more

--- a/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v1.6.x/docs/plugin/framework/diagnostics.mdx
@@ -33,7 +33,10 @@ functions or methods:
 
 ```go
 func (m myResource) Create(ctx context.Context,
-	req resource.CreateRequest, resp *resource.CreateResponse)
+	req resource.CreateRequest, resp *resource.CreateResponse) {
+	// resp.Diagnostics is a diag.Diagnostics slice used to return
+	// errors and warnings to practitioners.
+}
 ```
 
 This is the most common form for Diagnostics: a slice that has one or more

--- a/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v1.7.x/docs/plugin/framework/diagnostics.mdx
@@ -33,7 +33,10 @@ functions or methods:
 
 ```go
 func (m myResource) Create(ctx context.Context,
-	req resource.CreateRequest, resp *resource.CreateResponse)
+	req resource.CreateRequest, resp *resource.CreateResponse) {
+	// resp.Diagnostics is a diag.Diagnostics slice used to return
+	// errors and warnings to practitioners.
+}
 ```
 
 This is the most common form for Diagnostics: a slice that has one or more

--- a/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v1.8.x/docs/plugin/framework/diagnostics.mdx
@@ -33,7 +33,10 @@ functions or methods:
 
 ```go
 func (m myResource) Create(ctx context.Context,
-	req resource.CreateRequest, resp *resource.CreateResponse)
+	req resource.CreateRequest, resp *resource.CreateResponse) {
+	// resp.Diagnostics is a diag.Diagnostics slice used to return
+	// errors and warnings to practitioners.
+}
 ```
 
 This is the most common form for Diagnostics: a slice that has one or more

--- a/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/diagnostics.mdx
+++ b/content/terraform-plugin-framework/v1.9.x/docs/plugin/framework/diagnostics.mdx
@@ -33,7 +33,10 @@ functions or methods:
 
 ```go
 func (m myResource) Create(ctx context.Context,
-	req resource.CreateRequest, resp *resource.CreateResponse)
+	req resource.CreateRequest, resp *resource.CreateResponse) {
+	// resp.Diagnostics is a diag.Diagnostics slice used to return
+	// errors and warnings to practitioners.
+}
 ```
 
 This is the most common form for Diagnostics: a slice that has one or more


### PR DESCRIPTION
The Create method snippet on the diagnostics page cut off mid-signature and never showed where Diagnostics actually lives.

Filled in the method body so it points at `resp.Diagnostics` (same idea as the Append/HasError examples further down). Applied across the versioned copies that had the truncated form.

Fixes #2899