### PR TITLE
docs(azurerm): use ado_pipeline_service_connection_id in Azure DevOps examples

### DIFF
--- a/content/terraform/v1.11.x/docs/language/backend/azurerm.mdx
+++ b/content/terraform/v1.11.x/docs/language/backend/azurerm.mdx
@@ -110,13 +110,13 @@ terraform {
 
 #### Example Configuration for Azure DevOps
 
-With Azure DevOps, the ID Token endpoint environment variables are automatically found, but you need to supply the service connection ID in `oidc_azure_service_connection_id`. If you are using the `AzureCLI` or `AzurePowerShell` tasks, the service connection ID is automatically set to the  `AZURESUBSCRIPTION_SERVICE_CONNECTION_ID` environment variable.
+With Azure DevOps, the ID Token endpoint environment variables are automatically found, but you need to supply the service connection ID in `ado_pipeline_service_connection_id`. If you are using the `AzureCLI` or `AzurePowerShell` tasks, the service connection ID is automatically set to the  `AZURESUBSCRIPTION_SERVICE_CONNECTION_ID` environment variable.
 
 ```hcl
 terraform {
   backend "azurerm" {
     use_oidc                         = true                                    # Can also be set via `ARM_USE_OIDC` environment variable.
-    oidc_azure_service_connection_id = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_OIDC_AZURE_SERVICE_CONNECTION_ID` environment variable.
+    ado_pipeline_service_connection_id = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_ADO_PIPELINE_SERVICE_CONNECTION_ID` environment variable (or `ARM_OIDC_AZURE_SERVICE_CONNECTION_ID`).
     use_azuread_auth                 = true                                    # Can also be set via `ARM_USE_AZUREAD` environment variable.
     tenant_id                        = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
     client_id                        = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.
@@ -383,13 +383,13 @@ terraform {
 
 #### Example Configuration for Azure DevOps
 
-With Azure DevOps, the ID Token endpoint environment variables are automatically found, but you need to supply the service connection ID in `oidc_azure_service_connection_id`. If you are using the `AzureCLI` or `AzurePowerShell` tasks, the service connection ID is automatically set to the  `AZURESUBSCRIPTION_SERVICE_CONNECTION_ID` environment variable.
+With Azure DevOps, the ID Token endpoint environment variables are automatically found, but you need to supply the service connection ID in `ado_pipeline_service_connection_id`. If you are using the `AzureCLI` or `AzurePowerShell` tasks, the service connection ID is automatically set to the  `AZURESUBSCRIPTION_SERVICE_CONNECTION_ID` environment variable.
 
 ```hcl
 terraform {
   backend "azurerm" {
     use_oidc                         = true                                    # Can also be set via `ARM_USE_OIDC` environment variable.
-    oidc_azure_service_connection_id = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_OIDC_AZURE_SERVICE_CONNECTION_ID` environment variable.
+    ado_pipeline_service_connection_id = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_ADO_PIPELINE_SERVICE_CONNECTION_ID` environment variable (or `ARM_OIDC_AZURE_SERVICE_CONNECTION_ID`).
     tenant_id                        = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
     subscription_id                  = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
     client_id                        = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.

--- a/content/terraform/v1.12.x/docs/language/backend/azurerm.mdx
+++ b/content/terraform/v1.12.x/docs/language/backend/azurerm.mdx
@@ -110,13 +110,13 @@ terraform {
 
 #### Example Configuration for Azure DevOps
 
-With Azure DevOps, the ID Token endpoint environment variables are automatically found, but you need to supply the service connection ID in `oidc_azure_service_connection_id`. If you are using the `AzureCLI` or `AzurePowerShell` tasks, the service connection ID is automatically set to the  `AZURESUBSCRIPTION_SERVICE_CONNECTION_ID` environment variable.
+With Azure DevOps, the ID Token endpoint environment variables are automatically found, but you need to supply the service connection ID in `ado_pipeline_service_connection_id`. If you are using the `AzureCLI` or `AzurePowerShell` tasks, the service connection ID is automatically set to the  `AZURESUBSCRIPTION_SERVICE_CONNECTION_ID` environment variable.
 
 ```hcl
 terraform {
   backend "azurerm" {
     use_oidc                         = true                                    # Can also be set via `ARM_USE_OIDC` environment variable.
-    oidc_azure_service_connection_id = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_OIDC_AZURE_SERVICE_CONNECTION_ID` environment variable.
+    ado_pipeline_service_connection_id = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_ADO_PIPELINE_SERVICE_CONNECTION_ID` environment variable (or `ARM_OIDC_AZURE_SERVICE_CONNECTION_ID`).
     use_azuread_auth                 = true                                    # Can also be set via `ARM_USE_AZUREAD` environment variable.
     tenant_id                        = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
     client_id                        = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.
@@ -383,13 +383,13 @@ terraform {
 
 #### Example Configuration for Azure DevOps
 
-With Azure DevOps, the ID Token endpoint environment variables are automatically found, but you need to supply the service connection ID in `oidc_azure_service_connection_id`. If you are using the `AzureCLI` or `AzurePowerShell` tasks, the service connection ID is automatically set to the  `AZURESUBSCRIPTION_SERVICE_CONNECTION_ID` environment variable.
+With Azure DevOps, the ID Token endpoint environment variables are automatically found, but you need to supply the service connection ID in `ado_pipeline_service_connection_id`. If you are using the `AzureCLI` or `AzurePowerShell` tasks, the service connection ID is automatically set to the  `AZURESUBSCRIPTION_SERVICE_CONNECTION_ID` environment variable.
 
 ```hcl
 terraform {
   backend "azurerm" {
     use_oidc                         = true                                    # Can also be set via `ARM_USE_OIDC` environment variable.
-    oidc_azure_service_connection_id = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_OIDC_AZURE_SERVICE_CONNECTION_ID` environment variable.
+    ado_pipeline_service_connection_id = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_ADO_PIPELINE_SERVICE_CONNECTION_ID` environment variable (or `ARM_OIDC_AZURE_SERVICE_CONNECTION_ID`).
     tenant_id                        = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
     subscription_id                  = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
     client_id                        = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.

--- a/content/terraform/v1.13.x/docs/language/backend/azurerm.mdx
+++ b/content/terraform/v1.13.x/docs/language/backend/azurerm.mdx
@@ -109,13 +109,13 @@ terraform {
 
 #### Example Configuration for Azure DevOps
 
-With Azure DevOps, the ID Token endpoint environment variables are automatically found, but you need to supply the service connection ID in `oidc_azure_service_connection_id`. If you are using the `AzureCLI` or `AzurePowerShell` tasks, the service connection ID is automatically set to the  `AZURESUBSCRIPTION_SERVICE_CONNECTION_ID` environment variable.
+With Azure DevOps, the ID Token endpoint environment variables are automatically found, but you need to supply the service connection ID in `ado_pipeline_service_connection_id`. If you are using the `AzureCLI` or `AzurePowerShell` tasks, the service connection ID is automatically set to the  `AZURESUBSCRIPTION_SERVICE_CONNECTION_ID` environment variable.
 
 ```hcl
 terraform {
   backend "azurerm" {
     use_oidc                         = true                                    # Can also be set via `ARM_USE_OIDC` environment variable.
-    oidc_azure_service_connection_id = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_OIDC_AZURE_SERVICE_CONNECTION_ID` environment variable.
+    ado_pipeline_service_connection_id = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_ADO_PIPELINE_SERVICE_CONNECTION_ID` environment variable (or `ARM_OIDC_AZURE_SERVICE_CONNECTION_ID`).
     use_azuread_auth                 = true                                    # Can also be set via `ARM_USE_AZUREAD` environment variable.
     tenant_id                        = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
     client_id                        = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.
@@ -381,13 +381,13 @@ terraform {
 
 #### Example Configuration for Azure DevOps
 
-With Azure DevOps, the ID Token endpoint environment variables are automatically found, but you need to supply the service connection ID in `oidc_azure_service_connection_id`. If you are using the `AzureCLI` or `AzurePowerShell` tasks, the service connection ID is automatically set to the  `AZURESUBSCRIPTION_SERVICE_CONNECTION_ID` environment variable.
+With Azure DevOps, the ID Token endpoint environment variables are automatically found, but you need to supply the service connection ID in `ado_pipeline_service_connection_id`. If you are using the `AzureCLI` or `AzurePowerShell` tasks, the service connection ID is automatically set to the  `AZURESUBSCRIPTION_SERVICE_CONNECTION_ID` environment variable.
 
 ```hcl
 terraform {
   backend "azurerm" {
     use_oidc                         = true                                    # Can also be set via `ARM_USE_OIDC` environment variable.
-    oidc_azure_service_connection_id = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_OIDC_AZURE_SERVICE_CONNECTION_ID` environment variable.
+    ado_pipeline_service_connection_id = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_ADO_PIPELINE_SERVICE_CONNECTION_ID` environment variable (or `ARM_OIDC_AZURE_SERVICE_CONNECTION_ID`).
     tenant_id                        = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
     subscription_id                  = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
     client_id                        = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.

--- a/content/terraform/v1.14.x/docs/language/backend/azurerm.mdx
+++ b/content/terraform/v1.14.x/docs/language/backend/azurerm.mdx
@@ -109,13 +109,13 @@ terraform {
 
 #### Example Configuration for Azure DevOps
 
-With Azure DevOps, the ID Token endpoint environment variables are automatically found, but you need to supply the service connection ID in `oidc_azure_service_connection_id`. If you are using the `AzureCLI` or `AzurePowerShell` tasks, the service connection ID is automatically set to the  `AZURESUBSCRIPTION_SERVICE_CONNECTION_ID` environment variable.
+With Azure DevOps, the ID Token endpoint environment variables are automatically found, but you need to supply the service connection ID in `ado_pipeline_service_connection_id`. If you are using the `AzureCLI` or `AzurePowerShell` tasks, the service connection ID is automatically set to the  `AZURESUBSCRIPTION_SERVICE_CONNECTION_ID` environment variable.
 
 ```hcl
 terraform {
   backend "azurerm" {
     use_oidc                         = true                                    # Can also be set via `ARM_USE_OIDC` environment variable.
-    oidc_azure_service_connection_id = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_OIDC_AZURE_SERVICE_CONNECTION_ID` environment variable.
+    ado_pipeline_service_connection_id = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_ADO_PIPELINE_SERVICE_CONNECTION_ID` environment variable (or `ARM_OIDC_AZURE_SERVICE_CONNECTION_ID`).
     use_azuread_auth                 = true                                    # Can also be set via `ARM_USE_AZUREAD` environment variable.
     tenant_id                        = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
     client_id                        = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.
@@ -381,13 +381,13 @@ terraform {
 
 #### Example Configuration for Azure DevOps
 
-With Azure DevOps, the ID Token endpoint environment variables are automatically found, but you need to supply the service connection ID in `oidc_azure_service_connection_id`. If you are using the `AzureCLI` or `AzurePowerShell` tasks, the service connection ID is automatically set to the  `AZURESUBSCRIPTION_SERVICE_CONNECTION_ID` environment variable.
+With Azure DevOps, the ID Token endpoint environment variables are automatically found, but you need to supply the service connection ID in `ado_pipeline_service_connection_id`. If you are using the `AzureCLI` or `AzurePowerShell` tasks, the service connection ID is automatically set to the  `AZURESUBSCRIPTION_SERVICE_CONNECTION_ID` environment variable.
 
 ```hcl
 terraform {
   backend "azurerm" {
     use_oidc                         = true                                    # Can also be set via `ARM_USE_OIDC` environment variable.
-    oidc_azure_service_connection_id = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_OIDC_AZURE_SERVICE_CONNECTION_ID` environment variable.
+    ado_pipeline_service_connection_id = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_ADO_PIPELINE_SERVICE_CONNECTION_ID` environment variable (or `ARM_OIDC_AZURE_SERVICE_CONNECTION_ID`).
     tenant_id                        = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
     subscription_id                  = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
     client_id                        = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.

--- a/content/terraform/v1.15.x/docs/language/backend/azurerm.mdx
+++ b/content/terraform/v1.15.x/docs/language/backend/azurerm.mdx
@@ -109,13 +109,13 @@ terraform {
 
 #### Example Configuration for Azure DevOps
 
-With Azure DevOps, the ID Token endpoint environment variables are automatically found, but you need to supply the service connection ID in `oidc_azure_service_connection_id`. If you are using the `AzureCLI` or `AzurePowerShell` tasks, the service connection ID is automatically set to the  `AZURESUBSCRIPTION_SERVICE_CONNECTION_ID` environment variable.
+With Azure DevOps, the ID Token endpoint environment variables are automatically found, but you need to supply the service connection ID in `ado_pipeline_service_connection_id`. If you are using the `AzureCLI` or `AzurePowerShell` tasks, the service connection ID is automatically set to the  `AZURESUBSCRIPTION_SERVICE_CONNECTION_ID` environment variable.
 
 ```hcl
 terraform {
   backend "azurerm" {
     use_oidc                         = true                                    # Can also be set via `ARM_USE_OIDC` environment variable.
-    oidc_azure_service_connection_id = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_OIDC_AZURE_SERVICE_CONNECTION_ID` environment variable.
+    ado_pipeline_service_connection_id = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_ADO_PIPELINE_SERVICE_CONNECTION_ID` environment variable (or `ARM_OIDC_AZURE_SERVICE_CONNECTION_ID`).
     use_azuread_auth                 = true                                    # Can also be set via `ARM_USE_AZUREAD` environment variable.
     tenant_id                        = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
     client_id                        = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.
@@ -381,13 +381,13 @@ terraform {
 
 #### Example Configuration for Azure DevOps
 
-With Azure DevOps, the ID Token endpoint environment variables are automatically found, but you need to supply the service connection ID in `oidc_azure_service_connection_id`. If you are using the `AzureCLI` or `AzurePowerShell` tasks, the service connection ID is automatically set to the  `AZURESUBSCRIPTION_SERVICE_CONNECTION_ID` environment variable.
+With Azure DevOps, the ID Token endpoint environment variables are automatically found, but you need to supply the service connection ID in `ado_pipeline_service_connection_id`. If you are using the `AzureCLI` or `AzurePowerShell` tasks, the service connection ID is automatically set to the  `AZURESUBSCRIPTION_SERVICE_CONNECTION_ID` environment variable.
 
 ```hcl
 terraform {
   backend "azurerm" {
     use_oidc                         = true                                    # Can also be set via `ARM_USE_OIDC` environment variable.
-    oidc_azure_service_connection_id = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_OIDC_AZURE_SERVICE_CONNECTION_ID` environment variable.
+    ado_pipeline_service_connection_id = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_ADO_PIPELINE_SERVICE_CONNECTION_ID` environment variable (or `ARM_OIDC_AZURE_SERVICE_CONNECTION_ID`).
     tenant_id                        = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
     subscription_id                  = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
     client_id                        = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.

--- a/content/terraform/v1.16.x (beta)/docs/language/backend/azurerm.mdx
+++ b/content/terraform/v1.16.x (beta)/docs/language/backend/azurerm.mdx
@@ -109,13 +109,13 @@ terraform {
 
 #### Example Configuration for Azure DevOps
 
-With Azure DevOps, the ID Token endpoint environment variables are automatically found, but you need to supply the service connection ID in `oidc_azure_service_connection_id`. If you are using the `AzureCLI` or `AzurePowerShell` tasks, the service connection ID is automatically set to the  `AZURESUBSCRIPTION_SERVICE_CONNECTION_ID` environment variable.
+With Azure DevOps, the ID Token endpoint environment variables are automatically found, but you need to supply the service connection ID in `ado_pipeline_service_connection_id`. If you are using the `AzureCLI` or `AzurePowerShell` tasks, the service connection ID is automatically set to the  `AZURESUBSCRIPTION_SERVICE_CONNECTION_ID` environment variable.
 
 ```hcl
 terraform {
   backend "azurerm" {
     use_oidc                         = true                                    # Can also be set via `ARM_USE_OIDC` environment variable.
-    oidc_azure_service_connection_id = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_OIDC_AZURE_SERVICE_CONNECTION_ID` environment variable.
+    ado_pipeline_service_connection_id = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_ADO_PIPELINE_SERVICE_CONNECTION_ID` environment variable (or `ARM_OIDC_AZURE_SERVICE_CONNECTION_ID`).
     use_azuread_auth                 = true                                    # Can also be set via `ARM_USE_AZUREAD` environment variable.
     tenant_id                        = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
     client_id                        = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.
@@ -381,13 +381,13 @@ terraform {
 
 #### Example Configuration for Azure DevOps
 
-With Azure DevOps, the ID Token endpoint environment variables are automatically found, but you need to supply the service connection ID in `oidc_azure_service_connection_id`. If you are using the `AzureCLI` or `AzurePowerShell` tasks, the service connection ID is automatically set to the  `AZURESUBSCRIPTION_SERVICE_CONNECTION_ID` environment variable.
+With Azure DevOps, the ID Token endpoint environment variables are automatically found, but you need to supply the service connection ID in `ado_pipeline_service_connection_id`. If you are using the `AzureCLI` or `AzurePowerShell` tasks, the service connection ID is automatically set to the  `AZURESUBSCRIPTION_SERVICE_CONNECTION_ID` environment variable.
 
 ```hcl
 terraform {
   backend "azurerm" {
     use_oidc                         = true                                    # Can also be set via `ARM_USE_OIDC` environment variable.
-    oidc_azure_service_connection_id = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_OIDC_AZURE_SERVICE_CONNECTION_ID` environment variable.
+    ado_pipeline_service_connection_id = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_ADO_PIPELINE_SERVICE_CONNECTION_ID` environment variable (or `ARM_OIDC_AZURE_SERVICE_CONNECTION_ID`).
     tenant_id                        = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_TENANT_ID` environment variable.
     subscription_id                  = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_SUBSCRIPTION_ID` environment variable.
     client_id                        = "00000000-0000-0000-0000-000000000000"  # Can also be set via `ARM_CLIENT_ID` environment variable.


### PR DESCRIPTION
Azure DevOps examples still said `oidc_azure_service_connection_id`, which isn't a real backend arg — you get "argument not expected".

Switched the examples (and the short prose above them) to `ado_pipeline_service_connection_id`, matching the argument list further down. Env var comment prefers `ARM_ADO_PIPELINE_SERVICE_CONNECTION_ID` and still mentions the legacy name.

Fixes #2881