### PR TITLE
docs: deployment groups note should say Premium, not Plus

### DIFF
--- a/content/terraform/v1.15.x/docs/partials/premium-deployment-groups.mdx
+++ b/content/terraform/v1.15.x/docs/partials/premium-deployment-groups.mdx
@@ -1,5 +1,5 @@
 <Note title="Premium tier">
 
-Running orchestration rules for deployment groups is available in the HCP Terraform **Plus** Edition. Refer to [HCP Terraform pricing](https://www.hashicorp.com/products/terraform/pricing) for details.
+Running orchestration rules for deployment groups is available in the HCP Terraform **Premium** Edition. Refer to [HCP Terraform pricing](https://www.hashicorp.com/products/terraform/pricing) for details.
 
 </Note>

--- a/content/terraform/v1.16.x (beta)/docs/partials/premium-deployment-groups.mdx
+++ b/content/terraform/v1.16.x (beta)/docs/partials/premium-deployment-groups.mdx
@@ -1,5 +1,5 @@
 <Note title="Premium tier">
 
-Running orchestration rules for deployment groups is available in the HCP Terraform **Plus** Edition. Refer to [HCP Terraform pricing](https://www.hashicorp.com/products/terraform/pricing) for details.
+Running orchestration rules for deployment groups is available in the HCP Terraform **Premium** Edition. Refer to [HCP Terraform pricing](https://www.hashicorp.com/products/terraform/pricing) for details.
 
 </Note>


### PR DESCRIPTION
The deployment-groups callout still said HCP Terraform **Plus**. Pricing puts that under **Premium**, and older doc versions already used Premium.

Updated the partial.

Fixes #2657