### PR TITLE
docs(vault): correct optimistic failure tolerance figures

### DIFF
--- a/content/vault/v1.17.x/content/docs/internals/integrated-storage.mdx
+++ b/content/vault/v1.17.x/content/docs/internals/integrated-storage.mdx
@@ -324,9 +324,9 @@ on how many redundancy zones and servers per redundancy zone that you choose.
 Redundancy zones | Servers per zone | Quorum size | Failure tolerance | Optimistic failure tolerance
 :--------------: | :--------------: | :---------: | :---------------: | :--------------------------:
 2                | 2                | 2           | 0                 | 2
-3                | 2                | 2           | 1                 | 3
-3                | 3                | 2           | 1                 | 5
-5                | 2                | 3           | 2                 | 6
+3                | 2                | 2           | 1                 | 4
+3                | 3                | 2           | 1                 | 7
+5                | 2                | 3           | 2                 | 7
 
 [consensus protocol]: https://en.wikipedia.org/wiki/Consensus_(computer_science)
 [consistency]: https://en.wikipedia.org/wiki/CAP_theorem

--- a/content/vault/v1.17.x/content/partials/autopilot/redundancy-zones.mdx
+++ b/content/vault/v1.17.x/content/partials/autopilot/redundancy-zones.mdx
@@ -21,5 +21,5 @@ to take the place of voters.
 For example, consider a cluster that is configured to have 3 redundancy zones
 with 2 nodes in each zone. If a voting node becomes unreachable, the zone standby
 in that zone is promoted. The cluster then maintains 3 voting nodes with 2 remaining
-standbys. The cluster can handle an additional 2 gradual failures before it loses
-quorum.
+standbys. The cluster can handle an additional 3 gradual failures before it loses
+quorum (optimistic failure tolerance of 4 including the first failure).

--- a/content/vault/v1.19.x/content/docs/internals/integrated-storage.mdx
+++ b/content/vault/v1.19.x/content/docs/internals/integrated-storage.mdx
@@ -324,9 +324,9 @@ on how many redundancy zones and servers per redundancy zone that you choose.
 Redundancy zones | Servers per zone | Quorum size | Failure tolerance | Optimistic failure tolerance
 :--------------: | :--------------: | :---------: | :---------------: | :--------------------------:
 2                | 2                | 2           | 0                 | 2
-3                | 2                | 2           | 1                 | 3
-3                | 3                | 2           | 1                 | 5
-5                | 2                | 3           | 2                 | 6
+3                | 2                | 2           | 1                 | 4
+3                | 3                | 2           | 1                 | 7
+5                | 2                | 3           | 2                 | 7
 
 [consensus protocol]: https://en.wikipedia.org/wiki/Consensus_(computer_science)
 [consistency]: https://en.wikipedia.org/wiki/CAP_theorem

--- a/content/vault/v1.19.x/content/partials/autopilot/redundancy-zones.mdx
+++ b/content/vault/v1.19.x/content/partials/autopilot/redundancy-zones.mdx
@@ -21,5 +21,5 @@ to take the place of voters.
 For example, consider a cluster that is configured to have 3 redundancy zones
 with 2 nodes in each zone. If a voting node becomes unreachable, the zone standby
 in that zone is promoted. The cluster then maintains 3 voting nodes with 2 remaining
-standbys. The cluster can handle an additional 2 gradual failures before it loses
-quorum.
+standbys. The cluster can handle an additional 3 gradual failures before it loses
+quorum (optimistic failure tolerance of 4 including the first failure).

--- a/content/vault/v1.20.x/content/docs/internals/integrated-storage.mdx
+++ b/content/vault/v1.20.x/content/docs/internals/integrated-storage.mdx
@@ -330,9 +330,9 @@ on how many redundancy zones and servers per redundancy zone that you choose.
 Redundancy zones | Servers per zone | Quorum size | Failure tolerance | Optimistic failure tolerance
 :--------------: | :--------------: | :---------: | :---------------: | :--------------------------:
 2                | 2                | 2           | 0                 | 2
-3                | 2                | 2           | 1                 | 3
-3                | 3                | 2           | 1                 | 5
-5                | 2                | 3           | 2                 | 6
+3                | 2                | 2           | 1                 | 4
+3                | 3                | 2           | 1                 | 7
+5                | 2                | 3           | 2                 | 7
 
 [consensus protocol]: https://en.wikipedia.org/wiki/Consensus_(computer_science)
 [consistency]: https://en.wikipedia.org/wiki/CAP_theorem

--- a/content/vault/v1.20.x/content/partials/autopilot/redundancy-zones.mdx
+++ b/content/vault/v1.20.x/content/partials/autopilot/redundancy-zones.mdx
@@ -21,5 +21,5 @@ to take the place of voters.
 For example, consider a cluster that is configured to have 3 redundancy zones
 with 2 nodes in each zone. If a voting node becomes unreachable, the zone standby
 in that zone is promoted. The cluster then maintains 3 voting nodes with 2 remaining
-standbys. The cluster can handle an additional 2 gradual failures before it loses
-quorum.
+standbys. The cluster can handle an additional 3 gradual failures before it loses
+quorum (optimistic failure tolerance of 4 including the first failure).

--- a/content/vault/v1.21.x/content/docs/internals/integrated-storage.mdx
+++ b/content/vault/v1.21.x/content/docs/internals/integrated-storage.mdx
@@ -330,9 +330,9 @@ on how many redundancy zones and servers per redundancy zone that you choose.
 Redundancy zones | Servers per zone | Quorum size | Failure tolerance | Optimistic failure tolerance
 :--------------: | :--------------: | :---------: | :---------------: | :--------------------------:
 2                | 2                | 2           | 0                 | 2
-3                | 2                | 2           | 1                 | 3
-3                | 3                | 2           | 1                 | 5
-5                | 2                | 3           | 2                 | 6
+3                | 2                | 2           | 1                 | 4
+3                | 3                | 2           | 1                 | 7
+5                | 2                | 3           | 2                 | 7
 
 [consensus protocol]: https://en.wikipedia.org/wiki/Consensus_(computer_science)
 [consistency]: https://en.wikipedia.org/wiki/CAP_theorem

--- a/content/vault/v1.21.x/content/partials/autopilot/redundancy-zones.mdx
+++ b/content/vault/v1.21.x/content/partials/autopilot/redundancy-zones.mdx
@@ -21,5 +21,5 @@ to take the place of voters.
 For example, consider a cluster that is configured to have 3 redundancy zones
 with 2 nodes in each zone. If a voting node becomes unreachable, the zone standby
 in that zone is promoted. The cluster then maintains 3 voting nodes with 2 remaining
-standbys. The cluster can handle an additional 2 gradual failures before it loses
-quorum.
+standbys. The cluster can handle an additional 3 gradual failures before it loses
+quorum (optimistic failure tolerance of 4 including the first failure).

--- a/content/vault/v2.x/content/docs/internals/integrated-storage.mdx
+++ b/content/vault/v2.x/content/docs/internals/integrated-storage.mdx
@@ -330,9 +330,9 @@ on how many redundancy zones and servers per redundancy zone that you choose.
 Redundancy zones | Servers per zone | Quorum size | Failure tolerance | Optimistic failure tolerance
 :--------------: | :--------------: | :---------: | :---------------: | :--------------------------:
 2                | 2                | 2           | 0                 | 2
-3                | 2                | 2           | 1                 | 3
-3                | 3                | 2           | 1                 | 5
-5                | 2                | 3           | 2                 | 6
+3                | 2                | 2           | 1                 | 4
+3                | 3                | 2           | 1                 | 7
+5                | 2                | 3           | 2                 | 7
 
 [consensus protocol]: https://en.wikipedia.org/wiki/Consensus_(computer_science)
 [consistency]: https://en.wikipedia.org/wiki/CAP_theorem

--- a/content/vault/v2.x/content/partials/autopilot/redundancy-zones.mdx
+++ b/content/vault/v2.x/content/partials/autopilot/redundancy-zones.mdx
@@ -21,5 +21,5 @@ to take the place of voters.
 For example, consider a cluster that is configured to have 3 redundancy zones
 with 2 nodes in each zone. If a voting node becomes unreachable, the zone standby
 in that zone is promoted. The cluster then maintains 3 voting nodes with 2 remaining
-standbys. The cluster can handle an additional 2 gradual failures before it loses
-quorum.
+standbys. The cluster can handle an additional 3 gradual failures before it loses
+quorum (optimistic failure tolerance of 4 including the first failure).


### PR DESCRIPTION
The redundancy-zones OFT table and the 3-zone/2-node walkthrough were a bit low (e.g. 3 instead of 4 for 3×2).

Updated the optimistic failure tolerance column and the example prose to match gradual promote-then-fail counting (standbys + voters − quorum). Same numbers as the raft redundancy-zones tutorial.

Fixes #2914