### PR TITLE
docs(cli): document stale saved plan rejection on apply

### DIFF
--- a/content/terraform/v1.13.x/docs/cli/commands/apply.mdx
+++ b/content/terraform/v1.13.x/docs/cli/commands/apply.mdx
@@ -34,6 +34,8 @@ When you pass a [saved plan file](/terraform/cli/commands/plan#out-filename) to 
 
 Use [`terraform show`](/terraform/cli/commands/show) to inspect a saved plan file before applying it.
 
+Terraform checks that the saved plan still matches the current state before applying it. If another operation changed the state after the plan was created (for example another apply bumped the state serial), Terraform refuses to apply the file and returns **Saved plan is stale**. If the plan was created from a different state lineage, Terraform returns **Saved plan does not match the given state**. In either case, create a new plan with `terraform plan -out=...` and apply that file instead.
+
 When using a saved plan, you cannot specify any additional planning modes or options. These options only affect Terraform's decisions about which
 actions to take, and the plan file contains the final results of those
 decisions.

--- a/content/terraform/v1.13.x/docs/cli/commands/plan.mdx
+++ b/content/terraform/v1.13.x/docs/cli/commands/plan.mdx
@@ -340,6 +340,8 @@ The available options are:
   be saved in cleartext in the plan file. You should therefore treat any
   saved plan files as potentially-sensitive artifacts.
 
+  Terraform also records enough state metadata in the plan file to detect if the state changed after planning. `terraform apply` rejects a plan with **Saved plan is stale** (or a lineage mismatch error) so you never apply a plan against a state it was not built for. Generate a fresh plan if that happens.
+
 * `-parallelism=n` - Limit the number of concurrent operations as Terraform
   [walks the graph](/terraform/internals/graph#walking-the-graph). Defaults
   to 10.

--- a/content/terraform/v1.14.x/docs/cli/commands/apply.mdx
+++ b/content/terraform/v1.14.x/docs/cli/commands/apply.mdx
@@ -34,6 +34,8 @@ When you pass a [saved plan file](/terraform/cli/commands/plan#out-filename) to 
 
 Use [`terraform show`](/terraform/cli/commands/show) to inspect a saved plan file before applying it.
 
+Terraform checks that the saved plan still matches the current state before applying it. If another operation changed the state after the plan was created (for example another apply bumped the state serial), Terraform refuses to apply the file and returns **Saved plan is stale**. If the plan was created from a different state lineage, Terraform returns **Saved plan does not match the given state**. In either case, create a new plan with `terraform plan -out=...` and apply that file instead.
+
 When using a saved plan, you cannot specify any additional planning modes or options. These options only affect Terraform's decisions about which
 actions to take, and the plan file contains the final results of those
 decisions.

--- a/content/terraform/v1.14.x/docs/cli/commands/plan.mdx
+++ b/content/terraform/v1.14.x/docs/cli/commands/plan.mdx
@@ -341,6 +341,8 @@ The available options are:
   be saved in cleartext in the plan file. You should therefore treat any
   saved plan files as potentially-sensitive artifacts.
 
+  Terraform also records enough state metadata in the plan file to detect if the state changed after planning. `terraform apply` rejects a plan with **Saved plan is stale** (or a lineage mismatch error) so you never apply a plan against a state it was not built for. Generate a fresh plan if that happens.
+
 * `-parallelism=n` - Limit the number of concurrent operations as Terraform
   [walks the graph](/terraform/internals/graph#walking-the-graph). Defaults
   to 10.

--- a/content/terraform/v1.15.x/docs/cli/commands/apply.mdx
+++ b/content/terraform/v1.15.x/docs/cli/commands/apply.mdx
@@ -34,6 +34,8 @@ When you pass a [saved plan file](/terraform/cli/commands/plan#out-filename) to 
 
 Use [`terraform show`](/terraform/cli/commands/show) to inspect a saved plan file before applying it.
 
+Terraform checks that the saved plan still matches the current state before applying it. If another operation changed the state after the plan was created (for example another apply bumped the state serial), Terraform refuses to apply the file and returns **Saved plan is stale**. If the plan was created from a different state lineage, Terraform returns **Saved plan does not match the given state**. In either case, create a new plan with `terraform plan -out=...` and apply that file instead.
+
 When using a saved plan, you cannot specify any additional planning modes or options. These options only affect Terraform's decisions about which
 actions to take, and the plan file contains the final results of those
 decisions.

--- a/content/terraform/v1.15.x/docs/cli/commands/plan.mdx
+++ b/content/terraform/v1.15.x/docs/cli/commands/plan.mdx
@@ -341,6 +341,8 @@ The available options are:
   be saved in cleartext in the plan file. You should therefore treat any
   saved plan files as potentially-sensitive artifacts.
 
+  Terraform also records enough state metadata in the plan file to detect if the state changed after planning. `terraform apply` rejects a plan with **Saved plan is stale** (or a lineage mismatch error) so you never apply a plan against a state it was not built for. Generate a fresh plan if that happens.
+
 * `-parallelism=n` - Limit the number of concurrent operations as Terraform
   [walks the graph](/terraform/internals/graph#walking-the-graph). Defaults
   to 10.


### PR DESCRIPTION
Saved-plan apply already fails with **Saved plan is stale** / lineage mismatch when state moved on, but the CLI pages didn't say that.

Added a short note on `apply` (and a matching line under `plan -out`) so people know to re-plan instead of retrying the same file.

Fixes #2827