### PR TITLE
Docs updated with Kube KMS API related changes

### DIFF
--- a/content/vault/v2.x/content/docs/deploy/kubernetes/kms/best-practices.mdx
+++ b/content/vault/v2.x/content/docs/deploy/kubernetes/kms/best-practices.mdx
@@ -10,8 +10,6 @@ last_modified: 2026-03-20T22:19:15.000Z
 
 # Best practices for Vault Kubernetes Key Management 
 
-{/* TODO: Replace with GA banner once confirmed with docs team — @include '../../../global/partials/alerts/status/ga.mdx' */}
-{/* @include '../../../global/partials/alerts/status/beta.mdx' */}
 
 To use Vault Kubernetes Key Management securely, consider the following best
 practices.

--- a/content/vault/v2.x/content/docs/deploy/kubernetes/kms/best-practices.mdx
+++ b/content/vault/v2.x/content/docs/deploy/kubernetes/kms/best-practices.mdx
@@ -10,7 +10,8 @@ last_modified: 2026-03-20T22:19:15.000Z
 
 # Best practices for Vault Kubernetes Key Management 
 
-@include '../../../global/partials/alerts/status/beta.mdx'
+{/* TODO: Replace with GA banner once confirmed with docs team — @include '../../../global/partials/alerts/status/ga.mdx' */}
+{/* @include '../../../global/partials/alerts/status/beta.mdx' */}
 
 To use Vault Kubernetes Key Management securely, consider the following best
 practices.

--- a/content/vault/v2.x/content/docs/deploy/kubernetes/kms/configuration.mdx
+++ b/content/vault/v2.x/content/docs/deploy/kubernetes/kms/configuration.mdx
@@ -54,7 +54,7 @@ required parameters, the process exits with an error.
   **Environment variable**: `VAULT_KUBE_KMS_VAULT_AUTH_NAMESPACE`
 
 
-`--vault-key-path` (`string: <required>`)  
+- `--vault-key-path` (`string: <required>`)
   Path to the Transit encryption key in Vault, in the format
   `<mount>/keys/<key-name>` (for example, `transit/keys/my-key`). The
   `vault-kube-kms` process uses this single path to craft encrypt and decrypt
@@ -156,7 +156,7 @@ You must include the following parameters for AppRole authentication:
       `vault-kube-kms` process is alive and the HTTP server is responding.
       This endpoint does not check Vault connectivity or gRPC socket status.
     - `/readyz` — readiness probe; returns `200 OK` only when the gRPC KMS
-      server has fully initialised and is actively serving requests. Returns
+      server has fully initialized and is actively serving requests. Returns
       `500` with the message `"plugin is not ready"` before the gRPC server
       starts, and again if the gRPC server stops for any reason (including
       a Unix socket failure), until the process is restarted.
@@ -164,7 +164,8 @@ You must include the following parameters for AppRole authentication:
   Set to `0` or a negative value to disable health check endpoints.
   **Environment variable**: `VAULT_KUBE_KMS_HEALTH_PORT`
 
-<Note title="systemd deployments">
+
+## systemd configuration
 
 When deploying as a systemd service on bare-metal nodes, set configuration
 via environment variables in `/etc/vault-kube-kms/vault-kube-kms.env` instead
@@ -172,22 +173,6 @@ of CLI flags. Every parameter listed above has a corresponding environment
 variable shown under **Environment variable**. See
 [Set up Vault Kubernetes Key Management](/vault/docs/deploy/kubernetes/kms/setup#systemd-deployment-bare-metal)
 for the full installation steps.
-
-When running as a standalone binary (not managed by a systemd unit), the
-`vault-kube-kms` process automatically writes log entries directly to the
-systemd journal socket. No additional configuration is required. Logs are
-queryable via:
-
-```shell-session
-$ journalctl -t vault-kube-kms
-```
-
-When systemd manages the process as a service unit, it sets the
-`$JOURNAL_STREAM` environment variable and connects stdout directly to
-journald — no extra wiring is applied. On hosts without systemd (for example
-macOS or vanilla Docker containers), journal writing is skipped automatically.
-
-</Note>
 
 ## Minimal configuration example
 
@@ -224,7 +209,7 @@ data:
   vault-namespace:        "transit-ns"
   vault-auth-namespace:   "auth-ns"
   vault-key-path:         "transit/keys/kubernetes-etcd"
-  auth-method:            "approle"
+  auth-mount:             "approle"
   approle-role-id:        "example-role-id"
   approle-secret-id-path: "/var/run/secrets/vault/secret-id"
 ```

--- a/content/vault/v2.x/content/docs/deploy/kubernetes/kms/configuration.mdx
+++ b/content/vault/v2.x/content/docs/deploy/kubernetes/kms/configuration.mdx
@@ -22,11 +22,15 @@ required parameters, the process exits with an error.
 
 ## Connection parameters
 
-- `--listen-address` (`string : "unix:///tmp/vault-kube-kms.socket"`)  
+- `--listen-address` (`string : "unix:///tmp/vault-kube-kms.socket"`)
   Unix domain socket address where the `vault-kube-kms` process listens for requests from
   the Kubernetes API server. The `kube-apiserver` process must have filesystem
-  access to the socket to communicate with the `vault-kube-kms` process.  
-  **Environment variable**: `VAULT_KUBE_KMS_LISTEN_ADDRESS`  
+  access to the socket to communicate with the `vault-kube-kms` process.
+  **This value must exactly match the `endpoint:` field in your `EncryptionConfiguration`.**
+  The binary default (`unix:///tmp/vault-kube-kms.socket`) differs from the paths used in
+  the setup examples — always set this explicitly and update `EncryptionConfiguration` to
+  agree, or the Kubernetes API server will not start.
+  **Environment variable**: `VAULT_KUBE_KMS_LISTEN_ADDRESS`
 
 
 - `--vault-address` (`string : <required>`)  

--- a/content/vault/v2.x/content/docs/deploy/kubernetes/kms/configuration.mdx
+++ b/content/vault/v2.x/content/docs/deploy/kubernetes/kms/configuration.mdx
@@ -10,7 +10,8 @@ last_modified: 2026-03-20T22:19:18.000Z
 
 # Vault Kubernetes Key Management parameters
 
-@include '../../../global/partials/alerts/status/beta.mdx'
+{/* TODO: Replace with GA banner once confirmed with docs team — @include '../../../global/partials/alerts/status/ga.mdx' */}
+{/* @include '../../../global/partials/alerts/status/beta.mdx' */}
 
 Configure the `vault-kube-kms` process to control how it exposes the KMS
 v2 gRPC endpoint to Kubernetes, connects to Vault, authenticates, selects a
@@ -38,27 +39,32 @@ required parameters, the process exits with an error.
 
 
 - `--vault-namespace` (`string : ""`)  
-  Vault namespace where you have the Transit plugin mounted. Leave
-  `vault-namespace` unset if you have the plugin mounted in the root namespace.
-  If you use namespaces with your Vault deployment, you must provide the plugin
-  namespace with `vault-namespace` rather than including it in the mount path.  
+  Vault namespace where the Transit secrets engine is mounted. Leave
+  `vault-namespace` unset if the Transit engine is in the root namespace.
+  When `--vault-auth-namespace` is not set, `vault-namespace` is also used
+  as the namespace for AppRole authentication.
   **Environment variable**: `VAULT_KUBE_KMS_VAULT_NAMESPACE`
 
 
-- `--transit-mount` (`string: "transit"`)  
-  Mount path to the Vault Transit plugin. The `vault-kube-kms` process uses
-  `transit-mount` to craft Vault requests to encrypt and decrypt data encryption
-  keys (DEKs).  
-  **Environment variable**: `VAULT_KUBE_KMS_TRANSIT_MOUNT`
+- `--vault-auth-namespace` (`string : ""`)
+  Vault namespace used exclusively for AppRole authentication. When set,
+  the `vault-kube-kms` process authenticates in this namespace and performs
+  Transit operations in the namespace specified by `--vault-namespace`. Leave
+  unset when the AppRole mount and the Transit engine share the same namespace
+  (the common case). Use this flag only when Vault is configured for
+  [cross-namespace access](https://developer.hashicorp.com/vault/docs/enterprise/namespaces/configure-cross-namespace-access).
+  **Environment variable**: `VAULT_KUBE_KMS_VAULT_AUTH_NAMESPACE`
 
 
-- `--transit-key` (`string: <required>`)
-  Name of an existing key in the Transit plugin that the `vault-kube-kms`
-  process should use for crafting requests to Vault during DEK encryption
-  and decryption. You must have a Vault policy configured that grants
-  the `vault-kube-kms` process permission to access the named key.
-  **Environment variable**: `VAULT_KUBE_KMS_TRANSIT_KEY`
-
+`--vault-key-path` (`string: <required>`)  
+  Path to the Transit encryption key in Vault, in the format
+  `<mount>/keys/<key-name>` (for example, `transit/keys/my-key`). The
+  `vault-kube-kms` process uses this single path to craft encrypt and decrypt
+  requests for data encryption keys (DEKs). You must have a Vault policy that
+  grants the `vault-kube-kms` process permission to read, encrypt, and decrypt
+  the named key. The path is validated at startup to prevent path traversal
+  attacks.  
+  **Environment variable**: `VAULT_KUBE_KMS_VAULT_KEY_PATH`
 
 - `--tls-ca-file` (`string: ""`)  
   Path to a CA certificate file that the `vault-kube-kms` process can 
@@ -96,6 +102,8 @@ You must include the following parameters for AppRole authentication:
 - `--auth-mount` (`string: "approle"`)
   Mount path to the Vault auth method plugin that the `vault-kube-kms`
   process uses to authenticate to Vault. Required.
+  When using cross-namespace auth,
+  this mount is looked up in the namespace specified by `--vault-auth-namespace`.
   **Environment variable**: `VAULT_KUBE_KMS_AUTH_MOUNT`
 
 
@@ -141,7 +149,47 @@ You must include the following parameters for AppRole authentication:
   statistics, goroutine counts, and memory usage are exposed.
   **Environment variable**: `VAULT_KUBE_KMS_DISABLE_RUNTIME_METRICS`
 
+- `--health-port` (`int: 8081`)
+  TCP port on all interfaces (`0.0.0.0`) where the `vault-kube-kms` process
+  exposes HTTP health check endpoints for use as Kubernetes liveness and
+  readiness probes:
 
+    - `/healthz` — liveness probe; always returns `200 OK` as long as the
+      `vault-kube-kms` process is alive and the HTTP server is responding.
+      This endpoint does not check Vault connectivity or gRPC socket status.
+    - `/readyz` — readiness probe; returns `200 OK` only when the gRPC KMS
+      server has fully initialised and is actively serving requests. Returns
+      `500` with the message `"plugin is not ready"` before the gRPC server
+      starts, and again if the gRPC server stops for any reason (including
+      a Unix socket failure), until the process is restarted.
+
+  Set to `0` or a negative value to disable health check endpoints.
+  **Environment variable**: `VAULT_KUBE_KMS_HEALTH_PORT`
+
+<Note title="systemd deployments">
+
+When deploying as a systemd service on bare-metal nodes, set configuration
+via environment variables in `/etc/vault-kube-kms/vault-kube-kms.env` instead
+of CLI flags. Every parameter listed above has a corresponding environment
+variable shown under **Environment variable**. See
+[Set up Vault Kubernetes Key Management](/vault/docs/deploy/kubernetes/kms/setup#systemd-deployment-bare-metal)
+for the full installation steps.
+
+When running as a standalone binary (not managed by a systemd unit), the
+`vault-kube-kms` process automatically writes log entries directly to the
+systemd journal socket. No additional configuration is required. Logs are
+queryable via:
+
+```shell-session
+$ journalctl -t vault-kube-kms
+```
+
+When systemd manages the process as a service unit, it sets the
+`$JOURNAL_STREAM` environment variable and connects stdout directly to
+journald — no extra wiring is applied. On hosts without systemd (for example
+macOS or vanilla Docker containers), journal writing is skipped automatically.
+
+</Note>
 
 ## Minimal configuration example
 
@@ -155,8 +203,36 @@ metadata:
 data:
   listen-address:         "/var/run/kms/vault-kms.sock"
   vault-address:          "https://vault.example.com:8200"
-  transit-mount:          "transit"
-  transit-key:            "kubernetes-etcd"
+  vault-key-path:         "transit/keys/kubernetes-etcd"
   approle-role-id:        "example-role-id"
   approle-secret-id-path: "/var/run/secrets/vault/secret-id"
 ```
+
+## Cross-namespace configuration example
+
+Use this configuration when AppRole authentication lives in a different Vault
+namespace from the Transit secrets engine. This requires Vault Enterprise with
+[cross-namespace access](https://developer.hashicorp.com/vault/docs/enterprise/namespaces/configure-cross-namespace-access)
+configured.
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vault-kms-config
+data:
+  listen-address:         "/var/run/kms/vault-kms.sock"
+  vault-address:          "https://vault.example.com:8200"
+  vault-namespace:        "transit-ns"
+  vault-auth-namespace:   "auth-ns"
+  vault-key-path:         "transit/keys/kubernetes-etcd"
+  auth-method:            "approle"
+  approle-role-id:        "example-role-id"
+  approle-secret-id-path: "/var/run/secrets/vault/secret-id"
+```
+
+In this example:
+- `vault-namespace` (`transit-ns`) is the Vault namespace where the Transit engine is mounted.
+- `vault-auth-namespace` (`auth-ns`) is the Vault namespace where the AppRole auth method is mounted.
+
+When `vault-auth-namespace` is omitted, both operations use the namespace set by `vault-namespace`.

--- a/content/vault/v2.x/content/docs/deploy/kubernetes/kms/configuration.mdx
+++ b/content/vault/v2.x/content/docs/deploy/kubernetes/kms/configuration.mdx
@@ -10,8 +10,6 @@ last_modified: 2026-03-20T22:19:18.000Z
 
 # Vault Kubernetes Key Management parameters
 
-{/* TODO: Replace with GA banner once confirmed with docs team — @include '../../../global/partials/alerts/status/ga.mdx' */}
-{/* @include '../../../global/partials/alerts/status/beta.mdx' */}
 
 Configure the `vault-kube-kms` process to control how it exposes the KMS
 v2 gRPC endpoint to Kubernetes, connects to Vault, authenticates, selects a

--- a/content/vault/v2.x/content/docs/deploy/kubernetes/kms/index.mdx
+++ b/content/vault/v2.x/content/docs/deploy/kubernetes/kms/index.mdx
@@ -10,8 +10,6 @@ last_modified: 2026-03-20T22:19:20.000Z
 
 # Use Vault as a Kubernetes KMS provider
 
-{/* TODO: Replace with GA banner once confirmed with docs team — @include '../../../global/partials/alerts/status/ga.mdx' */}
-{/* @include '../../../global/partials/alerts/status/beta.mdx' */}
 
 @include '../../../global/partials/alerts/ent/ent-only.mdx'
 

--- a/content/vault/v2.x/content/docs/deploy/kubernetes/kms/index.mdx
+++ b/content/vault/v2.x/content/docs/deploy/kubernetes/kms/index.mdx
@@ -10,7 +10,8 @@ last_modified: 2026-03-20T22:19:20.000Z
 
 # Use Vault as a Kubernetes KMS provider
 
-@include '../../../global/partials/alerts/status/beta.mdx'
+{/* TODO: Replace with GA banner once confirmed with docs team — @include '../../../global/partials/alerts/status/ga.mdx' */}
+{/* @include '../../../global/partials/alerts/status/beta.mdx' */}
 
 @include '../../../global/partials/alerts/ent/ent-only.mdx'
 

--- a/content/vault/v2.x/content/docs/deploy/kubernetes/kms/rotate-kek.mdx
+++ b/content/vault/v2.x/content/docs/deploy/kubernetes/kms/rotate-kek.mdx
@@ -11,8 +11,6 @@ last_modified: 2026-03-20T22:19:21.000Z
 
 # Rotate the key encryption key
 
-{/* TODO: Replace with GA banner once confirmed with docs team — @include '../../../global/partials/alerts/status/ga.mdx' */}
-{/* @include '../../../global/partials/alerts/status/beta.mdx' */}
 
 You can rotate the KEK in Vault without restarting the `vault-kube-kms` process or the
 Kubernetes API server. During the rotation process, the `vault-kube-kms` process emits

--- a/content/vault/v2.x/content/docs/deploy/kubernetes/kms/rotate-kek.mdx
+++ b/content/vault/v2.x/content/docs/deploy/kubernetes/kms/rotate-kek.mdx
@@ -48,13 +48,13 @@ Vault creates a new version of the key while retaining previous versions for
 decryption. Once you rotate the key in Vault:
 
 1. The `vault-kube-kms` process automatically detects the new Transit key version.
-1. Within a few minutes of rotation, the `vault-kube-kms` process updates the active key
+2. Within a few minutes of rotation, the `vault-kube-kms` process updates the active key
    version used for encryption.
-1. The Kubernetes API server encrypts the new DEK using the latest key version.
+3. The Kubernetes API server encrypts the new DEK using the latest key version.
    Refer to the Kubernetes doc,
    [Understanding key_id and Key Rotation][k8s_rotation]
    for more details on the timing.
-1. Existing encrypted DEKs remain decryptable using older key versions.
+4. Existing encrypted DEKs remain decryptable using older key versions.
 
 
 [k8s_rotation]: https://kubernetes.io/docs/tasks/administer-cluster/kms-provider/#developing-a-kms-plugin-gRPC-server-notes-kms-v2

--- a/content/vault/v2.x/content/docs/deploy/kubernetes/kms/rotate-kek.mdx
+++ b/content/vault/v2.x/content/docs/deploy/kubernetes/kms/rotate-kek.mdx
@@ -11,7 +11,8 @@ last_modified: 2026-03-20T22:19:21.000Z
 
 # Rotate the key encryption key
 
-@include '../../../global/partials/alerts/status/beta.mdx'
+{/* TODO: Replace with GA banner once confirmed with docs team — @include '../../../global/partials/alerts/status/ga.mdx' */}
+{/* @include '../../../global/partials/alerts/status/beta.mdx' */}
 
 You can rotate the KEK in Vault without restarting the `vault-kube-kms` process or the
 Kubernetes API server. During the rotation process, the `vault-kube-kms` process emits

--- a/content/vault/v2.x/content/docs/deploy/kubernetes/kms/security.mdx
+++ b/content/vault/v2.x/content/docs/deploy/kubernetes/kms/security.mdx
@@ -11,7 +11,8 @@ last_modified: 2026-03-20T22:19:22.000Z
 
 # Security model for Vault Kubernetes Key Management
 
-@include '../../../global/partials/alerts/status/beta.mdx'
+{/* TODO: Replace with GA banner once confirmed with docs team — @include '../../../global/partials/alerts/status/ga.mdx' */}
+{/* @include '../../../global/partials/alerts/status/beta.mdx' */}
 
 The Kubernetes KMS plugin uses the Vault Transit secrets engine plugin as an
 external KEK provider for envelope encryption. Envelope encryption is a

--- a/content/vault/v2.x/content/docs/deploy/kubernetes/kms/security.mdx
+++ b/content/vault/v2.x/content/docs/deploy/kubernetes/kms/security.mdx
@@ -63,14 +63,14 @@ Before startup:
 1. The Vault administrator uses the Transit plugin to create the KEK as a named
    encryption key in Vault and limits access with a Vault policy.
 
-1. The Vault administrator ties authentication (AppRole) to the policy and
+2. The Vault administrator ties authentication (AppRole) to the policy and
    provides the associated appRole ID and secret ID to the Kubernetes
    administrator.
    - **The role ID** is a non-sensitive identifier that you can configure with a
      flag or environment variable.
    - **The secret ID** is a sensitive credential stored on the Kubernetes control plane node and read by the `vault-kube-kms` process from a filesystem path.
 
-1. The Kubernetes administrator uses the Vault server address, appRole ID, and
+3. The Kubernetes administrator uses the Vault server address, appRole ID, and
    secret ID to configure the `vault-kube-kms` process.
 
 On startup:
@@ -79,25 +79,25 @@ On startup:
    Vault, automatically renew authentication tokens, and handles
    re-authentication if the token expires.
 
-1. The Kubernetes API server generates a single DEK seed and uses the client to
+2. The Kubernetes API server generates a single DEK seed and uses the client to
    request encryption from the `vault-kube-kms` process.
 
-1. The Vault client connects to the Vault server over TLS and authenticates
+3. The Vault client connects to the Vault server over TLS and authenticates
    using the AppRole authentication details provided by the Kubernetes administrator.
 
-1. Once authenticated, the `vault-kube-kms` process sends the seed to the Transit plugin
+4. Once authenticated, the `vault-kube-kms` process sends the seed to the Transit plugin
    for encryption. **The KEK never leaves Vault and all cryptographic operations
    involving the KEK happen within the Transit plugin**.
 
-1. The Transit plugin returns the encrypted seed to the `vault-kube-kms` process.
+5. The Transit plugin returns the encrypted seed to the `vault-kube-kms` process.
 
-1. The `vault-kube-kms` process reports the encrypted seed to the Kubernetes
+6. The `vault-kube-kms` process reports the encrypted seed to the Kubernetes
    API server along with health status and the current KEK version.
 
-1. The Kubernetes API server derives unique, single-use DEKs from the seed using
+7. The Kubernetes API server derives unique, single-use DEKs from the seed using
    random data and an HMAC-based key derivation function (HKDF).
 
-1. The Kubernetes API server stores the data encryption keys alongside the
+8. The Kubernetes API server stores the data encryption keys alongside the
    encrypted data in `etcd`. **Vault does not store the data or the seed**.
 
 

--- a/content/vault/v2.x/content/docs/deploy/kubernetes/kms/security.mdx
+++ b/content/vault/v2.x/content/docs/deploy/kubernetes/kms/security.mdx
@@ -11,8 +11,6 @@ last_modified: 2026-03-20T22:19:22.000Z
 
 # Security model for Vault Kubernetes Key Management
 
-{/* TODO: Replace with GA banner once confirmed with docs team — @include '../../../global/partials/alerts/status/ga.mdx' */}
-{/* @include '../../../global/partials/alerts/status/beta.mdx' */}
 
 The Kubernetes KMS plugin uses the Vault Transit secrets engine plugin as an
 external KEK provider for envelope encryption. Envelope encryption is a

--- a/content/vault/v2.x/content/docs/deploy/kubernetes/kms/setup.mdx
+++ b/content/vault/v2.x/content/docs/deploy/kubernetes/kms/setup.mdx
@@ -35,7 +35,7 @@ for use with Vault Kubernetes Key Management.
 
 ## Step 1: Configure the Transit plugin 
 
-1. Enable the Transit secret engine. For example, to enable the plugin at the 
+1. Enable the Transit secret engine. For example, to enable the plugin at the
    path `k8s-transit`:
 
   ```shell-session
@@ -44,7 +44,7 @@ for use with Vault Kubernetes Key Management.
   Success! Enabled the transit secrets engine at: k8s-transit/
   ```
 
-1. Create a named encryption key. For example, to create a key called `kms-kek`:
+2. Create a named encryption key. For example, to create a key called `kms-kek`:
 
   ```shell-session
   $ vault write -f k8s-transit/keys/kms-kek
@@ -70,7 +70,7 @@ for use with Vault Kubernetes Key Management.
     type                      aes256-gcm96
   ```
 
-1. Create an access policy file, `kms-policy.hcl` to control access to the
+3. Create an access policy file, `kms-policy.hcl` to control access to the
    encryption key stored by the Transit plugin. For example to create a basic
    policy with the minimum required permissions:
 
@@ -92,7 +92,7 @@ for use with Vault Kubernetes Key Management.
   }
   ```
 
-1. Save the policy to Vault. For example, to save the policy as
+4. Save the policy to Vault. For example, to save the policy as
    `k8s-kms-policy`:
 
   ```shell-session
@@ -129,7 +129,7 @@ for use with Vault Kubernetes Key Management.
   Success! Enabled the approle auth method at: k8s-approle/
   ```
 
-1. Create a named role for authentication that uses your Transit access policy.
+2. Create a named role for authentication that uses your Transit access policy.
    For example, to create a new role called `k8s-kms-role`:
 
   ```shell-session
@@ -140,7 +140,7 @@ for use with Vault Kubernetes Key Management.
   Success! Data written to: auth/k8s-approle/role/k8s-kms-role
   ```
 
-1. Generate a secret ID for the new role for later use when configuring the
+3. Generate a secret ID for the new role for later use when configuring the
    Vault Kubernetes Key Management static Pod:
 
   ```shell-session
@@ -154,7 +154,7 @@ for use with Vault Kubernetes Key Management.
     secret_id_ttl         0s
   ```
 
-1. Fetch the role ID associated with the role for later use when configuring the
+4. Fetch the role ID associated with the role for later use when configuring the
    Vault Kubernetes Key Management static Pod:
 
     ```shell-session
@@ -170,10 +170,10 @@ for use with Vault Kubernetes Key Management.
 
 The Vault Kubernetes Key Management process, `vault-kube-kms`, communicates with the kube-apiserver process over a Unix
 socket. As a
-result, `vault-kube-kms` must run on the control plane node . Choose the deployment model
+result, `vault-kube-kms` must run on the control plane node. Choose the deployment model
 that matches your environment:
-[static Pod](https://kubernetes.io/docs/tasks/configure-pod-container/static-pod/).
-[systemd service](#systemd-deployment-bare-metal)
+- [Static Pod](https://kubernetes.io/docs/tasks/configure-pod-container/static-pod/) — for nodes with a container runtime (most clusters).
+- [systemd service](#systemd-deployment-bare-metal) — for bare-metal or VM nodes without a container runtime.
 
 1. Create an EncryptionConfiguration file, `encryption-config.yaml` for your
    nodes. Make sure `endpoint` matches the path where the `vault-kube-kms`
@@ -195,15 +195,15 @@ resources:
 
   ```
 
-1. Save the EncryptionConfiguration file on each control-plane node. Make sure
+2. Save the EncryptionConfiguration file on each control-plane node. Make sure
    to use a path that exists on every control-plane node. We recommend using a
    path like `/etc/kubernetes/encryption/encryption-config.yaml`.
 
-1. Copy the AppRole secret ID from your Transit plugin to each control plane
+3. Copy the AppRole secret ID from your Transit plugin to each control plane
    node at `/etc/vault-kms/approle-secret-id`.
 
-1. Create a manifest file, `vault-kms-plugin.yaml`, for the `vault-kube-kms`
-   process. For example: 
+4. Create a manifest file, `vault-kms-plugin.yaml`, for the `vault-kube-kms`
+   process. For example:
 
   <CodeBlockConfig highlight="13,16-22">
 
@@ -238,14 +238,14 @@ resources:
           # - --vault-auth-namespace=<auth_namespace>
           livenessProbe:
             httpGet:
-             path: /healthz
-             port: 8081
+              path: /healthz
+              port: 8081
             initialDelaySeconds: 5
             periodSeconds: 10
           readinessProbe:
             httpGet:
-             path: /readyz
-             port: 8081
+              path: /readyz
+              port: 8081
             initialDelaySeconds: 5
             periodSeconds: 10
         volumeMounts:
@@ -276,7 +276,7 @@ resources:
   
   </CodeBlockConfig>
 
-1. Save your manifest file to `/etc/kubernetes/manifests/` on the control-plane
+5. Save your manifest file to `/etc/kubernetes/manifests/` on the control-plane
    node where you run your Kubernetes API server. If you run multiple API
    servers, you must deploy the `vault-kube-kms` process on each control-plane node, so
    each Kubernetes API server instance can dial its own local Unix socket.
@@ -302,14 +302,14 @@ The unit file (`vault-kube-kms.service`) and environment template
   $ install -m 0755 vault-kube-kms /usr/local/bin/vault-kube-kms
   ```
 
-1. Install the systemd unit file:
+2. Install the systemd unit file:
 
   ```shell-session
   $ install -m 0444 vault-kube-kms.service \
       /etc/systemd/system/vault-kube-kms.service
   ```
 
-1. Create the configuration directory and install the environment file:
+3. Create the configuration directory and install the environment file:
 
   ```shell-session
   $ mkdir -p /etc/vault-kube-kms
@@ -317,7 +317,7 @@ The unit file (`vault-kube-kms.service`) and environment template
       /etc/vault-kube-kms/vault-kube-kms.env
   ```
 
-1. Edit `/etc/vault-kube-kms/vault-kube-kms.env` and set the required values:
+4. Edit `/etc/vault-kube-kms/vault-kube-kms.env` and set the required values:
 
   ```shell-session
   VAULT_KUBE_KMS_VAULT_ADDRESS=https://vault.example.com:8200
@@ -327,14 +327,14 @@ The unit file (`vault-kube-kms.service`) and environment template
   VAULT_KUBE_KMS_LISTEN_ADDRESS=unix:///run/vault-kube-kms/vault-kube-kms.sock
   ```
 
-1. Copy the AppRole secret ID from Step 2 to the node:
+5. Copy the AppRole secret ID from Step 2 to the node:
 
   ```shell-session
   $ install -m 0600 approle-secret-id \
       /etc/vault-kube-kms/approle-secret-id
   ```
 
-1. Enable and start the service:
+6. Enable and start the service:
 
   ```shell-session
   $ systemctl daemon-reload
@@ -363,7 +363,7 @@ each control-plane to enable encryption at rest.
    encryption configuration file at
    `/etc/kubernetes/encryption/encryption-config.yaml`.
 
-1. Update the manifest with a named volume linked to the
+2. Update the manifest with a named volume linked to the
    `encryption-config.yaml` file. For example:
 
   ```yaml
@@ -374,7 +374,7 @@ volumes:
       type: File
   ```
 
-1. Update the `volumeMounts` stanza in the manifest to mount the
+3. Update the `volumeMounts` stanza in the manifest to mount the
    `encryption-config.yaml` file:
 
   ```yaml
@@ -384,7 +384,7 @@ volumeMounts:
     readOnly: true
   ```
 
-1. Update the `kube-apiserver` command to add `--encryption-provider-config` and set it to your
+4. Update the `kube-apiserver` command to add `--encryption-provider-config` and set it to your
    `encryption-config.yaml` file. For example:
 
   ```yaml
@@ -394,4 +394,4 @@ volumeMounts:
     ...
   ```
 
-1. Save the manifest so the kubelet restarts the `kube-apiserver` static Pod.
+5. Save the manifest so the kubelet restarts the `kube-apiserver` static Pod.

--- a/content/vault/v2.x/content/docs/deploy/kubernetes/kms/setup.mdx
+++ b/content/vault/v2.x/content/docs/deploy/kubernetes/kms/setup.mdx
@@ -11,7 +11,8 @@ last_modified: 2026-06-15T21:26:18.000Z
 
 # Set up Vault Kubernetes Key Management
 
-@include '../../../global/partials/alerts/status/beta.mdx'
+{/* TODO: Replace with GA banner once confirmed with docs team — @include '../../../global/partials/alerts/status/ga.mdx' */}
+{/* @include '../../../global/partials/alerts/status/beta.mdx' */}
 
 @include '../../../global/partials/alerts/ent/ent-only.mdx'
 
@@ -110,6 +111,18 @@ for use with Vault Kubernetes Key Management.
 
 </Note>
 
+<Note title="Cross-namespace authentication (Vault Enterprise)">
+
+  If your AppRole auth method and Transit secrets engine are in different Vault
+  namespaces, configure [cross-namespace access](https://developer.hashicorp.com/vault/docs/enterprise/namespaces/configure-cross-namespace-access)
+  on the Vault server and then set the `--vault-auth-namespace` flag (or
+  `VAULT_KUBE_KMS_VAULT_AUTH_NAMESPACE` environment variable)
+  to the namespace containing the AppRole mount. Set `--vault-namespace` to the
+  namespace containing the Transit engine. When `--vault-auth-namespace` is omitted,
+  both operations use the namespace set by `--vault-namespace`.
+
+</Note>
+
 1. Enable the AppRole plugin:
 
   ```shell-session
@@ -159,8 +172,10 @@ for use with Vault Kubernetes Key Management.
 
 The Vault Kubernetes Key Management process, `vault-kube-kms`, communicates with the kube-apiserver process over a Unix
 socket. As a
-result, `vault-kube-kms` must run on the control plane node as a
+result, `vault-kube-kms` must run on the control plane node . Choose the deployment model
+that matches your environment:
 [static Pod](https://kubernetes.io/docs/tasks/configure-pod-container/static-pod/).
+[systemd service](#systemd-deployment-bare-metal)
 
 1. Create an EncryptionConfiguration file, `encryption-config.yaml` for your
    nodes. Make sure `endpoint` matches the path where the `vault-kube-kms`
@@ -214,9 +229,27 @@ resources:
           - --listen-address=unix:///var/run/kmsplugin/kms.sock
           - --approle-role-id=<approle_id_from_vault>
           - --approle-secret-id-path=/etc/vault-kms/approle-secret-id
-          - --transit-mount=k8s-transit
-          - --transit-key=kms-kek
+          - --vault-key-path=k8s-transit/keys/kms-kek
           - --zap-log-level=info
+          # Optional: set --vault-namespace if your Transit engine is in a
+          # Vault Enterprise namespace.
+          # - --vault-namespace=<transit_namespace>
+          # Optional: set --vault-auth-namespace only when AppRole authentication
+          # lives in a different Vault namespace from the Transit engine
+          # (cross-namespace auth). Omit when both share the same namespace.
+          # - --vault-auth-namespace=<auth_namespace>
+          livenessProbe:
+            httpGet:
+             path: /healthz
+             port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+             path: /readyz
+             port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
         volumeMounts:
           - name: kmsplugin-sockdir
             mountPath: /var/run/kmsplugin
@@ -253,7 +286,75 @@ resources:
 The kubelet process should find your manifest file and start `vault-kube-kms` as
 a static Pod automatically.
 
+### systemd deployment (bare-metal)
 
+Use this model for bare-metal or VM control-plane nodes that do not have a
+container runtime. The plugin binary runs as a native systemd service. systemd
+manages the process lifecycle — it starts the plugin before `kube-apiserver`,
+restarts it automatically on failure, and creates the Unix socket directory via
+`RuntimeDirectory=`.
+
+The unit file (`vault-kube-kms.service`) and environment template
+(`vault-kube-kms.env`) are included in the release archive under
+`config/systemd/`.
+
+1. Install the plugin binary on the control-plane node:
+
+  ```shell-session
+  $ install -m 0755 vault-kube-kms /usr/local/bin/vault-kube-kms
+  ```
+
+1. Install the systemd unit file:
+
+  ```shell-session
+  $ install -m 0444 vault-kube-kms.service \
+      /etc/systemd/system/vault-kube-kms.service
+  ```
+
+1. Create the configuration directory and install the environment file:
+
+  ```shell-session
+  $ mkdir -p /etc/vault-kube-kms
+  $ install -m 0600 vault-kube-kms.env \
+      /etc/vault-kube-kms/vault-kube-kms.env
+  ```
+
+1. Edit `/etc/vault-kube-kms/vault-kube-kms.env` and set the required values:
+
+  ```shell-session
+  VAULT_KUBE_KMS_VAULT_ADDRESS=https://vault.example.com:8200
+  VAULT_KUBE_KMS_VAULT_KEY_PATH=k8s-transit/keys/kms-kek
+  VAULT_KUBE_KMS_APPROLE_ROLE_ID=<role-id-from-step-2>
+  VAULT_KUBE_KMS_APPROLE_SECRET_ID_PATH=/etc/vault-kube-kms/approle-secret-id
+  VAULT_KUBE_KMS_LISTEN_ADDRESS=unix:///run/vault-kube-kms/vault-kube-kms.sock
+  ```
+
+1. Copy the AppRole secret ID from Step 2 to the node:
+
+  ```shell-session
+  $ install -m 0600 approle-secret-id \
+      /etc/vault-kube-kms/approle-secret-id
+  ```
+
+1. Enable and start the service:
+
+  ```shell-session
+  $ systemctl daemon-reload
+  $ systemctl enable --now vault-kube-kms
+  $ systemctl status vault-kube-kms
+  ```
+
+  The service must show `active (running)` before you proceed to Step 4.
+
+<Warning>
+
+`VAULT_KUBE_KMS_LISTEN_ADDRESS` in `vault-kube-kms.env` **must match** the
+`endpoint:` value in your `EncryptionConfiguration`. The systemd unit creates
+`/run/vault-kube-kms/` automatically via `RuntimeDirectory=` — no manual
+`mkdir` is needed. Update both files to agree on the same socket path before
+enabling encryption in Step 4.
+
+</Warning>
 
 ## Step 4: Enable encryption at rest
 

--- a/content/vault/v2.x/content/docs/deploy/kubernetes/kms/setup.mdx
+++ b/content/vault/v2.x/content/docs/deploy/kubernetes/kms/setup.mdx
@@ -11,8 +11,6 @@ last_modified: 2026-06-15T21:26:18.000Z
 
 # Set up Vault Kubernetes Key Management
 
-{/* TODO: Replace with GA banner once confirmed with docs team — @include '../../../global/partials/alerts/status/ga.mdx' */}
-{/* @include '../../../global/partials/alerts/status/beta.mdx' */}
 
 @include '../../../global/partials/alerts/ent/ent-only.mdx'
 

--- a/content/vault/v2.x/content/docs/deploy/kubernetes/kms/setup.mdx
+++ b/content/vault/v2.x/content/docs/deploy/kubernetes/kms/setup.mdx
@@ -176,8 +176,12 @@ that matches your environment:
 - [systemd service](#systemd-deployment-bare-metal) — for bare-metal or VM nodes without a container runtime.
 
 1. Create an EncryptionConfiguration file, `encryption-config.yaml` for your
-   nodes. Make sure `endpoint` matches the path where the `vault-kube-kms`
-   process creates its Unix socket on the host. For example:
+   nodes. The `endpoint` value **must exactly match** the socket path where the
+   `vault-kube-kms` process listens — set by `--listen-address` (static Pod) or
+   `VAULT_KUBE_KMS_LISTEN_ADDRESS` (systemd). The example below uses the static
+   Pod path; if you use the [systemd deployment](#systemd-deployment-bare-metal),
+   update `endpoint` to match the path in your `vault-kube-kms.env` file. A
+   mismatch prevents the Kubernetes API server from starting.
 
   ```yaml
 apiVersion: apiserver.config.k8s.io/v1

--- a/content/vault/v2.x/content/docs/deploy/kubernetes/kms/telemetry.mdx
+++ b/content/vault/v2.x/content/docs/deploy/kubernetes/kms/telemetry.mdx
@@ -10,7 +10,8 @@ last_modified: 2026-03-20T22:19:26.000Z
 
 # Telemetry
 
-@include '../../../global/partials/alerts/status/beta.mdx'
+{/* TODO: Replace with GA banner once confirmed with docs team — @include '../../../global/partials/alerts/status/ga.mdx' */}
+{/* @include '../../../global/partials/alerts/status/beta.mdx' */}
 
 If you enable metrics, the `vault-kube-kms` process exposes Prometheus-compatible
 metrics on the `/metrics` endpoint. You can configure the endpoint using the

--- a/content/vault/v2.x/content/docs/deploy/kubernetes/kms/telemetry.mdx
+++ b/content/vault/v2.x/content/docs/deploy/kubernetes/kms/telemetry.mdx
@@ -10,8 +10,6 @@ last_modified: 2026-03-20T22:19:26.000Z
 
 # Telemetry
 
-{/* TODO: Replace with GA banner once confirmed with docs team — @include '../../../global/partials/alerts/status/ga.mdx' */}
-{/* @include '../../../global/partials/alerts/status/beta.mdx' */}
 
 If you enable metrics, the `vault-kube-kms` process exposes Prometheus-compatible
 metrics on the `/metrics` endpoint. You can configure the endpoint using the

--- a/content/vault/v2.x/content/docs/deploy/kubernetes/kms/troubleshooting.mdx
+++ b/content/vault/v2.x/content/docs/deploy/kubernetes/kms/troubleshooting.mdx
@@ -85,9 +85,9 @@ Secret ID may have expired.
    $ vault write -f auth/approle/role/<role_name>/secret-id
    ```
 
-1. Copy the new Secret ID to the file on each control plane node.
+2. Copy the new Secret ID to the file on each control plane node.
 
-1. Restart the `vault-kube-kms` process after updating the Secret ID to ensure it reads the updated file.
+3. Restart the `vault-kube-kms` process after updating the Secret ID to ensure it reads the updated file.
 
 ### Vault Enterprise validation failing
 

--- a/content/vault/v2.x/content/docs/deploy/kubernetes/kms/troubleshooting.mdx
+++ b/content/vault/v2.x/content/docs/deploy/kubernetes/kms/troubleshooting.mdx
@@ -12,8 +12,6 @@ last_modified: 2026-03-20T22:19:28.000Z
 
 # Troubleshoot Vault Kubernetes Key Management
 
-{/* TODO: Replace with GA banner once confirmed with docs team — @include '../../../global/partials/alerts/status/ga.mdx' */}
-{/* @include '../../../global/partials/alerts/status/beta.mdx' */}
 
 ## Process cannot access Vault
 

--- a/content/vault/v2.x/content/docs/deploy/kubernetes/kms/troubleshooting.mdx
+++ b/content/vault/v2.x/content/docs/deploy/kubernetes/kms/troubleshooting.mdx
@@ -12,7 +12,8 @@ last_modified: 2026-03-20T22:19:28.000Z
 
 # Troubleshoot Vault Kubernetes Key Management
 
-@include '../../../global/partials/alerts/status/beta.mdx'
+{/* TODO: Replace with GA banner once confirmed with docs team — @include '../../../global/partials/alerts/status/ga.mdx' */}
+{/* @include '../../../global/partials/alerts/status/beta.mdx' */}
 
 ## Process cannot access Vault
 


### PR DESCRIPTION
Update web-unified docs for vault-kube-kms GA preparation
Updated the web-unified documentation pages for Vault Kubernetes Key Management for the following API changes.

1.  --vault-key-path

- Added --vault-key-path (VAULT_KUBE_KMS_VAULT_KEY_PATH) as a required flag replacing the deprecated --transit-mount and --transit-key flags

2. Cross-namespace authentication

- Updated --vault-namespace description — clarified it applies to the Transit engine and is used as the auth namespace fallback

- Added new --vault-auth-namespace (VAULT_KUBE_KMS_VAULT_AUTH_NAMESPACE) flag — enables AppRole authentication in a different Vault namespace from the Transit engine

- Updated --auth-mount description to note the mount is resolved in --vault-auth-namespace when cross-namespace auth is configured

- Added Cross-namespace configuration example section with a full ConfigMap example

3. Health check endpoints

- Added --health-port (VAULT_KUBE_KMS_HEALTH_PORT, default 8081) documenting:

    /healthz — liveness probe; 

    /readyz — readiness probe; 
    

4.     Native journald logger and Systemd service 
      Added  details of journald logging behaviour and systemd service deployment of Plugin
      