### PR TITLE
Nomad: FIPS-140-3 compliant binaries

### DIFF
--- a/content/nomad/v1.10.x/content/docs/enterprise/fips.mdx
+++ b/content/nomad/v1.10.x/content/docs/enterprise/fips.mdx
@@ -7,13 +7,17 @@ description: >-
 
 # Deploy FIPS 140-3 compliant Nomad servers
 
+The [Federal Information Processing Standard][FIPS] is a cryptography-focused
+certification standard for U.S. Government usage.
+
 Builds of Nomad Enterprise marked with a `fips1403` feature name include
-built-in support for FIPS 140-3 compliance.
+built-in support for FIPS 140-3 compliance. Environments that don't have a
+specific need for FIPS-140-3 compliance should not run these variants of Nomad
+Enterprise.
 
 To use this feature, you must have an [active or trial license for Nomad
 Enterprise](/nomad/docs/enterprise/license). To start a trial, contact HashiCorp
-sales. Environments that don't have a specific need for FIPS-140-3 compliance
-should not run these variants of Nomad Enterprise.
+sales.
 
 <EnterpriseAlert product="nomad" />
 
@@ -37,10 +41,9 @@ general guidance about using Nomad Enterprise in a FIPS-compliant manner. We
 recommend consulting an approved auditor for further information.
 
 The FIPS 140-3 variant of Nomad uses separate binaries that are available from
-the following sources:
-
-- The [HashiCorp Releases page](https://releases.hashicorp.com/nomad), releases
-  ending with the `+ent.fips1403` suffix. Only Linux binaries are available.
+the [HashiCorp Releases page](https://releases.hashicorp.com/nomad). Use
+releases ending with the `+ent.fips1403` suffix. Only Linux binaries are
+available.
 
 ### Usage restrictions
 
@@ -92,8 +95,8 @@ binaries:
 
 - The `nomad alloc exec` and `nomad job action` commands, and their related
   APIs, are not available and return an error message.
-- OIDC configuration does not allow the `x5t` key ID header. Only the `x5t#S256`
-  header is allowed.
+- OIDC auth method configuration does not allow the [`x5t` key ID header][x5t]
+  for client assertions. Only the `x5t#S256` header is allowed.
 - The `md5` and `sha1` HCL2 functions return an error if used in a job
   specification.
 - The `md5` and `sha1` checksum functions for `artifact` blocks return an error
@@ -117,7 +120,8 @@ binary or deployment type.
 
 Running a heterogeneous cluster is not permitted by FIPS, as components of the
 system are not compliant with FIPS. Attempts to join non-FIPS and FIPS nodes or
-servers may fail.
+servers may fail. Federation between non-FIPS and FIPS clusters is not supported
+and may fail.
 
 ## Technical details
 
@@ -160,3 +164,6 @@ On both Linux and Windows non-FIPS builds, the search output yields no results.
 ## Certification
 
 Nomad Enterprise FIPS compliance has not yet been independently certified.
+
+[FIPS]: https://www.nist.gov/federal-information-standards-fips
+[x5t]: /nomad/api-docs/acl/auth-methods#keyidheader

--- a/content/nomad/v1.10.x/content/docs/enterprise/fips.mdx
+++ b/content/nomad/v1.10.x/content/docs/enterprise/fips.mdx
@@ -1,0 +1,139 @@
+---
+layout: docs
+page_title: Deploy FIPS 140-3 compliant Nomad servers
+description: >-
+  A version of Nomad compliant with FIPS 140-3 is available to Enterprise users. Learn about where to find FIPS-compliant versions of Nomad, as well as usage restrictions and technical details.
+---
+
+# Deploy FIPS 140-3 compliant Nomad servers
+
+Builds of Nomad Enterprise marked with a `fips1403` feature name include
+built-in support for FIPS 140-3 compliance.
+
+To use this feature, you must have an [active or trial license for Nomad
+Enterprise](/nomad/docs/enterprise/license). To start a trial, contact HashiCorp
+sales. Environments that don't have a specific need for FIPS-140-3 compliance
+should not run these variants of Nomad Enterprise.
+
+<EnterpriseAlert product="nomad" />
+
+## Using FIPS 140-3 Nomad Enterprise
+
+FIPS 140-3 builds of Nomad Enterprise behave in the same way as non-FIPS
+builds. Ensuring that Nomad remains in a FIPS-compliant mode of operation is
+your responsibility. To maintain FIPS-compliant operation, you must [ensure that
+TLS is enabled](/nomad/docs/secure/encryption/tls/enable/new/builtin) so that
+communication is encrypted. Nomad surfaces some helpful error messages where
+settings are insecure.
+
+Transport encryption is disabled in Nomad Enterprise by default. As a result,
+Nomad may transmit sensitive control plane information. You must ensure that
+gossip encryption and mTLS is enabled for all agents when running Nomad with
+FIPS-compliant settings. In addition, be aware that TLSv1.3 does not work with
+FIPS 140-3, as HKDF is not a certified primitive.
+
+HashiCorp is not a NIST-certified testing laboratory and can only provide
+general guidance about using Nomad Enterprise in a FIPS-compliant manner. We
+recommend consulting an approved auditor for further information.
+
+The FIPS 140-3 variant of Nomad uses separate binaries that are available from
+the following sources:
+
+- The [HashiCorp Releases page](https://releases.hashicorp.com/nomad), releases
+  ending with the `+ent.fips1403` suffix. Only Linux binaries are available.
+
+### Usage restrictions
+
+When using Nomad Enterprise with FIPS 140-3, be aware of the following operation
+restrictions.
+
+#### Migration restrictions
+
+We do not support in-place migrations from non-FIPS builds of Nomad to FIPS
+builds of Nomad, regardless of version. A fresh cluster installation is required
+to support FIPS 140-3. You cannot upgrade directly to a FIPS-compliant build.
+
+#### TLS restrictions
+
+Nomad Enterprise's FIPS modifications include restrictions to supported TLS
+cipher suites and key information. Only the following cipher suites are allowed:
+
+- `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`
+- `TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384`
+- `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256`
+- `TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384`
+- `TLS_RSA_WITH_AES_128_GCM_SHA256`
+- `TLS_RSA_WITH_AES_256_GCM_SHA384`
+
+In addition, only the following key types are allowed in TLS chains of trust:
+
+- RSA 2048, 3072, 4096, 7680, and 8192-bit
+- ECDSA P-256, P-384, and P-521
+
+Finally, only TLSv1.2 is supported in FIPS mode. These settings are in line with
+recent NIST guidance and FIPS requirements.
+
+#### Feature restrictions
+
+The following features are not available or work in a modified way on FIPS mode
+binaries.
+
+- The `nomad alloc exec` and `nomad job action` commands, and their related
+  APIs, are not available and return an error message.
+- OIDC configuration does not allow the `x5t` key ID header. Only the `x5t#S256`
+  header is allowed.
+- The `md5` and `sha1` HCL2 functions return an error if used in a job
+  specification.
+
+#### Heterogeneous cluster deployments
+
+We do not support mixed deployment scenarios within the same Nomad cluster. An
+example of an unsupported deployment scenario is one that mixes FIPS and
+non-FIPS Nomad binaries. Nodes across the entire cluster must use a single
+binary or deployment type.
+
+Running a heterogeneous cluster is not permitted by FIPS, as components of the
+system are not compliant with FIPS. Attempts to join non-FIPS and FIPS nodes or
+servers may fail.
+
+## Technical details
+
+Nomad's FIPS 140-3 Linux products use the Go Cryptographic Module version 1.0.0
+in the official Go 1.26+ toolchain, which include a FIPS-validated crypto
+module.
+
+To ensure your build of Nomad Enterprise includes FIPS support, confirm that the
+`version` command includes the string `fips1403`. For example:
+
+<CodeBlockConfig hideClipboard>
+
+```log
+Nomad v2.0.5+ent.fips1403
+```
+
+</CodeBlockConfig>
+
+In addition, the following message appears in the agent's banner on startup.
+
+<CodeBlockConfig hideClipboard>
+
+```log
+Fips Mode: FIPS-140-3 enabled (version: v1.0.0)
+```
+
+</CodeBlockConfig>
+
+### Validating FIPS crypto modules
+
+To validate that a FIPS 140-3 Linux binary is configured correctly to enable the Go Cryptographi Module, run `go version -m` on the binary to get build metadata.
+
+```shell-session
+$ go version -m ./nomad | grep FIPS
+	build	GOFIPS140=v1.0.0-c2097c7c
+```
+
+On both Linux and Windows non-FIPS builds, the search output yields no results.
+
+## Certification
+
+Nomad Enterprise FIPS compliance has not yet been independently certified.

--- a/content/nomad/v1.10.x/content/docs/enterprise/fips.mdx
+++ b/content/nomad/v1.10.x/content/docs/enterprise/fips.mdx
@@ -51,7 +51,21 @@ restrictions.
 
 We do not support in-place migrations from non-FIPS builds of Nomad to FIPS
 builds of Nomad, regardless of version. A fresh cluster installation is required
-to support FIPS 140-3. You cannot upgrade directly to a FIPS-compliant build.
+to receive support.
+
+We generally recommend avoiding direct upgrades and replicated-migrations
+because existing wrapped key material is encrypted with non-FIPS compliant
+cryptographic modules, and all Nomad Variables and Workload Identities have been
+encrypted or signed with this non-compliant key material. Additionally, service
+IDs and other identifiers have been derived from non-compliant hash functions,
+which may lead to workload service interruptions during migration.
+
+As such Hashicorp cannot provide support for workloads that are affected either
+technically or via non-compliance that results from converting existing cluster
+workloads to the FIPS-compliant binary.
+
+Instead, we suggest leaving the existing cluster in place, and carefully
+consider migration of specific workloads to the FIPS cluster.
 
 #### TLS restrictions
 
@@ -84,6 +98,17 @@ binaries.
   header is allowed.
 - The `md5` and `sha1` HCL2 functions return an error if used in a job
   specification.
+- The `md5` and `sha1` checksum functions for `artifact` blocks return an error
+  if used in a job specification.
+- The `md5sum` function will return an error if used in the content of a
+  `template` block.
+
+#### Third-party restrictions
+
+Nomad executes third-party binaries and workloads and communicates with external
+APIs that may not meet FIPS-140-3 compliance requirements, such as git, Docker,
+or a cloud provider. You have responsibility for ensuring that the other
+software in your cluster is compliant.
 
 #### Heterogeneous cluster deployments
 

--- a/content/nomad/v1.10.x/content/docs/enterprise/fips.mdx
+++ b/content/nomad/v1.10.x/content/docs/enterprise/fips.mdx
@@ -70,7 +70,8 @@ consider migration of specific workloads to the FIPS cluster.
 #### TLS restrictions
 
 Nomad Enterprise's FIPS modifications include restrictions to supported TLS
-cipher suites and key information. Only the following cipher suites are allowed:
+cipher suites and key information. Only the following cipher suites are allowed
+in TLS1.2 and below:
 
 - `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`
 - `TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384`
@@ -83,9 +84,6 @@ In addition, only the following key types are allowed in TLS chains of trust:
 
 - RSA 2048, 3072, 4096, 7680, and 8192-bit
 - ECDSA P-256, P-384, and P-521
-
-Finally, only TLSv1.2 is supported in FIPS mode. These settings are in line with
-recent NIST guidance and FIPS requirements.
 
 #### Feature restrictions
 

--- a/content/nomad/v1.10.x/content/docs/enterprise/fips.mdx
+++ b/content/nomad/v1.10.x/content/docs/enterprise/fips.mdx
@@ -60,7 +60,7 @@ encrypted or signed with this non-compliant key material. Additionally, service
 IDs and other identifiers have been derived from non-compliant hash functions,
 which may lead to workload service interruptions during migration.
 
-As such Hashicorp cannot provide support for workloads that are affected either
+As such HashiCorp cannot provide support for workloads that are affected either
 technically or via non-compliance that results from converting existing cluster
 workloads to the FIPS-compliant binary.
 
@@ -88,7 +88,7 @@ In addition, only the following key types are allowed in TLS chains of trust:
 #### Feature restrictions
 
 The following features are not available or work in a modified way on FIPS mode
-binaries.
+binaries:
 
 - The `nomad alloc exec` and `nomad job action` commands, and their related
   APIs, are not available and return an error message.
@@ -98,7 +98,7 @@ binaries.
   specification.
 - The `md5` and `sha1` checksum functions for `artifact` blocks return an error
   if used in a job specification.
-- The `md5sum` function will return an error if used in the content of a
+- The `md5sum` function returns an error if used in the content of a
   `template` block.
 
 #### Third-party restrictions

--- a/content/nomad/v1.10.x/data/docs-nav-data.json
+++ b/content/nomad/v1.10.x/data/docs-nav-data.json
@@ -871,6 +871,10 @@
         "path": "enterprise"
       },
       {
+        "title": "FIPS",
+        "path": "enterprise/fips"
+      },
+      {
         "title": "License",
         "routes": [
           {

--- a/content/nomad/v1.11.x/content/docs/enterprise/fips.mdx
+++ b/content/nomad/v1.11.x/content/docs/enterprise/fips.mdx
@@ -7,13 +7,17 @@ description: >-
 
 # Deploy FIPS 140-3 compliant Nomad servers
 
+The [Federal Information Processing Standard][FIPS] is a cryptography-focused
+certification standard for U.S. Government usage.
+
 Builds of Nomad Enterprise marked with a `fips1403` feature name include
-built-in support for FIPS 140-3 compliance.
+built-in support for FIPS 140-3 compliance. Environments that don't have a
+specific need for FIPS-140-3 compliance should not run these variants of Nomad
+Enterprise.
 
 To use this feature, you must have an [active or trial license for Nomad
 Enterprise](/nomad/docs/enterprise/license). To start a trial, contact HashiCorp
-sales. Environments that don't have a specific need for FIPS-140-3 compliance
-should not run these variants of Nomad Enterprise.
+sales.
 
 <EnterpriseAlert product="nomad" />
 
@@ -37,10 +41,9 @@ general guidance about using Nomad Enterprise in a FIPS-compliant manner. We
 recommend consulting an approved auditor for further information.
 
 The FIPS 140-3 variant of Nomad uses separate binaries that are available from
-the following sources:
-
-- The [HashiCorp Releases page](https://releases.hashicorp.com/nomad), releases
-  ending with the `+ent.fips1403` suffix. Only Linux binaries are available.
+the [HashiCorp Releases page](https://releases.hashicorp.com/nomad). Use
+releases ending with the `+ent.fips1403` suffix. Only Linux binaries are
+available.
 
 ### Usage restrictions
 
@@ -92,8 +95,8 @@ binaries:
 
 - The `nomad alloc exec` and `nomad job action` commands, and their related
   APIs, are not available and return an error message.
-- OIDC configuration does not allow the `x5t` key ID header. Only the `x5t#S256`
-  header is allowed.
+- OIDC auth method configuration does not allow the [`x5t` key ID header][x5t]
+  for client assertions. Only the `x5t#S256` header is allowed.
 - The `md5` and `sha1` HCL2 functions return an error if used in a job
   specification.
 - The `md5` and `sha1` checksum functions for `artifact` blocks return an error
@@ -117,7 +120,8 @@ binary or deployment type.
 
 Running a heterogeneous cluster is not permitted by FIPS, as components of the
 system are not compliant with FIPS. Attempts to join non-FIPS and FIPS nodes or
-servers may fail.
+servers may fail. Federation between non-FIPS and FIPS clusters is not supported
+and may fail.
 
 ## Technical details
 
@@ -160,3 +164,6 @@ On both Linux and Windows non-FIPS builds, the search output yields no results.
 ## Certification
 
 Nomad Enterprise FIPS compliance has not yet been independently certified.
+
+[FIPS]: https://www.nist.gov/federal-information-standards-fips
+[x5t]: /nomad/api-docs/acl/auth-methods#keyidheader

--- a/content/nomad/v1.11.x/content/docs/enterprise/fips.mdx
+++ b/content/nomad/v1.11.x/content/docs/enterprise/fips.mdx
@@ -1,0 +1,139 @@
+---
+layout: docs
+page_title: Deploy FIPS 140-3 compliant Nomad servers
+description: >-
+  A version of Nomad compliant with FIPS 140-3 is available to Enterprise users. Learn about where to find FIPS-compliant versions of Nomad, as well as usage restrictions and technical details.
+---
+
+# Deploy FIPS 140-3 compliant Nomad servers
+
+Builds of Nomad Enterprise marked with a `fips1403` feature name include
+built-in support for FIPS 140-3 compliance.
+
+To use this feature, you must have an [active or trial license for Nomad
+Enterprise](/nomad/docs/enterprise/license). To start a trial, contact HashiCorp
+sales. Environments that don't have a specific need for FIPS-140-3 compliance
+should not run these variants of Nomad Enterprise.
+
+<EnterpriseAlert product="nomad" />
+
+## Using FIPS 140-3 Nomad Enterprise
+
+FIPS 140-3 builds of Nomad Enterprise behave in the same way as non-FIPS
+builds. Ensuring that Nomad remains in a FIPS-compliant mode of operation is
+your responsibility. To maintain FIPS-compliant operation, you must [ensure that
+TLS is enabled](/nomad/docs/secure/encryption/tls/enable/new/builtin) so that
+communication is encrypted. Nomad surfaces some helpful error messages where
+settings are insecure.
+
+Transport encryption is disabled in Nomad Enterprise by default. As a result,
+Nomad may transmit sensitive control plane information. You must ensure that
+gossip encryption and mTLS is enabled for all agents when running Nomad with
+FIPS-compliant settings. In addition, be aware that TLSv1.3 does not work with
+FIPS 140-3, as HKDF is not a certified primitive.
+
+HashiCorp is not a NIST-certified testing laboratory and can only provide
+general guidance about using Nomad Enterprise in a FIPS-compliant manner. We
+recommend consulting an approved auditor for further information.
+
+The FIPS 140-3 variant of Nomad uses separate binaries that are available from
+the following sources:
+
+- The [HashiCorp Releases page](https://releases.hashicorp.com/nomad), releases
+  ending with the `+ent.fips1403` suffix. Only Linux binaries are available.
+
+### Usage restrictions
+
+When using Nomad Enterprise with FIPS 140-3, be aware of the following operation
+restrictions.
+
+#### Migration restrictions
+
+We do not support in-place migrations from non-FIPS builds of Nomad to FIPS
+builds of Nomad, regardless of version. A fresh cluster installation is required
+to support FIPS 140-3. You cannot upgrade directly to a FIPS-compliant build.
+
+#### TLS restrictions
+
+Nomad Enterprise's FIPS modifications include restrictions to supported TLS
+cipher suites and key information. Only the following cipher suites are allowed:
+
+- `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`
+- `TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384`
+- `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256`
+- `TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384`
+- `TLS_RSA_WITH_AES_128_GCM_SHA256`
+- `TLS_RSA_WITH_AES_256_GCM_SHA384`
+
+In addition, only the following key types are allowed in TLS chains of trust:
+
+- RSA 2048, 3072, 4096, 7680, and 8192-bit
+- ECDSA P-256, P-384, and P-521
+
+Finally, only TLSv1.2 is supported in FIPS mode. These settings are in line with
+recent NIST guidance and FIPS requirements.
+
+#### Feature restrictions
+
+The following features are not available or work in a modified way on FIPS mode
+binaries.
+
+- The `nomad alloc exec` and `nomad job action` commands, and their related
+  APIs, are not available and return an error message.
+- OIDC configuration does not allow the `x5t` key ID header. Only the `x5t#S256`
+  header is allowed.
+- The `md5` and `sha1` HCL2 functions return an error if used in a job
+  specification.
+
+#### Heterogeneous cluster deployments
+
+We do not support mixed deployment scenarios within the same Nomad cluster. An
+example of an unsupported deployment scenario is one that mixes FIPS and
+non-FIPS Nomad binaries. Nodes across the entire cluster must use a single
+binary or deployment type.
+
+Running a heterogeneous cluster is not permitted by FIPS, as components of the
+system are not compliant with FIPS. Attempts to join non-FIPS and FIPS nodes or
+servers may fail.
+
+## Technical details
+
+Nomad's FIPS 140-3 Linux products use the Go Cryptographic Module version 1.0.0
+in the official Go 1.26+ toolchain, which include a FIPS-validated crypto
+module.
+
+To ensure your build of Nomad Enterprise includes FIPS support, confirm that the
+`version` command includes the string `fips1403`. For example:
+
+<CodeBlockConfig hideClipboard>
+
+```log
+Nomad v2.0.5+ent.fips1403
+```
+
+</CodeBlockConfig>
+
+In addition, the following message appears in the agent's banner on startup.
+
+<CodeBlockConfig hideClipboard>
+
+```log
+Fips Mode: FIPS-140-3 enabled (version: v1.0.0)
+```
+
+</CodeBlockConfig>
+
+### Validating FIPS crypto modules
+
+To validate that a FIPS 140-3 Linux binary is configured correctly to enable the Go Cryptographi Module, run `go version -m` on the binary to get build metadata.
+
+```shell-session
+$ go version -m ./nomad | grep FIPS
+	build	GOFIPS140=v1.0.0-c2097c7c
+```
+
+On both Linux and Windows non-FIPS builds, the search output yields no results.
+
+## Certification
+
+Nomad Enterprise FIPS compliance has not yet been independently certified.

--- a/content/nomad/v1.11.x/content/docs/enterprise/fips.mdx
+++ b/content/nomad/v1.11.x/content/docs/enterprise/fips.mdx
@@ -51,7 +51,21 @@ restrictions.
 
 We do not support in-place migrations from non-FIPS builds of Nomad to FIPS
 builds of Nomad, regardless of version. A fresh cluster installation is required
-to support FIPS 140-3. You cannot upgrade directly to a FIPS-compliant build.
+to receive support.
+
+We generally recommend avoiding direct upgrades and replicated-migrations
+because existing wrapped key material is encrypted with non-FIPS compliant
+cryptographic modules, and all Nomad Variables and Workload Identities have been
+encrypted or signed with this non-compliant key material. Additionally, service
+IDs and other identifiers have been derived from non-compliant hash functions,
+which may lead to workload service interruptions during migration.
+
+As such Hashicorp cannot provide support for workloads that are affected either
+technically or via non-compliance that results from converting existing cluster
+workloads to the FIPS-compliant binary.
+
+Instead, we suggest leaving the existing cluster in place, and carefully
+consider migration of specific workloads to the FIPS cluster.
 
 #### TLS restrictions
 
@@ -84,6 +98,17 @@ binaries.
   header is allowed.
 - The `md5` and `sha1` HCL2 functions return an error if used in a job
   specification.
+- The `md5` and `sha1` checksum functions for `artifact` blocks return an error
+  if used in a job specification.
+- The `md5sum` function will return an error if used in the content of a
+  `template` block.
+
+#### Third-party restrictions
+
+Nomad executes third-party binaries and workloads and communicates with external
+APIs that may not meet FIPS-140-3 compliance requirements, such as git, Docker,
+or a cloud provider. You have responsibility for ensuring that the other
+software in your cluster is compliant.
 
 #### Heterogeneous cluster deployments
 

--- a/content/nomad/v1.11.x/content/docs/enterprise/fips.mdx
+++ b/content/nomad/v1.11.x/content/docs/enterprise/fips.mdx
@@ -70,7 +70,8 @@ consider migration of specific workloads to the FIPS cluster.
 #### TLS restrictions
 
 Nomad Enterprise's FIPS modifications include restrictions to supported TLS
-cipher suites and key information. Only the following cipher suites are allowed:
+cipher suites and key information. Only the following cipher suites are allowed
+in TLS1.2 and below:
 
 - `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`
 - `TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384`
@@ -83,9 +84,6 @@ In addition, only the following key types are allowed in TLS chains of trust:
 
 - RSA 2048, 3072, 4096, 7680, and 8192-bit
 - ECDSA P-256, P-384, and P-521
-
-Finally, only TLSv1.2 is supported in FIPS mode. These settings are in line with
-recent NIST guidance and FIPS requirements.
 
 #### Feature restrictions
 

--- a/content/nomad/v1.11.x/content/docs/enterprise/fips.mdx
+++ b/content/nomad/v1.11.x/content/docs/enterprise/fips.mdx
@@ -60,7 +60,7 @@ encrypted or signed with this non-compliant key material. Additionally, service
 IDs and other identifiers have been derived from non-compliant hash functions,
 which may lead to workload service interruptions during migration.
 
-As such Hashicorp cannot provide support for workloads that are affected either
+As such HashiCorp cannot provide support for workloads that are affected either
 technically or via non-compliance that results from converting existing cluster
 workloads to the FIPS-compliant binary.
 
@@ -88,7 +88,7 @@ In addition, only the following key types are allowed in TLS chains of trust:
 #### Feature restrictions
 
 The following features are not available or work in a modified way on FIPS mode
-binaries.
+binaries:
 
 - The `nomad alloc exec` and `nomad job action` commands, and their related
   APIs, are not available and return an error message.
@@ -98,7 +98,7 @@ binaries.
   specification.
 - The `md5` and `sha1` checksum functions for `artifact` blocks return an error
   if used in a job specification.
-- The `md5sum` function will return an error if used in the content of a
+- The `md5sum` function returns an error if used in the content of a
   `template` block.
 
 #### Third-party restrictions

--- a/content/nomad/v1.11.x/data/docs-nav-data.json
+++ b/content/nomad/v1.11.x/data/docs-nav-data.json
@@ -909,6 +909,10 @@
         "path": "enterprise"
       },
       {
+        "title": "FIPS",
+        "path": "enterprise/fips"
+      },
+      {
         "title": "License",
         "routes": [
           {

--- a/content/nomad/v2.0.x/content/docs/enterprise/fips.mdx
+++ b/content/nomad/v2.0.x/content/docs/enterprise/fips.mdx
@@ -7,13 +7,17 @@ description: >-
 
 # Deploy FIPS 140-3 compliant Nomad servers
 
+The [Federal Information Processing Standard][FIPS] is a cryptography-focused
+certification standard for U.S. Government usage.
+
 Builds of Nomad Enterprise marked with a `fips1403` feature name include
-built-in support for FIPS 140-3 compliance.
+built-in support for FIPS 140-3 compliance. Environments that don't have a
+specific need for FIPS-140-3 compliance should not run these variants of Nomad
+Enterprise.
 
 To use this feature, you must have an [active or trial license for Nomad
 Enterprise](/nomad/docs/enterprise/license). To start a trial, contact HashiCorp
-sales. Environments that don't have a specific need for FIPS-140-3 compliance
-should not run these variants of Nomad Enterprise.
+sales.
 
 <EnterpriseAlert product="nomad" />
 
@@ -37,10 +41,9 @@ general guidance about using Nomad Enterprise in a FIPS-compliant manner. We
 recommend consulting an approved auditor for further information.
 
 The FIPS 140-3 variant of Nomad uses separate binaries that are available from
-the following sources:
-
-- The [HashiCorp Releases page](https://releases.hashicorp.com/nomad), releases
-  ending with the `+ent.fips1403` suffix. Only Linux binaries are available.
+the [HashiCorp Releases page](https://releases.hashicorp.com/nomad). Use
+releases ending with the `+ent.fips1403` suffix. Only Linux binaries are
+available.
 
 ### Usage restrictions
 
@@ -92,8 +95,8 @@ binaries:
 
 - The `nomad alloc exec` and `nomad job action` commands, and their related
   APIs, are not available and return an error message.
-- OIDC configuration does not allow the `x5t` key ID header. Only the `x5t#S256`
-  header is allowed.
+- OIDC auth method configuration does not allow the [`x5t` key ID header][x5t]
+  for client assertions. Only the `x5t#S256` header is allowed.
 - The `md5` and `sha1` HCL2 functions return an error if used in a job
   specification.
 - The `md5` and `sha1` checksum functions for `artifact` blocks return an error
@@ -117,7 +120,8 @@ binary or deployment type.
 
 Running a heterogeneous cluster is not permitted by FIPS, as components of the
 system are not compliant with FIPS. Attempts to join non-FIPS and FIPS nodes or
-servers may fail.
+servers may fail. Federation between non-FIPS and FIPS clusters is not supported
+and may fail.
 
 ## Technical details
 
@@ -160,3 +164,6 @@ On both Linux and Windows non-FIPS builds, the search output yields no results.
 ## Certification
 
 Nomad Enterprise FIPS compliance has not yet been independently certified.
+
+[FIPS]: https://www.nist.gov/federal-information-standards-fips
+[x5t]: /nomad/api-docs/acl/auth-methods#keyidheader

--- a/content/nomad/v2.0.x/content/docs/enterprise/fips.mdx
+++ b/content/nomad/v2.0.x/content/docs/enterprise/fips.mdx
@@ -1,0 +1,139 @@
+---
+layout: docs
+page_title: Deploy FIPS 140-3 compliant Nomad servers
+description: >-
+  A version of Nomad compliant with FIPS 140-3 is available to Enterprise users. Learn about where to find FIPS-compliant versions of Nomad, as well as usage restrictions and technical details.
+---
+
+# Deploy FIPS 140-3 compliant Nomad servers
+
+Builds of Nomad Enterprise marked with a `fips1403` feature name include
+built-in support for FIPS 140-3 compliance.
+
+To use this feature, you must have an [active or trial license for Nomad
+Enterprise](/nomad/docs/enterprise/license). To start a trial, contact HashiCorp
+sales. Environments that don't have a specific need for FIPS-140-3 compliance
+should not run these variants of Nomad Enterprise.
+
+<EnterpriseAlert product="nomad" />
+
+## Using FIPS 140-3 Nomad Enterprise
+
+FIPS 140-3 builds of Nomad Enterprise behave in the same way as non-FIPS
+builds. Ensuring that Nomad remains in a FIPS-compliant mode of operation is
+your responsibility. To maintain FIPS-compliant operation, you must [ensure that
+TLS is enabled](/nomad/docs/secure/encryption/tls/enable/new/builtin) so that
+communication is encrypted. Nomad surfaces some helpful error messages where
+settings are insecure.
+
+Transport encryption is disabled in Nomad Enterprise by default. As a result,
+Nomad may transmit sensitive control plane information. You must ensure that
+gossip encryption and mTLS is enabled for all agents when running Nomad with
+FIPS-compliant settings. In addition, be aware that TLSv1.3 does not work with
+FIPS 140-3, as HKDF is not a certified primitive.
+
+HashiCorp is not a NIST-certified testing laboratory and can only provide
+general guidance about using Nomad Enterprise in a FIPS-compliant manner. We
+recommend consulting an approved auditor for further information.
+
+The FIPS 140-3 variant of Nomad uses separate binaries that are available from
+the following sources:
+
+- The [HashiCorp Releases page](https://releases.hashicorp.com/nomad), releases
+  ending with the `+ent.fips1403` suffix. Only Linux binaries are available.
+
+### Usage restrictions
+
+When using Nomad Enterprise with FIPS 140-3, be aware of the following operation
+restrictions.
+
+#### Migration restrictions
+
+We do not support in-place migrations from non-FIPS builds of Nomad to FIPS
+builds of Nomad, regardless of version. A fresh cluster installation is required
+to support FIPS 140-3. You cannot upgrade directly to a FIPS-compliant build.
+
+#### TLS restrictions
+
+Nomad Enterprise's FIPS modifications include restrictions to supported TLS
+cipher suites and key information. Only the following cipher suites are allowed:
+
+- `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`
+- `TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384`
+- `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256`
+- `TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384`
+- `TLS_RSA_WITH_AES_128_GCM_SHA256`
+- `TLS_RSA_WITH_AES_256_GCM_SHA384`
+
+In addition, only the following key types are allowed in TLS chains of trust:
+
+- RSA 2048, 3072, 4096, 7680, and 8192-bit
+- ECDSA P-256, P-384, and P-521
+
+Finally, only TLSv1.2 is supported in FIPS mode. These settings are in line with
+recent NIST guidance and FIPS requirements.
+
+#### Feature restrictions
+
+The following features are not available or work in a modified way on FIPS mode
+binaries.
+
+- The `nomad alloc exec` and `nomad job action` commands, and their related
+  APIs, are not available and return an error message.
+- OIDC configuration does not allow the `x5t` key ID header. Only the `x5t#S256`
+  header is allowed.
+- The `md5` and `sha1` HCL2 functions return an error if used in a job
+  specification.
+
+#### Heterogeneous cluster deployments
+
+We do not support mixed deployment scenarios within the same Nomad cluster. An
+example of an unsupported deployment scenario is one that mixes FIPS and
+non-FIPS Nomad binaries. Nodes across the entire cluster must use a single
+binary or deployment type.
+
+Running a heterogeneous cluster is not permitted by FIPS, as components of the
+system are not compliant with FIPS. Attempts to join non-FIPS and FIPS nodes or
+servers may fail.
+
+## Technical details
+
+Nomad's FIPS 140-3 Linux products use the Go Cryptographic Module version 1.0.0
+in the official Go 1.26+ toolchain, which include a FIPS-validated crypto
+module.
+
+To ensure your build of Nomad Enterprise includes FIPS support, confirm that the
+`version` command includes the string `fips1403`. For example:
+
+<CodeBlockConfig hideClipboard>
+
+```log
+Nomad v2.0.5+ent.fips1403
+```
+
+</CodeBlockConfig>
+
+In addition, the following message appears in the agent's banner on startup.
+
+<CodeBlockConfig hideClipboard>
+
+```log
+Fips Mode: FIPS-140-3 enabled (version: v1.0.0)
+```
+
+</CodeBlockConfig>
+
+### Validating FIPS crypto modules
+
+To validate that a FIPS 140-3 Linux binary is configured correctly to enable the Go Cryptographi Module, run `go version -m` on the binary to get build metadata.
+
+```shell-session
+$ go version -m ./nomad | grep FIPS
+	build	GOFIPS140=v1.0.0-c2097c7c
+```
+
+On both Linux and Windows non-FIPS builds, the search output yields no results.
+
+## Certification
+
+Nomad Enterprise FIPS compliance has not yet been independently certified.

--- a/content/nomad/v2.0.x/content/docs/enterprise/fips.mdx
+++ b/content/nomad/v2.0.x/content/docs/enterprise/fips.mdx
@@ -51,7 +51,21 @@ restrictions.
 
 We do not support in-place migrations from non-FIPS builds of Nomad to FIPS
 builds of Nomad, regardless of version. A fresh cluster installation is required
-to support FIPS 140-3. You cannot upgrade directly to a FIPS-compliant build.
+to receive support.
+
+We generally recommend avoiding direct upgrades and replicated-migrations
+because existing wrapped key material is encrypted with non-FIPS compliant
+cryptographic modules, and all Nomad Variables and Workload Identities have been
+encrypted or signed with this non-compliant key material. Additionally, service
+IDs and other identifiers have been derived from non-compliant hash functions,
+which may lead to workload service interruptions during migration.
+
+As such Hashicorp cannot provide support for workloads that are affected either
+technically or via non-compliance that results from converting existing cluster
+workloads to the FIPS-compliant binary.
+
+Instead, we suggest leaving the existing cluster in place, and carefully
+consider migration of specific workloads to the FIPS cluster.
 
 #### TLS restrictions
 
@@ -84,6 +98,17 @@ binaries.
   header is allowed.
 - The `md5` and `sha1` HCL2 functions return an error if used in a job
   specification.
+- The `md5` and `sha1` checksum functions for `artifact` blocks return an error
+  if used in a job specification.
+- The `md5sum` function will return an error if used in the content of a
+  `template` block.
+
+#### Third-party restrictions
+
+Nomad executes third-party binaries and workloads and communicates with external
+APIs that may not meet FIPS-140-3 compliance requirements, such as git, Docker,
+or a cloud provider. You have responsibility for ensuring that the other
+software in your cluster is compliant.
 
 #### Heterogeneous cluster deployments
 

--- a/content/nomad/v2.0.x/content/docs/enterprise/fips.mdx
+++ b/content/nomad/v2.0.x/content/docs/enterprise/fips.mdx
@@ -70,7 +70,8 @@ consider migration of specific workloads to the FIPS cluster.
 #### TLS restrictions
 
 Nomad Enterprise's FIPS modifications include restrictions to supported TLS
-cipher suites and key information. Only the following cipher suites are allowed:
+cipher suites and key information. Only the following cipher suites are allowed
+in TLS1.2 and below:
 
 - `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`
 - `TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384`
@@ -83,9 +84,6 @@ In addition, only the following key types are allowed in TLS chains of trust:
 
 - RSA 2048, 3072, 4096, 7680, and 8192-bit
 - ECDSA P-256, P-384, and P-521
-
-Finally, only TLSv1.2 is supported in FIPS mode. These settings are in line with
-recent NIST guidance and FIPS requirements.
 
 #### Feature restrictions
 

--- a/content/nomad/v2.0.x/content/docs/enterprise/fips.mdx
+++ b/content/nomad/v2.0.x/content/docs/enterprise/fips.mdx
@@ -60,7 +60,7 @@ encrypted or signed with this non-compliant key material. Additionally, service
 IDs and other identifiers have been derived from non-compliant hash functions,
 which may lead to workload service interruptions during migration.
 
-As such Hashicorp cannot provide support for workloads that are affected either
+As such HashiCorp cannot provide support for workloads that are affected either
 technically or via non-compliance that results from converting existing cluster
 workloads to the FIPS-compliant binary.
 
@@ -88,7 +88,7 @@ In addition, only the following key types are allowed in TLS chains of trust:
 #### Feature restrictions
 
 The following features are not available or work in a modified way on FIPS mode
-binaries.
+binaries:
 
 - The `nomad alloc exec` and `nomad job action` commands, and their related
   APIs, are not available and return an error message.
@@ -98,7 +98,7 @@ binaries.
   specification.
 - The `md5` and `sha1` checksum functions for `artifact` blocks return an error
   if used in a job specification.
-- The `md5sum` function will return an error if used in the content of a
+- The `md5sum` function returns an error if used in the content of a
   `template` block.
 
 #### Third-party restrictions

--- a/content/nomad/v2.0.x/data/docs-nav-data.json
+++ b/content/nomad/v2.0.x/data/docs-nav-data.json
@@ -19,7 +19,7 @@
       },
       {
         "title": "Turn manifests into jobspecs",
-        "path": "k8s-nomad/manifest-jobspec"        
+        "path": "k8s-nomad/manifest-jobspec"
       }
     ]
   },
@@ -211,7 +211,7 @@
           {
             "title": "Federate multi-region clusters",
             "path": "deploy/clusters/federate-regions"
-          },          
+          },
           {
             "title": "Configure a web UI reverse proxy",
             "path": "deploy/clusters/reverse-proxy-ui"
@@ -425,23 +425,23 @@
           "routes": [
             {
               "title": "Overview",
-              "path": "networking/load-balancer"                
+              "path": "networking/load-balancer"
             },
             {
               "title": "Fabio",
-              "path": "networking/load-balancer/fabio"                
+              "path": "networking/load-balancer/fabio"
             },
             {
               "title": "HAProxy",
-              "path": "networking/load-balancer/haproxy"                
+              "path": "networking/load-balancer/haproxy"
             },
             {
               "title": "NGINX",
-              "path": "networking/load-balancer/nginx"                
+              "path": "networking/load-balancer/nginx"
             },
             {
               "title": "Traefik",
-              "path": "networking/load-balancer/traefik"                
+              "path": "networking/load-balancer/traefik"
             }
           ]
         }
@@ -901,6 +901,10 @@
       {
         "title": "Features",
         "path": "enterprise"
+      },
+      {
+        "title": "FIPS",
+        "path": "enterprise/fips"
       },
       {
         "title": "License",


### PR DESCRIPTION
We're making FIPS-140 compliant binaries available for Nomad Enterprise customers. These binaries have not yet been audited and are not being made available for the full set of deployment targets (ex. no Windows).

Ref: https://hashicorp.atlassian.net/browse/NMD-1658
Ref: https://go.dev/doc/security/fips140
Ref: https://go.dev/blog/fips140


## Contributor checklists

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [x] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [x] Verify that all status checks passed
- [x] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [x] I added redirects for any moved or removed pages
- [x] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [x] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [ ] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.
