### PR TITLE
terraform 1.16 doc updates

### DIFF
--- a/content/terraform/v1.16.x (beta)/docs/cli/commands/state/show.mdx
+++ b/content/terraform/v1.16.x (beta)/docs/cli/commands/state/show.mdx
@@ -25,17 +25,37 @@ state file that matches the given address.
 This command requires an address that points to a single resource in the
 state. Addresses are
 in [resource addressing format](/terraform/cli/state/resource-addressing).
-
 The command-line flags are all optional. The following flags are available:
 
 * `-state=path` - Path to the state file. Defaults to "terraform.tfstate".
   [Legacy option for the local backend only](/terraform/language/backend/local#command-line-arguments).
 
-The output of `terraform state show` is intended for human consumption, not
-programmatic consumption. To extract state data for use in other software, use
-[`terraform show -json`](/terraform/cli/commands/show#json-output) and decode the result
-using the documented structure.
+* `-json` - Displays the resource in machine-readable output
 
+-> JSON output via the `-json` option requires **Terraform v1.16 or later**.
+
+## JSON Output
+
+Add the `-json` command-line flag to generate machine-readable output.
+
+For Terraform state files, including when no path is provided, `terraform state
+show -json` shows a JSON representation of the requested resource.
+
+If you updated providers that contain new schema versions since the state
+was written, upgrade the state before so that Terraform can display it with
+`show -json`. If you are viewing a state file, run `terraform refresh`
+first.
+
+The general output format for this command is:
+```
+{
+  "format_version": "1.0", // the json format version
+  "resource": { },         // the resource requested
+  "diagnostics": []        // any diagnostics 
+}
+```
+
+The resource output format is covered in detail in [JSON Output Format](/terraform/internals/json-format).
 ## Example: Show a Resource
 
 The example below shows a `packet_device` resource named `worker`:
@@ -50,6 +70,35 @@ resource "packet_device" "worker" {
     hostname      = "prod-xyz01"
     id            = "6015bg2b-b8c4-4925-aad2-f0671d5d3b13"
     locked        = false
+}
+```
+
+## Example: Show a Resource with JSON output
+
+The example below shows a `packet_device` resource named `worker` in the json output format:
+
+```
+$ terraform state show 'packet_device.worker' -json
+{
+  "format_version": "1.0",
+  "resource": { 
+    "address": "packet_device.worker",
+    "mode": "managed",
+    "type": "device",
+    "name": "worker",
+    "provider_name": "registry.terraform.io/hashicorp/packet",
+    "schema_version": 0,
+    "values": {
+      "billing_cycle": "hourly",
+      "created": "2015-12-17T00:06:56Z",
+      "facility": "ewr1",
+      "hostname":  "prod-xyz01",
+      "id": "6015bg2b-b8c4-4925-aad2-f0671d5d3b13",
+      "locked": "false"
+    },
+    "sensitive_values": {}
+  }, 
+  "diagnostics": []
 }
 ```
 

--- a/content/terraform/v1.16.x (beta)/docs/language/meta-arguments/lifecycle.mdx
+++ b/content/terraform/v1.16.x (beta)/docs/language/meta-arguments/lifecycle.mdx
@@ -189,7 +189,7 @@ You can use `postcondition` in the following Terraform configuration blocks:
 
 ### `destroy` 
 
-Set to `false` to remove a resource from state without destroying the actual infrastructure resource. You can only use this rule in [`removed`](/terraform/language/block/removed) block.
+Set to `false` to remove a resource from state without destroying the actual infrastructure resource.
 
 ## Supported constructs
 


### PR DESCRIPTION
### What
<!-- Explain what you changed and provide a list of changed page names. -->

lifecycle.mdx: destroy=false is now available inside the resource lifecycle, so removed the sentence about its restriction
PR: https://github.com/hashicorp/terraform/pull/38784

<no changes> import blocks can now be used in modules, but i couldn't find the limitation documented, so no changes
PR: https://github.com/hashicorp/terraform/pull/38352

show.mdx: state show now has a -json command that returns the single Resource result as json
PR: https://github.com/hashicorp/terraform/pull/38341

### Why
updating docs with new features

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] You added redirects to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages **across all affected versions**. Refer to [Redirects](https://github.com/hashicorp/web-unified-docs/blob/main/docs/content-guide/redirects.md#example-redirects) for examples and guidance. 
- [ ] Links to related content where appropriate (e.g., CLI, language, API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
