### PR TITLE
chore: Remove v1.15 init message codes from v1.16 docs

### DIFF
--- a/content/terraform/v1.16.x (beta)/docs/internals/machine-readable-ui.mdx
+++ b/content/terraform/v1.16.x (beta)/docs/internals/machine-readable-ui.mdx
@@ -105,8 +105,7 @@ Messages with `init_output` type have an additional `message_code` documented be
 
 #### Provider Installation
 
-- `initializing_provider_plugin_from_config_message`: indicates progress during installation of providers from configuration
-- `initializing_provider_plugin_from_state_message`: indicates progress during installation of providers from state
+- `initializing_provider_plugin_message`: indicates progress during installation of providers
 - `reusing_version_during_state_provider_init`: indicates provider version reuse during state-based provider installation
 - `provider_already_installed_message`: indicates a provider that is already installed during installation
 - `built_in_provider_available_message`: indicates a built-in provider in use during installation


### PR DESCRIPTION
We split provider download into a config/state split to enable PSS, but then we needed to change the split to 0-1PSS providers/all other providers to enable the Terraform Policy project.

As a result there were message types we changed in v1.15.0 that then were reverted. This PR makes sure the v1.16 docs are accurate.