### PR TITLE
Explicitly provide instana agent key to GH build

### DIFF
--- a/.github/workflows/deploy-udr.yml
+++ b/.github/workflows/deploy-udr.yml
@@ -46,7 +46,7 @@ jobs:
         run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
         env:
           INSTANA_OTLP_ENDPOINT: ${{ secrets.INSTANA_OTLP_ENDPOINT }}
-          INSTANA_OTLP_AGENT_TOKEN: ${{ secrets.INSTANA_OTLP_AGENT_TOKEN }}
+          INSTANA_AGENT_TOKEN: ${{ secrets.INSTANA_AGENT_TOKEN }}
           HASHI_ENV: production
 
       - name: Deploy Project Artifacts to Vercel

--- a/.github/workflows/deploy-udr.yml
+++ b/.github/workflows/deploy-udr.yml
@@ -44,6 +44,10 @@ jobs:
 
       - name: Build Project Artifacts
         run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          INSTANA_OTLP_ENDPOINT: ${{ secrets.INSTANA_OTLP_ENDPOINT }}
+          INSTANA_OTLP_AGENT_TOKEN: ${{ secrets.INSTANA_OTLP_AGENT_TOKEN }}
+          HASHI_ENV: production
 
       - name: Deploy Project Artifacts to Vercel
         run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }} --logs --archive=tgz

--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -174,4 +174,4 @@ jobs:
             --host-id 'github-actions'
         env:
           INSTANA_OTLP_ENDPOINT: ${{ secrets.INSTANA_OTLP_ENDPOINT }}
-          INSTANA_OTLP_AGENT_TOKEN: ${{ secrets.INSTANA_OTLP_AGENT_TOKEN }}
+          INSTANA_AGENT_TOKEN: ${{ secrets.INSTANA_AGENT_TOKEN }}

--- a/scripts/emit-otel-span-cli.mjs
+++ b/scripts/emit-otel-span-cli.mjs
@@ -27,7 +27,7 @@
  *
  * The OTLP endpoint and token are read from the environment:
  * - INSTANA_OTLP_ENDPOINT  (required) OTLP endpoint (`endpoint`).
- * - INSTANA_OTLP_AGENT_TOKEN (required) Instana API token (`apiToken`).
+ * - INSTANA_AGENT_TOKEN (required) Instana API token (`apiToken`).
  */
 
 import { parseArgs } from 'node:util'

--- a/scripts/emit-otel-span.mjs
+++ b/scripts/emit-otel-span.mjs
@@ -84,7 +84,7 @@ const STATUS_CODE_ERROR = 2
  * Defaults to `process.env.INSTANA_OTLP_ENDPOINT`.
  *
  * @property {string} [apiToken] The Instana OTLP API token. Defaults to
- * `process.env.INSTANA_OTLP_AGENT_TOKEN`.
+ * `process.env.INSTANA_AGENT_TOKEN`.
  */
 function buildSpan({ name, attributes = {}, status, durationMs = 1 }) {
 	// Timestamps in nanoseconds (millisecond precision). Give the span a small
@@ -126,7 +126,7 @@ export function emitOtelSpan({
 	scopeName,
 	hostId = process.env.INSTANA_HOST_ID ?? serviceName,
 	endpoint = process.env.INSTANA_OTLP_ENDPOINT,
-	apiToken = process.env.INSTANA_OTLP_AGENT_TOKEN,
+	agentToken = process.env.INSTANA_AGENT_TOKEN,
 }) {
 	if (!endpoint) {
 		return Promise.reject(
@@ -135,10 +135,10 @@ export function emitOtelSpan({
 			),
 		)
 	}
-	if (!apiToken) {
+	if (!agentToken) {
 		return Promise.reject(
 			new Error(
-				'emitOtelSpan: missing OTLP API token (set INSTANA_OTLP_AGENT_TOKEN or pass `apiToken`)',
+				'emitOtelSpan: missing OTLP API token (set INSTANA_AGENT_TOKEN or pass `apiToken`)',
 			),
 		)
 	}
@@ -168,7 +168,7 @@ export function emitOtelSpan({
 		method: 'POST',
 		headers: {
 			'Content-Type': 'application/json',
-			'x-instana-key': apiToken,
+			'x-instana-key': agentToken,
 			'x-instana-host': hostId,
 		},
 		body: JSON.stringify(payload),

--- a/terraform/github.tf
+++ b/terraform/github.tf
@@ -10,8 +10,8 @@ locals {
   ])
 
   secrets = {
-    INSTANA_OTLP_AGENT_TOKEN = var.instana_agent_key
-    INSTANA_OTLP_ENDPOINT    = var.instana_otlp_endpoint
+    INSTANA_AGENT_TOKEN   = var.instana_agent_key
+    INSTANA_OTLP_ENDPOINT = var.instana_otlp_endpoint
   }
 
   variables = {}

--- a/terraform/vercel.tf
+++ b/terraform/vercel.tf
@@ -13,9 +13,9 @@ locals {
       sensitive      = false
       targets        = ["production", "preview"]
     },
-    INSTANA_OTLP_AGENT_TOKEN = {
+    INSTANA_AGENT_TOKEN = {
       value          = var.instana_agent_key
-      comment        = "Instana OTel agent key. Used to submit build metrics to Instana for tracking build times."
+      comment        = "Instana agent key used to authenticate to Instana when submitting metrics and telemetry."
       client_visible = false
       sensitive      = true
       targets        = ["production", "preview"]
@@ -23,9 +23,9 @@ locals {
   }
 }
 
-# Enviornment variables
+# Environment variables
 #
-# The `vercel_project_environment_variable` resource is used here isntead of
+# The `vercel_project_environment_variable` resource is used here instead of
 # `vercel_project_environment_variables` because the former allows us to just
 # add the env vars we want to manage, while the latter would completely replace
 # anything not included in the array specified in the configuration.


### PR DESCRIPTION
Currently build metrics are not being sent to Instana. Since dev portal's build happens in vercel (not github actions) it has access to all environment variables (even those marked as sensitive). According to [vercel's documentation](https://vercel.com/docs/environment-variables/sensitive-environment-variables) - _"Sensitive environment variables are [environment variables](https://vercel.com/docs/environment-variables)
whose values are non-readable once created. They help protect sensitive information stored in environment variables, such as API keys."_. I suspect that the reason that these metrics aren't showing up in Instana is that (although we do run a `vercel env pull`) in the build step, they are replaced with `[SENSITIVE]` instead of the actual value causing the build metrics to be not emitted to Instana correctly.

<img width="1230" height="421" alt="image" src="https://github.com/user-attachments/assets/83a7fef5-e988-41c3-8b4f-0f1cd34d6b9e" />


Additionally, it makes sense to rename the environment variable for this value slightly to something more meaningful as `INSTANA_OTLP_AGENT_TOKEN` implies that this secrets is only used for emitting OTel metrics (which is not correct).
