### PR TITLE
copied usage docs, set up usage nav

### DIFF
--- a/content/terraform-docs-common/data/cloud-docs-nav-data.json
+++ b/content/terraform-docs-common/data/cloud-docs-nav-data.json
@@ -128,7 +128,53 @@
             "path": "users-teams-organizations/single-sign-on/testing"
           }
         ]
-      }
+      },
+      {
+        "title": "SCIM provisioning",
+        "routes": [
+          {
+            "title": "Overview",
+            "path": "scim"
+          },
+          {
+            "title": "User lifecycle",
+            "path": "scim/users"
+          },
+          {
+            "title": "Group syncronization",
+            "path": "scim/groups"
+          },
+          {
+            "title": "Configuration",
+            "routes":[
+              {
+                "title": "Overview",
+                "path": "scim/configure"
+              },
+              {
+                "title": "Microsoft Entra ID",
+                "path": "scim/configure/entra-id"
+              },
+              {
+                "title": "Okta",
+                "path": "scim/configure/okta"
+              },
+              {
+                "title": "Post-setup management",
+                "path": "scim/manage"
+              }
+            ]
+          },
+          {
+            "title": "Manage tokens",
+            "path": "scim/manage/tokens"
+          },
+          {
+            "title": "Troubleshooting",
+            "path": "scim/troubleshooting"
+          }
+        ]
+      }      
     ]
   },
   {

--- a/content/terraform-docs-common/data/cloud-docs-nav-data.json
+++ b/content/terraform-docs-common/data/cloud-docs-nav-data.json
@@ -141,7 +141,7 @@
             "path": "scim/users"
           },
           {
-            "title": "Group syncronization",
+            "title": "Group lifecycle",
             "path": "scim/groups"
           },
           {

--- a/content/terraform-docs-common/docs/cloud-docs/scim/configure/entra-id.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/scim/configure/entra-id.mdx
@@ -1,0 +1,211 @@
+---
+page_title: Configure Microsoft Entra ID as the SCIM identity provider for Terraform Enterprise
+description: >-
+  Learn how to configure Microsoft Entra ID (Azure AD) as the SCIM identity
+  provider for Terraform Enterprise to enable automated user and group provisioning.
+---
+
+# Configure Microsoft Entra ID as the SCIM identity provider
+
+This topic describes how to configure Microsoft Entra ID (formerly Azure Active Directory) as the SCIM identity provider for Terraform Enterprise. After completing this configuration, Terraform Enterprise can accept SCIM provisioning requests from Microsoft Entra ID for users and groups.
+
+## Overview
+
+Complete the following steps to configure Entra ID as your SCIM IdP:
+
+1. Create a SCIM token
+1. Configure provisioning in Microsoft Entra ID
+1. Configure attribute mappings
+1. Configure users and groups to provision
+1. Start provisioning
+
+## Prerequisites
+
+Before configuring SCIM provisioning with Microsoft Entra ID, verify that you meet the following requirements:
+
+- **SAML SSO configured**: You must have SAML single sign-on configured with Microsoft Entra ID for your Terraform Enterprise instance. Refer to [Configure Azure Active Directory as the Identity Provider](/terraform/enterprise/saml/idp-configuration/aad) for instructions.
+- **SCIM enabled in Terraform Enterprise**: SCIM must be enabled in your Terraform Enterprise instance. Refer to [Configure SCIM provisioning](/terraform/enterprise/scim/configure) for instructions.
+- **Entra ID admin access**: You must have administrative access to Microsoft Entra ID with permissions to configure enterprise application provisioning.
+- **Non-SSO admin account**: We strongly recommend creating a [non-SSO admin account for recovery](/terraform/enterprise/saml/troubleshooting#create-a-non-sso-admin-account-for-recovery) before enabling SCIM. This account allows you to log in and troubleshoot if there are issues with your SCIM or SAML configuration.
+
+## Create a SCIM token
+
+Create a SCIM token that Entra ID uses to authenticate with Terraform Enterprise:
+
+1. On the SCIM settings page in Terraform Enterprise, navigate to the **SCIM Tokens** section.
+1. Click **Create Token**.
+1. Enter a **Description** for the token, such as `Microsoft Entra ID Provisioning`.
+1. Optionally, configure the token expiration.
+1. Click **Create Token**.
+1. Copy the token value and store it securely. You need this token when configuring Entra ID.
+
+Terraform Enterprise only displays the token value once. You cannot retrieve the token value after you close the dialog. If you lose the token, you must create a new one.
+
+For complete instructions on managing tokens, refer to [Tokens](/terraform/enterprise/scim/manage/tokens).
+
+## Configure provisioning in Microsoft Entra ID
+
+In Microsoft Entra ID, open your existing Terraform Enterprise enterprise application and configure SCIM provisioning:
+
+1. Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com).
+1. Navigate to **Identity** > **Applications** > **Enterprise applications**.
+1. Select your existing Terraform Enterprise application that you configured for SAML SSO.
+1. In the left navigation, select **Provisioning**.
+1. Click **Get started** to begin the provisioning configuration.
+1. Set **Provisioning Mode** to **Automatic**.
+1. Expand the **Admin Credentials** section.
+1. In the **Tenant URL** field, enter your Terraform Enterprise SCIM endpoint:
+
+   ```
+   https://<TFE_HOSTNAME>/scim/v2
+   ```
+
+   Replace `<TFE_HOSTNAME>` with your Terraform Enterprise hostname.
+
+1. In the **Secret Token** field, paste the SCIM token you created in Terraform Enterprise.
+1. Click **Test Connection** to verify that Microsoft Entra ID can connect to Terraform Enterprise.
+1. If the connection test succeeds, click **Save** to save the provisioning configuration.
+
+-> **Note**: If the connection test fails, verify that your SCIM token is valid and that your Terraform Enterprise instance is accessible from the internet. For Terraform Enterprise-side diagnosis, refer to [Troubleshoot SCIM provisioning](/terraform/enterprise/scim/troubleshooting).
+
+## Configure attribute mappings
+
+Microsoft Entra ID uses attribute mappings to synchronize user data with Terraform Enterprise. Review and configure the default mappings in the Microsoft Entra admin center:
+
+1. In the **Provisioning** settings, expand the **Mappings** section.
+1. Click **Provision Microsoft Entra ID Users** to review user attribute mappings.
+
+### User attribute mappings
+
+Verify the following user attribute mappings are configured in Entra ID:
+
+| Microsoft Entra ID Attribute | SCIM Attribute | Configured in Entra ID | Notes |
+|------------------------------|----------------|------------------------|-------|
+| `userPrincipalName` | `userName` | Yes | Primary identifier for the user |
+| `mail` | `emails[type eq "work"].value` | Yes | User's email address |
+| `objectId` | `externalId` | Yes | Entra ID uses this to identify existing users. `externalId` is a SCIM attribute that Terraform Enterprise stores on the SCIM identity. Terraform Enterprise supports user lookups by `externalId`. During user creation, Terraform Enterprise still links an existing Terraform Enterprise user by email address when the email matches. |
+| `Switch([IsSoftDeleted], , "False", "True", "True", "False")` | `active` | Yes | User active status |
+
+### Group attribute mappings
+
+Microsoft Entra ID uses attribute mappings to synchronize group data with Terraform Enterprise. Review and configure the default mappings in the Microsoft Entra admin center:
+
+1. Return to the **Mappings** section.
+1. In the **Provisioning** settings, click **Provision Microsoft Entra ID Groups** to review group attribute mappings.
+
+Verify the following group attribute mappings are configured in Entra ID:
+
+| Microsoft Entra ID Attribute | SCIM Attribute | Configured in Entra ID | Notes |
+|------------------------------|----------------|------------------------|-------|
+| `displayName` | `displayName` | Yes | Group display name |
+| `objectId` | `externalId` | Yes | Value stored on the SCIM group for lookup and update matching. `externalId` is a SCIM attribute that Terraform Enterprise stores on the SCIM group. Terraform Enterprise supports group lookups by `externalId`. |
+| `members` | `members` | Yes | Group membership list |
+
+## Configure users and groups to provision
+
+Configure which users and groups Microsoft Entra ID synchronizes to Terraform Enterprise:
+
+1. In the **Provisioning** settings, expand the **Settings** section.
+1. In the **Scope** dropdown, select one of the following options:
+   - **Sync only assigned users and groups**: Entra ID provisions only users and groups assigned to the enterprise application. This is the recommended option.
+   - **Sync all users and groups**: Entra ID provisions all users and groups in your Entra ID tenant.
+1. Click **Save** to apply the scope setting.
+
+### Assign users and groups
+
+Assigning groups to the application provisions all members of those groups. When you add or remove users from an assigned group in Entra ID, those changes automatically synchronize to Terraform Enterprise.
+
+If you selected **Sync only assigned users and groups**, you must assign users and groups to the enterprise application:
+
+1. In your enterprise application, select **Users and groups** from the left navigation.
+1. Click **Add user/group**.
+1. Select the users or groups you want to provision to Terraform Enterprise.
+1. Click **Assign**.
+
+### Plan your group assignments
+
+Consider the following when planning group assignments:
+
+- **Team mapping**: After groups are provisioned to Terraform Enterprise, you can map them to Terraform Enterprise teams. Refer to [Link SCIM groups to teams](/terraform/enterprise/scim/manage/team-mapping) for instructions.
+- **Group size limits**: Terraform Enterprise public SCIM group create and update requests support groups with up to 1,000 members. Larger groups are rejected by the public SCIM group provisioning endpoints. We recommend splitting larger groups into smaller functional teams.
+- **Site admin group**: If you configure a site admin group in Terraform Enterprise, do not also link that group to a Terraform Enterprise team. Terraform Enterprise uses the site admin group exclusively for administrator provisioning.
+
+## Start provisioning
+
+After you have configured SCIM provisioning, start the provisioning service:
+
+1. In Microsoft Entra ID, in the **Provisioning** settings, expand the **Settings** section.
+1. Set **Provisioning Status** to **On**.
+1. Click **Save** to start provisioning.
+
+### Initial provisioning cycle
+
+The first provisioning cycle is a complete synchronization of the users and groups currently in scope. Initial provisioning may take longer than later syncs, especially for large directories.
+
+### Monitor provisioning logs
+
+In Microsoft Entra ID, monitor the provisioning status and logs to verify successful synchronization:
+
+1. In your enterprise application, select **Provisioning** from the left navigation.
+1. Click **View provisioning logs** to see detailed operation logs.
+1. Review the logs for any errors or warnings.
+
+The provisioning logs show:
+
+- **Provision**: Users and groups created in Terraform Enterprise.
+- **Update**: Existing users or groups updated with new attribute values.
+- **Disable**: Users deactivated in Terraform Enterprise.
+- **Delete**: Groups removed from Terraform Enterprise.
+
+### Incremental cycles
+
+After the initial cycle completes, later syncs only process subsequent changes.
+
+## Troubleshooting
+
+This section describes common issues specific to Microsoft Entra ID SCIM integration and their solutions. For broader Terraform Enterprise-side diagnosis, refer to [Troubleshoot SCIM provisioning](/terraform/enterprise/scim/troubleshooting).
+
+### Connection test fails
+
+If the connection test fails when configuring provisioning:
+
+- Verify that the tenant URL is correct and includes the `/scim/v2` path.
+- Verify that the SCIM token is valid and has not expired. Create a new token if necessary.
+- Verify that Microsoft Entra ID can reach your Terraform Enterprise instance over HTTPS. Check firewall rules and network configurations.
+- Verify that SCIM is enabled and not paused in Terraform Enterprise.
+
+### Users not provisioned
+
+If users are not being provisioned to Terraform Enterprise:
+
+- Verify the user is in scope for provisioning based on your scope configuration.
+- If using assignment-based scoping, verify the user is assigned to the application directly or through a group.
+- Check the provisioning logs for errors related to the specific user.
+- Verify required attributes, such as `externalId` and `userName`, are correctly mapped.
+
+### Groups not synchronizing
+
+If groups are not synchronizing to Terraform Enterprise:
+
+- Verify group provisioning is enabled in the attribute mappings.
+- Verify that the group is assigned to the enterprise application if using assignment-based scoping.
+- Verify the group has fewer than 1,000 members. Larger groups are rejected by the public SCIM group provisioning endpoints.
+- Verify the group attribute mappings for `displayName`, `externalId`, and `members`.
+
+### Rate limiting errors
+
+HTTP `429` errors in the provisioning logs indicate that the IdP has reached the request rate limit.
+
+Terraform Enterprise temporarily rate-limits SCIM requests when request volume is too high. These responses include a `Retry-After` header. Review the provisioning logs, wait for the sync to continue, and refer to [Troubleshoot SCIM provisioning](/terraform/enterprise/scim/troubleshooting) if the condition persists.
+
+For additional troubleshooting information, refer to [Troubleshoot SCIM provisioning](/terraform/enterprise/scim/troubleshooting).
+
+## Next steps
+
+After configuring SCIM provisioning with Microsoft Entra ID:
+
+- **Verify group provisioning**: Confirm group provisioning is enabled in the attribute mappings.
+- **Verify group assignment**: Ensure the group is assigned to the enterprise application if using assignment-based scoping.
+- **Review group size**: Verify the group has fewer than 1,000 members. Larger groups are rejected by the public SCIM group provisioning endpoints.
+- Review [SCIM user management](/terraform/enterprise/scim/users) to understand how SCIM-managed users work in Terraform Enterprise.
+- Review [SCIM group management](/terraform/enterprise/scim/groups) to understand how SCIM groups integrate with Terraform Enterprise teams.

--- a/content/terraform-docs-common/docs/cloud-docs/scim/configure/index.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/scim/configure/index.mdx
@@ -1,0 +1,108 @@
+---
+page_title: Configure SCIM provisioning in Terraform Enterprise
+description: >-
+  Learn how to configure SCIM provisioning in Terraform Enterprise and set up
+  supported identity providers such as Okta and Microsoft Entra ID.
+---
+
+# Configure SCIM provisioning
+
+This topic provides the setup workflow for configuring SCIM provisioning in Terraform Enterprise and then configuring your identity provider.
+
+## Overview
+
+Complete the following steps to configure SCIM provisioning:
+
+1. Enable SAML SSO. SCIM handles provisioning, but SAML handles sign-in. Refer to [Configure SAML](/terraform/enterprise/saml/configuration).
+1. Enable SCIM provisioning in Terraform Enterprise.
+1. Create a SCIM token for your identity provider. Refer to [Tokens](/terraform/enterprise/scim/manage/tokens).
+1. Configure your identity provider with the Terraform Enterprise SCIM base URL, token, and attribute mappings.
+1. Map IdP groups to Terraform Enterprise teams. Refer to [Link SCIM groups to teams](/terraform/enterprise/scim/manage/team-mapping).
+1. Test and verify the setup before broader rollout.
+
+### SCIM states
+
+| State | What it means |
+|-------|---------------|
+| **Disabled** | Default state. Terraform Enterprise does not process public SCIM provisioning requests to `/scim/v2/Users` or `/scim/v2/Groups`. You cannot pause SCIM until it is enabled. |
+| **Enabled** | Terraform Enterprise processes public SCIM provisioning requests to `/scim/v2/Users` and `/scim/v2/Groups`. Your identity provider can create and update users and groups. Team membership sync happens only for teams that are linked to a SCIM group. |
+| **Paused** | SCIM stays enabled, but Terraform Enterprise stops processing public SCIM provisioning requests to `/scim/v2/Users` and `/scim/v2/Groups`. Existing SCIM users, groups, team links, and tokens stay in place. Users can still sign in with SAML. |
+
+## Requirements
+
+Before you enable SCIM:
+
+- You must be a site administrator. For more information, refer to [Site Administration Permissions](/terraform/enterprise/users-teams-organizations/users#site-admin-permissions).
+- SAML SSO must already be enabled. SCIM handles provisioning. SAML handles sign-in. For setup steps, refer to [Configure SAML](/terraform/enterprise/saml/configuration).
+- Configure SCIM on the same identity provider that you use for SAML SSO.
+- Terraform Enterprise supports SCIM with Microsoft Entra ID, Okta, and supported generic SAML provider configurations. We provide setup guides for Okta and Microsoft Entra ID.
+- Keep at least one [non-SSO admin account for recovery](/terraform/enterprise/saml/troubleshooting#create-a-non-sso-admin-account-for-recovery).
+
+## Configure Terraform Enterprise for SCIM
+
+1. Open your user icon menu and click **Site Admin**, or go to `https://<TFE_HOSTNAME>/app/admin/scim`.
+1. Click **Enable SCIM provisioning**.
+1. Copy the SCIM base URL. Use `https://<TFE_HOSTNAME>/scim/v2` when you configure your identity provider.
+
+After you enable SCIM, generate a token and configure your identity provider.
+
+For API-based configuration, refer to the [Admin SCIM Settings API](/terraform/enterprise/api-docs/admin/scim-settings).
+
+## Create a SCIM token
+
+Your identity provider uses a SCIM token to authenticate to Terraform Enterprise.
+
+1. In **Site Admin** > **SCIM**, click **Create Token**.
+1. Enter a description.
+1. Choose an expiration.
+1. Copy the token and store it securely.
+
+Terraform Enterprise shows the token only once.
+
+You can keep more than one active SCIM token at the same time. This lets you rotate tokens without downtime. For detailed token management steps, refer to [Tokens](/terraform/enterprise/scim/manage/tokens).
+
+## Configure your identity provider
+
+Use one of the following provider-specific setup guides:
+
+- [Okta](/terraform/enterprise/scim/configure/okta)
+- [Microsoft Entra ID](/terraform/enterprise/scim/configure/entra-id)
+
+You need the following information:
+
+- the SCIM base URL: `https://<TFE_HOSTNAME>/scim/v2`
+- a SCIM token generated in Terraform Enterprise
+- the attribute mappings required by your identity provider
+
+When SCIM is enabled and not paused, Terraform Enterprise can create and update users and groups from incoming SCIM requests. Team membership does not change until you link a SCIM group to a Terraform Enterprise team.
+
+## Verify the setup
+
+Test SCIM with a small rollout before using it more broadly.
+
+1. Provision a test user from your identity provider and confirm the user appears in Terraform Enterprise.
+1. Provision a test group and confirm the SCIM group appears in Terraform Enterprise.
+1. Link the SCIM group to a test team. Refer to [Link SCIM groups to teams](/terraform/enterprise/scim/manage/team-mapping).
+1. Confirm that team membership updates as expected.
+1. Deactivate or unassign the test user in your identity provider and verify that Terraform Enterprise suspends the user.
+
+Use this test pass to confirm token setup, attribute mappings, and linked-team behavior before wider rollout.
+
+## Next steps
+
+After initial setup, use the following topics to manage and troubleshoot SCIM provisioning:
+
+- Maintain the site-level SCIM configuration, including pause and resume behavior, site admin group mapping, token rotation, and disabling SCIM. Refer to [Manage SCIM](/terraform/enterprise/scim/manage).
+- Manage group-to-team links and team-level synchronization behavior. Refer to [Link SCIM groups to teams](/terraform/enterprise/scim/manage/team-mapping).
+- Troubleshoot provisioning, synchronization, and token issues. Refer to [Troubleshoot SCIM provisioning](/terraform/enterprise/scim/troubleshooting).
+
+Refer to [Integration settings](/terraform/enterprise/application-administration/integration) for the admin interface reference for the **Enable SCIM provisioning** setting.
+
+## API reference
+
+For endpoint-specific behavior, request and response details, limits, and rate limits, refer to:
+
+- [Admin SCIM Settings API](/terraform/enterprise/api-docs/admin/scim-settings)
+- [Admin SCIM Tokens API](/terraform/enterprise/api-docs/admin/scim-tokens)
+- [Team SCIM Group Mapping API](/terraform/enterprise/api-docs/admin/team-scim-group-mapping)
+- [Public SCIM API](/terraform/enterprise/api-docs/scim)

--- a/content/terraform-docs-common/docs/cloud-docs/scim/configure/okta.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/scim/configure/okta.mdx
@@ -1,0 +1,237 @@
+---
+page_title: Configure Okta as the SCIM identity provider for Terraform Enterprise
+description: >-
+  Learn how to configure Okta as the SCIM identity provider for Terraform
+  Enterprise to enable automated user and group provisioning.
+---
+
+# Configure Okta as the SCIM identity provider
+
+This topic describes how to configure Okta as the SCIM identity provider for Terraform Enterprise. In Terraform Enterprise, SAML handles authentication and SCIM handles provisioning.
+
+After completing this configuration, Terraform Enterprise can accept SCIM provisioning requests from Okta for users and groups.
+
+## Overview
+
+Complete the following steps to configure Okta for SCIM provisioning:
+
+1. Enable SCIM provisioning in Terraform Enterprise and create a SCIM token.
+1. Configure the SCIM API integration in Okta.
+1. Enable the provisioning actions that Okta should perform.
+1. Configure group push for any groups that you want Okta to provision.
+1. Assign test users or groups and verify the resulting behavior in Terraform Enterprise.
+
+## Prerequisites
+
+Before configuring SCIM provisioning with Okta, verify that you meet the following requirements:
+
+- **Terraform Enterprise with SAML SSO configured for Okta**: SCIM provisioning requires SAML single sign-on to be enabled first. If you have not configured SAML, refer to [Configure Okta as the SAML identity provider](/terraform/enterprise/saml/idp-configuration/okta) for instructions.
+- **Okta administrator access**: You must have administrator permissions in Okta to configure SCIM provisioning for the Terraform Enterprise application.
+- **Non-SSO admin account**: We strongly recommend creating a [non-SSO admin account for recovery](/terraform/enterprise/saml/troubleshooting#create-a-non-sso-admin-account-for-recovery) before enabling SCIM. This account allows you to log in and troubleshoot if there are issues with your SCIM or SAML configuration.
+
+Before broad rollout, validate your Okta user identifier and attribute mappings with a small set of test users. During SCIM user creation, Terraform Enterprise links an existing Terraform Enterprise user by email address when the email matches.
+
+## Enable SCIM provisioning in Terraform Enterprise
+
+To start the synchronization process, enable SCIM provisioning in Terraform Enterprise so that you can obtain the base URL and token required for Okta.
+
+1. Log in to Terraform Enterprise as a site administrator.
+1. Open your user icon menu and click **Site Admin**, or go directly to `https://<TFE_HOSTNAME>/app/admin/scim`.
+1. Click **SCIM** in the left navigation.
+1. Click **Enable SCIM provisioning** if SCIM is not already enabled.
+1. Click **Create Token** in the **SCIM Tokens** section.
+1. Enter a description for the token, such as `Okta SCIM Integration`.
+1. Optionally, configure the token expiration.
+1. Click **Create Token**.
+1. Copy and save the token value.
+1. Note the SCIM base URL displayed on the settings page. The URL format is:
+
+   ```
+   https://<TFE_HOSTNAME>/scim/v2
+   ```
+
+For configuration in Okta, you need:
+
+- The SCIM base URL.
+- The token value from the SCIM token you created.
+
+Terraform Enterprise only displays the token value once. If you lose the token, you must create a new one.
+
+For more information about enabling SCIM and managing tokens, refer to [Configure SCIM provisioning](/terraform/enterprise/scim/configure) and [Tokens](/terraform/enterprise/scim/manage/tokens).
+
+## Configure API integration in Okta
+
+After SCIM is enabled in Terraform Enterprise, configure the SCIM connection in Okta.
+
+1. Log in to the Okta Admin Console.
+1. Navigate to **Applications** > **Applications**.
+1. Open your existing Terraform Enterprise application.
+1. Click the **Provisioning** tab.
+1. Click **Configure API Integration**.
+1. Select the **Enable API integration** checkbox.
+1. In the **SCIM connector base URL** field, enter the SCIM base URL from Terraform Enterprise:
+
+   ```
+   https://<TFE_HOSTNAME>/scim/v2
+   ```
+
+1. In the **Authentication Mode** section, select **HTTP Header**.
+1. In the **Authorization** field, enter the SCIM token you created in Terraform Enterprise without the `Bearer` prefix. Okta automatically adds the `Bearer` prefix when making requests to Terraform Enterprise.
+
+1. Configure the **Unique identifier field for users** according to your validated Okta provisioning setup.
+1. Click **Test API Credentials** to verify the connection.
+1. If the test succeeds, click **Save**.
+
+The following table summarizes the required SCIM connection settings:
+
+| Setting | Value |
+|---------|-------|
+| SCIM connector base URL | `https://<TFE_HOSTNAME>/scim/v2` |
+| Unique identifier field for users | Your validated Okta provisioning configuration |
+| Authentication Mode | HTTP Header |
+| Authorization | Your SCIM token value |
+
+## Configure provisioning actions in Okta
+
+After the API integration is verified, new settings appear under the **Provisioning** tab.
+
+1. On the **Provisioning** tab, click **To App** in the left sidebar.
+1. Click **Edit**.
+1. Enable the following options:
+   - **Create Users**: Allows Okta to create new users in Terraform Enterprise.
+   - **Update User Attributes**: Allows Okta to update user attributes in Terraform Enterprise.
+   - **Deactivate Users**: Allows Okta to deactivate users in Terraform Enterprise when they are unassigned or suspended in Okta.
+1. Click **Save**.
+
+## Configure group push
+
+To synchronize Okta groups with Terraform Enterprise:
+
+1. Click the **Push Groups** tab.
+1. Click **Push Groups** and select **Find groups by name** or **Find groups by rule**.
+1. Search for and select the groups you want to push to Terraform Enterprise.
+1. Click **Save**.
+
+Okta creates corresponding SCIM groups in Terraform Enterprise for each pushed group. You can then link these SCIM groups to Terraform Enterprise teams. Refer to [Link SCIM groups to teams](/terraform/enterprise/scim/manage/team-mapping) for instructions.
+
+## Start provisioning
+
+After the Okta provisioning configuration is complete, start with a small rollout to verify provisioning before broader adoption:
+
+1. Click the **Assignments** tab in your Terraform Enterprise application.
+1. Click **Assign** and select either **Assign to People** or **Assign to Groups**.
+1. Select a test user or group to provision to Terraform Enterprise.
+1. Click **Assign** for each selection, then click **Done**.
+
+Initial provisioning may take longer than later updates, especially when provisioning many users or groups. Later provisioning runs only process subsequent changes.
+
+When you assign users or groups:
+
+- **Users**: Okta immediately provisions assigned users to Terraform Enterprise. Users can log in using SAML SSO after provisioning.
+- **Groups**: If you configured group push, Okta creates the groups in Terraform Enterprise. Group membership is synchronized automatically.
+
+When Terraform Enterprise receives a SCIM user deactivation request, it suspends the user.
+
+Assigning groups to the application does not automatically create team memberships in Terraform Enterprise. You must link SCIM groups to Terraform Enterprise teams after the groups are provisioned. Refer to [Link SCIM groups to teams](/terraform/enterprise/scim/manage/team-mapping).
+
+## Attribute mappings
+
+The following tables show the Okta-to-SCIM mappings relevant to Terraform Enterprise. The **Required** column reflects what Terraform Enterprise requires on incoming SCIM requests.
+
+### Users
+
+| Okta attribute | SCIM attribute | Required |
+|----------------|----------------|----------|
+| `userName` | `userName` | Yes |
+| `emails` | `emails` | Yes |
+
+Terraform Enterprise requires `userName` and at least one email value for each user. During user creation, Terraform Enterprise links existing users by email address when the email matches.
+
+### Groups
+
+| Okta attribute | SCIM attribute | Required |
+|----------------|----------------|----------|
+| `displayName` | `displayName` | Yes |
+| `members` | `members` | No |
+| `externalId` | `externalId` | No |
+
+## Test provisioning
+
+After completing the configuration, verify that provisioning works correctly.
+
+### Verify user provisioning
+
+1. Assign a test user to the Terraform Enterprise application in Okta.
+1. Wait a few moments for Okta to provision the user.
+1. Log in to Terraform Enterprise as a site administrator.
+1. Navigate to **Site Admin** > **Users**.
+1. Verify that the test user appears in the user list.
+1. Check that the user's email address matches the Okta user.
+
+### Verify group provisioning
+
+1. Push a test group from Okta to Terraform Enterprise.
+1. Log in to Terraform Enterprise as a site administrator.
+1. Navigate to **Site Admin** > **SCIM**.
+1. Verify that the group appears in the SCIM groups list.
+1. Link the group to a Terraform Enterprise team and verify membership synchronization.
+
+### Verify user deactivation
+
+1. Unassign a test user from the Terraform Enterprise application in Okta.
+1. Wait a few moments for Okta to deactivate the user.
+1. Log in to Terraform Enterprise and verify that the user is deactivated.
+
+## Troubleshooting
+
+If you encounter issues with Okta SCIM provisioning, use the following guidance to diagnose and resolve common problems.
+
+### Authentication failures
+
+| Issue | Cause | Solution |
+|-------|-------|----------|
+| `401 Unauthorized` error | Invalid or expired SCIM token | Create a new SCIM token in Terraform Enterprise and update the Okta configuration. |
+| Test API Credentials fails | Incorrect base URL or token | Verify the SCIM base URL format and ensure the token value is correct. |
+| Connection timeout | Network or firewall issues | Verify that Okta can reach your Terraform Enterprise instance. Check firewall rules and network connectivity. |
+
+### User provisioning failures
+
+| Issue | Cause | Solution |
+|-------|-------|----------|
+| Users not created | Incorrect user identifier or attribute mapping | Review the Okta user identifier and attribute mappings, then test with a single user before broad rollout. |
+| Duplicate user errors | Existing Terraform Enterprise user or SCIM identity conflicts with the incoming Okta user | If the email matches an existing Terraform Enterprise user, Terraform Enterprise links that user to SCIM. If the conflict is with an existing SCIM identity or another unique attribute, review the Terraform Enterprise-side conflict guidance in [Troubleshoot SCIM provisioning](/terraform/enterprise/scim/troubleshooting#users-not-syncing). |
+| User attributes not updating | Update User Attributes not enabled | Enable **Update User Attributes** in the Okta provisioning settings. |
+
+### Group provisioning failures
+
+| Issue | Cause | Solution |
+|-------|-------|----------|
+| Groups not appearing in Terraform Enterprise | Push Groups not configured | Configure group push in Okta and select the groups to push. |
+| Group membership not syncing | SCIM group not linked to a team | Link the SCIM group to a Terraform Enterprise team. Refer to [Link SCIM groups to teams](/terraform/enterprise/scim/manage/team-mapping). |
+| Large group operations timeout | Group exceeds size limits | Split large groups into smaller groups. Terraform Enterprise public SCIM group create and update requests support a maximum of 1,000 members per group. |
+
+### Rate limiting
+
+Okta may encounter rate limits when provisioning large numbers of users or groups. If you see `429 Too Many Requests` errors:
+
+Terraform Enterprise temporarily rate-limits SCIM requests when request volume is too high. Review the Okta provisioning logs, wait for provisioning to continue, and refer to [Troubleshoot SCIM provisioning](/terraform/enterprise/scim/troubleshooting) if the condition persists.
+
+### View provisioning logs in Okta
+
+To view detailed provisioning logs and error messages:
+
+1. In the Okta Admin Console, navigate to your Terraform Enterprise application.
+1. Click the **Provisioning** tab.
+1. Click **View Logs** to see recent provisioning events.
+1. Filter by status to find failed operations.
+
+For additional troubleshooting guidance, refer to [Troubleshoot SCIM provisioning](/terraform/enterprise/scim/troubleshooting).
+
+## Next steps
+
+After configuring Okta for SCIM provisioning, complete the following tasks:
+
+- [Link SCIM groups to Terraform Enterprise teams](/terraform/enterprise/scim/manage/team-mapping) to control team membership through your IdP.
+- [Configure a site admin group](/terraform/enterprise/scim/manage#configure-site-admin-group) to automatically provision site administrators.
+- Review [SCIM user management](/terraform/enterprise/scim/users) to understand how SCIM-managed users behave in Terraform Enterprise.
+- Review [SCIM group management](/terraform/enterprise/scim/groups) to understand how SCIM groups integrate with Terraform Enterprise teams.

--- a/content/terraform-docs-common/docs/cloud-docs/scim/groups.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/scim/groups.mdx
@@ -1,0 +1,174 @@
+---
+page_title: Group management with SCIM for Terraform Enterprise
+description: >-
+  Learn how SCIM 2.0 manages identity provider groups and synchronizes
+  membership with Terraform Enterprise.
+---
+
+# Group management with SCIM
+
+This topic describes how Terraform Enterprise manages SCIM groups from your identity provider (IdP) and how group membership synchronizes with Terraform Enterprise teams.
+
+## Overview
+
+SCIM groups represent groups from your IdP. Terraform Enterprise stores groups provisioned through SCIM separately from native Terraform Enterprise teams. You can then link these SCIM groups to teams to automate team membership management.
+
+SCIM groups enable you to:
+
+- Automatically sync group membership from your IdP to Terraform Enterprise
+- Link a single IdP group to multiple Terraform Enterprise teams across different organizations
+- Maintain your IdP as the single source of truth for group membership
+
+## Groups and teams
+
+SCIM groups are representations of IdP groups. Terraform Enterprise provisions them through SCIM and stores them separately from native Terraform Enterprise teams. Team mapping links SCIM groups to Terraform Enterprise teams so Terraform Enterprise can automatically synchronize team membership according to the groups defined in your IdP.
+
+The following table provides more information about how SCIM groups relate to Terraform Enterprise teams.
+
+| | SCIM groups | Terraform Enterprise teams |
+| --- | --- | --- |
+| **Description** | Stored separately from native teams and contain membership information synced from your IdP. | Organization-scoped entities that control access to workspaces, projects, and other resources. Teams have associated permissions and can contain members. |
+| **Management** | Managed by your IdP through SCIM API calls. | Managed in the Terraform Enterprise UI or API, or linked to SCIM groups for automated membership. |
+| **Scope** | Global to your Terraform Enterprise instance. | Scoped to a specific organization in Terraform Enterprise. |
+| **Permissions** | No permissions. | Configurable permissions for workspaces, projects, and organization-level access. |
+| **Membership source** | IdP. | Managed manually or synchronized from a linked SCIM group. |
+
+Refer to [Link SCIM groups to teams](/terraform/enterprise/scim/manage/team-mapping) for instructions on creating and managing team mappings.
+
+### Group-to-team links
+
+When you link a SCIM group to one or more Terraform Enterprise teams, Terraform Enterprise performs the following actions:
+
+1. Replaces the Terraform Enterprise team's existing human user membership with the SCIM group's membership. Existing service account memberships are preserved.
+1. Adds users in the SCIM group to the organization if they are not already members.
+1. Automatically propagates membership changes in the IdP to all linked Terraform Enterprise teams.
+
+A single SCIM group can be linked to up to 10,000 Terraform Enterprise teams across different organizations, but you can only link a team to one SCIM group.
+
+You can't create a team mapping in the following cases:
+
+- **Owners team**: The owners team in each organization cannot be SCIM-managed. This ensures administrators can always access Terraform Enterprise even if SCIM or SSO experiences issues.
+- **Site admin group**: The group configured as the site administrator group in SCIM settings cannot be mapped to regular Terraform Enterprise teams.
+
+## Group lifecycle
+
+SCIM groups follow a standard create, update, and delete lifecycle managed by your identity provider.
+
+### Create stage
+
+Terraform Enterprise performs the following actions when your IdP creates a group through SCIM:
+
+1. Generates a unique SCIM `id` for the group.
+1. Stores the group with its `displayName` and any `externalId` from the IdP.
+
+Terraform Enterprise teams aren't linked to the group until you explicitly create a mapping to establish the connection. After creation, the group is available for team mapping.
+
+SCIM group `displayName` values must be unique across Terraform Enterprise. Values aren't case-sensitive. As a result, Terraform Enterprise considers `Engineering` and `engineering` to be the same `displayName`. When you attempt to provision a group with an existing `displayName`, Terraform Enterprise rejects the request with HTTP `409 Conflict`.
+
+Terraform Enterprise preserves the original letter case of SCIM group display names when it stores them. API responses return the stored `displayName` with that preserved letter case.
+
+To reference a group member in the `members[].value` object, you must include the user's public SCIM `id` value from `/scim/v2/Users`. Before you can perform group membership operations, the user must already be provisioned in Terraform Enterprise through SCIM.
+
+### Update stage
+
+Your IdP can update the following group properties:
+
+- **Display name changes**: Updates to the group's display name are stored in Terraform Enterprise with the letter case provided by the IdP.
+- **Membership changes**: Adding or removing users from the group triggers membership synchronization to all linked Terraform Enterprise teams.
+
+Terraform Enterprise supports both full group replacement and partial group updates from supported identity providers:
+
+- Full replacement updates reconcile the group's membership to the roster provided by the IdP.
+- Partial updates support the common group change patterns used by Okta and Microsoft Entra ID, including display name changes, full member replacement, and incremental member add or remove operations.
+
+For the exact public SCIM endpoints, request shapes, supported `PATCH` request forms, and omitted-attribute behavior, refer to the [SCIM Groups API](/terraform/enterprise/api-docs/scim/groups).
+
+Refer to [Membership synchronization](#membership-synchronization) for details on how membership updates propagate.
+
+### Delete stage
+
+Terraform Enterprise performs the following actions when your IdP deletes a group through SCIM:
+
+1. Removes the SCIM group record.
+1. Removes the SCIM group as a synchronization source for any linked teams.
+1. Stops sending updates from that group to previously linked Terraform Enterprise teams.
+
+After deletion, verify the resulting mapping state and team membership for affected teams. Decide whether each affected team should be managed manually in Terraform Enterprise or linked to a different SCIM group.
+
+If the deleted SCIM group was configured as the site admin group, Terraform Enterprise clears the site admin group mapping. Existing site administrator grants are not automatically revoked.
+
+For exact delete semantics and status codes, refer to the [SCIM Groups API](/terraform/enterprise/api-docs/scim/groups).
+
+## Membership synchronization
+
+When your IdP updates group membership, Terraform Enterprise synchronizes the changes to all linked Terraform Enterprise teams.
+
+### Synchronization process
+
+Terraform Enterprise performs the following actions when your IdP sends a membership update:
+
+1. Updates the SCIM group's membership records.
+1. For each linked Terraform Enterprise team where synchronization is not paused, Terraform Enterprise:
+   - Removes users who are no longer in the SCIM group.
+   - Adds users newly added to the SCIM group.
+   - Creates organization membership for users if needed.
+1. Applies all changes as discrete records in a single transaction.
+
+### Transaction behavior
+
+Terraform Enterprise synchronizes membership as discrete records in a transaction to ensure data consistency.
+
+Terraform Enterprise doesn't partially apply changes. All changes either succeed or roll back depending on the success of the synchronization. If the transaction times out or fails, the team retains its previous membership state.
+
+### Synchronization scope
+
+Membership changes propagate to all linked Terraform Enterprise teams where synchronization is active. Teams with paused synchronization are not affected until you unpause them.
+
+When you unpause synchronization for a team, Terraform Enterprise compares the current SCIM group membership with the team's membership and reconciles any differences to match the SCIM group.
+
+If the linked SCIM group is deleted, Terraform Enterprise no longer has a source group to sync from. Verify the resulting mapping state and current team membership before making manual changes.
+
+## Group size limits
+
+Terraform Enterprise enforces limits on group membership to ensure reliable synchronization within transaction timeouts.
+
+| Limit | Value | Behavior |
+|-------|-------|----------|
+| Maximum members per SCIM group request | 1,000 | Public SCIM group create or update requests that would create or project a group over this limit return HTTP `413 Payload Too Large` |
+
+Terraform Enterprise also enforces public SCIM request-size and PATCH request limits. Refer to the [Public SCIM API](/terraform/enterprise/api-docs/scim) and the [SCIM Groups API](/terraform/enterprise/api-docs/scim/groups) for the exact request-size, operation-count, and response details.
+
+### Handling large groups
+
+If you have IdP groups exceeding the maximum limit, consider the following approaches:
+
+- **Split into smaller groups**: Create multiple smaller IdP groups based on functional roles or departments
+- **Use multiple team mappings**: Link smaller groups to separate Terraform Enterprise teams with appropriate permissions
+- **Consolidate access patterns**: Review whether all members need the same level of access
+
+## Rate limits
+
+SCIM group operations are subject to rate limiting to protect Terraform Enterprise performance.
+
+Public SCIM provisioning requests and admin team-linking operations use different rate limits.
+
+Public SCIM provisioning uses shared rate limits across the public SCIM endpoints, while admin team-linking and pause-toggle operations use separate admin rate limits.
+
+For the exact rate limit values, refer to the [Public SCIM API](/terraform/enterprise/api-docs/scim) and the [Team SCIM Group Mapping API](/terraform/enterprise/api-docs/admin/team-scim-group-mapping).
+
+## API reference
+
+Use the following API references for SCIM group operations:
+
+- Refer to the [Public SCIM API](/terraform/enterprise/api-docs/scim) for authentication, discovery endpoints, pagination, supported filters, and shared rate limits.
+- Refer to the [SCIM Groups API](/terraform/enterprise/api-docs/scim/groups) for the public `/scim/v2/Groups` provisioning endpoints, supported `excludedAttributes` behavior, and group create or update semantics.
+- Refer to the [Admin SCIM Groups API](/terraform/enterprise/api-docs/admin/scim-groups) to list the SCIM groups available for team mapping.
+
+### IdP-specific behavior
+
+Different identity providers send membership updates in different formats:
+
+- **Okta**: Sends `PUT` requests with a complete list of all group members
+- **Microsoft Entra ID**: Sends `PATCH` requests with lists of members to add and remove
+
+Terraform Enterprise handles both formats and applies the appropriate membership changes.

--- a/content/terraform-docs-common/docs/cloud-docs/scim/index.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/scim/index.mdx
@@ -1,0 +1,143 @@
+---
+page_title: SCIM provisioning overview for Terraform Enterprise
+description: >-
+  Learn how to use SCIM 2.0 to automatically provision and manage users and
+  groups in Terraform Enterprise from your identity provider.
+---
+
+# SCIM provisioning overview
+
+This topic provides an overview of SCIM 2.0 provisioning in Terraform Enterprise. SCIM (System for Cross-domain Identity Management) enables automated user provisioning, deprovisioning, and group management from your identity provider (IdP) directly into Terraform Enterprise.
+
+## Introduction
+
+SCIM 2.0 is an open standard protocol designed to simplify user identity management across cloud-based applications and services. For enterprise organizations, SCIM eliminates the manual processes required to onboard and offboard users, ensuring that identity changes in your corporate directory are automatically reflected in Terraform Enterprise.
+
+When you integrate SCIM with Terraform Enterprise, your identity provider becomes the authoritative source for user lifecycle management. This means that when employees join, change roles, or leave your organization, their access to Terraform Enterprise is automatically updated without manual intervention.
+
+Terraform Enterprise implements SCIM for Terraform Enterprise only. The SCIM configuration is instance-wide.
+
+Terraform Enterprise exposes two SCIM-related API surfaces:
+
+- The public SCIM provisioning and discovery endpoints under `/scim/v2`, which your identity provider uses for user and group provisioning.
+- Terraform Enterprise admin endpoints under `/api/v2/admin/*`, which site administrators use to manage SCIM settings, SCIM tokens, provisioned SCIM groups for team mapping, and team-to-group links.
+
+The [Configure SCIM provisioning](/terraform/enterprise/scim/configure)
+topic is the primary enablement page for this workflow.
+
+## Benefits
+
+SCIM provisioning provides several key benefits for enterprise identity management:
+
+### Automated provisioning
+
+When a new employee is added to your identity provider, SCIM automatically creates their account in Terraform Enterprise. Team membership is synchronized separately through SCIM group provisioning and team mapping. This eliminates manual account creation and reduces IT administrative overhead.
+
+### Reduced manual overhead
+
+SCIM synchronizes user profile changes, such as email updates or group membership changes, automatically between your IdP and Terraform Enterprise. Administrators no longer need to manually update user information across multiple systems.
+
+### Enhanced security through instant deprovisioning
+
+When an employee leaves your organization or loses Terraform Enterprise access in your IdP, SCIM immediately revokes their access to Terraform Enterprise. Unlike SAML authentication alone, which only updates access at login time, SCIM proactively removes access regardless of whether the user attempts to log in. This ensures that terminated employees cannot retain access to your infrastructure.
+
+### Centralized identity management
+
+Your identity provider serves as the single source of truth for user identities. All user and group management happens in one place, reducing the risk of access inconsistencies and simplifying compliance auditing.
+
+## SCIM complements SAML
+
+SCIM and SAML serve complementary but distinct purposes in Terraform Enterprise:
+
+| Protocol | Purpose | When it runs |
+|----------|---------|--------------|
+| SAML | Authentication | At user login |
+| SCIM | Provisioning | Continuously, as changes occur in IdP |
+
+You must enable SAML single sign-on (SSO) in Terraform Enterprise before configuring SCIM.
+
+When SCIM is enabled, Terraform Enterprise ignores team membership information in SAML assertions. This prevents potential conflicts between the two systems and ensures that SCIM remains the authoritative source for provisioning.
+
+When SCIM is enabled, Terraform Enterprise does not create users on login. You must provision users through SCIM before they can authenticate with SAML.
+
+## Key concepts
+
+### User types
+
+Terraform Enterprise distinguishes between users provisioned in your IdP and users that you manually manage in the platform.
+
+- **IdP-provisioned users**: Users created and managed through SCIM. These users cannot be modified directly in Terraform Enterprise. Profile updates and deprovisioning must occur through the identity provider.
+- **Manually-managed users**: Users created directly in Terraform Enterprise, including site administrators created for recovery purposes. These users can be modified within Terraform Enterprise and are not affected by SCIM operations.
+
+### SCIM groups
+
+SCIM groups represent groups from your identity provider. When your IdP syncs groups to Terraform Enterprise, Terraform Enterprise:
+
+- Stores them as SCIM groups.
+- Synchronizes group membership automatically.
+- Lets you link groups to Terraform Enterprise teams.
+
+### Automated team membership management
+
+Link SCIM groups from your IdP to teams in Terraform Enterprise to enable automatic team membership management.
+
+- A single SCIM group can be linked to multiple Terraform Enterprise teams across different organizations, up to 10,000 teams per group.
+- Each Terraform Enterprise team can only be linked to one SCIM group.
+- When users are added or removed from a group in the IdP, Terraform Enterprise automatically updates their team memberships.
+- You cannot directly modify team membership in Terraform Enterprise when the team is linked to a SCIM group.
+- You cannot configure the `owners` team as a SCIM-managed team. This ensures administrators can always access Terraform Enterprise for troubleshooting.
+
+Refer to [Link SCIM groups to teams](/terraform/enterprise/scim/manage/team-mapping) for detailed instructions.
+
+### Source of truth
+
+Terraform Enterprise provides granular control over how user and team membership is managed:
+
+- Site-level control: Administrators can enable, pause, or disable SCIM provisioning for the entire Terraform Enterprise instance. Pausing SCIM preserves all existing configurations and mappings but stops processing updates from the IdP.
+- Team-level control: Administrators can pause SCIM synchronization for individual teams for debugging purposes. This lets administrators troubleshoot specific team mappings without affecting other teams.
+
+## Supported identity providers
+
+Terraform Enterprise supports SCIM with the following identity providers and provider configurations:
+
+- Okta
+- Microsoft Entra ID
+- Supported generic SAML provider configurations
+
+Terraform Enterprise implements SCIM as a custom application in each identity provider, not as a pre-built gallery application.
+
+Terraform Enterprise does not claim broad interoperability with every SCIM client. The implementation is validated for Okta and Microsoft Entra ID request patterns.
+
+## SCIM interfaces
+
+Terraform Enterprise implements SCIM `User` and `Group` resources, as well as the discovery endpoints required by common identity providers.
+
+On the public `/scim/v2` surface, Terraform Enterprise exposes:
+
+- Discovery endpoints under `/scim/v2/ServiceProviderConfig`, `/scim/v2/Schemas`, and `/scim/v2/ResourceTypes`.
+- User provisioning endpoints under `/scim/v2/Users`.
+- Group provisioning endpoints under `/scim/v2/Groups`.
+
+Terraform Enterprise documents the separate admin JSON:API surface under `/api/v2/admin/*` in the [admin API reference pages](/terraform/enterprise/api-docs/admin).
+
+Terraform Enterprise partially implements the SCIM 2.0 specification. The following limitations apply:
+
+- Bulk operations are not supported.
+- Filtering is limited to equality (`eq`) lookups on the following set of attributes:
+  - `Users` support `userName eq` and `externalId eq`.
+  - `Groups` support `displayName eq` and `externalId eq`.
+- `PATCH` support is limited to the `User` and `Group` attributes described in the [SCIM Users API](/terraform/enterprise/api-docs/scim/users) and [SCIM Groups API](/terraform/enterprise/api-docs/scim/groups).
+- SCIM does not synchronize passwords or full profile data.
+
+## Related documentation
+
+- [Configure SCIM provisioning](/terraform/enterprise/scim/configure)
+- [Tokens](/terraform/enterprise/scim/manage/tokens)
+- [SCIM users](/terraform/enterprise/scim/users)
+- [SCIM groups](/terraform/enterprise/scim/groups)
+- [Link SCIM groups to teams](/terraform/enterprise/scim/manage/team-mapping)
+- [Configure Okta for SCIM](/terraform/enterprise/scim/configure/okta)
+- [Configure Microsoft Entra ID for SCIM](/terraform/enterprise/scim/configure/entra-id)
+- [Troubleshoot SCIM provisioning](/terraform/enterprise/scim/troubleshooting)
+- [SAML configuration](/terraform/enterprise/saml/configuration)
+- [Admin Settings API](/terraform/enterprise/api-docs/admin/settings)

--- a/content/terraform-docs-common/docs/cloud-docs/scim/index.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/scim/index.mdx
@@ -7,14 +7,15 @@ description: >-
 
 # SCIM provisioning overview
 
-This topic provides an overview of SCIM 2.0 provisioning in Terraform Enterprise. SCIM (System for Cross-domain Identity Management) enables automated user provisioning, deprovisioning, and group management from your identity provider (IdP) directly into Terraform Enterprise.
+This topic provides an overview of SCIM 2.0 provisioning. SCIM (System for Cross-domain Identity Management) lets you automate user provisioning and deprovisioning and manage groups using your identity provider (IdP) as the source of truth. 
 
 ## Introduction
 
-SCIM 2.0 is an open standard protocol designed to simplify user identity management across cloud-based applications and services. For enterprise organizations, SCIM eliminates the manual processes required to onboard and offboard users, ensuring that identity changes in your corporate directory are automatically reflected in Terraform Enterprise.
+SCIM is an open standard protocol designed to simplify user identity management across cloud-based applications and services. SCIM eliminates the manual processes required to onboard and offboard users, ensuring that identity changes in your corporate directory are automatically reflected in <!-- BEGIN: TFEnterprise:only name:product-name -->Terraform Enterprise<!-- END: TFEnterprise:only name:product-name --><!-- BEGIN: TFC:only name:product-name -->HCP Terraform<!-- END: TFC:only name:product-name -->.
 
-When you integrate SCIM with Terraform Enterprise, your identity provider becomes the authoritative source for user lifecycle management. This means that when employees join, change roles, or leave your organization, their access to Terraform Enterprise is automatically updated without manual intervention.
+When you enable SCIM provisioning, your identity provider becomes the authoritative source for user lifecycle management so that when employees join, change roles, or leave your organization, their access to <!-- BEGIN: TFEnterprise:only name:product-name -->Terraform Enterprise<!-- END: TFEnterprise:only name:product-name --><!-- BEGIN: TFC:only name:product-name -->HCP Terraform<!-- END: TFC:only name:product-name --> is automatically updated without manual intervention.
 
+<!-- BEGIN: TFEnterprise:only name:scim-scope -->
 Terraform Enterprise implements SCIM for Terraform Enterprise only. The SCIM configuration is instance-wide.
 
 Terraform Enterprise exposes two SCIM-related API surfaces:
@@ -24,22 +25,23 @@ Terraform Enterprise exposes two SCIM-related API surfaces:
 
 The [Configure SCIM provisioning](/terraform/enterprise/scim/configure)
 topic is the primary enablement page for this workflow.
+<!-- END: TFEnterprise:only name:scim-scope -->
 
 ## Benefits
 
-SCIM provisioning provides several key benefits for enterprise identity management:
+SCIM provisioning provides several key benefits for enterprise identity management.
 
 ### Automated provisioning
 
-When a new employee is added to your identity provider, SCIM automatically creates their account in Terraform Enterprise. Team membership is synchronized separately through SCIM group provisioning and team mapping. This eliminates manual account creation and reduces IT administrative overhead.
+When a new employee is added to your identity provider, SCIM automatically creates their account in <!-- BEGIN: TFEnterprise:only name:product-name -->Terraform Enterprise<!-- END: TFEnterprise:only name:product-name --><!-- BEGIN: TFC:only name:product-name -->HCP Terraform<!-- END: TFC:only name:product-name -->. Team membership is synchronized separately through SCIM group provisioning and team mapping. This eliminates manual account creation and reduces IT administrative overhead.
 
 ### Reduced manual overhead
 
-SCIM synchronizes user profile changes, such as email updates or group membership changes, automatically between your IdP and Terraform Enterprise. Administrators no longer need to manually update user information across multiple systems.
+SCIM synchronizes user profile changes, such as email updates or group membership changes, automatically between your IdP and <!-- BEGIN: TFEnterprise:only name:product-name -->Terraform Enterprise<!-- END: TFEnterprise:only name:product-name --><!-- BEGIN: TFC:only name:product-name -->HCP Terraform<!-- END: TFC:only name:product-name -->. Administrators no longer need to manually update user information across multiple systems.
 
 ### Enhanced security through instant deprovisioning
 
-When an employee leaves your organization or loses Terraform Enterprise access in your IdP, SCIM immediately revokes their access to Terraform Enterprise. Unlike SAML authentication alone, which only updates access at login time, SCIM proactively removes access regardless of whether the user attempts to log in. This ensures that terminated employees cannot retain access to your infrastructure.
+When an employee leaves your organization or loses <!-- BEGIN: TFEnterprise:only name:product-name -->Terraform Enterprise<!-- END: TFEnterprise:only name:product-name --><!-- BEGIN: TFC:only name:product-name -->HCP Terraform<!-- END: TFC:only name:product-name --> access in your IdP, SCIM immediately revokes their access to <!-- BEGIN: TFEnterprise:only name:product-name -->Terraform Enterprise<!-- END: TFEnterprise:only name:product-name --><!-- BEGIN: TFC:only name:product-name -->HCP Terraform<!-- END: TFC:only name:product-name -->. Unlike SAML authentication alone, which only updates access at login time, SCIM proactively removes access regardless of whether the user attempts to log in. This ensures that terminated employees cannot retain access to your infrastructure.
 
 ### Centralized identity management
 
@@ -54,64 +56,67 @@ SCIM and SAML serve complementary but distinct purposes in Terraform Enterprise:
 | SAML | Authentication | At user login |
 | SCIM | Provisioning | Continuously, as changes occur in IdP |
 
-You must enable SAML single sign-on (SSO) in Terraform Enterprise before configuring SCIM.
+You must enable SAML single sign-on (SSO) before configuring SCIM.
 
-When SCIM is enabled, Terraform Enterprise ignores team membership information in SAML assertions. This prevents potential conflicts between the two systems and ensures that SCIM remains the authoritative source for provisioning.
+When SCIM is enabled, <!-- BEGIN: TFEnterprise:only name:product-name -->Terraform Enterprise<!-- END: TFEnterprise:only name:product-name --><!-- BEGIN: TFC:only name:product-name -->HCP Terraform<!-- END: TFC:only name:product-name --> ignores team membership information in SAML assertions. This prevents potential conflicts between the two systems and ensures that SCIM remains the authoritative source for provisioning.
 
-When SCIM is enabled, Terraform Enterprise does not create users on login. You must provision users through SCIM before they can authenticate with SAML.
+When SCIM is enabled, <!-- BEGIN: TFEnterprise:only name:product-name -->Terraform Enterprise<!-- END: TFEnterprise:only name:product-name --><!-- BEGIN: TFC:only name:product-name -->HCP Terraform<!-- END: TFC:only name:product-name --> does not create users on login. You must provision users through SCIM before they can authenticate with SAML.
 
-## Key concepts
+## User types
 
-### User types
+Users provisioned by your IdP cannot be modified directly in <!-- BEGIN: TFEnterprise:only name:product-name -->Terraform Enterprise<!-- END: TFEnterprise:only name:product-name --><!-- BEGIN: TFC:only name:product-name -->HCP Terraform<!-- END: TFC:only name:product-name -->. Profile updates and deprovisioning must occur through the identity provider.
 
-Terraform Enterprise distinguishes between users provisioned in your IdP and users that you manually manage in the platform.
+Manually-managed users, including site administrators created for recovery purposes, can be modified within <!-- BEGIN: TFEnterprise:only name:product-name -->Terraform Enterprise<!-- END: TFEnterprise:only name:product-name --><!-- BEGIN: TFC:only name:product-name -->HCP Terraform<!-- END: TFC:only name:product-name --> and are not affected by SCIM operations.
 
-- **IdP-provisioned users**: Users created and managed through SCIM. These users cannot be modified directly in Terraform Enterprise. Profile updates and deprovisioning must occur through the identity provider.
-- **Manually-managed users**: Users created directly in Terraform Enterprise, including site administrators created for recovery purposes. These users can be modified within Terraform Enterprise and are not affected by SCIM operations.
+## SCIM groups
 
-### SCIM groups
-
-SCIM groups represent groups from your identity provider. When your IdP syncs groups to Terraform Enterprise, Terraform Enterprise:
+SCIM groups represent groups from your identity provider. <!-- BEGIN: TFEnterprise:only name:product-name -->Terraform Enterprise<!-- END: TFEnterprise:only name:product-name --><!-- BEGIN: TFC:only name:product-name -->HCP Terraform<!-- END: TFC:only name:product-name --> performs the following acitons during synchronization:
 
 - Stores them as SCIM groups.
 - Synchronizes group membership automatically.
-- Lets you link groups to Terraform Enterprise teams.
+- Lets you link groups to teams in <!-- BEGIN: TFEnterprise:only name:product-name -->Terraform Enterprise<!-- END: TFEnterprise:only name:product-name --><!-- BEGIN: TFC:only name:product-name -->HCP Terraform<!-- END: TFC:only name:product-name -->.
 
-### Automated team membership management
+## Automated team membership management
 
-Link SCIM groups from your IdP to teams in Terraform Enterprise to enable automatic team membership management.
+Link SCIM groups from your IdP to teams in <!-- BEGIN: TFEnterprise:only name:product-name -->Terraform Enterprise<!-- END: TFEnterprise:only name:product-name --><!-- BEGIN: TFC:only name:product-name -->HCP Terraform<!-- END: TFC:only name:product-name --> to enable automatic team membership management.
 
-- A single SCIM group can be linked to multiple Terraform Enterprise teams across different organizations, up to 10,000 teams per group.
-- Each Terraform Enterprise team can only be linked to one SCIM group.
-- When users are added or removed from a group in the IdP, Terraform Enterprise automatically updates their team memberships.
-- You cannot directly modify team membership in Terraform Enterprise when the team is linked to a SCIM group.
-- You cannot configure the `owners` team as a SCIM-managed team. This ensures administrators can always access Terraform Enterprise for troubleshooting.
+- You can link a single SCIM group to multiple <!-- BEGIN: TFEnterprise:only name:product-name -->Terraform Enterprise<!-- END: TFEnterprise:only name:product-name --><!-- BEGIN: TFC:only name:product-name -->HCP Terraform<!-- END: TFC:only name:product-name --> teams across different organizations, up to 10,000 teams per group.
+- You can only link team to one SCIM group.
+- When users are added or removed from a group in the IdP, <!-- BEGIN: TFEnterprise:only name:product-name -->Terraform Enterprise<!-- END: TFEnterprise:only name:product-name --><!-- BEGIN: TFC:only name:product-name -->HCP Terraform<!-- END: TFC:only name:product-name --> automatically updates their team memberships.
+- You cannot directly modify team membership in <!-- BEGIN: TFEnterprise:only name:product-name -->Terraform Enterprise<!-- END: TFEnterprise:only name:product-name --><!-- BEGIN: TFC:only name:product-name -->HCP Terraform<!-- END: TFC:only name:product-name --> when the team is linked to a SCIM group.
+- You cannot configure the `owners` team as a SCIM-managed team. This ensures administrators can always access <!-- BEGIN: TFEnterprise:only name:product-name -->Terraform Enterprise<!-- END: TFEnterprise:only name:product-name --><!-- BEGIN: TFC:only name:product-name -->HCP Terraform<!-- END: TFC:only name:product-name --> for troubleshooting.
 
+<!-- BEGIN: TFEnterprise:only name:team-mapping -->
 Refer to [Link SCIM groups to teams](/terraform/enterprise/scim/manage/team-mapping) for detailed instructions.
+<!-- END: TFEnterprise:only name:team-mapping -->
 
-### Source of truth
+## Source of truth
 
-Terraform Enterprise provides granular control over how user and team membership is managed:
+The IdP is the source of truth for user and team membership management, but <!-- BEGIN: TFEnterprise:only name:product-name -->site administrators<!-- END: TFEnterprise:only name:product-name --><!-- BEGIN: TFC:only name:product-name -->organization owners<!-- END: TFC:only name:product-name --> can enable, pause, or disable SCIM provisioning for the <!-- BEGIN: TFEnterprise:only name:scim-scope -->entire Terraform Enterprise instance<!-- END: TFEnterprise:only name:scim-scope --><!-- BEGIN: TFC:only name:scim-scope -->organization<!-- END: TFC:only name:scim-scope -->. Pausing SCIM preserves all existing configurations and mappings but stops processing updates from the IdP.
 
-- Site-level control: Administrators can enable, pause, or disable SCIM provisioning for the entire Terraform Enterprise instance. Pausing SCIM preserves all existing configurations and mappings but stops processing updates from the IdP.
-- Team-level control: Administrators can pause SCIM synchronization for individual teams for debugging purposes. This lets administrators troubleshoot specific team mappings without affecting other teams.
+<!-- BEGIN: TFEnterprise:only name:scim-scope -->
+Administrators can pause SCIM synchronization for individual teams for debugging purposes. This lets administrators troubleshoot specific team mappings without affecting other teams.
+<!-- END: TFEnterprise:only name:scim-scope -->
 
 ## Supported identity providers
 
-Terraform Enterprise supports SCIM with the following identity providers and provider configurations:
+You can enable SCIM with the following identity providers and provider configurations:
 
 - Okta
 - Microsoft Entra ID
 - Supported generic SAML provider configurations
 
+<!-- BEGIN: TFEnterprise:only name:scim-scope -->
 Terraform Enterprise implements SCIM as a custom application in each identity provider, not as a pre-built gallery application.
 
 Terraform Enterprise does not claim broad interoperability with every SCIM client. The implementation is validated for Okta and Microsoft Entra ID request patterns.
+<!-- END: TFEnterprise:only name:scim-scope -->
 
 ## SCIM interfaces
 
-Terraform Enterprise implements SCIM `User` and `Group` resources, as well as the discovery endpoints required by common identity providers.
+The <!-- BEGIN: TFEnterprise:only name:api -->Terraform Enterprise<!-- END: TFEnterprise:only name:api --><!-- BEGIN: TFC:only name:api -->HCP Terraform<!-- END: TFC:only name:api --> API implements SCIM `User` and `Group` resources, as well as the discovery endpoints required by common identity providers.
 
+<!-- BEGIN: TFEnterprise:only name:api -->
 On the public `/scim/v2` surface, Terraform Enterprise exposes:
 
 - Discovery endpoints under `/scim/v2/ServiceProviderConfig`, `/scim/v2/Schemas`, and `/scim/v2/ResourceTypes`.
@@ -128,9 +133,15 @@ Terraform Enterprise partially implements the SCIM 2.0 specification. The follow
   - `Groups` support `displayName eq` and `externalId eq`.
 - `PATCH` support is limited to the `User` and `Group` attributes described in the [SCIM Users API](/terraform/enterprise/api-docs/scim/users) and [SCIM Groups API](/terraform/enterprise/api-docs/scim/groups).
 - SCIM does not synchronize passwords or full profile data.
+<!-- END: TFEnterprise:only name:api -->
+
+<!-- BEGIN: TFC:only name:api -->
+TODO: describe the interfaces for HCPTF
+<!-- END: TFC:only name:api -->
 
 ## Related documentation
 
+<!-- BEGIN: TFEnterprise:only name:guidance -->
 - [Configure SCIM provisioning](/terraform/enterprise/scim/configure)
 - [Tokens](/terraform/enterprise/scim/manage/tokens)
 - [SCIM users](/terraform/enterprise/scim/users)
@@ -141,3 +152,15 @@ Terraform Enterprise partially implements the SCIM 2.0 specification. The follow
 - [Troubleshoot SCIM provisioning](/terraform/enterprise/scim/troubleshooting)
 - [SAML configuration](/terraform/enterprise/saml/configuration)
 - [Admin Settings API](/terraform/enterprise/api-docs/admin/settings)
+<!-- END: TFEnterprise:only name:guidance -->
+
+<!-- BEGIN: TFC:only name:guidance -->
+- [Configure SCIM provisioning](/terraform/cloud-docs/scim/configure)
+- [Manage tokens](/terraform/enterprise/scim/manage/tokens)
+- [SCIM user lifecycle](/terraform/cloud-docs/scim/users)
+- [SCIM group synchronization](/terraform/cloud-docs/scim/groups)
+- [Configure Okta for SCIM](/terraform/cloud-docs/scim/configure/okta)
+- [Configure Microsoft Entra ID for SCIM](/terraform/cloud-docs/scim/configure/entra-id)
+- [Troubleshoot SCIM provisioning](/terraform/cloud-docs/scim/troubleshooting)
+- [SAML configuration](/terraform/cloud-docs/users-teams-organizations/single-sign-on/saml)
+<!-- END: TFC:only name:guidance -->

--- a/content/terraform-docs-common/docs/cloud-docs/scim/manage/index.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/scim/manage/index.mdx
@@ -1,0 +1,126 @@
+---
+page_title: Manage SCIM provisioning for Terraform Enterprise
+description: >-
+  Learn how to manage the site-level SCIM configuration in Terraform
+  Enterprise, including pause and resume behavior, site admin group mapping,
+  token rotation, and disabling SCIM.
+---
+
+# Manage SCIM provisioning
+
+This page explains how to maintain the site-level SCIM configuration after initial setup.
+
+## Overview
+
+Use this page for the following operational tasks:
+
+1. Pause or resume SCIM provisioning for the Terraform Enterprise instance.
+1. Configure or update the site admin group.
+1. Rotate SCIM tokens.
+1. Disable SCIM when necessary.
+
+For the initial setup workflow, refer to [Configure SCIM provisioning](/terraform/enterprise/scim/configure).
+
+## Pause and resume SCIM provisioning
+
+Pausing SCIM is different from disabling it. When SCIM is paused, Terraform Enterprise keeps the existing SCIM data and tokens, but stops processing provisioning requests from your identity provider.
+
+### Pause SCIM provisioning
+
+1. Open **Site Admin** > **SCIM**.
+1. Open **Manage**.
+1. Click **Pause SCIM provisioning**.
+1. Confirm the action.
+
+While SCIM is paused:
+
+- Existing SCIM users, groups, team links, and tokens stay in place.
+- Public provisioning requests to `/scim/v2/Users` and `/scim/v2/Groups` return `403 Forbidden`.
+- Linked teams stop receiving SCIM updates.
+- Users can still sign in with SAML.
+
+### Resume SCIM provisioning
+
+1. Open **Site Admin** > **SCIM**.
+1. Open **Manage** and click **Resume SCIM provisioning**.
+
+When you resume SCIM:
+
+- Terraform Enterprise starts processing provisioning requests again.
+- SCIM-linked teams can receive updates again.
+- Team links that were paused individually stay paused until you resume them.
+
+For team-level pause and resume behavior, refer to [Link SCIM groups to teams](/terraform/enterprise/scim/manage/team-mapping#pause-synchronization).
+
+## Configure site admin group
+
+Use a SCIM group to grant site administrator access automatically.
+
+1. Open **Site Admin** > **SCIM**.
+1. In **Site Admin IdP Group**, select the SCIM group to use for site admins.
+1. Click **Update site admin provisioning**.
+
+### Site admin group behavior
+
+- Setting or changing the selected SCIM group updates site admin access immediately for the current members of the mapped group.
+- Members added to the selected SCIM group through later SCIM group updates also gain site admin access.
+- Suspended users in the selected SCIM group do not receive site admin access until they are reactivated.
+- When you change the site admin group, Terraform Enterprise revokes site admin access from users in the previous mapped group who currently have the `SITE_ADMIN` role, then grants site admin access to the current members of the new mapped group.
+- Clearing the site admin group removes the mapping. Existing site administrator grants are not automatically revoked.
+- A SCIM group used for site admin access cannot also be linked to a Terraform Enterprise team.
+- When SCIM is enabled, use this setting to manage site admin access. Terraform Enterprise does not use SAML site admin attributes for site admin provisioning.
+
+We still recommend keeping at least one non-SSO admin account for recovery.
+
+## Rotate SCIM tokens
+
+To rotate a SCIM token:
+
+1. Generate a new token.
+1. Update your identity provider to use the new token.
+1. Verify that provisioning still works.
+1. Delete the old token.
+
+Deleting a token revokes it immediately. SCIM requests that still use that token fail until your identity provider starts using another valid token.
+
+For detailed token lifecycle guidance, refer to [Tokens](/terraform/enterprise/scim/manage/tokens).
+
+## Disable SCIM provisioning
+
+Disabling SCIM is different from pausing it. Disabling removes the SCIM configuration from Terraform Enterprise.
+
+When you disable SCIM, Terraform Enterprise:
+
+- deletes all SCIM groups
+- deletes all SCIM group memberships
+- deletes all team-to-SCIM-group links
+- deletes all SCIM identities
+- revokes all SCIM tokens
+
+Terraform Enterprise keeps:
+
+- existing users
+- existing teams and their permissions
+- organization memberships
+- existing site administrator grants
+
+Users can still sign in with SAML after SCIM is disabled.
+
+1. Open **Site Admin** > **SCIM**.
+1. Open **Manage** and click **Disable SCIM provisioning**.
+1. Review the warning.
+1. Confirm the action.
+1. Remove or disable the SCIM connection in your identity provider.
+
+If you enable SCIM again later, you must generate new tokens and reconnect your identity provider.
+
+If you disable SCIM through the admin settings API, use `DELETE /api/v2/admin/scim-settings`. Do not use `PATCH` with `enabled=false`; Terraform Enterprise rejects that request.
+
+After the delete completes, Terraform Enterprise resets the SCIM settings to `enabled=false`, `paused=false`, and clears the configured site admin group without revoking existing site administrator grants. Repeating the delete while SCIM is already disabled is safe and leaves SCIM in the same disabled state.
+
+## Related docs
+
+- [Configure SCIM provisioning](/terraform/enterprise/scim/configure)
+- [Tokens](/terraform/enterprise/scim/manage/tokens)
+- [Link SCIM groups to teams](/terraform/enterprise/scim/manage/team-mapping)
+- [Troubleshoot SCIM provisioning](/terraform/enterprise/scim/troubleshooting)

--- a/content/terraform-docs-common/docs/cloud-docs/scim/manage/tokens.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/scim/manage/tokens.mdx
@@ -1,0 +1,123 @@
+---
+page_title: Manage SCIM tokens for Terraform Enterprise
+description: >-
+  Learn how to create, manage, and rotate SCIM authentication tokens for
+  identity provider integration with Terraform Enterprise.
+---
+
+# Manage SCIM Tokens
+
+This topic describes how to generate, rotate, and delete SCIM tokens in Terraform Enterprise. Your identity provider (IdP) uses SCIM tokens to authenticate with Terraform Enterprise when provisioning users and groups.
+
+## Overview
+
+SCIM tokens are bearer tokens that authenticate your identity provider when it communicates with Terraform Enterprise's SCIM endpoints. The IdP includes the token in the `Authorization` header of each SCIM API request.
+
+SCIM tokens have the following characteristics:
+
+- **Scope**: Tokens are valid only for SCIM endpoints (`/scim/v2/*`). They cannot access other Terraform Enterprise APIs.
+- **Expiration**: Tokens created through the API default to 365 days when no expiration is specified. You can configure token expiration up to 12 months.
+- **Multiple tokens**: You can create multiple active tokens simultaneously. This enables zero-downtime token rotation. Refer to the [Public SCIM API](/terraform/enterprise/api-docs/scim) for public SCIM rate-limit behavior.
+
+### Token properties
+
+Each SCIM token has the following properties:
+
+| Property | Description |
+| --- | --- |
+| Description | A human-readable label to help identify the token's purpose. |
+| Token value | The secret bearer token value. Terraform Enterprise stores tokens as one-way hashes using HMAC-SHA512, so the original value cannot be retrieved. Terraform Enterprise only displays this value once at creation time. |
+| Created at | The timestamp when the token was created. |
+| Expired at | The timestamp when the token expires. Tokens created through the API default to 365 days if no expiration is specified. |
+| Last used at | The timestamp when the token was last used for a SCIM API request. Updated with a 1-minute throttle to reduce database writes. |
+
+## Requirements
+
+Only site administrators can create, view, and revoke SCIM tokens. For more information about site admin permissions, refer to [Site Administration Permissions](/terraform/enterprise/users-teams-organizations/users#site-admin-permissions).
+
+Before using SCIM tokens for provisioning, enable SCIM. Terraform Enterprise only accepts SCIM token-authenticated provisioning requests while SCIM is enabled. Refer to [Configure SCIM provisioning](/terraform/enterprise/scim/configure) for instructions.
+
+## Create a SCIM token
+
+To create a new SCIM token:
+
+1. Open your user icon menu and click **Site Admin**.
+2. Click **SCIM** in the left navigation.
+3. In the **SCIM Tokens** section, click **Create Token**.
+4. Enter a **Description** for the token, for example `IdP name` or `environment`.
+5. Optionally, set the token expiration. You can choose one of the following presets: **30-day**, **90-day**, or **365-day**.
+6. Click **Create Token**.
+7. Copy the token value and store it securely. You will not be able to retrieve it again.
+
+Terraform Enterprise stores tokens as one-way hashes using HMAC-SHA512. As a result, the original token value cannot be retrieved after creation. If you lose the token, you must create a new one.
+
+After creating the token, configure your identity provider to use this token for SCIM provisioning. Refer to the IdP-specific configuration guides:
+
+- [Configure Okta for SCIM](/terraform/enterprise/scim/configure/okta)
+- [Configure Microsoft Entra ID for SCIM](/terraform/enterprise/scim/configure/entra-id)
+
+Note that Terraform Enterprise blocks SCIM token creation while you are impersonating another user. Refer to [Impersonating a User](/terraform/enterprise/application-administration/resources#impersonating-a-user) for more information.
+
+## List tokens
+
+You can view all SCIM tokens from the SCIM settings page:
+
+1. Open your user icon menu and click **Site Admin**.
+1. Click **SCIM** in the left navigation.
+1. View the list of tokens in the **SCIM Tokens** section.
+
+The token list displays metadata for each token, including the description, creation date, expiration date, and last used timestamp. The list does not display the secret token values.
+
+Use the **Last used at** timestamp to identify which tokens are actively in use by your identity provider. Terraform Enterprise updates this value with a 1-minute throttle, so recent requests may not appear immediately.
+
+## Delete a token
+
+Deleting a SCIM token revokes access. Revoking a token immediately invalidates it, and any SCIM requests using that token fail with an HTTP `401 Unauthorized` error. You can delete a token at any time.
+
+<Warning>
+
+Revoking a token is immediate and irreversible. If your identity provider is actively using the token, SCIM requests authenticated with that token begin failing until you update the IdP with a new token.
+
+</Warning>
+
+To delete a token:
+
+1. Open your user icon menu and click **Site Admin**.
+2. Click **SCIM** in the left navigation.
+3. In the **SCIM Tokens** section, locate the token you want to delete.
+4. Click the delete icon next to the token.
+5. Confirm the deletion.
+
+## Rotate a token
+
+To rotate a SCIM token with zero downtime:
+
+1. **Generate a new token** before the old token expires. Refer to [Token properties](#token-properties) for expiration details.
+2. **Update your identity provider** with the new token value.
+3. **Verify the new token works** by checking that SCIM provisioning operations succeed and the new token's **Last used at** timestamp updates.
+4. **Delete the old token** after confirming the new token is working.
+
+Terraform Enterprise supports multiple active tokens, so you can rotate tokens without interrupting SCIM provisioning.
+
+## Expired token status
+
+Terraform Enterprise does not send alerts before a SCIM token expires. When a token has expired, Terraform Enterprise surfaces that status in the following places:
+
+- On the **Site Admin** > **SCIM** page, a page alert appears above the SCIM settings.
+- In the **Site Admin** navigation, a warning icon appears next to **SCIM provisioning**.
+
+The token list shows an expiration badge for each token, including whether it is expired or when it will expire.
+
+Rotate tokens before they expire to avoid downtime.
+
+## Best practices for managing tokens
+
+- Use descriptive names for tokens, such as IdP name, environment, and creation date.
+- Plan for rotation and set reminders before expiration.
+- Monitor token usage and remove unused tokens.
+- Limit token lifetime according to your security policy.
+- Store token values securely and never share them through insecure channels.
+
+## API reference
+
+You can also manage SCIM tokens programmatically with the [SCIM Tokens API](/terraform/enterprise/api-docs/admin/scim-tokens). Refer to that page for list, create, and delete operations, request and response details, expiration fields, and rate limits.

--- a/content/terraform-docs-common/docs/cloud-docs/scim/troubleshooting.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/scim/troubleshooting.mdx
@@ -1,0 +1,392 @@
+---
+page_title: Troubleshoot SCIM provisioning for Terraform Enterprise
+description: >-
+  Diagnose and resolve common issues with SCIM provisioning in Terraform
+  Enterprise, including authentication failures, validation errors, team linking
+  conflicts, and rate limits.
+---
+
+# Troubleshoot SCIM provisioning
+
+This topic describes troubleshooting steps for diagnosing and resolving issues with SCIM provisioning in Terraform Enterprise.
+
+Use this page for Terraform Enterprise-side behavior, SCIM responses, team linking, and operational follow-up. If the failure occurs before Terraform Enterprise receives the request, check your identity provider provisioning logs first.
+
+For provider-specific setup, assignment, scope, and attribute-mapping checks, use the [configure guides](/terraform/enterprise/scim/configure) after these Terraform Enterprise-side checks.
+
+## Escalation path
+
+Complete the following steps in order to investigate issues:
+
+1. Check your IdP provisioning logs first for connection, assignment, scope, and attribute-mapping failures.
+1. Check Terraform Enterprise audit logs when requests are reaching Terraform Enterprise but the resulting state is unexpected.
+1. Check Terraform Enterprise service logs and run diagnostics for repeated `500` errors, reconciliation timeouts, or suspected platform issues.
+1. Generate a support bundle and contact HashiCorp support if the issue persists after these checks.
+
+## Emergency access
+
+Terraform Enterprise can grant site administrator access through SCIM. To ensure you can always log in and troubleshoot issues even if SCIM provisioning is misconfigured or your identity provider (IdP) is unavailable, maintain at least one manually managed non-SSO admin account.
+
+### Create a non-SSO admin account
+
+We strongly recommend creating and maintaining a non-SSO admin account before enabling SCIM. This account provides a recovery path if you encounter issues with your SCIM or SAML configuration.
+
+Before troubleshooting SCIM issues, verify that you have a non-SSO admin account for emergency access. This account should use an email address not associated with your identity provider.
+
+To create a non-SSO recovery admin account in the Terraform Enterprise UI, open `https://<TFE HOSTNAME>/public/signup/account`, create the account, and grant it site administrator access.
+
+If you need the Rails console recovery procedure, refer to [Create a non-SSO admin account for recovery](/terraform/enterprise/saml/troubleshooting#create-a-non-sso-admin-account-for-recovery) in the SAML troubleshooting documentation.
+
+## Pause SCIM for debugging
+
+You can pause SCIM synchronization for the entire site or for individual teams so that you can isolate issues without deleting your configuration.
+
+### Pause SCIM at the site level
+
+Pausing SCIM at the site level stops all SCIM provisioning requests for the Terraform Enterprise instance.
+
+Terraform Enterprise site admin steps:
+
+1. Navigate to **Site Admin** > **SCIM**.
+1. Open **Manage**.
+1. Click **Pause SCIM provisioning**.
+1. Confirm the action.
+
+For the underlying site-level pause behavior, refer to [Manage SCIM provisioning](/terraform/enterprise/scim/manage#pause-and-resume-scim-provisioning).
+
+While SCIM is paused at the site level:
+
+- Provisioning requests from your IdP to `/scim/v2/Users` and `/scim/v2/Groups` return `403 Forbidden` because SCIM is disabled or paused.
+- Existing users, groups, and team links are preserved.
+- SCIM tokens remain valid and are not deleted.
+- Users can continue to log in using SAML.
+- Teams retain their configured links and pause state, and team-level SCIM metadata remains visible.
+
+To resume SCIM synchronization, open **Manage** and click **Resume SCIM provisioning**.
+
+Resuming site-level SCIM does not replay or backfill changes that your identity provider did not send while SCIM was paused. Terraform Enterprise resumes processing only new SCIM requests after you resume SCIM provisioning.
+
+### Pause SCIM for an individual team
+
+You can pause SCIM synchronization for a specific team without affecting other linked teams.
+
+Terraform Enterprise site admin steps in the UI:
+
+1. Navigate to the team's **Team Settings** tab.
+1. In the **SCIM Sync** section, click **Pause Sync**.
+1. Confirm the action.
+
+You can also pause or resume SCIM synchronization with the [Team SCIM Group Mapping API](/terraform/enterprise/api-docs/admin/team-scim-group-mapping).
+
+For the full procedure, refer to [Link SCIM groups to teams](/terraform/enterprise/scim/manage/team-mapping#pause-synchronization).
+
+While team-level synchronization is paused:
+
+- The team retains its current membership.
+- SCIM updates to the linked group do not affect the team.
+- The team remains linked to the SCIM group.
+- Other teams linked to the same SCIM group continue to receive updates.
+- Direct membership changes in Terraform Enterprise remain blocked while the link exists. To manage membership manually, unlink the team instead. Refer to [Link SCIM groups to teams](/terraform/enterprise/scim/manage/team-mapping).
+
+When you resume synchronization, Terraform Enterprise immediately reconciles the team's membership with the current SCIM group state.
+
+## Check HTTP status codes
+
+Use the table that matches the endpoint family you are troubleshooting.
+
+### Public SCIM provisioning endpoints
+
+The public SCIM endpoints `/scim/v2/Users` and `/scim/v2/Groups` are called by your IdP and authenticated with a SCIM token.
+
+For exact status codes, validation rules, discovery endpoints, and request details, refer to:
+
+- [Public SCIM API](/terraform/enterprise/api-docs/scim)
+- [SCIM Users API](/terraform/enterprise/api-docs/scim/users)
+- [SCIM Groups API](/terraform/enterprise/api-docs/scim/groups)
+
+### Admin SCIM settings and token endpoints
+
+The admin endpoints `/api/v2/admin/scim-settings` and `/api/v2/admin/scim-tokens` use site admin API credentials, not SCIM tokens.
+
+For exact status codes, validation rules, and request details, refer to:
+
+- [Admin SCIM Settings API](/terraform/enterprise/api-docs/admin/scim-settings)
+- [Admin SCIM Tokens API](/terraform/enterprise/api-docs/admin/scim-tokens)
+
+### Admin team linking endpoints
+
+The admin endpoints `/api/v2/admin/teams/:external_id/scim-group-mapping` and `/api/v2/admin/scim-groups` are used for site-level team-linking operations.
+
+For exact status codes, validation rules, and request details, refer to:
+
+- [Team SCIM Group Mapping API](/terraform/enterprise/api-docs/admin/team-scim-group-mapping)
+- [Admin SCIM Groups API](/terraform/enterprise/api-docs/admin/scim-groups)
+
+## Common issues
+
+This section describes common SCIM provisioning issues and their solutions.
+
+### `401 Unauthorized` errors
+
+HTTP `401` errors indicate authentication problems with your public SCIM token.
+
+Check for the following conditions:
+
+- The `Authorization` header is missing.
+- The `Authorization` header is malformed.
+- The token is invalid or expired.
+- The token belongs to another token type and is not a SCIM token.
+
+The Terraform Enterprise site admin and IdP administrator must complete tasks to resolve this issue:
+
+Terraform Enterprise site admin:
+
+1. Navigate to **Site Admin** > **SCIM** > **Tokens**.
+1. Verify that an active token exists and has not expired.
+1. Check the `last-used-at` timestamp to confirm the IdP is successfully authenticating.
+1. If necessary, create a new token. SCIM token values are displayed only once when created. If you lose the token value, create a new token and rotate the IdP to use it.
+
+IdP administrator:
+
+After the Terraform Enterprise site admin provides a new token, update the IdP configuration to use the new token and rerun the provisioning test.
+
+### `403 Forbidden` error
+
+HTTP `403` errors returned by the public SCIM provisioning endpoints, `/scim/v2/Users` or `/scim/v2/Groups`, usually mean Terraform Enterprise is not currently accepting SCIM provisioning requests.
+
+Check the following:
+
+- SCIM is disabled.
+- SCIM is paused at the site level.
+- The deployment is not Terraform Enterprise.
+
+Terraform Enterprise site admin and IdP administrators must complete tasks to resolve this issue.
+
+Terraform Enterprise site admin:
+
+1. Navigate to **Site Admin** > **SCIM**.
+1. Verify that SCIM is enabled.
+1. Verify that SCIM provisioning is enabled and not paused.
+
+IdP administrator:
+
+Retry provisioning from your IdP after Terraform Enterprise is accepting SCIM requests again.
+
+### Users not syncing
+
+If Terraform Enterprise does not provision or update users, verify that the request is reaching Terraform Enterprise. If not, check your IdP provisioning logs, then check the [configure guides](/terraform/enterprise/scim/configure) for provider-specific assignment, scope, and mapping steps.
+
+Check for the following conditions:
+
+- The user is assigned or otherwise in scope for provisioning in your identity provider.
+- The IdP is not sending a `userName` that already exists for another SCIM identity. That condition returns `409 Conflict`.
+- The IdP request includes at least one email entry. A primary email is preferred, but Terraform Enterprise can also use the first email entry if none is marked primary. Missing email data returns `400 Bad Request`.
+- If Terraform Enterprise already has a manually created user with the same email address, verify that the IdP is sending the same email address for that user so linking can occur.
+
+If the issue is a duplicate `userName`:
+
+1. Terraform Enterprise site admin should identify the existing SCIM-managed user that already owns that `userName`.
+1. IdP administrator should rename the user in the IdP or correct the conflicting SCIM identity before retrying.
+1. Retry provisioning.
+
+If the issue is a delete request for a missing SCIM user, verify that the IdP is using the current Terraform Enterprise SCIM user `id`. Terraform Enterprise returns HTTP `404 Not Found` for `DELETE /scim/v2/Users/:id` when that SCIM user no longer exists.
+
+### User deactivation or deletion does not behave as expected
+
+Terraform Enterprise treats SCIM deactivation and deletion differently:
+
+- When your IdP sends the `active=false` attribute, Terraform Enterprise suspends the user.
+- When your IdP makes a `DELETE` request to the `/scim/v2/Users/:id` endpoint, Terraform Enterprise removes the SCIM identity and suspends the user.
+- If the affected user is a SCIM-provisioned site administrator, Terraform Enterprise revokes site admin access.
+
+If the user remains active in Terraform Enterprise, confirm that your IdP is sending either `active=false` or a SCIM delete request, not only removing the user from a group.
+
+Deprovision triggers and timing are IdP-specific. If the expected change is not being sent, review your IdP provisioning logs and provider-specific deprovisioning guidance.
+
+### Groups not syncing
+
+If SCIM groups are not being provisioned or membership changes are not reflected, verify that the request is reaching Terraform Enterprise. If not, check your IdP provisioning logs, then check the [configure guides](/terraform/enterprise/scim/configure) for provider-specific group-push, scope, and mapping steps.
+
+Check for the following conditions:
+
+- The group is configured for provisioning in your identity provider and is in scope for synchronization to Terraform Enterprise.
+- Group membership updates reference Terraform Enterprise SCIM user IDs for users that were already provisioned through `/scim/v2/Users`.
+- The IdP is not trying to create or rename a group to a `displayName` that already exists. That condition returns `409 Conflict`.
+
+If the issue is a duplicate group name, the IdP administrator should rename or remove the conflicting SCIM group in the identity provider before retrying.
+
+### Admin team linking fails
+
+If linking a SCIM group to a team fails, check the following:
+
+These are Terraform Enterprise site admin operations. For the full linking workflow, refer to [Link SCIM groups to teams](/terraform/enterprise/scim/manage/team-mapping).
+
+Check for the following conditions:
+
+- The SCIM group has 1,000 or fewer members. Larger groups return `413 Payload Too Large`.
+- The team is not already linked to another SCIM group. Existing links return `409 Conflict`.
+- The SCIM group is not configured as the site admin group.
+- The target team is not the owners team.
+
+To resolve:
+
+1. Split oversized IdP groups into smaller groups if needed.
+1. Unlink any existing SCIM group before linking a different one to the same team.
+1. Use a different SCIM group for team linking if the current group is the configured site admin group.
+1. Leave the owners team manually managed.
+
+### Admin team sync pause or unpause fails
+
+If pausing or unpausing a team link fails:
+
+- Verify that the team is currently linked to a SCIM group.
+- Verify that the request uses the admin endpoint `/api/v2/admin/teams/:external_id/scim-group-mapping`.
+- Verify that `scim-sync-paused` is a boolean value.
+
+If the team is not linked, the request fails. If the payload omits `scim-sync-paused` or uses a non-boolean value, the request is rejected.
+
+For exact request and response behavior for link pause and resume, including repeated requests, refer to the [Team SCIM Group Mapping API](/terraform/enterprise/api-docs/admin/team-scim-group-mapping).
+
+Only Terraform Enterprise site administrators can link, unlink, pause, or resume SCIM team links.
+
+### `400 Bad Request` error
+
+Terraform Enterprise returns `400` when the SCIM request format is invalid. An invalid format includes unsupported filters or malformed payloads.
+
+Common causes include:
+
+- Unsupported SCIM filter expressions.
+- Malformed JSON.
+- Missing required attributes such as an email entry.
+- Too many `PATCH` operations in a single request.
+
+To resolve:
+
+1. Compare the IdP request body with the [SCIM Users API](/terraform/enterprise/api-docs/scim/users) or [SCIM Groups API](/terraform/enterprise/api-docs/scim/groups) requirements. Those references document supported `PATCH` forms, filter rules, and request limits.
+1. Validate that the JSON is well formed.
+1. Confirm that your IdP is only using supported equality filters. Users support `userName eq` and `externalId eq`. Groups support `displayName eq` and `externalId eq`.
+
+### `413 Payload Too Large` errors
+
+The public SCIM endpoint returns an HTTP `413` error when one of the following events occur:
+
+- The request body exceeds the maximum supported SCIM request size
+- A request to create or update a SCIM group exceeds the maximum supported group membership.
+- The linked SCIM group has more than 1,000 members.
+
+If you receive `413` during public SCIM user or group provisioning calls, inspect both the IdP request payload size and the affected SCIM group membership count. Public group provisioning requests return `413` when they try to create or update a group with more than 1,000 members. Oversized public SCIM requests also return `413`. If you receive `413` while linking a group to a team, reduce the group size before retrying the mapping.
+
+For the exact public SCIM request-size and per-endpoint request limits, refer to the [Public SCIM API](/terraform/enterprise/api-docs/scim) and the [SCIM Groups API](/terraform/enterprise/api-docs/scim/groups).
+
+### `429 Too Many Requests` errors
+
+HTTP `429` errors indicate your IdP or administrator is sending requests faster than Terraform Enterprise allows.
+
+Terraform Enterprise applies the following SCIM-related rate limits:
+
+| Endpoint or operation | Rate limit |
+|-----------------------|------------|
+| Public SCIM `/scim/v2/Users` and `/scim/v2/Groups` endpoints | 10 requests per second, shared across the public SCIM provisioning endpoints |
+| Admin SCIM settings endpoint | 20 requests per second |
+| Team linking, unlinking, pause, and resume operations | 10 requests per minute per authenticated site administrator |
+
+For public SCIM `/scim/v2/*`, use the `Retry-After` header to determine how long to wait before retrying.
+
+Admin SCIM `429` responses use the standard admin API error format.
+
+For exact rate-limit values and response details, refer to the [Public SCIM API](/terraform/enterprise/api-docs/scim), the [SCIM Settings API](/terraform/enterprise/api-docs/admin/scim-settings), and the [Team SCIM Group Mapping API](/terraform/enterprise/api-docs/admin/team-scim-group-mapping).
+
+If you frequently encounter rate limits:
+
+1. For public SCIM `/scim/v2/*`, ask your IdP administrator to reduce provisioning frequency and avoid repeated full syncs during troubleshooting.
+1. For admin SCIM settings or tokens, slow down site-level automation or scripted retries.
+1. For admin team linking operations, stagger link changes when working with many teams.
+
+### `500 Internal Server Error` errors
+
+HTTP `500` errors indicate Terraform Enterprise failed while processing the request.
+
+For public SCIM `/scim/v2/*`, retry one time after confirming the IdP request is valid. If the error repeats, inspect Terraform Enterprise logs and diagnostics.
+
+For admin team linking or reconciliation, `500` errors usually indicate an internal failure such as a transaction timing out.
+
+Large linking operations use a 30-second transaction timeout. When a timeout occurs:
+
+- The transaction rolls back completely.
+- No partial membership changes are applied.
+- The team retains its previous membership state.
+- Your IdP or administrator must retry the operation.
+
+If linking repeatedly times out, reduce the size of the linked SCIM group.
+
+If `500` errors continue after a retry, inspect Terraform Enterprise service logs and run diagnostics. Refer to [Logs](/terraform/enterprise/deploy/manage/monitor/logs) and [Perform diagnostics](/terraform/enterprise/deploy/troubleshoot/perform-diagnostics).
+
+## Check sync status
+
+Terraform Enterprise tracks synchronization timestamps for SCIM-managed users and linked teams.
+
+These sync-status fields are exposed on Terraform Enterprise API responses outside the public `/scim/v2/*` provisioning surface.
+
+### User sync status
+
+For SCIM-managed users, the `scim-updated-at` attribute indicates when the user was last synchronized. You can inspect this in `GET /api/v2/account/details` for the current user and in `GET /api/v2/admin/users` responses when SCIM is enabled.
+
+Use this timestamp to:
+
+- Verify that IdP changes are being applied.
+- Identify users that have not been updated recently.
+- Troubleshoot synchronization delays.
+
+### Team sync status
+
+For teams linked to SCIM groups, the `scim-updated-at` attribute indicates when the team's membership was last synchronized from the SCIM group. You can inspect this in `GET /api/v2/teams/:external_id` responses.
+
+Use this timestamp to:
+
+- Confirm that membership changes are propagating.
+- Identify teams that may have synchronization issues.
+- Verify that unpausing synchronization applied updates correctly.
+
+Also check `scim-linked`, `scim-group-name`, and `scim-sync-paused` to confirm the link state.
+
+## Site admin group issues
+
+If site admin access is not changing as expected, verify that the correct site admin group is configured in **Site Admin** > **SCIM** and that the relevant group membership update or SCIM settings change completed successfully.
+
+For the site admin group behavior, including grant, revoke, remap, and clear semantics, refer to [Manage SCIM provisioning](/terraform/enterprise/scim/manage#site-admin-group-behavior).
+
+Deleting or disabling SCIM does not automatically revoke site admin access that was already granted.
+
+## Audit logs
+
+Terraform Enterprise logs SCIM operations for compliance and troubleshooting purposes. SCIM-related audit log entries include:
+
+- User provisioning, replacement, update, and deprovisioning.
+- Group creation, update, membership changes, and deletion.
+- Team-to-group link creation and removal.
+- Team sync pause or resume actions.
+- SCIM configuration changes.
+- Token creation and revocation.
+
+Use audit logs to:
+
+- Track user access changes for compliance reporting.
+- Investigate unexpected permission changes.
+- Verify that IdP changes are being applied correctly.
+- Debug issues by reviewing the sequence of operations.
+
+To inspect audit logs and service logs, refer to [Logs](/terraform/enterprise/deploy/manage/monitor/logs).
+
+## Disable SCIM
+
+<Warning>
+
+Disabling SCIM is destructive. If you enable SCIM again later, you must recreate SCIM tokens, reprovision groups, and recreate team mappings. Use it only as a last resort after capturing exact timestamps, relevant IdP log entries, Terraform Enterprise audit or service logs, and a support bundle for further investigation.
+
+</Warning>
+
+Refer to [Disable SCIM provisioning](/terraform/enterprise/scim/manage#disable-scim-provisioning) for the full impact, UI steps, and API behavior.
+
+## Contact support
+
+If you cannot resolve your SCIM issue using the troubleshooting steps in this topic, contact HashiCorp support. Refer to [Get support for Terraform Enterprise](/terraform/enterprise/deploy/troubleshoot/contact-support) for instructions on opening a ticket, creating diagnostic support bundles, and other information.

--- a/content/terraform-docs-common/docs/cloud-docs/scim/users.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/scim/users.mdx
@@ -1,0 +1,184 @@
+---
+page_title: SCIM user lifecycle
+description: >-
+  Learn about user lifecycle operations from your identity provider when SCIM
+  2.0 provisioning is configured in Terraform Enterprise.
+---
+
+# SCIM user lifecycle
+
+This topic describes how Terraform Enterprise manages user lifecycle through SCIM 2.0 provisioning. When you enable SCIM, your identity provider (IdP) becomes the source of truth for user management, automatically synchronizing user creation, updates, and deactivation with Terraform Enterprise.
+
+## Overview
+
+SCIM (System for Cross-domain Identity Management) 2.0 enables your identity provider to automatically manage the complete user lifecycle in Terraform Enterprise:
+
+- **Create**: When a new employee is assigned to the Terraform Enterprise application in your IdP, SCIM automatically creates their account. No manual account creation is required.
+- **Update**: When user attributes change in your IdP (such as email or username), SCIM synchronizes those changes to Terraform Enterprise in real-time.
+- **Deactivate**: When an employee leaves or is removed from the application in your IdP, SCIM immediately revokes their access by suspending their account.
+
+This automation eliminates manual user management overhead and ensures that terminated employees cannot retain access to Terraform Enterprise.
+
+## User lifecycle operations
+
+Terraform Enterprise supports the following SCIM user operations. All operations use the `/scim/v2/Users` endpoint.
+
+### Create user
+
+When your IdP provisions a new user, Terraform Enterprise performs the following actions:
+
+1. Creates a user record or links an existing user with the same email address.
+1. Creates a SCIM identity record that links the user to your IdP.
+1. Returns a unique SCIM `id` that your IdP uses for all subsequent operations on this user.
+
+The new user has no team memberships or organization access by default. Team membership is managed separately through [SCIM group provisioning](/terraform/enterprise/scim/groups).
+
+### Update user
+
+When user attributes change in your IdP, Terraform Enterprise updates the corresponding user record. Supported updates include:
+
+- Email address changes
+- SCIM `userName` changes
+- External ID changes
+- Active status changes
+
+Updates are applied synchronously and take effect immediately.
+
+Terraform Enterprise supports the following PATCH behaviors for users:
+
+- `Replace` on supported user attributes, either as a targeted operation with a `path` or without a `path` when `value` is an object
+- `Add` on single-valued supported user attributes, which Terraform Enterprise treats the same as `Replace`
+- `Remove` for `externalId`
+
+Terraform Enterprise ignores attempts to clear required user attributes such as `userName`, `emails`, or `active`. A `Remove` operation without a `path` is ignored.
+
+### Deactivate user
+
+When your IdP sets `active=false` for a user or removes them from the application, Terraform Enterprise suspends the user by setting a `suspended_at` timestamp. Suspended users:
+
+- Cannot log in to Terraform Enterprise
+- Retain their user record and historical data
+- Can be reactivated if the IdP provisions them again with `active=true`
+
+If the suspended user was a site administrator through SCIM, Terraform Enterprise revokes that administrative access when the user is suspended.
+
+### Delete user
+
+When your IdP sends a delete request, Terraform Enterprise deprovisions the user. This action:
+
+- Deletes the SCIM identity record that links the user to the IdP.
+- Suspends the Terraform Enterprise user record.
+- Revokes site administrator access if the user had it through SCIM.
+
+Terraform Enterprise does not delete the underlying Terraform Enterprise user record through SCIM delete.
+
+## SCIM attribute mapping
+
+Terraform Enterprise maps SCIM attributes to internal user fields as follows:
+
+| SCIM attribute | Terraform Enterprise field | Description |
+|----------------|---------------------------|-------------|
+| `userName` | `scim_username` | The IdP-managed username stored with the SCIM identity. Must be unique across the instance. |
+| `emails[primary=true].value` | `email` | The user's primary email address. Must be unique across the instance. |
+| `active` | `suspended_at` | When `active=false`, sets `suspended_at` to the current timestamp. When `active=true`, clears `suspended_at`. |
+| `externalId` | `scim_external_id` | The IdP-assigned identifier for the user. Used by some IdPs (such as Microsoft Entra ID) to look up users. |
+
+Terraform Enterprise generates the internal Terraform Enterprise `username` value when the user record is created. SCIM `userName` does not become the Terraform Enterprise username.
+
+Terraform Enterprise does not store SCIM name fields (`givenName`, `familyName`, `middleName`). These attributes are accepted in requests but not persisted.
+
+## Linking existing users
+
+If an incoming SCIM user has the same email address as an existing Terraform Enterprise user, Terraform Enterprise links that existing user to SCIM management, as long as the incoming `userName` is not already owned by a different SCIM identity.
+
+After Terraform Enterprise creates the SCIM identity link, later updates to that user come from the IdP. Terraform Enterprise keeps a single underlying user record.
+
+If Terraform Enterprise does not find a matching email address, it creates a new user record and generates the local Terraform Enterprise `username` separately from the SCIM `userName`.
+
+Terraform Enterprise stores the original `userName` sent by the IdP in the `scim_username` field. This enables the IdP to query by its original username even when the Terraform Enterprise username differs.
+
+## SCIM-managed versus manually-managed users
+
+Users in Terraform Enterprise can be either SCIM-managed or manually-managed. The management type affects what operations are allowed.
+
+### Identifying SCIM-managed users
+
+A note on surfaces: the indicators below appear on Terraform Enterprise JSON:API user responses, not on the public SCIM `/scim/v2/Users` response shape.
+
+A user is SCIM-managed if they have an associated SCIM identity record. You can identify SCIM-managed users through the following indicators:
+
+- Terraform Enterprise JSON:API user responses include `scim-username` and `scim-updated-at` attributes
+- The user was created or linked through SCIM provisioning
+
+### Behavior when SCIM is enabled
+
+When SCIM is enabled:
+
+- Users provisioned through SCIM become SCIM-managed
+- Existing manually-created users remain manually-managed until provisioned through SCIM
+- If an IdP provisions a user whose email matches an existing manual user, that user becomes SCIM-managed
+- Manually-managed users can still be created directly in Terraform Enterprise for emergency access
+
+### Transitioning from manual to SCIM management
+
+When you enable SCIM, existing users are not automatically converted. A user becomes SCIM-managed only when:
+
+- The IdP creates the user through SCIM
+- The IdP provisions a user whose email matches an existing user
+
+## Site administrator provisioning
+
+You can provision site administrators through SCIM using a designated SCIM group.
+
+Configure the `site-admin-group-scim-id` setting in your SCIM configuration to specify which SCIM group Terraform Enterprise uses for site administrator provisioning. For the full site admin group behavior, refer to [Manage SCIM provisioning](/terraform/enterprise/scim/manage#site-admin-group-behavior).
+
+-> **Note:** When SCIM is enabled, site administrator provisioning through SAML attributes is disabled. All site administrator management must go through the configured site admin group.
+
+For more information about site administrators, refer to [Site Administration Permissions](/terraform/enterprise/users-teams-organizations/users#site-admin-permissions).
+
+## Blocked operations for SCIM-managed users
+
+To maintain the IdP as the single source of truth, certain operations are blocked for SCIM-managed users. Administrators must make changes through the IdP rather than directly in Terraform Enterprise.
+
+### Account API
+
+A note on surfaces: these are Terraform Enterprise JSON:API endpoints, not the public SCIM `/scim/v2/*` provisioning endpoints.
+
+| Endpoint | Method | Blocked | Reason |
+|----------|--------|---------|--------|
+| `/api/v2/account/details` | GET | No | Read operations are always allowed. |
+| `/api/v2/account/update` | PATCH | Yes (403) | Identity attributes are managed by SCIM. |
+| `/api/v2/account/password` | PATCH | Yes (403) | Identity and access state are managed through SCIM and SSO configuration. |
+
+### Users API
+
+| Endpoint | Method | Blocked | Reason |
+|----------|--------|---------|--------|
+| `/api/v2/users/:user_id` | GET | No | Read operations are always allowed. |
+
+### Admin UI actions
+
+| Action | Blocked | Reason |
+|--------|---------|--------|
+| Suspend user | Yes | User lifecycle is managed by SCIM. |
+| Anonymize user | Yes | User lifecycle is managed by SCIM. |
+| Delete user | Yes | User lifecycle is managed by SCIM. |
+
+### Operations that remain available
+
+The following operations remain available for SCIM-managed users because they control Terraform Enterprise-specific functionality rather than identity:
+
+- **User tokens API** (`/api/v2/users/:user_id/authentication-tokens`): Users can create, list, and revoke their own API tokens for programmatic access to Terraform Enterprise.
+
+SCIM controls _who_ the user is (identity attributes like email and username) and whether the user is active. It does not control _how_ the user authenticates to Terraform Enterprise APIs.
+
+## SAML and SCIM username handling
+
+When SCIM is enabled, Terraform Enterprise stops synchronizing SCIM-managed user identity from SAML assertions. Updates to SCIM `userName` must come through SCIM. This ensures SCIM remains the single source of truth for SCIM-managed user identity attributes.
+
+## API reference
+
+Use the following public API references for SCIM user provisioning:
+
+- Refer to the [Public SCIM API](/terraform/enterprise/api-docs/scim) for authentication, discovery endpoints, pagination, supported filters, and shared rate limits.
+- Refer to the [SCIM Users API](/terraform/enterprise/api-docs/scim/users) for `/scim/v2/Users` request and response details.


### PR DESCRIPTION
This PR sets up the structure and navigation of the SCIM usage docs for HCP TF.  This PR merges into the `atru/scim-hcptf-rollup` branch. 

We will open a new PR after merging this one to address the following TODOs: 

- Apply TFEnterprise:only and tfc:only tags where applicable
- Refine common information so that it makes sense for each edition

We will also create a separate PR for adding the API docs. 

Per the [docs plan](https://ibm-my.sharepoint.com/:w:/p/adam_trujillo/IQBVeHzZ1QKpR43qdzpgkyV-AfsJSKDODJ4E3036aI3d_LA?e=nXrTva), the goal is to create a single source of truth for SCIM docs in the /terraform-docs-common directory and use the exclusion tags to present HCPTF-specific and TFE-specific content when we publish to the website. 