### PR TITLE
Boundary Docs: Add OIDC account attributes to accounts domain model

### DIFF
--- a/content/boundary/v0.19.x/content/docs/domain-model/accounts.mdx
+++ b/content/boundary/v0.19.x/content/docs/domain-model/accounts.mdx
@@ -2,10 +2,10 @@
 layout: docs
 page_title: Account resource
 description: >-
-  Learn about using the accounts resource to establish the identities of users. Understand how to configure general, password, and LDAP account attributes.
+  Learn about using the accounts resource to establish the identities of users. Understand how to configure general, password, OIDC, and LDAP account attributes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-10-29T10:56:20-04:00
-last_modified: 2025-10-29T10:56:20-04:00
+last_modified: 2026-08-06T00:23:47.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -39,6 +39,37 @@ Password account types have the following additional attributes:
 
 - `password` - (optional)
   Not setting the `password` disables the account.
+
+### OIDC account attributes
+
+OIDC account types have the following additional attributes:
+
+- `subject` - (required)
+  A case-sensitive string that maps to the OIDC `sub` claim for the end-user.
+  You can set this value when you create the account. It is immutable
+  after creation.
+
+- `issuer` - (optional)
+  A case-sensitive URL that maps to the OIDC `iss` claim. You can set this
+  value when you create the account. It is immutable after creation.
+  If you do not set an `issuer`, it defaults to the issuer configured on
+  the account's OIDC auth method.
+
+- `full_name` - (output only)
+  Maps to the OIDC `name` claim for the authenticated user, and is updated
+  every time the user successfully authenticates. It is empty until the
+  user's first successful authentication.
+
+- `email` - (output only)
+  Maps to the OIDC `email` claim for the authenticated user, and is updated
+  every time the user successfully authenticates. It is empty until the
+  user's first successful authentication.
+
+- `token_claims` - (output only)
+  The marshaled claims from the ID token returned by the OIDC provider.
+
+- `userinfo_claims` - (output only)
+  The marshaled claims returned by the OIDC provider's userinfo endpoint.
 
 ### LDAP account attributes
 

--- a/content/boundary/v0.20.x/content/docs/domain-model/accounts.mdx
+++ b/content/boundary/v0.20.x/content/docs/domain-model/accounts.mdx
@@ -2,10 +2,10 @@
 layout: docs
 page_title: Account resource
 description: >-
-  Learn about using the accounts resource to establish the identities of users. Understand how to configure general, password, and LDAP account attributes.
+  Learn about using the accounts resource to establish the identities of users. Understand how to configure general, password, OIDC, and LDAP account attributes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-10-29T10:56:20-04:00
-last_modified: 2025-10-29T10:56:20-04:00
+last_modified: 2026-08-06T00:23:48.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -39,6 +39,37 @@ Password account types have the following additional attributes:
 
 - `password` - (optional)
   Not setting the `password` disables the account.
+
+### OIDC account attributes
+
+OIDC account types have the following additional attributes:
+
+- `subject` - (required)
+  A case-sensitive string that maps to the OIDC `sub` claim for the end-user.
+  You can set this value when you create the account. It is immutable
+  after creation.
+
+- `issuer` - (optional)
+  A case-sensitive URL that maps to the OIDC `iss` claim. You can set this
+  value when you create the account. It is immutable after creation.
+  If you do not set an `issuer`, it defaults to the issuer configured on
+  the account's OIDC auth method.
+
+- `full_name` - (output only)
+  Maps to the OIDC `name` claim for the authenticated user, and is updated
+  every time the user successfully authenticates. It is empty until the
+  user's first successful authentication.
+
+- `email` - (output only)
+  Maps to the OIDC `email` claim for the authenticated user, and is updated
+  every time the user successfully authenticates. It is empty until the
+  user's first successful authentication.
+
+- `token_claims` - (output only)
+  The marshaled claims from the ID token returned by the OIDC provider.
+
+- `userinfo_claims` - (output only)
+  The marshaled claims returned by the OIDC provider's userinfo endpoint.
 
 ### LDAP account attributes
 

--- a/content/boundary/v0.21.x/content/docs/domain-model/accounts.mdx
+++ b/content/boundary/v0.21.x/content/docs/domain-model/accounts.mdx
@@ -2,10 +2,10 @@
 layout: docs
 page_title: Account resource
 description: >-
-  Learn about using the accounts resource to establish the identities of users. Understand how to configure general, password, and LDAP account attributes.
+  Learn about using the accounts resource to establish the identities of users. Understand how to configure general, password, OIDC, and LDAP account attributes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-11-18T17:04:41-05:00
-last_modified: 2025-11-18T17:04:41-05:00
+last_modified: 2026-08-06T00:23:48.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -39,6 +39,37 @@ Password account types have the following additional attributes:
 
 - `password` - (optional)
   Not setting the `password` disables the account.
+
+### OIDC account attributes
+
+OIDC account types have the following additional attributes:
+
+- `subject` - (required)
+  A case-sensitive string that maps to the OIDC `sub` claim for the end-user.
+  You can set this value when you create the account. It is immutable
+  after creation.
+
+- `issuer` - (optional)
+  A case-sensitive URL that maps to the OIDC `iss` claim. You can set this
+  value when you create the account. It is immutable after creation.
+  If you do not set an `issuer`, it defaults to the issuer configured on
+  the account's OIDC auth method.
+
+- `full_name` - (output only)
+  Maps to the OIDC `name` claim for the authenticated user, and is updated
+  every time the user successfully authenticates. It is empty until the
+  user's first successful authentication.
+
+- `email` - (output only)
+  Maps to the OIDC `email` claim for the authenticated user, and is updated
+  every time the user successfully authenticates. It is empty until the
+  user's first successful authentication.
+
+- `token_claims` - (output only)
+  The marshaled claims from the ID token returned by the OIDC provider.
+
+- `userinfo_claims` - (output only)
+  The marshaled claims returned by the OIDC provider's userinfo endpoint.
 
 ### LDAP account attributes
 

--- a/content/boundary/v1.0.x/content/docs/domain-model/accounts.mdx
+++ b/content/boundary/v1.0.x/content/docs/domain-model/accounts.mdx
@@ -2,23 +2,18 @@
 layout: docs
 page_title: Account resource
 description: >-
-  Learn about using the accounts resource to establish the identities of users. Understand how to configure general, password, and LDAP account attributes.
+  Learn about using the accounts resource to establish the identities of users. Understand how to configure general, password, OIDC, and LDAP account attributes.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-11-18T17:04:41-05:00
-last_modified: 2025-11-18T17:04:41-05:00
+created_at: 2026-05-11T10:18:43-04:00
+last_modified: 2026-08-06T00:14:40.000Z
 # END AUTO GENERATED METADATA
 ---
 
 # Accounts
 
-An account is a resource
-that represents a unique set of credentials
-issued from a configured [auth method][]
-which can be used to establish the identity of a user.
-A [user][] can have zero or more accounts
-but an account can only belong to a single user.
-An account can only be associated with a user
-in the same scope as the account's [auth method][].
+An account is a resource that represents a unique set of credentials issued from a configured [auth method][] which can be used to establish the identity of a user.
+
+A [user][] can have zero or more accounts but an account can only belong to a single user. An account can only be associated with a user in the same scope as the account's [auth method][].
 
 ## Attributes
 
@@ -39,6 +34,37 @@ Password account types have the following additional attributes:
 
 - `password` - (optional)
   Not setting the `password` disables the account.
+
+### OIDC account attributes
+
+OIDC account types have the following additional attributes:
+
+- `subject` - (required)
+  A case-sensitive string that maps to the OIDC `sub` claim for the end-user.
+  You can set this value when you create the account. It is immutable
+  after creation.
+
+- `issuer` - (optional)
+  A case-sensitive URL that maps to the OIDC `iss` claim. You can set this
+  value when you create the account. It is immutable after creation.
+  If you do not set an `issuer`, it defaults to the issuer configured on
+  the account's OIDC auth method.
+
+- `full_name` - (output only)
+  Maps to the OIDC `name` claim for the authenticated user, and is updated
+  every time the user successfully authenticates. It is empty until the
+  user's first successful authentication.
+
+- `email` - (output only)
+  Maps to the OIDC `email` claim for the authenticated user, and is updated
+  every time the user successfully authenticates. It is empty until the
+  user's first successful authentication.
+
+- `token_claims` - (output only)
+  The marshaled claims from the ID token returned by the OIDC provider.
+
+- `userinfo_claims` - (output only)
+  The marshaled claims returned by the OIDC provider's userinfo endpoint.
 
 ### LDAP account attributes
 


### PR DESCRIPTION
<!--
**Merge branch**

Make sure your PR uses the correct **base** branch for the merge destination.

For more information, refer to **Change the branch range and destination repository** (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request).

To update:

- Existing content

  Choose **base: main** to update existing documentation.
  Your content will be published when the PR is merged.

- Content for an upcoming Boundary release

  Choose the branch for the relevant upcoming Boundary release.
  Boundary release branches use the `boundary/<exact-release-number>` format.
  Your content will be published when the upcoming release goes live.

If you are not sure which base branch to use, or you cannot find the release branch you are looking for:

  - Choose the `main` branch.
  - Add the "do not merge" label.
  - Convert the PR to a DRAFT.
  - Explain the update in the **Description**.

**Back porting to older versions**

This repo stores versioned documentation in folders instead of branches.
There are no backport labels.
If your update applies to multiple versions, you must update the content in each of the corresponding version folders.

For example, you make an update to the Boundary code in the current release, 0.21.0, and back port it to versions 0.20.x and 0.19.x.
To document the update for each of the relevant versions, you would update the documentation in the v0.21.x, v0.20.x, and v0.19.x folders.
-->

## Description

Boundary accounts docs covered password and LDAP attribute sets but omitted OIDC, despite OIDC being a supported account type. 

Adds the missing `subject`, `issuer`, `full_name`, `email`, `token_claims`, and `userinfo_claims` attributes, sourced from the boundary controller API proto and account validation logic.

These were sourced from the Boundary codebase:

Field list and behavior classes — [account.proto:159-188](https://github.com/hashicorp/boundary/blob/main/internal/proto/controller/api/resources/accounts/v1/account.proto) defines OidcAccountAttributes with issuer, subject, full_name, email, token_claims, userinfo_claims. Only full_name, email, token_claims, userinfo_claims carry (google.api.field_behavior) = OUTPUT_ONLY; issuer/subject do not, confirming they're settable inputs. Proto comments state issuer/subject map to the iss/sub claims and are "immutable after creation time."
Generated Go struct matches 1:1 — [oidc_account_attributes.gen.go:13-20](https://github.com/hashicorp/boundary/blob/main/api/accounts/oidc_account_attributes.gen.go) has the same six fields with matching JSON tags.

## Links
<!--
Include links to any associated pull requests, GitHub issues, or documentation that is relevant to this update.

// GH-Jira integration generates the link and updates the Jira ticket.
Jira: [<jira-ticket-number>]  // for example, Jira: [ICU-1234]

GitHub Issue: <issue-link>
-->

[Jira Issue](https://hashicorp.atlassian.net/browse/SPE-309?atlOrigin=eyJpIjoiNTJmM2U1MWI4YmZhNDI5YjliMDEwMzY5MDBkNGY2MDEiLCJwIjoiaiJ9)

Deploy Previews:
[1.0.x accounts page](https://unified-docs-frontend-preview-47yyez74p-hashicorp.vercel.app/boundary/docs/domain-model/accounts)
[0.21.x accounts page](https://unified-docs-frontend-preview-47yyez74p-hashicorp.vercel.app/boundary/docs/v0.21.x/domain-model/accounts)
[0.20.x accounts page](https://unified-docs-frontend-preview-47yyez74p-hashicorp.vercel.app/boundary/docs/v0.20.x/domain-model/accounts)
[0.19.x accounts page](https://unified-docs-frontend-preview-47yyez74p-hashicorp.vercel.app/boundary/docs/v0.19.x/domain-model/accounts)

## Contributor checklists

<!--
Help your reviewer understand the type of review you need by selecting the scope and urgency.
-->

This is a longstanding issue with the docs. I have only backported this change through 0.19.

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [x] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [ ] Verify that the PR is set to merge into the correct base branch
- [ ] Verify that all status checks passed
- [ ] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [ ] I added redirects for any moved or removed pages
- [ ] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [ ] I looked at the local or Vercel build to make sure the content rendered correctly


[ICU-1234]: https://hashicorp.atlassian.net/browse/ICU-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ