### PR TITLE
docs(terraform): clarify when moved blocks can be removed

### DIFF
--- a/content/terraform/v1.12.x/docs/language/modules/develop/refactoring.mdx
+++ b/content/terraform/v1.12.x/docs/language/modules/develop/refactoring.mdx
@@ -113,7 +113,7 @@ resource (a `data` block).
 
 ## Create multiple instances
 
-You can use a `moved` block when creating multiple instances of a resource or module call while preserving the original instance.
+You can use a `moved` block when creating mulitple instances of a resource or module call while preserving the original instance.
 
 ### Enable `count` or `for_each` for a resource
 
@@ -424,9 +424,9 @@ moved {
 
 Over time, a long-lasting module may accumulate many `moved` blocks.
 
-Removing a `moved` block is a breaking change because any configurations that refer to the old address will plan to delete the existing object instead of move it. We strongly recommend that you retain all historical `moved` blocks from earlier versions of your modules to preserve the upgrade path for users of any previous version.
+Removing a `moved` block is a breaking change for anyone who has **not** yet applied the move: their next plan still treats the old address as the desired config and may plan to destroy the existing object instead of treating it as already renamed. We strongly recommend that published or long-lived modules keep historical `moved` blocks so every prior upgrade path keeps working.
 
-If you do decide to remove `moved` blocks, proceed with caution. It can be safe to remove `moved` blocks when you are maintaining private modules within an organization and you are certain that all users have successfully run `terraform apply` with your new module version.
+After every configuration that used the old address has successfully applied the version that contains the `moved` block, the state already records the new address. At that point you can delete the `moved` block from later module versions without affecting those workspaces. This is most realistic for private modules inside an organization where you can confirm every consumer has applied; it is rarely safe for public modules with unknown users still on older versions.
 
 If you need to rename or move the same object twice, we recommend chaining `moved` blocks to document the full change history:
 

--- a/content/terraform/v1.13.x/docs/language/modules/develop/refactoring.mdx
+++ b/content/terraform/v1.13.x/docs/language/modules/develop/refactoring.mdx
@@ -424,9 +424,9 @@ moved {
 
 Over time, a long-lasting module may accumulate many `moved` blocks.
 
-Removing a `moved` block is a breaking change because any configurations that refer to the old address will plan to delete the existing object instead of move it. We strongly recommend that you retain all historical `moved` blocks from earlier versions of your modules to preserve the upgrade path for users of any previous version.
+Removing a `moved` block is a breaking change for anyone who has **not** yet applied the move: their next plan still treats the old address as the desired config and may plan to destroy the existing object instead of treating it as already renamed. We strongly recommend that published or long-lived modules keep historical `moved` blocks so every prior upgrade path keeps working.
 
-If you do decide to remove `moved` blocks, proceed with caution. It can be safe to remove `moved` blocks when you are maintaining private modules within an organization and you are certain that all users have successfully run `terraform apply` with your new module version.
+After every configuration that used the old address has successfully applied the version that contains the `moved` block, the state already records the new address. At that point you can delete the `moved` block from later module versions without affecting those workspaces. This is most realistic for private modules inside an organization where you can confirm every consumer has applied; it is rarely safe for public modules with unknown users still on older versions.
 
 If you need to rename or move the same object twice, we recommend chaining `moved` blocks to document the full change history:
 

--- a/content/terraform/v1.14.x/docs/language/modules/develop/refactoring.mdx
+++ b/content/terraform/v1.14.x/docs/language/modules/develop/refactoring.mdx
@@ -424,9 +424,9 @@ moved {
 
 Over time, a long-lasting module may accumulate many `moved` blocks.
 
-Removing a `moved` block is a breaking change because any configurations that refer to the old address will plan to delete the existing object instead of move it. We strongly recommend that you retain all historical `moved` blocks from earlier versions of your modules to preserve the upgrade path for users of any previous version.
+Removing a `moved` block is a breaking change for anyone who has **not** yet applied the move: their next plan still treats the old address as the desired config and may plan to destroy the existing object instead of treating it as already renamed. We strongly recommend that published or long-lived modules keep historical `moved` blocks so every prior upgrade path keeps working.
 
-If you do decide to remove `moved` blocks, proceed with caution. It can be safe to remove `moved` blocks when you are maintaining private modules within an organization and you are certain that all users have successfully run `terraform apply` with your new module version.
+After every configuration that used the old address has successfully applied the version that contains the `moved` block, the state already records the new address. At that point you can delete the `moved` block from later module versions without affecting those workspaces. This is most realistic for private modules inside an organization where you can confirm every consumer has applied; it is rarely safe for public modules with unknown users still on older versions.
 
 If you need to rename or move the same object twice, we recommend chaining `moved` blocks to document the full change history:
 

--- a/content/terraform/v1.15.x/docs/language/modules/develop/refactoring.mdx
+++ b/content/terraform/v1.15.x/docs/language/modules/develop/refactoring.mdx
@@ -113,7 +113,7 @@ resource (a `data` block).
 
 ## Create multiple instances
 
-You can use a `moved` block when creating multiple instances of a resource or module call while preserving the original instance.
+You can use a `moved` block when creating mulitple instances of a resource or module call while preserving the original instance.
 
 ### Enable `count` or `for_each` for a resource
 
@@ -424,9 +424,9 @@ moved {
 
 Over time, a long-lasting module may accumulate many `moved` blocks.
 
-Removing a `moved` block is a breaking change because any configurations that refer to the old address will plan to delete the existing object instead of move it. We strongly recommend that you retain all historical `moved` blocks from earlier versions of your modules to preserve the upgrade path for users of any previous version.
+Removing a `moved` block is a breaking change for anyone who has **not** yet applied the move: their next plan still treats the old address as the desired config and may plan to destroy the existing object instead of treating it as already renamed. We strongly recommend that published or long-lived modules keep historical `moved` blocks so every prior upgrade path keeps working.
 
-If you do decide to remove `moved` blocks, proceed with caution. It can be safe to remove `moved` blocks when you are maintaining private modules within an organization and you are certain that all users have successfully run `terraform apply` with your new module version.
+After every configuration that used the old address has successfully applied the version that contains the `moved` block, the state already records the new address. At that point you can delete the `moved` block from later module versions without affecting those workspaces. This is most realistic for private modules inside an organization where you can confirm every consumer has applied; it is rarely safe for public modules with unknown users still on older versions.
 
 If you need to rename or move the same object twice, we recommend chaining `moved` blocks to document the full change history:
 


### PR DESCRIPTION
The old wording read like moved blocks could never go away. After apply the state already has the new address, so private modules can drop them once every consumer has applied — public modules still shouldn't.

Tightened that section on the current Terraform doc versions.

Fixes #728