### PR TITLE
Consolidate env var names for the agent key

### DIFF
--- a/.github/workflows/deploy-udr.yml
+++ b/.github/workflows/deploy-udr.yml
@@ -46,7 +46,7 @@ jobs:
         run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
         env:
           INSTANA_OTLP_ENDPOINT: ${{ secrets.INSTANA_OTLP_ENDPOINT }}
-          INSTANA_AGENT_TOKEN: ${{ secrets.INSTANA_AGENT_TOKEN }}
+          INSTANA_AGENT_KEY: ${{ secrets.INSTANA_AGENT_KEY }}
           HASHI_ENV: production
 
       - name: Deploy Project Artifacts to Vercel

--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -174,4 +174,4 @@ jobs:
             --host-id 'github-actions'
         env:
           INSTANA_OTLP_ENDPOINT: ${{ secrets.INSTANA_OTLP_ENDPOINT }}
-          INSTANA_AGENT_TOKEN: ${{ secrets.INSTANA_AGENT_TOKEN }}
+          INSTANA_AGENT_KEY: ${{ secrets.INSTANA_AGENT_KEY }}

--- a/scripts/emit-otel-span-cli.mjs
+++ b/scripts/emit-otel-span-cli.mjs
@@ -27,7 +27,7 @@
  *
  * The OTLP endpoint and token are read from the environment:
  * - INSTANA_OTLP_ENDPOINT  (required) OTLP endpoint (`endpoint`).
- * - INSTANA_AGENT_TOKEN (required) Instana API token (`apiToken`).
+ * - INSTANA_AGENT_KEY (required) Instana API token (`agentKey`).
  */
 
 import { parseArgs } from 'node:util'

--- a/scripts/emit-otel-span.mjs
+++ b/scripts/emit-otel-span.mjs
@@ -83,8 +83,8 @@ const STATUS_CODE_ERROR = 2
  * @property {string} [endpoint] The Instana OTLP endpoint to POST the span to.
  * Defaults to `process.env.INSTANA_OTLP_ENDPOINT`.
  *
- * @property {string} [apiToken] The Instana OTLP API token. Defaults to
- * `process.env.INSTANA_AGENT_TOKEN`.
+ * @property {string} [agentKey] The Instana OTLP API token. Defaults to
+ * `process.env.INSTANA_AGENT_KEY`.
  */
 function buildSpan({ name, attributes = {}, status, durationMs = 1 }) {
 	// Timestamps in nanoseconds (millisecond precision). Give the span a small
@@ -126,7 +126,7 @@ export function emitOtelSpan({
 	scopeName,
 	hostId = process.env.INSTANA_HOST_ID ?? serviceName,
 	endpoint = process.env.INSTANA_OTLP_ENDPOINT,
-	agentToken = process.env.INSTANA_AGENT_TOKEN,
+	agentKey = process.env.INSTANA_AGENT_KEY,
 }) {
 	if (!endpoint) {
 		return Promise.reject(
@@ -135,10 +135,10 @@ export function emitOtelSpan({
 			),
 		)
 	}
-	if (!agentToken) {
+	if (!agentKey) {
 		return Promise.reject(
 			new Error(
-				'emitOtelSpan: missing OTLP API token (set INSTANA_AGENT_TOKEN or pass `apiToken`)',
+				'emitOtelSpan: missing OTLP API token (set INSTANA_AGENT_KEY or pass `agentKey`)',
 			),
 		)
 	}
@@ -168,7 +168,7 @@ export function emitOtelSpan({
 		method: 'POST',
 		headers: {
 			'Content-Type': 'application/json',
-			'x-instana-key': agentToken,
+			'x-instana-key': agentKey,
 			'x-instana-host': hostId,
 		},
 		body: JSON.stringify(payload),

--- a/terraform/github.tf
+++ b/terraform/github.tf
@@ -10,7 +10,7 @@ locals {
   ])
 
   secrets = {
-    INSTANA_AGENT_TOKEN   = var.instana_agent_key
+    INSTANA_AGENT_KEY     = var.instana_agent_key
     INSTANA_OTLP_ENDPOINT = var.instana_otlp_endpoint
   }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -33,7 +33,7 @@ variable "instana_agent_key" {
 }
 
 variable "instana_otlp_endpoint" {
-  description = "Instana OTLP endpoint for sending metrics to Instana."
+  description = "Instana OTLP endpoint for sending traces. Must include the full path, e.g. https://otlp-http-red-saas.instana.io:443/v1/traces"
   type        = string
 }
 

--- a/terraform/vercel.tf
+++ b/terraform/vercel.tf
@@ -13,7 +13,7 @@ locals {
       sensitive      = false
       targets        = ["production", "preview"]
     },
-    INSTANA_AGENT_TOKEN = {
+    INSTANA_AGENT_KEY = {
       value          = var.instana_agent_key
       comment        = "Instana agent key used to authenticate to Instana when submitting metrics and telemetry."
       client_visible = false


### PR DESCRIPTION
There are various references to apiToken/AGENT_TOKEN/AGENT_KEY etc. in
secrets and in the code.

For simplicity and consistency, this should be consolidated into
`INSTANA_AGENT_KEY` and variations thereof to match the nomenclature of
Instana

<img width="1423" height="159" alt="image" src="https://github.com/user-attachments/assets/5fb24cd7-2eec-4915-b2e6-8efab134e920" />


