### PR TITLE
docs(terraform): clarify create_before_destroy with count/for_each

### DIFF
--- a/content/terraform/v1.12.x/docs/language/meta-arguments/lifecycle.mdx
+++ b/content/terraform/v1.12.x/docs/language/meta-arguments/lifecycle.mdx
@@ -46,6 +46,14 @@ to `false` on resource `B` because that would imply dependency cycles in the gra
 
 When the resource contains a provisioner that runs during the `destroy` operation,  setting `create_before_destroy` to `true` also prevents the provisioner from running. 
 
+#### `create_before_destroy` with `count` and `for_each`
+
+When a resource uses [`count`](/terraform/language/meta-arguments/count) or [`for_each`](/terraform/language/meta-arguments/for_each), Terraform expands it into multiple independent instances. Lifecycle rules such as `create_before_destroy` apply to each instance separately, not to the collection as a whole.
+
+For example, if a plan creates new instances (new keys or indices) and destroys others, Terraform does not create every new instance before destroying any removed instance. Create and destroy actions across different instances follow the dependency graph and are otherwise unordered relative to each other. `create_before_destroy` only changes the order when Terraform replaces a single instance: create the replacement first, then destroy the old object for that instance.
+
+If you need capacity or ordering guarantees across the whole collection, use explicit dependencies or manage the rollout outside Terraform. Do not assume that `create_before_destroy` batches all creates ahead of all destroys for a `count` or `for_each` resource.
+
 You can use `create_before_destroy` in [`resource`](/terraform/language/block/resource) blocks. 
 
 

--- a/content/terraform/v1.13.x/docs/language/meta-arguments/lifecycle.mdx
+++ b/content/terraform/v1.13.x/docs/language/meta-arguments/lifecycle.mdx
@@ -46,6 +46,14 @@ to `false` on resource `B` because that would imply dependency cycles in the gra
 
 When the resource contains a provisioner that runs during the `destroy` operation,  setting `create_before_destroy` to `true` also prevents the provisioner from running. 
 
+#### `create_before_destroy` with `count` and `for_each`
+
+When a resource uses [`count`](/terraform/language/meta-arguments/count) or [`for_each`](/terraform/language/meta-arguments/for_each), Terraform expands it into multiple independent instances. Lifecycle rules such as `create_before_destroy` apply to each instance separately, not to the collection as a whole.
+
+For example, if a plan creates new instances (new keys or indices) and destroys others, Terraform does not create every new instance before destroying any removed instance. Create and destroy actions across different instances follow the dependency graph and are otherwise unordered relative to each other. `create_before_destroy` only changes the order when Terraform replaces a single instance: create the replacement first, then destroy the old object for that instance.
+
+If you need capacity or ordering guarantees across the whole collection, use explicit dependencies or manage the rollout outside Terraform. Do not assume that `create_before_destroy` batches all creates ahead of all destroys for a `count` or `for_each` resource.
+
 You can use `create_before_destroy` in [`resource`](/terraform/language/block/resource) blocks. 
 
 

--- a/content/terraform/v1.14.x/docs/language/meta-arguments/lifecycle.mdx
+++ b/content/terraform/v1.14.x/docs/language/meta-arguments/lifecycle.mdx
@@ -65,6 +65,14 @@ to `false` on resource `B` because that would imply dependency cycles in the gra
 
 When the resource contains a provisioner that runs during the `destroy` operation,  setting `create_before_destroy` to `true` also prevents the provisioner from running. 
 
+#### `create_before_destroy` with `count` and `for_each`
+
+When a resource uses [`count`](/terraform/language/meta-arguments/count) or [`for_each`](/terraform/language/meta-arguments/for_each), Terraform expands it into multiple independent instances. Lifecycle rules such as `create_before_destroy` apply to each instance separately, not to the collection as a whole.
+
+For example, if a plan creates new instances (new keys or indices) and destroys others, Terraform does not create every new instance before destroying any removed instance. Create and destroy actions across different instances follow the dependency graph and are otherwise unordered relative to each other. `create_before_destroy` only changes the order when Terraform replaces a single instance: create the replacement first, then destroy the old object for that instance.
+
+If you need capacity or ordering guarantees across the whole collection, use explicit dependencies or manage the rollout outside Terraform. Do not assume that `create_before_destroy` batches all creates ahead of all destroys for a `count` or `for_each` resource.
+
 You can use `create_before_destroy` in [`resource`](/terraform/language/block/resource) blocks. 
 
 ### `prevent_destroy` 

--- a/content/terraform/v1.15.x/docs/language/meta-arguments/lifecycle.mdx
+++ b/content/terraform/v1.15.x/docs/language/meta-arguments/lifecycle.mdx
@@ -65,6 +65,14 @@ to `false` on resource `B` because that would imply dependency cycles in the gra
 
 When the resource contains a provisioner that runs during the `destroy` operation,  setting `create_before_destroy` to `true` also prevents the provisioner from running. 
 
+#### `create_before_destroy` with `count` and `for_each`
+
+When a resource uses [`count`](/terraform/language/meta-arguments/count) or [`for_each`](/terraform/language/meta-arguments/for_each), Terraform expands it into multiple independent instances. Lifecycle rules such as `create_before_destroy` apply to each instance separately, not to the collection as a whole.
+
+For example, if a plan creates new instances (new keys or indices) and destroys others, Terraform does not create every new instance before destroying any removed instance. Create and destroy actions across different instances follow the dependency graph and are otherwise unordered relative to each other. `create_before_destroy` only changes the order when Terraform replaces a single instance: create the replacement first, then destroy the old object for that instance.
+
+If you need capacity or ordering guarantees across the whole collection, use explicit dependencies or manage the rollout outside Terraform. Do not assume that `create_before_destroy` batches all creates ahead of all destroys for a `count` or `for_each` resource.
+
 You can use `create_before_destroy` in [`resource`](/terraform/language/block/resource) blocks. 
 
 ### `prevent_destroy` 


### PR DESCRIPTION
When a resource uses `count` or `for_each`, lifecycle rules like `create_before_destroy` apply per expanded instance, not to the collection as a whole. That distinction wasn't spelled out and is easy to get wrong in production.

Adds a short section under `create_before_destroy` on v1.12–v1.15.

Fixes #720