### PR TITLE
docs(vault): clarify Terraform secrets engine anchor token scope

### DIFF
--- a/content/vault/v1.21.x/content/docs/secrets/terraform.mdx
+++ b/content/vault/v1.21.x/content/docs/secrets/terraform.mdx
@@ -63,6 +63,13 @@ functions. An operator or configuration management tool usually completes these 
     [Organization, legacy team, team, and user roles](#organization-legacy-team-team-and-user-roles) 
     section for additional considerations.
 
+    ~> **Anchor token scope:** the token you set on `terraform/config` is the
+    credential Vault uses to create short-lived tokens. A **user** API token can
+    only create tokens for that same user account—it cannot mint user tokens for
+    other users, and it cannot create team or organization tokens. Prefer a team
+    or organization token when Vault must issue credentials for automation beyond
+    a single user.
+
 3.  Configure a role for an HCP Terraform Team
 
     Vault issues dynamic API tokens by mapping the Terraform secret role to an existing HCP Terraform 

--- a/content/vault/v2.x/content/docs/secrets/terraform.mdx
+++ b/content/vault/v2.x/content/docs/secrets/terraform.mdx
@@ -63,6 +63,13 @@ functions. An operator or configuration management tool usually completes these 
     [Organization, legacy team, team, and user roles](#organization-legacy-team-team-and-user-roles) 
     section for additional considerations.
 
+    ~> **Anchor token scope:** the token you set on `terraform/config` is the
+    credential Vault uses to create short-lived tokens. A **user** API token can
+    only create tokens for that same user account—it cannot mint user tokens for
+    other users, and it cannot create team or organization tokens. Prefer a team
+    or organization token when Vault must issue credentials for automation beyond
+    a single user.
+
 3.  Configure a role for an HCP Terraform Team
 
     Vault issues dynamic API tokens by mapping the Terraform secret role to an existing HCP Terraform 


### PR DESCRIPTION
Makes it clearer that a user API token used as the plugin config credential can only create tokens for that same user—not other users, teams, or the org. Team/org tokens are the right anchor for broader automation.

Touches the HCP Terraform secrets engine page on the current vault docs versions.

Fixes #1267