### PR TITLE
docs(terraform): clarify plugin_cache_dir vs dependency lock file

### DIFF
--- a/content/terraform/v1.12.x/docs/cli/config/config-file.mdx
+++ b/content/terraform/v1.12.x/docs/cli/config/config-file.mdx
@@ -345,8 +345,8 @@ then a separate copy of its plugin will be downloaded for each configuration.
 Given that provider plugins can be quite large (on the order of hundreds of
 megabytes), this default behavior can be inconvenient for those with slow
 or metered Internet connections. Therefore Terraform optionally allows the
-use of a local directory as a shared plugin cache, which then allows each
-distinct plugin binary to be downloaded only once.
+use of a local directory as a shared plugin cache, so each distinct
+plugin binary can be stored once and reused across working directories.
 
 To enable the plugin cache, use the `plugin_cache_dir` setting in
 the CLI configuration file. For example:
@@ -375,8 +375,17 @@ When a plugin cache directory is enabled, the `terraform init` command will
 still use the configured or implied installation methods to obtain metadata
 about which plugins are available, but once a suitable version has been
 selected it will first check to see if the chosen plugin is already available
-in the cache directory. If so, Terraform will use the previously-downloaded
-copy.
+in the cache directory. If so, and the package matches a checksum already
+recorded in the [dependency lock file](/terraform/language/files/dependency-lock),
+Terraform will use the previously-downloaded copy.
+
+Terraform still needs a lock-file checksum before it will trust a cached
+package. On the first install of a provider in a given configuration (or
+when the lock file is missing or incomplete for that provider), Terraform
+downloads the package again so it can record checksums—even if a copy is
+already present in the cache. See
+[Allowing the Provider Plugin Cache to break the dependency lock file](#allowing-the-provider-plugin-cache-to-break-the-dependency-lock-file)
+if you intentionally do not keep a lock file.
 
 If the selected plugin is not already in the cache, Terraform will download
 it into the cache first and then copy it from there into the correct location

--- a/content/terraform/v1.13.x/docs/cli/config/config-file.mdx
+++ b/content/terraform/v1.13.x/docs/cli/config/config-file.mdx
@@ -345,8 +345,8 @@ then a separate copy of its plugin will be downloaded for each configuration.
 Given that provider plugins can be quite large (on the order of hundreds of
 megabytes), this default behavior can be inconvenient for those with slow
 or metered Internet connections. Therefore Terraform optionally allows the
-use of a local directory as a shared plugin cache, which then allows each
-distinct plugin binary to be downloaded only once.
+use of a local directory as a shared plugin cache, so each distinct
+plugin binary can be stored once and reused across working directories.
 
 To enable the plugin cache, use the `plugin_cache_dir` setting in
 the CLI configuration file. For example:
@@ -375,8 +375,17 @@ When a plugin cache directory is enabled, the `terraform init` command will
 still use the configured or implied installation methods to obtain metadata
 about which plugins are available, but once a suitable version has been
 selected it will first check to see if the chosen plugin is already available
-in the cache directory. If so, Terraform will use the previously-downloaded
-copy.
+in the cache directory. If so, and the package matches a checksum already
+recorded in the [dependency lock file](/terraform/language/files/dependency-lock),
+Terraform will use the previously-downloaded copy.
+
+Terraform still needs a lock-file checksum before it will trust a cached
+package. On the first install of a provider in a given configuration (or
+when the lock file is missing or incomplete for that provider), Terraform
+downloads the package again so it can record checksums—even if a copy is
+already present in the cache. See
+[Allowing the Provider Plugin Cache to break the dependency lock file](#allowing-the-provider-plugin-cache-to-break-the-dependency-lock-file)
+if you intentionally do not keep a lock file.
 
 If the selected plugin is not already in the cache, Terraform will download
 it into the cache first and then copy it from there into the correct location

--- a/content/terraform/v1.14.x/docs/cli/config/config-file.mdx
+++ b/content/terraform/v1.14.x/docs/cli/config/config-file.mdx
@@ -345,8 +345,8 @@ then a separate copy of its plugin will be downloaded for each configuration.
 Given that provider plugins can be quite large (on the order of hundreds of
 megabytes), this default behavior can be inconvenient for those with slow
 or metered Internet connections. Therefore Terraform optionally allows the
-use of a local directory as a shared plugin cache, which then allows each
-distinct plugin binary to be downloaded only once.
+use of a local directory as a shared plugin cache, so each distinct
+plugin binary can be stored once and reused across working directories.
 
 To enable the plugin cache, use the `plugin_cache_dir` setting in
 the CLI configuration file. For example:
@@ -375,8 +375,17 @@ When a plugin cache directory is enabled, the `terraform init` command will
 still use the configured or implied installation methods to obtain metadata
 about which plugins are available, but once a suitable version has been
 selected it will first check to see if the chosen plugin is already available
-in the cache directory. If so, Terraform will use the previously-downloaded
-copy.
+in the cache directory. If so, and the package matches a checksum already
+recorded in the [dependency lock file](/terraform/language/files/dependency-lock),
+Terraform will use the previously-downloaded copy.
+
+Terraform still needs a lock-file checksum before it will trust a cached
+package. On the first install of a provider in a given configuration (or
+when the lock file is missing or incomplete for that provider), Terraform
+downloads the package again so it can record checksums—even if a copy is
+already present in the cache. See
+[Allowing the Provider Plugin Cache to break the dependency lock file](#allowing-the-provider-plugin-cache-to-break-the-dependency-lock-file)
+if you intentionally do not keep a lock file.
 
 If the selected plugin is not already in the cache, Terraform will download
 it into the cache first and then copy it from there into the correct location

--- a/content/terraform/v1.15.x/docs/cli/config/config-file.mdx
+++ b/content/terraform/v1.15.x/docs/cli/config/config-file.mdx
@@ -345,8 +345,8 @@ then a separate copy of its plugin will be downloaded for each configuration.
 Given that provider plugins can be quite large (on the order of hundreds of
 megabytes), this default behavior can be inconvenient for those with slow
 or metered Internet connections. Therefore Terraform optionally allows the
-use of a local directory as a shared plugin cache, which then allows each
-distinct plugin binary to be downloaded only once.
+use of a local directory as a shared plugin cache, so each distinct
+plugin binary can be stored once and reused across working directories.
 
 To enable the plugin cache, use the `plugin_cache_dir` setting in
 the CLI configuration file. For example:
@@ -375,8 +375,17 @@ When a plugin cache directory is enabled, the `terraform init` command will
 still use the configured or implied installation methods to obtain metadata
 about which plugins are available, but once a suitable version has been
 selected it will first check to see if the chosen plugin is already available
-in the cache directory. If so, Terraform will use the previously-downloaded
-copy.
+in the cache directory. If so, and the package matches a checksum already
+recorded in the [dependency lock file](/terraform/language/files/dependency-lock),
+Terraform will use the previously-downloaded copy.
+
+Terraform still needs a lock-file checksum before it will trust a cached
+package. On the first install of a provider in a given configuration (or
+when the lock file is missing or incomplete for that provider), Terraform
+downloads the package again so it can record checksums—even if a copy is
+already present in the cache. See
+[Allowing the Provider Plugin Cache to break the dependency lock file](#allowing-the-provider-plugin-cache-to-break-the-dependency-lock-file)
+if you intentionally do not keep a lock file.
 
 If the selected plugin is not already in the cache, Terraform will download
 it into the cache first and then copy it from there into the correct location


### PR DESCRIPTION
The intro made it sound like `plugin_cache_dir` means each provider binary is only ever downloaded once. In practice Terraform only reuses a cached package when the dependency lock file already has a matching checksum, so a first `terraform init` in a new working directory can still hit the network even if the binary is sitting in the cache.

Added that detail next to the cache docs and linked the existing `plugin_cache_may_break_dependency_lock_file` section for the unusual unlock path.

Applies to terraform v1.12.x–v1.15.x config-file pages.

Fixes #731