### PR TITLE
docs(terraform): note yamldecode bool-like map keys

### DIFF
--- a/content/terraform/v1.12.x/docs/language/functions/yamldecode.mdx
+++ b/content/terraform/v1.12.x/docs/language/functions/yamldecode.mdx
@@ -56,6 +56,27 @@ supports only a subset of YAML 1.2, with restrictions including the following:
 - Only one YAML document is permitted. If multiple documents are present in
   the given string then this function will return an error.
 
+- Unquoted YAML 1.1-style boolean scalars (`true`/`false`, `yes`/`no`,
+  `on`/`off`, and a few other spellings) are decoded as Terraform `bool`
+  values. That applies to **map keys** as well as values. For example,
+  `yamldecode("{on: 1}")` yields an object whose attribute name is the string
+  `"true"`, not `"on"`. Quote the key if you need the literal name:
+
+  ```
+  > yamldecode("{on: 1}")
+  {
+    "true" = 1
+  }
+
+  > yamldecode("{\"on\": 1}")
+  {
+    "on" = 1
+  }
+  ```
+
+  This often surprises people decoding GitHub Actions workflows or other
+  YAML that uses unquoted `on:` keys.
+
 ## Examples
 
 ```

--- a/content/terraform/v1.13.x/docs/language/functions/yamldecode.mdx
+++ b/content/terraform/v1.13.x/docs/language/functions/yamldecode.mdx
@@ -56,6 +56,27 @@ supports only a subset of YAML 1.2, with restrictions including the following:
 - Only one YAML document is permitted. If multiple documents are present in
   the given string then this function will return an error.
 
+- Unquoted YAML 1.1-style boolean scalars (`true`/`false`, `yes`/`no`,
+  `on`/`off`, and a few other spellings) are decoded as Terraform `bool`
+  values. That applies to **map keys** as well as values. For example,
+  `yamldecode("{on: 1}")` yields an object whose attribute name is the string
+  `"true"`, not `"on"`. Quote the key if you need the literal name:
+
+  ```
+  > yamldecode("{on: 1}")
+  {
+    "true" = 1
+  }
+
+  > yamldecode("{\"on\": 1}")
+  {
+    "on" = 1
+  }
+  ```
+
+  This often surprises people decoding GitHub Actions workflows or other
+  YAML that uses unquoted `on:` keys.
+
 ## Examples
 
 ```

--- a/content/terraform/v1.14.x/docs/language/functions/yamldecode.mdx
+++ b/content/terraform/v1.14.x/docs/language/functions/yamldecode.mdx
@@ -56,6 +56,27 @@ supports only a subset of YAML 1.2, with restrictions including the following:
 - Only one YAML document is permitted. If multiple documents are present in
   the given string then this function will return an error.
 
+- Unquoted YAML 1.1-style boolean scalars (`true`/`false`, `yes`/`no`,
+  `on`/`off`, and a few other spellings) are decoded as Terraform `bool`
+  values. That applies to **map keys** as well as values. For example,
+  `yamldecode("{on: 1}")` yields an object whose attribute name is the string
+  `"true"`, not `"on"`. Quote the key if you need the literal name:
+
+  ```
+  > yamldecode("{on: 1}")
+  {
+    "true" = 1
+  }
+
+  > yamldecode("{\"on\": 1}")
+  {
+    "on" = 1
+  }
+  ```
+
+  This often surprises people decoding GitHub Actions workflows or other
+  YAML that uses unquoted `on:` keys.
+
 ## Examples
 
 ```

--- a/content/terraform/v1.15.x/docs/language/functions/yamldecode.mdx
+++ b/content/terraform/v1.15.x/docs/language/functions/yamldecode.mdx
@@ -56,6 +56,27 @@ supports only a subset of YAML 1.2, with restrictions including the following:
 - Only one YAML document is permitted. If multiple documents are present in
   the given string then this function will return an error.
 
+- Unquoted YAML 1.1-style boolean scalars (`true`/`false`, `yes`/`no`,
+  `on`/`off`, and a few other spellings) are decoded as Terraform `bool`
+  values. That applies to **map keys** as well as values. For example,
+  `yamldecode("{on: 1}")` yields an object whose attribute name is the string
+  `"true"`, not `"on"`. Quote the key if you need the literal name:
+
+  ```
+  > yamldecode("{on: 1}")
+  {
+    "true" = 1
+  }
+
+  > yamldecode("{\"on\": 1}")
+  {
+    "on" = 1
+  }
+  ```
+
+  This often surprises people decoding GitHub Actions workflows or other
+  YAML that uses unquoted `on:` keys.
+
 ## Examples
 
 ```


### PR DESCRIPTION
Unquoted YAML 1.1 booleans like `on`/`yes` decode as bool even when they're map keys, so `yamldecode(\"{on: 1}\")` gives an attribute named `\"true\"`. Added a short note and a quoted-key example — this bites people parsing GitHub Actions workflows among other things.

v1.12.x–v1.15.x.

Fixes #734