### PR TITLE
docs(terraform): drop jsondecode from mocking override examples

### DIFF
--- a/content/terraform/v1.12.x/docs/language/tests/mocking.mdx
+++ b/content/terraform/v1.12.x/docs/language/tests/mocking.mdx
@@ -210,7 +210,7 @@ module "credentials" {
 
 resource "local_file" "credentials_json" {
   filename = "credentials.json"
-  content  = jsonencode(module.credentials.data)
+  content  = module.credentials.data
 }
 ```
 
@@ -227,7 +227,7 @@ data "aws_s3_object" "data_bucket" {
 }
 
 output "data" {
-  value = jsondecode(data.aws_s3_object.data_bucket.body)
+  value = data.aws_s3_object.data_bucket.body
 }
 ```
 
@@ -302,7 +302,7 @@ mock_provider "aws" {}
 override_module {
   target = module.credentials
   outputs = {
-    data = { username = "username", password = "password" }
+    data = "{"username":"username","password":"password"}"
   }
 }
 
@@ -314,7 +314,7 @@ run "test" {
 }
 ```
 
-In this case, the override block specifies `outputs` instead of `values` and the output value is specified as HCL instead of as a string as the real module is passing the data through the `jsondecode` function. As with `override_data` blocks, you can also specify the `override_module` block in the `run` block and the same precedence rules apply.
+In this case, the override block specifies `outputs` instead of `values`. Because the module output is the raw object body string, the mocked output is also a JSON string (not an HCL object). As with `override_data` blocks, you can also specify the `override_module` block in the `run` block and the same precedence rules apply.
 
 ## Repeated blocks and nested attributes
 

--- a/content/terraform/v1.13.x/docs/language/tests/mocking.mdx
+++ b/content/terraform/v1.13.x/docs/language/tests/mocking.mdx
@@ -210,7 +210,7 @@ module "credentials" {
 
 resource "local_file" "credentials_json" {
   filename = "credentials.json"
-  content  = jsonencode(module.credentials.data)
+  content  = module.credentials.data
 }
 ```
 
@@ -227,7 +227,7 @@ data "aws_s3_object" "data_bucket" {
 }
 
 output "data" {
-  value = jsondecode(data.aws_s3_object.data_bucket.body)
+  value = data.aws_s3_object.data_bucket.body
 }
 ```
 
@@ -302,7 +302,7 @@ mock_provider "aws" {}
 override_module {
   target = module.credentials
   outputs = {
-    data = { username = "username", password = "password" }
+    data = "{"username":"username","password":"password"}"
   }
 }
 
@@ -314,7 +314,7 @@ run "test" {
 }
 ```
 
-In this case, the override block specifies `outputs` instead of `values` and the output value is specified as HCL instead of as a string as the real module is passing the data through the `jsondecode` function. As with `override_data` blocks, you can also specify the `override_module` block in the `run` block and the same precedence rules apply.
+In this case, the override block specifies `outputs` instead of `values`. Because the module output is the raw object body string, the mocked output is also a JSON string (not an HCL object). As with `override_data` blocks, you can also specify the `override_module` block in the `run` block and the same precedence rules apply.
 
 ## Repeated blocks and nested attributes
 

--- a/content/terraform/v1.14.x/docs/language/tests/mocking.mdx
+++ b/content/terraform/v1.14.x/docs/language/tests/mocking.mdx
@@ -210,7 +210,7 @@ module "credentials" {
 
 resource "local_file" "credentials_json" {
   filename = "credentials.json"
-  content  = jsonencode(module.credentials.data)
+  content  = module.credentials.data
 }
 ```
 
@@ -227,7 +227,7 @@ data "aws_s3_object" "data_bucket" {
 }
 
 output "data" {
-  value = jsondecode(data.aws_s3_object.data_bucket.body)
+  value = data.aws_s3_object.data_bucket.body
 }
 ```
 
@@ -302,7 +302,7 @@ mock_provider "aws" {}
 override_module {
   target = module.credentials
   outputs = {
-    data = { username = "username", password = "password" }
+    data = "{"username":"username","password":"password"}"
   }
 }
 
@@ -314,7 +314,7 @@ run "test" {
 }
 ```
 
-In this case, the override block specifies `outputs` instead of `values` and the output value is specified as HCL instead of as a string as the real module is passing the data through the `jsondecode` function. As with `override_data` blocks, you can also specify the `override_module` block in the `run` block and the same precedence rules apply.
+In this case, the override block specifies `outputs` instead of `values`. Because the module output is the raw object body string, the mocked output is also a JSON string (not an HCL object). As with `override_data` blocks, you can also specify the `override_module` block in the `run` block and the same precedence rules apply.
 
 ## Repeated blocks and nested attributes
 

--- a/content/terraform/v1.15.x/docs/language/tests/mocking.mdx
+++ b/content/terraform/v1.15.x/docs/language/tests/mocking.mdx
@@ -210,7 +210,7 @@ module "credentials" {
 
 resource "local_file" "credentials_json" {
   filename = "credentials.json"
-  content  = jsonencode(module.credentials.data)
+  content  = module.credentials.data
 }
 ```
 
@@ -227,7 +227,7 @@ data "aws_s3_object" "data_bucket" {
 }
 
 output "data" {
-  value = jsondecode(data.aws_s3_object.data_bucket.body)
+  value = data.aws_s3_object.data_bucket.body
 }
 ```
 
@@ -302,7 +302,7 @@ mock_provider "aws" {}
 override_module {
   target = module.credentials
   outputs = {
-    data = { username = "username", password = "password" }
+    data = "{"username":"username","password":"password"}"
   }
 }
 
@@ -314,7 +314,7 @@ run "test" {
 }
 ```
 
-In this case, the override block specifies `outputs` instead of `values` and the output value is specified as HCL instead of as a string as the real module is passing the data through the `jsondecode` function. As with `override_data` blocks, you can also specify the `override_module` block in the `run` block and the same precedence rules apply.
+In this case, the override block specifies `outputs` instead of `values`. Because the module output is the raw object body string, the mocked output is also a JSON string (not an HCL object). As with `override_data` blocks, you can also specify the `override_module` block in the `run` block and the same precedence rules apply.
 
 ## Repeated blocks and nested attributes
 


### PR DESCRIPTION
The override examples decoded the S3 body in the module and re-encoded it for local_file. That made the override_module sample awkward (HCL object vs string) and can fail jsondecode depending on the mocked body. Passing the body through as a string keeps the shapes consistent.

v1.12.x–v1.15.x.

Fixes #732