### PR TITLE
docs(terraform): how to set S3 backend endpoints on the CLI

### DIFF
--- a/content/terraform/v1.12.x/docs/language/backend/s3.mdx
+++ b/content/terraform/v1.12.x/docs/language/backend/s3.mdx
@@ -279,6 +279,26 @@ Setting the parameter `endpoint_url` on a profile will set that endpoint for all
 To set endpoints for specific services, create a `services` section and set the `endpoint_url` parameters for each desired service.
 Endpoints set for specific services will override the base endpoint configured in the profile.
 
+Nested `endpoints` values cannot be set with a dotted `-backend-config` key such as
+`-backend-config="endpoints.s3=http://127.0.0.1:9000"`. Terraform treats that form as a
+single top-level argument name (`endpoints.s3`), which the S3 backend does not accept.
+Pass nested settings through a [partial configuration](/terraform/language/backend#partial-configuration)
+file instead:
+
+```hcl
+# backend-endpoints.hcl
+endpoints = {
+  s3 = "http://127.0.0.1:9000"
+}
+```
+
+```shell
+terraform init -backend-config=backend-endpoints.hcl
+```
+
+For local development you can also set service-specific environment variables such as
+`AWS_ENDPOINT_URL_S3` without changing backend configuration files.
+
 #### Assume Role Configuration
 
 The argument `assume_role` contains the following arguments:

--- a/content/terraform/v1.13.x/docs/language/backend/s3.mdx
+++ b/content/terraform/v1.13.x/docs/language/backend/s3.mdx
@@ -279,6 +279,26 @@ Setting the parameter `endpoint_url` on a profile will set that endpoint for all
 To set endpoints for specific services, create a `services` section and set the `endpoint_url` parameters for each desired service.
 Endpoints set for specific services will override the base endpoint configured in the profile.
 
+Nested `endpoints` values cannot be set with a dotted `-backend-config` key such as
+`-backend-config="endpoints.s3=http://127.0.0.1:9000"`. Terraform treats that form as a
+single top-level argument name (`endpoints.s3`), which the S3 backend does not accept.
+Pass nested settings through a [partial configuration](/terraform/language/backend#partial-configuration)
+file instead:
+
+```hcl
+# backend-endpoints.hcl
+endpoints = {
+  s3 = "http://127.0.0.1:9000"
+}
+```
+
+```shell
+terraform init -backend-config=backend-endpoints.hcl
+```
+
+For local development you can also set service-specific environment variables such as
+`AWS_ENDPOINT_URL_S3` without changing backend configuration files.
+
 #### Assume Role Configuration
 
 The argument `assume_role` contains the following arguments:

--- a/content/terraform/v1.14.x/docs/language/backend/s3.mdx
+++ b/content/terraform/v1.14.x/docs/language/backend/s3.mdx
@@ -279,6 +279,26 @@ Setting the parameter `endpoint_url` on a profile will set that endpoint for all
 To set endpoints for specific services, create a `services` section and set the `endpoint_url` parameters for each desired service.
 Endpoints set for specific services will override the base endpoint configured in the profile.
 
+Nested `endpoints` values cannot be set with a dotted `-backend-config` key such as
+`-backend-config="endpoints.s3=http://127.0.0.1:9000"`. Terraform treats that form as a
+single top-level argument name (`endpoints.s3`), which the S3 backend does not accept.
+Pass nested settings through a [partial configuration](/terraform/language/backend#partial-configuration)
+file instead:
+
+```hcl
+# backend-endpoints.hcl
+endpoints = {
+  s3 = "http://127.0.0.1:9000"
+}
+```
+
+```shell
+terraform init -backend-config=backend-endpoints.hcl
+```
+
+For local development you can also set service-specific environment variables such as
+`AWS_ENDPOINT_URL_S3` without changing backend configuration files.
+
 #### Assume Role Configuration
 
 The argument `assume_role` contains the following arguments:

--- a/content/terraform/v1.15.x/docs/language/backend/s3.mdx
+++ b/content/terraform/v1.15.x/docs/language/backend/s3.mdx
@@ -279,6 +279,26 @@ Setting the parameter `endpoint_url` on a profile will set that endpoint for all
 To set endpoints for specific services, create a `services` section and set the `endpoint_url` parameters for each desired service.
 Endpoints set for specific services will override the base endpoint configured in the profile.
 
+Nested `endpoints` values cannot be set with a dotted `-backend-config` key such as
+`-backend-config="endpoints.s3=http://127.0.0.1:9000"`. Terraform treats that form as a
+single top-level argument name (`endpoints.s3`), which the S3 backend does not accept.
+Pass nested settings through a [partial configuration](/terraform/language/backend#partial-configuration)
+file instead:
+
+```hcl
+# backend-endpoints.hcl
+endpoints = {
+  s3 = "http://127.0.0.1:9000"
+}
+```
+
+```shell
+terraform init -backend-config=backend-endpoints.hcl
+```
+
+For local development you can also set service-specific environment variables such as
+`AWS_ENDPOINT_URL_S3` without changing backend configuration files.
+
 #### Assume Role Configuration
 
 The argument `assume_role` contains the following arguments:


### PR DESCRIPTION
`-backend-config="endpoints.s3=..."` fails because Terraform treats that as a flat key name, not a nested map. Document using a partial config file (and `AWS_ENDPOINT_URL_S3`) instead.

v1.12.x–v1.15.x.

Fixes #733