### PR TITLE
docs(terraform): note plantimestamp is unavailable in tests

### DIFF
--- a/content/terraform/v1.12.x/docs/language/functions/plantimestamp.mdx
+++ b/content/terraform/v1.12.x/docs/language/functions/plantimestamp.mdx
@@ -31,6 +31,11 @@ timestamps generated in the configuration.
 
 The `plantimestamp` function is not available within the Terraform console.
 
+It is also not available in `terraform test` files (`.tftest.hcl`), including in
+`variables` blocks inside `run` blocks. Tests do not create a real plan context,
+so there is no plan timestamp to return. Prefer a plain string variable or
+`timestamp()` when a test needs a time value.
+
 ## Examples
 
 ```

--- a/content/terraform/v1.13.x/docs/language/functions/plantimestamp.mdx
+++ b/content/terraform/v1.13.x/docs/language/functions/plantimestamp.mdx
@@ -31,6 +31,11 @@ timestamps generated in the configuration.
 
 The `plantimestamp` function is not available within the Terraform console.
 
+It is also not available in `terraform test` files (`.tftest.hcl`), including in
+`variables` blocks inside `run` blocks. Tests do not create a real plan context,
+so there is no plan timestamp to return. Prefer a plain string variable or
+`timestamp()` when a test needs a time value.
+
 ## Examples
 
 ```

--- a/content/terraform/v1.14.x/docs/language/functions/plantimestamp.mdx
+++ b/content/terraform/v1.14.x/docs/language/functions/plantimestamp.mdx
@@ -31,6 +31,11 @@ timestamps generated in the configuration.
 
 The `plantimestamp` function is not available within the Terraform console.
 
+It is also not available in `terraform test` files (`.tftest.hcl`), including in
+`variables` blocks inside `run` blocks. Tests do not create a real plan context,
+so there is no plan timestamp to return. Prefer a plain string variable or
+`timestamp()` when a test needs a time value.
+
 ## Examples
 
 ```

--- a/content/terraform/v1.15.x/docs/language/functions/plantimestamp.mdx
+++ b/content/terraform/v1.15.x/docs/language/functions/plantimestamp.mdx
@@ -31,6 +31,11 @@ timestamps generated in the configuration.
 
 The `plantimestamp` function is not available within the Terraform console.
 
+It is also not available in `terraform test` files (`.tftest.hcl`), including in
+`variables` blocks inside `run` blocks. Tests do not create a real plan context,
+so there is no plan timestamp to return. Prefer a plain string variable or
+`timestamp()` when a test needs a time value.
+
 ## Examples
 
 ```


### PR DESCRIPTION
`plantimestamp()` already says it is missing from the console. Same limitation applies under `terraform test` (no plan context). Note that next to the console line so people do not hit "unknown function" in `.tftest.hcl`.

v1.12.x–v1.15.x.

Fixes #722