### PR TITLE
docs(registry): point Registry API page at provider protocol

### DIFF
--- a/content/terraform-docs-common/docs/registry/api-docs.mdx
+++ b/content/terraform-docs-common/docs/registry/api-docs.mdx
@@ -30,6 +30,12 @@ implement your own module registry, please refer to
 [the module registry protocol](/terraform/internals/module-registry-protocol)
 instead.
 
+For **providers**, Terraform CLI uses a separate protocol documented under
+[Provider Registry Protocol](/terraform/internals/provider-registry-protocol).
+That page covers the service discovery ID and HTTP endpoints needed to host a
+provider registry. This Registry API page is the extended HTTP API for **modules**
+on the public/private Terraform Registry UIs and clients.
+
 Terraform Registry also has some additional internal API endpoints used to
 support its UI. Any endpoints or properties not documented on this page are
 subject to change over time.


### PR DESCRIPTION
Registry API docs are about the extended module HTTP API. Easy to miss that providers use a different protocol page under internals. Added a short pointer.

Fixes #730