### PR TITLE
docs(sdkv2): Planned Value mismatch is not only Optional+Computed

### DIFF
--- a/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
+++ b/content/terraform-plugin-sdk/v2.29.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
@@ -125,7 +125,7 @@ TIMESTAMP [WARN]  Provider "TYPE" produced an invalid plan for ADDRESS, but we a
       - .ATTRIBUTE: planned value cty.StringVal("VALUE") does not match config value cty.StringVal("value")
 ```
 
-This occurs for attribute schema definitions that are `Optional: true` and `Computed: true`; where the planned value, returned by the provider, does not match the attribute's config value or prior state value. For example, value's for an attribute of type string must match byte-for-byte.
+This occurs when the planned value returned by the provider does not match the attribute's config value or prior state value (for example, string values must match byte-for-byte). It commonly shows up for attributes that are both `Optional: true` and `Computed: true`, but the same class of mismatch can also be reported for `Required: true` attributes when the provider normalizes or otherwise rewrites the configured value.
 
 An example root cause of this issue could be from API normalization, such as a JSON string being returned from an API and stored in state with differing whitespace then what was originally in config.
 

--- a/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
+++ b/content/terraform-plugin-sdk/v2.30.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
@@ -125,7 +125,7 @@ TIMESTAMP [WARN]  Provider "TYPE" produced an invalid plan for ADDRESS, but we a
       - .ATTRIBUTE: planned value cty.StringVal("VALUE") does not match config value cty.StringVal("value")
 ```
 
-This occurs for attribute schema definitions that are `Optional: true` and `Computed: true`; where the planned value, returned by the provider, does not match the attribute's config value or prior state value. For example, value's for an attribute of type string must match byte-for-byte.
+This occurs when the planned value returned by the provider does not match the attribute's config value or prior state value (for example, string values must match byte-for-byte). It commonly shows up for attributes that are both `Optional: true` and `Computed: true`, but the same class of mismatch can also be reported for `Required: true` attributes when the provider normalizes or otherwise rewrites the configured value.
 
 An example root cause of this issue could be from API normalization, such as a JSON string being returned from an API and stored in state with differing whitespace then what was originally in config.
 

--- a/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
+++ b/content/terraform-plugin-sdk/v2.31.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
@@ -125,7 +125,7 @@ TIMESTAMP [WARN]  Provider "TYPE" produced an invalid plan for ADDRESS, but we a
       - .ATTRIBUTE: planned value cty.StringVal("VALUE") does not match config value cty.StringVal("value")
 ```
 
-This occurs for attribute schema definitions that are `Optional: true` and `Computed: true`; where the planned value, returned by the provider, does not match the attribute's config value or prior state value. For example, value's for an attribute of type string must match byte-for-byte.
+This occurs when the planned value returned by the provider does not match the attribute's config value or prior state value (for example, string values must match byte-for-byte). It commonly shows up for attributes that are both `Optional: true` and `Computed: true`, but the same class of mismatch can also be reported for `Required: true` attributes when the provider normalizes or otherwise rewrites the configured value.
 
 An example root cause of this issue could be from API normalization, such as a JSON string being returned from an API and stored in state with differing whitespace then what was originally in config.
 

--- a/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
+++ b/content/terraform-plugin-sdk/v2.32.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
@@ -125,7 +125,7 @@ TIMESTAMP [WARN]  Provider "TYPE" produced an invalid plan for ADDRESS, but we a
       - .ATTRIBUTE: planned value cty.StringVal("VALUE") does not match config value cty.StringVal("value")
 ```
 
-This occurs for attribute schema definitions that are `Optional: true` and `Computed: true`; where the planned value, returned by the provider, does not match the attribute's config value or prior state value. For example, value's for an attribute of type string must match byte-for-byte.
+This occurs when the planned value returned by the provider does not match the attribute's config value or prior state value (for example, string values must match byte-for-byte). It commonly shows up for attributes that are both `Optional: true` and `Computed: true`, but the same class of mismatch can also be reported for `Required: true` attributes when the provider normalizes or otherwise rewrites the configured value.
 
 An example root cause of this issue could be from API normalization, such as a JSON string being returned from an API and stored in state with differing whitespace then what was originally in config.
 

--- a/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
+++ b/content/terraform-plugin-sdk/v2.33.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
@@ -125,7 +125,7 @@ TIMESTAMP [WARN]  Provider "TYPE" produced an invalid plan for ADDRESS, but we a
       - .ATTRIBUTE: planned value cty.StringVal("VALUE") does not match config value cty.StringVal("value")
 ```
 
-This occurs for attribute schema definitions that are `Optional: true` and `Computed: true`; where the planned value, returned by the provider, does not match the attribute's config value or prior state value. For example, value's for an attribute of type string must match byte-for-byte.
+This occurs when the planned value returned by the provider does not match the attribute's config value or prior state value (for example, string values must match byte-for-byte). It commonly shows up for attributes that are both `Optional: true` and `Computed: true`, but the same class of mismatch can also be reported for `Required: true` attributes when the provider normalizes or otherwise rewrites the configured value.
 
 An example root cause of this issue could be from API normalization, such as a JSON string being returned from an API and stored in state with differing whitespace then what was originally in config.
 

--- a/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
+++ b/content/terraform-plugin-sdk/v2.34.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
@@ -125,7 +125,7 @@ TIMESTAMP [WARN]  Provider "TYPE" produced an invalid plan for ADDRESS, but we a
       - .ATTRIBUTE: planned value cty.StringVal("VALUE") does not match config value cty.StringVal("value")
 ```
 
-This occurs for attribute schema definitions that are `Optional: true` and `Computed: true`; where the planned value, returned by the provider, does not match the attribute's config value or prior state value. For example, value's for an attribute of type string must match byte-for-byte.
+This occurs when the planned value returned by the provider does not match the attribute's config value or prior state value (for example, string values must match byte-for-byte). It commonly shows up for attributes that are both `Optional: true` and `Computed: true`, but the same class of mismatch can also be reported for `Required: true` attributes when the provider normalizes or otherwise rewrites the configured value.
 
 An example root cause of this issue could be from API normalization, such as a JSON string being returned from an API and stored in state with differing whitespace then what was originally in config.
 

--- a/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
+++ b/content/terraform-plugin-sdk/v2.35.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
@@ -125,7 +125,7 @@ TIMESTAMP [WARN]  Provider "TYPE" produced an invalid plan for ADDRESS, but we a
       - .ATTRIBUTE: planned value cty.StringVal("VALUE") does not match config value cty.StringVal("value")
 ```
 
-This occurs for attribute schema definitions that are `Optional: true` and `Computed: true`; where the planned value, returned by the provider, does not match the attribute's config value or prior state value. For example, value's for an attribute of type string must match byte-for-byte.
+This occurs when the planned value returned by the provider does not match the attribute's config value or prior state value (for example, string values must match byte-for-byte). It commonly shows up for attributes that are both `Optional: true` and `Computed: true`, but the same class of mismatch can also be reported for `Required: true` attributes when the provider normalizes or otherwise rewrites the configured value.
 
 An example root cause of this issue could be from API normalization, such as a JSON string being returned from an API and stored in state with differing whitespace then what was originally in config.
 

--- a/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
+++ b/content/terraform-plugin-sdk/v2.36.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
@@ -125,7 +125,7 @@ TIMESTAMP [WARN]  Provider "TYPE" produced an invalid plan for ADDRESS, but we a
       - .ATTRIBUTE: planned value cty.StringVal("VALUE") does not match config value cty.StringVal("value")
 ```
 
-This occurs for attribute schema definitions that are `Optional: true` and `Computed: true`; where the planned value, returned by the provider, does not match the attribute's config value or prior state value. For example, value's for an attribute of type string must match byte-for-byte.
+This occurs when the planned value returned by the provider does not match the attribute's config value or prior state value (for example, string values must match byte-for-byte). It commonly shows up for attributes that are both `Optional: true` and `Computed: true`, but the same class of mismatch can also be reported for `Required: true` attributes when the provider normalizes or otherwise rewrites the configured value.
 
 An example root cause of this issue could be from API normalization, such as a JSON string being returned from an API and stored in state with differing whitespace then what was originally in config.
 

--- a/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
+++ b/content/terraform-plugin-sdk/v2.37.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
@@ -125,7 +125,7 @@ TIMESTAMP [WARN]  Provider "TYPE" produced an invalid plan for ADDRESS, but we a
       - .ATTRIBUTE: planned value cty.StringVal("VALUE") does not match config value cty.StringVal("value")
 ```
 
-This occurs for attribute schema definitions that are `Optional: true` and `Computed: true`; where the planned value, returned by the provider, does not match the attribute's config value or prior state value. For example, value's for an attribute of type string must match byte-for-byte.
+This occurs when the planned value returned by the provider does not match the attribute's config value or prior state value (for example, string values must match byte-for-byte). It commonly shows up for attributes that are both `Optional: true` and `Computed: true`, but the same class of mismatch can also be reported for `Required: true` attributes when the provider normalizes or otherwise rewrites the configured value.
 
 An example root cause of this issue could be from API normalization, such as a JSON string being returned from an API and stored in state with differing whitespace then what was originally in config.
 

--- a/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
+++ b/content/terraform-plugin-sdk/v2.38.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
@@ -125,7 +125,7 @@ TIMESTAMP [WARN]  Provider "TYPE" produced an invalid plan for ADDRESS, but we a
       - .ATTRIBUTE: planned value cty.StringVal("VALUE") does not match config value cty.StringVal("value")
 ```
 
-This occurs for attribute schema definitions that are `Optional: true` and `Computed: true`; where the planned value, returned by the provider, does not match the attribute's config value or prior state value. For example, value's for an attribute of type string must match byte-for-byte.
+This occurs when the planned value returned by the provider does not match the attribute's config value or prior state value (for example, string values must match byte-for-byte). It commonly shows up for attributes that are both `Optional: true` and `Computed: true`, but the same class of mismatch can also be reported for `Required: true` attributes when the provider normalizes or otherwise rewrites the configured value.
 
 An example root cause of this issue could be from API normalization, such as a JSON string being returned from an API and stored in state with differing whitespace then what was originally in config.
 

--- a/content/terraform-plugin-sdk/v2.39.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
+++ b/content/terraform-plugin-sdk/v2.39.x/docs/plugin/sdkv2/resources/data-consistency-errors.mdx
@@ -125,7 +125,7 @@ TIMESTAMP [WARN]  Provider "TYPE" produced an invalid plan for ADDRESS, but we a
       - .ATTRIBUTE: planned value cty.StringVal("VALUE") does not match config value cty.StringVal("value")
 ```
 
-This occurs for attribute schema definitions that are `Optional: true` and `Computed: true`; where the planned value, returned by the provider, does not match the attribute's config value or prior state value. For example, value's for an attribute of type string must match byte-for-byte.
+This occurs when the planned value returned by the provider does not match the attribute's config value or prior state value (for example, string values must match byte-for-byte). It commonly shows up for attributes that are both `Optional: true` and `Computed: true`, but the same class of mismatch can also be reported for `Required: true` attributes when the provider normalizes or otherwise rewrites the configured value.
 
 An example root cause of this issue could be from API normalization, such as a JSON string being returned from an API and stored in state with differing whitespace then what was originally in config.
 


### PR DESCRIPTION
The data consistency page said Planned Value vs Config Value only happens for Optional+Computed attributes. Same class of mismatch can show up for Required fields when the provider rewrites the value. Broadened the wording.

Fixes #726