### PR TITLE
docs(terraform): how to default optional object attributes

### DIFF
--- a/content/terraform/v1.12.x/docs/language/block/variable.mdx
+++ b/content/terraform/v1.12.x/docs/language/block/variable.mdx
@@ -112,6 +112,32 @@ variable "region" {
 
 If you specify both the `type` and `default` arguments, the default value must convert to the specified type. The `default` argument requires a literal value and cannot reference other objects in the configuration.
 
+If the variable type is an object (or a collection of objects), a `default`
+on the **variable** still has to satisfy every **required** attribute in that
+type. You cannot use the variable-level `default` to supply only the optional
+fields.
+
+To give optional attributes fallback values when a caller omits them, set the
+default on the attribute itself with
+[`optional(type, default)`](/terraform/language/expressions/type-constraints#optional-object-type-attributes)
+in the type constraint:
+
+```hcl
+variable "db" {
+  type = object({
+    name                = string
+    user_name           = string
+    deletion_protection = optional(bool, true)
+    backup              = optional(bool, true)
+  })
+}
+```
+
+With that type, a caller can pass `{ name = "app", user_name = "app" }` and
+Terraform fills in `deletion_protection` and `backup`. See
+[Optional Object Type Attributes](/terraform/language/expressions/type-constraints#optional-object-type-attributes)
+for nested structures and more examples.
+
 #### Summary
 
 - Data type: Expression

--- a/content/terraform/v1.13.x/docs/language/block/variable.mdx
+++ b/content/terraform/v1.13.x/docs/language/block/variable.mdx
@@ -112,6 +112,32 @@ variable "region" {
 
 If you specify both the `type` and `default` arguments, the default value must convert to the specified type. The `default` argument requires a literal value and cannot reference other objects in the configuration.
 
+If the variable type is an object (or a collection of objects), a `default`
+on the **variable** still has to satisfy every **required** attribute in that
+type. You cannot use the variable-level `default` to supply only the optional
+fields.
+
+To give optional attributes fallback values when a caller omits them, set the
+default on the attribute itself with
+[`optional(type, default)`](/terraform/language/expressions/type-constraints#optional-object-type-attributes)
+in the type constraint:
+
+```hcl
+variable "db" {
+  type = object({
+    name                = string
+    user_name           = string
+    deletion_protection = optional(bool, true)
+    backup              = optional(bool, true)
+  })
+}
+```
+
+With that type, a caller can pass `{ name = "app", user_name = "app" }` and
+Terraform fills in `deletion_protection` and `backup`. See
+[Optional Object Type Attributes](/terraform/language/expressions/type-constraints#optional-object-type-attributes)
+for nested structures and more examples.
+
 #### Summary
 
 - Data type: Expression

--- a/content/terraform/v1.14.x/docs/language/block/variable.mdx
+++ b/content/terraform/v1.14.x/docs/language/block/variable.mdx
@@ -110,6 +110,32 @@ variable "region" {
 
 If you specify both the `type` and `default` arguments, the default value must convert to the specified type. The `default` argument requires a literal value and cannot reference other objects in the configuration.
 
+If the variable type is an object (or a collection of objects), a `default`
+on the **variable** still has to satisfy every **required** attribute in that
+type. You cannot use the variable-level `default` to supply only the optional
+fields.
+
+To give optional attributes fallback values when a caller omits them, set the
+default on the attribute itself with
+[`optional(type, default)`](/terraform/language/expressions/type-constraints#optional-object-type-attributes)
+in the type constraint:
+
+```hcl
+variable "db" {
+  type = object({
+    name                = string
+    user_name           = string
+    deletion_protection = optional(bool, true)
+    backup              = optional(bool, true)
+  })
+}
+```
+
+With that type, a caller can pass `{ name = "app", user_name = "app" }` and
+Terraform fills in `deletion_protection` and `backup`. See
+[Optional Object Type Attributes](/terraform/language/expressions/type-constraints#optional-object-type-attributes)
+for nested structures and more examples.
+
 #### Summary
 
 - Data type: Expression

--- a/content/terraform/v1.15.x/docs/language/block/variable.mdx
+++ b/content/terraform/v1.15.x/docs/language/block/variable.mdx
@@ -118,6 +118,32 @@ variable "region" {
 
 If you specify both the `type` and `default` arguments, the default value must convert to the specified type. The `default` argument requires a literal value and cannot reference other objects in the configuration.
 
+If the variable type is an object (or a collection of objects), a `default`
+on the **variable** still has to satisfy every **required** attribute in that
+type. You cannot use the variable-level `default` to supply only the optional
+fields.
+
+To give optional attributes fallback values when a caller omits them, set the
+default on the attribute itself with
+[`optional(type, default)`](/terraform/language/expressions/type-constraints#optional-object-type-attributes)
+in the type constraint:
+
+```hcl
+variable "db" {
+  type = object({
+    name                = string
+    user_name           = string
+    deletion_protection = optional(bool, true)
+    backup              = optional(bool, true)
+  })
+}
+```
+
+With that type, a caller can pass `{ name = "app", user_name = "app" }` and
+Terraform fills in `deletion_protection` and `backup`. See
+[Optional Object Type Attributes](/terraform/language/expressions/type-constraints#optional-object-type-attributes)
+for nested structures and more examples.
+
 #### Summary
 
 - Data type: Expression


### PR DESCRIPTION
Variable-level `default` has to satisfy every required attribute on an object type, so you cannot use it to “fill in” only the optional ones. That belongs on `optional(type, default)` in the type constraint.

Added a short note under the `default` argument with a small example and a link to the optional object attributes docs.

Fixes #727