### PR TITLE
docs(terraform): clarify map(...) in for_each is a type constructor

### DIFF
--- a/content/terraform/v1.12.x/docs/language/meta-arguments/for_each.mdx
+++ b/content/terraform/v1.12.x/docs/language/meta-arguments/for_each.mdx
@@ -106,6 +106,8 @@ internet gateway for each VPC:
 
 ```hcl
 variable "vpcs" {
+  # map(...) here is a type constructor (a map of objects), not the removed
+  # map() function. See type constraints for details.
   type = map(object({
     cidr_block = string
   }))

--- a/content/terraform/v1.13.x/docs/language/meta-arguments/for_each.mdx
+++ b/content/terraform/v1.13.x/docs/language/meta-arguments/for_each.mdx
@@ -106,6 +106,8 @@ internet gateway for each VPC:
 
 ```hcl
 variable "vpcs" {
+  # map(...) here is a type constructor (a map of objects), not the removed
+  # map() function. See type constraints for details.
   type = map(object({
     cidr_block = string
   }))

--- a/content/terraform/v1.14.x/docs/language/meta-arguments/for_each.mdx
+++ b/content/terraform/v1.14.x/docs/language/meta-arguments/for_each.mdx
@@ -106,6 +106,8 @@ internet gateway for each VPC:
 
 ```hcl
 variable "vpcs" {
+  # map(...) here is a type constructor (a map of objects), not the removed
+  # map() function. See type constraints for details.
   type = map(object({
     cidr_block = string
   }))

--- a/content/terraform/v1.15.x/docs/language/meta-arguments/for_each.mdx
+++ b/content/terraform/v1.15.x/docs/language/meta-arguments/for_each.mdx
@@ -106,6 +106,8 @@ internet gateway for each VPC:
 
 ```hcl
 variable "vpcs" {
+  # map(...) here is a type constructor (a map of objects), not the removed
+  # map() function. See type constraints for details.
   type = map(object({
     cidr_block = string
   }))


### PR DESCRIPTION
The for_each chaining example uses `type = map(object({...}))`. That looks a lot like the removed `map()` function page, so people click through and hit the deprecation note.

Added a short comment that this is the map type constructor.

Fixes #740