### PR TITLE
docs(terraform): keep heredoc sections consecutive

### DIFF
--- a/content/terraform/v1.12.x/docs/language/expressions/strings.mdx
+++ b/content/terraform/v1.12.x/docs/language/expressions/strings.mdx
@@ -78,25 +78,6 @@ In the above example, `EOT` is the identifier selected. Any identifier is
 allowed, but conventionally this identifier is in all-uppercase and begins with
 `EO`, meaning "end of". `EOT` in this case stands for "end of text".
 
-<Highlight>
-
-Don't use "heredoc" strings to generate JSON or YAML. Instead, use
-[the `jsonencode` function](/terraform/language/functions/jsonencode) or
-[the `yamlencode` function](/terraform/language/functions/yamlencode) so that Terraform
-can be responsible for guaranteeing valid JSON or YAML syntax.
-
-<CodeBlockConfig>
-
-```hcl
-example = jsonencode({
-  a = 1
-  b = "hello"
-})
-```
-
-</CodeBlockConfig>
-</Highlight>
-
 ### Indented Heredocs
 
 The standard heredoc form (shown above) treats all space characters as literal
@@ -133,6 +114,25 @@ from the beginning of all of the lines, leading to the following result:
 hello
   world
 ```
+
+<Highlight>
+
+Don't use "heredoc" strings to generate JSON or YAML. Instead, use
+[the `jsonencode` function](/terraform/language/functions/jsonencode) or
+[the `yamlencode` function](/terraform/language/functions/yamlencode) so that Terraform
+can be responsible for guaranteeing valid JSON or YAML syntax.
+
+<CodeBlockConfig>
+
+```hcl
+example = jsonencode({
+  a = 1
+  b = "hello"
+})
+```
+
+</CodeBlockConfig>
+</Highlight>
 
 ### Escape Sequences
 

--- a/content/terraform/v1.13.x/docs/language/expressions/strings.mdx
+++ b/content/terraform/v1.13.x/docs/language/expressions/strings.mdx
@@ -78,25 +78,6 @@ In the above example, `EOT` is the identifier selected. Any identifier is
 allowed, but conventionally this identifier is in all-uppercase and begins with
 `EO`, meaning "end of". `EOT` in this case stands for "end of text".
 
-<Highlight>
-
-Don't use "heredoc" strings to generate JSON or YAML. Instead, use
-[the `jsonencode` function](/terraform/language/functions/jsonencode) or
-[the `yamlencode` function](/terraform/language/functions/yamlencode) so that Terraform
-can be responsible for guaranteeing valid JSON or YAML syntax.
-
-<CodeBlockConfig>
-
-```hcl
-example = jsonencode({
-  a = 1
-  b = "hello"
-})
-```
-
-</CodeBlockConfig>
-</Highlight>
-
 ### Indented Heredocs
 
 The standard heredoc form (shown above) treats all space characters as literal
@@ -133,6 +114,25 @@ from the beginning of all of the lines, leading to the following result:
 hello
   world
 ```
+
+<Highlight>
+
+Don't use "heredoc" strings to generate JSON or YAML. Instead, use
+[the `jsonencode` function](/terraform/language/functions/jsonencode) or
+[the `yamlencode` function](/terraform/language/functions/yamlencode) so that Terraform
+can be responsible for guaranteeing valid JSON or YAML syntax.
+
+<CodeBlockConfig>
+
+```hcl
+example = jsonencode({
+  a = 1
+  b = "hello"
+})
+```
+
+</CodeBlockConfig>
+</Highlight>
 
 ### Escape Sequences
 

--- a/content/terraform/v1.14.x/docs/language/expressions/strings.mdx
+++ b/content/terraform/v1.14.x/docs/language/expressions/strings.mdx
@@ -78,25 +78,6 @@ In the above example, `EOT` is the identifier selected. Any identifier is
 allowed, but conventionally this identifier is in all-uppercase and begins with
 `EO`, meaning "end of". `EOT` in this case stands for "end of text".
 
-<Highlight>
-
-Don't use "heredoc" strings to generate JSON or YAML. Instead, use
-[the `jsonencode` function](/terraform/language/functions/jsonencode) or
-[the `yamlencode` function](/terraform/language/functions/yamlencode) so that Terraform
-can be responsible for guaranteeing valid JSON or YAML syntax.
-
-<CodeBlockConfig>
-
-```hcl
-example = jsonencode({
-  a = 1
-  b = "hello"
-})
-```
-
-</CodeBlockConfig>
-</Highlight>
-
 ### Indented Heredocs
 
 The standard heredoc form (shown above) treats all space characters as literal
@@ -133,6 +114,25 @@ from the beginning of all of the lines, leading to the following result:
 hello
   world
 ```
+
+<Highlight>
+
+Don't use "heredoc" strings to generate JSON or YAML. Instead, use
+[the `jsonencode` function](/terraform/language/functions/jsonencode) or
+[the `yamlencode` function](/terraform/language/functions/yamlencode) so that Terraform
+can be responsible for guaranteeing valid JSON or YAML syntax.
+
+<CodeBlockConfig>
+
+```hcl
+example = jsonencode({
+  a = 1
+  b = "hello"
+})
+```
+
+</CodeBlockConfig>
+</Highlight>
 
 ### Escape Sequences
 

--- a/content/terraform/v1.15.x/docs/language/expressions/strings.mdx
+++ b/content/terraform/v1.15.x/docs/language/expressions/strings.mdx
@@ -78,25 +78,6 @@ In the above example, `EOT` is the identifier selected. Any identifier is
 allowed, but conventionally this identifier is in all-uppercase and begins with
 `EO`, meaning "end of". `EOT` in this case stands for "end of text".
 
-<Highlight>
-
-Don't use "heredoc" strings to generate JSON or YAML. Instead, use
-[the `jsonencode` function](/terraform/language/functions/jsonencode) or
-[the `yamlencode` function](/terraform/language/functions/yamlencode) so that Terraform
-can be responsible for guaranteeing valid JSON or YAML syntax.
-
-<CodeBlockConfig>
-
-```hcl
-example = jsonencode({
-  a = 1
-  b = "hello"
-})
-```
-
-</CodeBlockConfig>
-</Highlight>
-
 ### Indented Heredocs
 
 The standard heredoc form (shown above) treats all space characters as literal
@@ -133,6 +114,25 @@ from the beginning of all of the lines, leading to the following result:
 hello
   world
 ```
+
+<Highlight>
+
+Don't use "heredoc" strings to generate JSON or YAML. Instead, use
+[the `jsonencode` function](/terraform/language/functions/jsonencode) or
+[the `yamlencode` function](/terraform/language/functions/yamlencode) so that Terraform
+can be responsible for guaranteeing valid JSON or YAML syntax.
+
+<CodeBlockConfig>
+
+```hcl
+example = jsonencode({
+  a = 1
+  b = "hello"
+})
+```
+
+</CodeBlockConfig>
+</Highlight>
 
 ### Escape Sequences
 


### PR DESCRIPTION
Basic heredoc and indented heredoc were split by the jsonencode/yamlencode tip. Moved the tip so the two heredoc forms sit next to each other.

Fixes #739