### PR TITLE
docs(terraform): clarify -filter paths are from the configuration root

### DIFF
--- a/content/terraform/v1.12.x/docs/cli/commands/test.mdx
+++ b/content/terraform/v1.12.x/docs/cli/commands/test.mdx
@@ -32,7 +32,7 @@ The following options apply to the Terraform `terraform test` command:
 
 * `-cloud-run=<module source>` - This test run executes remotely on HCP Terraform within the specified Terraform [private registry](/terraform/language/modules/sources#terraform-registry) module.
 
-* `-filter=testfile` - Limits the `terraform test` operation to the specified test files.
+* `-filter=testfile` - Limits the `terraform test` operation to the specified test file(s). Paths are relative to the **configuration root** (the directory where you run `terraform test`), not relative to the testing directory alone. For a file under the default `tests/` directory, pass `tests/name.tftest.hcl` (for example `-filter=tests/02_test.tftest.hcl`). Passing only the basename (such as `-filter=02_test.tftest.hcl`) does not match files inside `tests/` and Terraform runs zero tests.
 
 * `-json` - Displays machine-readable JSON output for your testing results.
 
@@ -93,7 +93,7 @@ In addition, a [setup module](/terraform/language/tests#modules) for the tests e
 
 In order to execute the tests you should run `terraform test` from the root configuration directory as if running `terraform plan` or `terraform apply`. Despite the actual test files being in the nested `tests` directory, Terraform executes from the main configuration directory.
 
-Specific test files can be executed using the `-filter` option.
+Specific test files can be executed using the `-filter` option. Always include the path from the configuration root (including `tests/` when that is where the file lives)—a bare filename only matches a test file in the current directory, not under `tests/`.
 
 Linux, Mac OS, and UNIX:
 

--- a/content/terraform/v1.13.x/docs/cli/commands/test.mdx
+++ b/content/terraform/v1.13.x/docs/cli/commands/test.mdx
@@ -32,7 +32,7 @@ The following options apply to the Terraform `terraform test` command:
 
 * `-cloud-run=<module source>` - This test run executes remotely on HCP Terraform within the specified Terraform [private registry](/terraform/language/modules/sources#terraform-registry) module.
 
-* `-filter=testfile` - Limits the `terraform test` operation to the specified test files.
+* `-filter=testfile` - Limits the `terraform test` operation to the specified test file(s). Paths are relative to the **configuration root** (the directory where you run `terraform test`), not relative to the testing directory alone. For a file under the default `tests/` directory, pass `tests/name.tftest.hcl` (for example `-filter=tests/02_test.tftest.hcl`). Passing only the basename (such as `-filter=02_test.tftest.hcl`) does not match files inside `tests/` and Terraform runs zero tests.
 
 * `-json` - Displays machine-readable JSON output for your testing results.
 
@@ -93,7 +93,7 @@ In addition, a [setup module](/terraform/language/tests#modules) for the tests e
 
 In order to execute the tests you should run `terraform test` from the root configuration directory as if running `terraform plan` or `terraform apply`. Despite the actual test files being in the nested `tests` directory, Terraform executes from the main configuration directory.
 
-Specific test files can be executed using the `-filter` option.
+Specific test files can be executed using the `-filter` option. Always include the path from the configuration root (including `tests/` when that is where the file lives)—a bare filename only matches a test file in the current directory, not under `tests/`.
 
 Linux, Mac OS, and UNIX:
 

--- a/content/terraform/v1.14.x/docs/cli/commands/test.mdx
+++ b/content/terraform/v1.14.x/docs/cli/commands/test.mdx
@@ -32,7 +32,7 @@ The following options apply to the Terraform `terraform test` command:
 
 * `-cloud-run=<module source>` - This test run executes remotely on HCP Terraform within the specified Terraform [private registry](/terraform/language/modules/sources#terraform-registry) module.
 
-* `-filter=testfile` - Limits the `terraform test` operation to the specified test files.
+* `-filter=testfile` - Limits the `terraform test` operation to the specified test file(s). Paths are relative to the **configuration root** (the directory where you run `terraform test`), not relative to the testing directory alone. For a file under the default `tests/` directory, pass `tests/name.tftest.hcl` (for example `-filter=tests/02_test.tftest.hcl`). Passing only the basename (such as `-filter=02_test.tftest.hcl`) does not match files inside `tests/` and Terraform runs zero tests.
 
 * `-json` - Displays machine-readable JSON output for your testing results.
 
@@ -93,7 +93,7 @@ In addition, a [setup module](/terraform/language/tests#modules) for the tests e
 
 In order to execute the tests you should run `terraform test` from the root configuration directory as if running `terraform plan` or `terraform apply`. Despite the actual test files being in the nested `tests` directory, Terraform executes from the main configuration directory.
 
-Specific test files can be executed using the `-filter` option.
+Specific test files can be executed using the `-filter` option. Always include the path from the configuration root (including `tests/` when that is where the file lives)—a bare filename only matches a test file in the current directory, not under `tests/`.
 
 Linux, Mac OS, and UNIX:
 

--- a/content/terraform/v1.15.x/docs/cli/commands/test.mdx
+++ b/content/terraform/v1.15.x/docs/cli/commands/test.mdx
@@ -32,7 +32,7 @@ The following options apply to the Terraform `terraform test` command:
 
 * `-cloud-run=<module source>` - This test run executes remotely on HCP Terraform within the specified Terraform [private registry](/terraform/language/modules/sources#terraform-registry) module.
 
-* `-filter=testfile` - Limits the `terraform test` operation to the specified test files.
+* `-filter=testfile` - Limits the `terraform test` operation to the specified test file(s). Paths are relative to the **configuration root** (the directory where you run `terraform test`), not relative to the testing directory alone. For a file under the default `tests/` directory, pass `tests/name.tftest.hcl` (for example `-filter=tests/02_test.tftest.hcl`). Passing only the basename (such as `-filter=02_test.tftest.hcl`) does not match files inside `tests/` and Terraform runs zero tests.
 
 * `-json` - Displays machine-readable JSON output for your testing results.
 
@@ -93,7 +93,7 @@ In addition, a [setup module](/terraform/language/tests#modules) for the tests e
 
 In order to execute the tests you should run `terraform test` from the root configuration directory as if running `terraform plan` or `terraform apply`. Despite the actual test files being in the nested `tests` directory, Terraform executes from the main configuration directory.
 
-Specific test files can be executed using the `-filter` option.
+Specific test files can be executed using the `-filter` option. Always include the path from the configuration root (including `tests/` when that is where the file lives)—a bare filename only matches a test file in the current directory, not under `tests/`.
 
 Linux, Mac OS, and UNIX:
 

--- a/content/terraform/v1.16.x (beta)/docs/cli/commands/test.mdx
+++ b/content/terraform/v1.16.x (beta)/docs/cli/commands/test.mdx
@@ -32,7 +32,7 @@ The following options apply to the Terraform `terraform test` command:
 
 * `-cloud-run=<module source>` - This test run executes remotely on HCP Terraform within the specified Terraform [private registry](/terraform/language/modules/sources#terraform-registry) module.
 
-* `-filter=testfile` - Limits the `terraform test` operation to the specified test files.
+* `-filter=testfile` - Limits the `terraform test` operation to the specified test file(s). Paths are relative to the **configuration root** (the directory where you run `terraform test`), not relative to the testing directory alone. For a file under the default `tests/` directory, pass `tests/name.tftest.hcl` (for example `-filter=tests/02_test.tftest.hcl`). Passing only the basename (such as `-filter=02_test.tftest.hcl`) does not match files inside `tests/` and Terraform runs zero tests.
 
 * `-json` - Displays machine-readable JSON output for your testing results.
 
@@ -93,7 +93,7 @@ In addition, a [setup module](/terraform/language/tests#modules) for the tests e
 
 In order to execute the tests you should run `terraform test` from the root configuration directory as if running `terraform plan` or `terraform apply`. Despite the actual test files being in the nested `tests` directory, Terraform executes from the main configuration directory.
 
-Specific test files can be executed using the `-filter` option.
+Specific test files can be executed using the `-filter` option. Always include the path from the configuration root (including `tests/` when that is where the file lives)—a bare filename only matches a test file in the current directory, not under `tests/`.
 
 Linux, Mac OS, and UNIX:
 


### PR DESCRIPTION
`-filter` matches paths from the configuration root (where you run `terraform test`), not just the basename under `tests/`. If you pass only `02_test.tftest.hcl`, Terraform finds nothing and reports 0 tests.

Docs now say to use `tests/name.tftest.hcl` for files in the default directory, and call that out next to the examples.

v1.12.x–v1.16.x (beta).

Fixes #723