### PR TITLE
docs(vault): replace dead AWS Marketplace link with HCP Vault docs

### DIFF
--- a/content/vault/v1.18.x/content/docs/platform/aws/index.mdx
+++ b/content/vault/v1.18.x/content/docs/platform/aws/index.mdx
@@ -17,7 +17,7 @@ There are two varieties of Vault AMIs available through the AWS Marketplace. Vau
 
 The AWS Marketplace listings can be found below.
 
-- [HashiCorp Vault](https://aws.amazon.com/marketplace/pp/prodview-arpkegbgk6zfy?sr=0-6&ref_=beagle&applicationId=AWSMPContessa)
+- [HCP Vault Dedicated](/hcp/docs/vault/what-is-hcp-vault)
 
 ## Use cases
 

--- a/content/vault/v1.19.x/content/docs/deploy/aws/index.mdx
+++ b/content/vault/v1.19.x/content/docs/deploy/aws/index.mdx
@@ -11,8 +11,8 @@ last_modified: 2025-07-02T11:30:26-05:00
 
 # Run Vault on AWS
 
-You can deploy Vault on Amazon Web Services (AWS) with the official HashiCorp
-[AWS Marketplace offering of HCP Vault](https://aws.amazon.com/marketplace/pp/prodview-arpkegbgk6zfy?sr=0-6&ref_=beagle&applicationId=AWSMPContessa).
+You can deploy Vault on Amazon Web Services (AWS) with
+[HCP Vault Dedicated](/hcp/docs/vault/what-is-hcp-vault).
 
 <Note>
 

--- a/content/vault/v1.20.x/content/docs/deploy/aws/index.mdx
+++ b/content/vault/v1.20.x/content/docs/deploy/aws/index.mdx
@@ -11,8 +11,8 @@ last_modified: 2025-07-01T14:39:24-05:00
 
 # Run Vault on AWS
 
-You can deploy Vault on Amazon Web Services (AWS) with the official HashiCorp
-[AWS Marketplace offering of HCP Vault](https://aws.amazon.com/marketplace/pp/prodview-arpkegbgk6zfy?sr=0-6&ref_=beagle&applicationId=AWSMPContessa).
+You can deploy Vault on Amazon Web Services (AWS) with
+[HCP Vault Dedicated](/hcp/docs/vault/what-is-hcp-vault).
 
 <Note>
 

--- a/content/vault/v1.21.x/content/docs/deploy/aws/index.mdx
+++ b/content/vault/v1.21.x/content/docs/deploy/aws/index.mdx
@@ -11,8 +11,8 @@ last_modified: 2025-10-22T13:53:42-07:00
 
 # Run Vault on AWS
 
-You can deploy Vault on Amazon Web Services (AWS) with the official HashiCorp
-[AWS Marketplace offering of HCP Vault](https://aws.amazon.com/marketplace/pp/prodview-arpkegbgk6zfy?sr=0-6&ref_=beagle&applicationId=AWSMPContessa).
+You can deploy Vault on Amazon Web Services (AWS) with
+[HCP Vault Dedicated](/hcp/docs/vault/what-is-hcp-vault).
 
 <Note>
 

--- a/content/vault/v2.x/content/docs/deploy/aws/index.mdx
+++ b/content/vault/v2.x/content/docs/deploy/aws/index.mdx
@@ -11,8 +11,8 @@ last_modified: 2026-04-15T00:15:05.000Z
 
 # Run Vault on AWS
 
-You can deploy Vault on Amazon Web Services (AWS) with the official HashiCorp
-[AWS Marketplace offering of HCP Vault](https://aws.amazon.com/marketplace/pp/prodview-arpkegbgk6zfy?sr=0-6&ref_=beagle&applicationId=AWSMPContessa).
+You can deploy Vault on Amazon Web Services (AWS) with
+[HCP Vault Dedicated](/hcp/docs/vault/what-is-hcp-vault).
 
 <Note>
 


### PR DESCRIPTION
The AWS Marketplace product link on the Vault AWS deploy pages no longer shows a listing. Swapped it for the HCP Vault Dedicated docs.

v1.18.x–v2.x.

Fixes #1035