### PR TITLE
docs(vault): document max_json_* defaults on the API limits page

### DIFF
--- a/content/vault/v1.18.x/content/api-docs/index.mdx
+++ b/content/vault/v1.18.x/content/api-docs/index.mdx
@@ -346,16 +346,20 @@ Vault's server configuration file.
 Vault also supports several listener options to enforce payload size limits for to incoming JSON
 request bodies.
 
-You can configure the payload limits individullly on each listener and give
+You can configure the payload limits individually on each listener and give
 administrators granular control over the:
 
-- maximum allowed nesting depth of a JSON object or array (`max_json_depth`).
-- maximum allowed length for any single string value in the payload (`max_json_string_value_length`.)
-- maximum number of key-value pairs allowed in a single JSON object (`max_json_object_entry_count`).
-- maximum number of elements permitted in a single JSON array `max_json_array_element_count`.
+| Listener option | Default | Purpose |
+| --- | --- | --- |
+| [`max_json_depth`](/vault/docs/configuration/listener/tcp#max_json_depth) | `500` | Maximum nesting depth of a JSON object or array |
+| [`max_json_string_value_length`](/vault/docs/configuration/listener/tcp#max_json_string_value_length) | `1048576` (1 MiB) | Maximum length in bytes for any single string value |
+| [`max_json_object_entry_count`](/vault/docs/configuration/listener/tcp#max_json_object_entry_count) | `10000` | Maximum key-value pairs in a single JSON object |
+| [`max_json_array_element_count`](/vault/docs/configuration/listener/tcp#max_json_array_element_count) | `10000` | Maximum elements in a single JSON array |
+| [`max_json_token`](/vault/docs/configuration/listener/tcp#max_json_token) | `500000` | Maximum total tokens in a single JSON payload |
 
-The configuration defaults provide intentionally generous limits to accommodate
-a wide range of legitimate use cases while still guarding against most malicious
-or malformed requests.
+These options are set on the [TCP listener](/vault/docs/configuration/listener/tcp).
+The defaults are intentionally generous to accommodate a wide range of legitimate
+use cases while still guarding against most malicious or malformed requests.
+Tune them down for low-resource deployments.
 
 [proxy]: /vault/docs/agent-and-proxy/proxy#listener-stanza

--- a/content/vault/v1.19.x/content/api-docs/index.mdx
+++ b/content/vault/v1.19.x/content/api-docs/index.mdx
@@ -346,16 +346,20 @@ Vault's server configuration file.
 Vault also supports several listener options to enforce payload size limits for to incoming JSON
 request bodies.
 
-You can configure the payload limits individullly on each listener and give
+You can configure the payload limits individually on each listener and give
 administrators granular control over the:
 
-- maximum allowed nesting depth of a JSON object or array (`max_json_depth`).
-- maximum allowed length for any single string value in the payload (`max_json_string_value_length`.)
-- maximum number of key-value pairs allowed in a single JSON object (`max_json_object_entry_count`).
-- maximum number of elements permitted in a single JSON array `max_json_array_element_count`.
+| Listener option | Default | Purpose |
+| --- | --- | --- |
+| [`max_json_depth`](/vault/docs/configuration/listener/tcp#max_json_depth) | `500` | Maximum nesting depth of a JSON object or array |
+| [`max_json_string_value_length`](/vault/docs/configuration/listener/tcp#max_json_string_value_length) | `1048576` (1 MiB) | Maximum length in bytes for any single string value |
+| [`max_json_object_entry_count`](/vault/docs/configuration/listener/tcp#max_json_object_entry_count) | `10000` | Maximum key-value pairs in a single JSON object |
+| [`max_json_array_element_count`](/vault/docs/configuration/listener/tcp#max_json_array_element_count) | `10000` | Maximum elements in a single JSON array |
+| [`max_json_token`](/vault/docs/configuration/listener/tcp#max_json_token) | `500000` | Maximum total tokens in a single JSON payload |
 
-The configuration defaults provide intentionally generous limits to accommodate
-a wide range of legitimate use cases while still guarding against most malicious
-or malformed requests.
+These options are set on the [TCP listener](/vault/docs/configuration/listener/tcp).
+The defaults are intentionally generous to accommodate a wide range of legitimate
+use cases while still guarding against most malicious or malformed requests.
+Tune them down for low-resource deployments.
 
 [proxy]: /vault/docs/agent-and-proxy/proxy#listener-stanza

--- a/content/vault/v1.20.x/content/api-docs/index.mdx
+++ b/content/vault/v1.20.x/content/api-docs/index.mdx
@@ -346,16 +346,20 @@ Vault's server configuration file.
 Vault also supports several listener options to enforce payload size limits for to incoming JSON
 request bodies.
 
-You can configure the payload limits individullly on each listener and give
+You can configure the payload limits individually on each listener and give
 administrators granular control over the:
 
-- maximum allowed nesting depth of a JSON object or array (`max_json_depth`).
-- maximum allowed length for any single string value in the payload (`max_json_string_value_length`.)
-- maximum number of key-value pairs allowed in a single JSON object (`max_json_object_entry_count`).
-- maximum number of elements permitted in a single JSON array `max_json_array_element_count`.
+| Listener option | Default | Purpose |
+| --- | --- | --- |
+| [`max_json_depth`](/vault/docs/configuration/listener/tcp#max_json_depth) | `500` | Maximum nesting depth of a JSON object or array |
+| [`max_json_string_value_length`](/vault/docs/configuration/listener/tcp#max_json_string_value_length) | `1048576` (1 MiB) | Maximum length in bytes for any single string value |
+| [`max_json_object_entry_count`](/vault/docs/configuration/listener/tcp#max_json_object_entry_count) | `10000` | Maximum key-value pairs in a single JSON object |
+| [`max_json_array_element_count`](/vault/docs/configuration/listener/tcp#max_json_array_element_count) | `10000` | Maximum elements in a single JSON array |
+| [`max_json_token`](/vault/docs/configuration/listener/tcp#max_json_token) | `500000` | Maximum total tokens in a single JSON payload |
 
-The configuration defaults provide intentionally generous limits to accommodate
-a wide range of legitimate use cases while still guarding against most malicious
-or malformed requests.
+These options are set on the [TCP listener](/vault/docs/configuration/listener/tcp).
+The defaults are intentionally generous to accommodate a wide range of legitimate
+use cases while still guarding against most malicious or malformed requests.
+Tune them down for low-resource deployments.
 
 [proxy]: /vault/docs/agent-and-proxy/proxy#listener-stanza

--- a/content/vault/v1.21.x/content/api-docs/index.mdx
+++ b/content/vault/v1.21.x/content/api-docs/index.mdx
@@ -346,16 +346,20 @@ Vault's server configuration file.
 Vault also supports several listener options to enforce payload size limits for to incoming JSON
 request bodies.
 
-You can configure the payload limits individullly on each listener and give
+You can configure the payload limits individually on each listener and give
 administrators granular control over the:
 
-- maximum allowed nesting depth of a JSON object or array (`max_json_depth`).
-- maximum allowed length for any single string value in the payload (`max_json_string_value_length`.)
-- maximum number of key-value pairs allowed in a single JSON object (`max_json_object_entry_count`).
-- maximum number of elements permitted in a single JSON array `max_json_array_element_count`.
+| Listener option | Default | Purpose |
+| --- | --- | --- |
+| [`max_json_depth`](/vault/docs/configuration/listener/tcp#max_json_depth) | `500` | Maximum nesting depth of a JSON object or array |
+| [`max_json_string_value_length`](/vault/docs/configuration/listener/tcp#max_json_string_value_length) | `1048576` (1 MiB) | Maximum length in bytes for any single string value |
+| [`max_json_object_entry_count`](/vault/docs/configuration/listener/tcp#max_json_object_entry_count) | `10000` | Maximum key-value pairs in a single JSON object |
+| [`max_json_array_element_count`](/vault/docs/configuration/listener/tcp#max_json_array_element_count) | `10000` | Maximum elements in a single JSON array |
+| [`max_json_token`](/vault/docs/configuration/listener/tcp#max_json_token) | `500000` | Maximum total tokens in a single JSON payload |
 
-The configuration defaults provide intentionally generous limits to accommodate
-a wide range of legitimate use cases while still guarding against most malicious
-or malformed requests.
+These options are set on the [TCP listener](/vault/docs/configuration/listener/tcp).
+The defaults are intentionally generous to accommodate a wide range of legitimate
+use cases while still guarding against most malicious or malformed requests.
+Tune them down for low-resource deployments.
 
 [proxy]: /vault/docs/agent-and-proxy/proxy#listener-stanza

--- a/content/vault/v2.x/content/api-docs/index.mdx
+++ b/content/vault/v2.x/content/api-docs/index.mdx
@@ -346,16 +346,20 @@ Vault's server configuration file.
 Vault also supports several listener options to enforce payload size limits for to incoming JSON
 request bodies.
 
-You can configure the payload limits individullly on each listener and give
+You can configure the payload limits individually on each listener and give
 administrators granular control over the:
 
-- maximum allowed nesting depth of a JSON object or array (`max_json_depth`).
-- maximum allowed length for any single string value in the payload (`max_json_string_value_length`.)
-- maximum number of key-value pairs allowed in a single JSON object (`max_json_object_entry_count`).
-- maximum number of elements permitted in a single JSON array `max_json_array_element_count`.
+| Listener option | Default | Purpose |
+| --- | --- | --- |
+| [`max_json_depth`](/vault/docs/configuration/listener/tcp#max_json_depth) | `500` | Maximum nesting depth of a JSON object or array |
+| [`max_json_string_value_length`](/vault/docs/configuration/listener/tcp#max_json_string_value_length) | `1048576` (1 MiB) | Maximum length in bytes for any single string value |
+| [`max_json_object_entry_count`](/vault/docs/configuration/listener/tcp#max_json_object_entry_count) | `10000` | Maximum key-value pairs in a single JSON object |
+| [`max_json_array_element_count`](/vault/docs/configuration/listener/tcp#max_json_array_element_count) | `10000` | Maximum elements in a single JSON array |
+| [`max_json_token`](/vault/docs/configuration/listener/tcp#max_json_token) | `500000` | Maximum total tokens in a single JSON payload |
 
-The configuration defaults provide intentionally generous limits to accommodate
-a wide range of legitimate use cases while still guarding against most malicious
-or malformed requests.
+These options are set on the [TCP listener](/vault/docs/configuration/listener/tcp).
+The defaults are intentionally generous to accommodate a wide range of legitimate
+use cases while still guarding against most malicious or malformed requests.
+Tune them down for low-resource deployments.
 
 [proxy]: /vault/docs/agent-and-proxy/proxy#listener-stanza


### PR DESCRIPTION
The API Limits section mentioned the JSON payload options but not the defaults. Added a short table with the same numbers as the TCP listener docs, plus links over there.

Also fixed the “individullly” typo in that paragraph.

v1.18.x–v2.x.

Fixes #925