### PR TITLE
docs(vault): document kv metadata patch

### DIFF
--- a/content/vault/v1.19.x/content/docs/commands/kv/metadata.mdx
+++ b/content/vault/v1.19.x/content/docs/commands/kv/metadata.mdx
@@ -29,6 +29,7 @@ Usage: vault kv metadata <subcommand> [options] [args]
 Subcommands:
     delete    Deletes all versions and metadata for a key in the KV store
     get       Retrieves key metadata from the KV store
+    patch     Patches key settings in the KV store
     put       Sets or updates key settings in the KV store
 ```
 
@@ -87,6 +88,69 @@ destroyed        false
 
 ...
 ```
+
+### kv metadata patch
+
+The `kv metadata patch` command partially updates key settings for a
+specified key. Unlike `kv metadata put`, only the flags you pass are
+written; other metadata fields are left unchanged. Use
+`-remove-custom-metadata` to drop individual custom metadata keys.
+
+#### Examples
+
+Patch custom metadata on the key "creds" without replacing existing keys:
+
+```shell-session
+$ vault kv metadata patch -mount=secret -custom-metadata=owner=platform creds
+Success! Data written to: secret/metadata/creds
+```
+
+Remove a custom metadata key:
+
+```shell-session
+$ vault kv metadata patch -mount=secret -remove-custom-metadata=owner creds
+Success! Data written to: secret/metadata/creds
+```
+
+Set the maximum number of versions to keep for the key "creds":
+
+```shell-session
+$ vault kv metadata patch -mount=secret -max-versions=5 creds
+Success! Data written to: secret/metadata/creds
+```
+
+#### Output options
+
+- `-format` `(string: "table")` - Print the output in the given format. Valid
+  formats are "table", "json", or "yaml". This can also be specified via the
+  `VAULT_FORMAT` environment variable.
+
+#### Subcommand options
+
+- `-cas-required` `(bool: false)` - If true the key will require the cas
+  parameter to be set on all write requests. If false, the backend’s
+  configuration will be used.
+
+- `-max-versions` `(int)` - The number of versions to keep per key. If not
+  set, this field is left unchanged (or the backend’s configured max version
+  is used when creating a blank key).
+
+- `-delete-version-after` `(string)` – Set the `delete-version-after` value
+  to a duration to specify the `deletion_time` for all new versions written to
+  this key. Accepts [duration format strings](/vault/docs/concepts/duration-format).
+
+- `-custom-metadata` `(string: "")` - Specifies a key-value pair for the
+  `custom_metadata` field. This can be specified multiple times to add multiple
+  pieces of metadata. Existing keys not listed are preserved.
+
+- `-remove-custom-metadata` `(string: "")` - Removes a key from
+  `custom_metadata`. Specify this flag multiple times to remove multiple keys.
+
+- `-mount` `(string: "")` - Specifies the path where the KV backend is mounted. 
+  If specified, the next argument will be interpreted as the secret path. If 
+  this flag is not specified, the next argument will be interpreted as the 
+  combined mount path and secret path, with /metadata/ automatically inserted for 
+  KV v2 secrets.
 
 ### kv metadata put
 

--- a/content/vault/v1.20.x/content/docs/commands/kv/metadata.mdx
+++ b/content/vault/v1.20.x/content/docs/commands/kv/metadata.mdx
@@ -29,6 +29,7 @@ Usage: vault kv metadata <subcommand> [options] [args]
 Subcommands:
     delete    Deletes all versions and metadata for a key in the KV store
     get       Retrieves key metadata from the KV store
+    patch     Patches key settings in the KV store
     put       Sets or updates key settings in the KV store
 ```
 
@@ -87,6 +88,69 @@ destroyed        false
 
 ...
 ```
+
+### kv metadata patch
+
+The `kv metadata patch` command partially updates key settings for a
+specified key. Unlike `kv metadata put`, only the flags you pass are
+written; other metadata fields are left unchanged. Use
+`-remove-custom-metadata` to drop individual custom metadata keys.
+
+#### Examples
+
+Patch custom metadata on the key "creds" without replacing existing keys:
+
+```shell-session
+$ vault kv metadata patch -mount=secret -custom-metadata=owner=platform creds
+Success! Data written to: secret/metadata/creds
+```
+
+Remove a custom metadata key:
+
+```shell-session
+$ vault kv metadata patch -mount=secret -remove-custom-metadata=owner creds
+Success! Data written to: secret/metadata/creds
+```
+
+Set the maximum number of versions to keep for the key "creds":
+
+```shell-session
+$ vault kv metadata patch -mount=secret -max-versions=5 creds
+Success! Data written to: secret/metadata/creds
+```
+
+#### Output options
+
+- `-format` `(string: "table")` - Print the output in the given format. Valid
+  formats are "table", "json", or "yaml". This can also be specified via the
+  `VAULT_FORMAT` environment variable.
+
+#### Subcommand options
+
+- `-cas-required` `(bool: false)` - If true the key will require the cas
+  parameter to be set on all write requests. If false, the backend’s
+  configuration will be used.
+
+- `-max-versions` `(int)` - The number of versions to keep per key. If not
+  set, this field is left unchanged (or the backend’s configured max version
+  is used when creating a blank key).
+
+- `-delete-version-after` `(string)` – Set the `delete-version-after` value
+  to a duration to specify the `deletion_time` for all new versions written to
+  this key. Accepts [duration format strings](/vault/docs/concepts/duration-format).
+
+- `-custom-metadata` `(string: "")` - Specifies a key-value pair for the
+  `custom_metadata` field. This can be specified multiple times to add multiple
+  pieces of metadata. Existing keys not listed are preserved.
+
+- `-remove-custom-metadata` `(string: "")` - Removes a key from
+  `custom_metadata`. Specify this flag multiple times to remove multiple keys.
+
+- `-mount` `(string: "")` - Specifies the path where the KV backend is mounted. 
+  If specified, the next argument will be interpreted as the secret path. If 
+  this flag is not specified, the next argument will be interpreted as the 
+  combined mount path and secret path, with /metadata/ automatically inserted for 
+  KV v2 secrets.
 
 ### kv metadata put
 

--- a/content/vault/v1.21.x/content/docs/commands/kv/metadata.mdx
+++ b/content/vault/v1.21.x/content/docs/commands/kv/metadata.mdx
@@ -29,6 +29,7 @@ Usage: vault kv metadata <subcommand> [options] [args]
 Subcommands:
     delete    Deletes all versions and metadata for a key in the KV store
     get       Retrieves key metadata from the KV store
+    patch     Patches key settings in the KV store
     put       Sets or updates key settings in the KV store
 ```
 
@@ -87,6 +88,69 @@ destroyed        false
 
 ...
 ```
+
+### kv metadata patch
+
+The `kv metadata patch` command partially updates key settings for a
+specified key. Unlike `kv metadata put`, only the flags you pass are
+written; other metadata fields are left unchanged. Use
+`-remove-custom-metadata` to drop individual custom metadata keys.
+
+#### Examples
+
+Patch custom metadata on the key "creds" without replacing existing keys:
+
+```shell-session
+$ vault kv metadata patch -mount=secret -custom-metadata=owner=platform creds
+Success! Data written to: secret/metadata/creds
+```
+
+Remove a custom metadata key:
+
+```shell-session
+$ vault kv metadata patch -mount=secret -remove-custom-metadata=owner creds
+Success! Data written to: secret/metadata/creds
+```
+
+Set the maximum number of versions to keep for the key "creds":
+
+```shell-session
+$ vault kv metadata patch -mount=secret -max-versions=5 creds
+Success! Data written to: secret/metadata/creds
+```
+
+#### Output options
+
+- `-format` `(string: "table")` - Print the output in the given format. Valid
+  formats are "table", "json", or "yaml". This can also be specified via the
+  `VAULT_FORMAT` environment variable.
+
+#### Subcommand options
+
+- `-cas-required` `(bool: false)` - If true the key will require the cas
+  parameter to be set on all write requests. If false, the backend’s
+  configuration will be used.
+
+- `-max-versions` `(int)` - The number of versions to keep per key. If not
+  set, this field is left unchanged (or the backend’s configured max version
+  is used when creating a blank key).
+
+- `-delete-version-after` `(string)` – Set the `delete-version-after` value
+  to a duration to specify the `deletion_time` for all new versions written to
+  this key. Accepts [duration format strings](/vault/docs/concepts/duration-format).
+
+- `-custom-metadata` `(string: "")` - Specifies a key-value pair for the
+  `custom_metadata` field. This can be specified multiple times to add multiple
+  pieces of metadata. Existing keys not listed are preserved.
+
+- `-remove-custom-metadata` `(string: "")` - Removes a key from
+  `custom_metadata`. Specify this flag multiple times to remove multiple keys.
+
+- `-mount` `(string: "")` - Specifies the path where the KV backend is mounted. 
+  If specified, the next argument will be interpreted as the secret path. If 
+  this flag is not specified, the next argument will be interpreted as the 
+  combined mount path and secret path, with /metadata/ automatically inserted for 
+  KV v2 secrets.
 
 ### kv metadata put
 

--- a/content/vault/v2.x/content/docs/commands/kv/metadata.mdx
+++ b/content/vault/v2.x/content/docs/commands/kv/metadata.mdx
@@ -29,6 +29,7 @@ Usage: vault kv metadata <subcommand> [options] [args]
 Subcommands:
     delete    Deletes all versions and metadata for a key in the KV store
     get       Retrieves key metadata from the KV store
+    patch     Patches key settings in the KV store
     put       Sets or updates key settings in the KV store
 ```
 
@@ -87,6 +88,69 @@ destroyed        false
 
 ...
 ```
+
+### kv metadata patch
+
+The `kv metadata patch` command partially updates key settings for a
+specified key. Unlike `kv metadata put`, only the flags you pass are
+written; other metadata fields are left unchanged. Use
+`-remove-custom-metadata` to drop individual custom metadata keys.
+
+#### Examples
+
+Patch custom metadata on the key "creds" without replacing existing keys:
+
+```shell-session
+$ vault kv metadata patch -mount=secret -custom-metadata=owner=platform creds
+Success! Data written to: secret/metadata/creds
+```
+
+Remove a custom metadata key:
+
+```shell-session
+$ vault kv metadata patch -mount=secret -remove-custom-metadata=owner creds
+Success! Data written to: secret/metadata/creds
+```
+
+Set the maximum number of versions to keep for the key "creds":
+
+```shell-session
+$ vault kv metadata patch -mount=secret -max-versions=5 creds
+Success! Data written to: secret/metadata/creds
+```
+
+#### Output options
+
+- `-format` `(string: "table")` - Print the output in the given format. Valid
+  formats are "table", "json", or "yaml". This can also be specified via the
+  `VAULT_FORMAT` environment variable.
+
+#### Subcommand options
+
+- `-cas-required` `(bool: false)` - If true the key will require the cas
+  parameter to be set on all write requests. If false, the backend’s
+  configuration will be used.
+
+- `-max-versions` `(int)` - The number of versions to keep per key. If not
+  set, this field is left unchanged (or the backend’s configured max version
+  is used when creating a blank key).
+
+- `-delete-version-after` `(string)` – Set the `delete-version-after` value
+  to a duration to specify the `deletion_time` for all new versions written to
+  this key. Accepts [duration format strings](/vault/docs/concepts/duration-format).
+
+- `-custom-metadata` `(string: "")` - Specifies a key-value pair for the
+  `custom_metadata` field. This can be specified multiple times to add multiple
+  pieces of metadata. Existing keys not listed are preserved.
+
+- `-remove-custom-metadata` `(string: "")` - Removes a key from
+  `custom_metadata`. Specify this flag multiple times to remove multiple keys.
+
+- `-mount` `(string: "")` - Specifies the path where the KV backend is mounted. 
+  If specified, the next argument will be interpreted as the secret path. If 
+  this flag is not specified, the next argument will be interpreted as the 
+  combined mount path and secret path, with /metadata/ automatically inserted for 
+  KV v2 secrets.
 
 ### kv metadata put
 


### PR DESCRIPTION
The CLI supports `vault kv metadata patch` (partial updates / remove individual custom_metadata keys), but the commands page only listed delete/get/put. Added the subcommand to the list and a short section with examples for v1.19–v1.21 and v2.x.

Fixes hashicorp/vault#30954