### PR TITLE
docs(consul): document KV key rules for // and invalid names

### DIFF
--- a/content/consul/v1.20.x/content/api-docs/kv.mdx
+++ b/content/consul/v1.20.x/content/api-docs/kv.mdx
@@ -22,6 +22,11 @@ replication between datacenters, please view the
 
 ~> Values in the KV store cannot be larger than 512kb.
 
+~> Key names are path-cleaned by the HTTP API. Repeated slashes (`//`) collapse
+to a single `/` (so `foo//bar` becomes `foo/bar`). Keys must not begin with `/`.
+Unless `disable_kv_key_validation` is enabled, keys also cannot have leading or
+trailing spaces or `..` path segments.
+
 In order to perform atomic operations on multiple KV pairs (up to a limit of 64)
 please consider using [transactions](/consul/api-docs/txn) instead.
 

--- a/content/consul/v1.20.x/content/docs/dynamic-app-config/kv/index.mdx
+++ b/content/consul/v1.20.x/content/docs/dynamic-app-config/kv/index.mdx
@@ -59,15 +59,17 @@ should not need extra storage; the general [sizing
 recommendations](/consul/docs/agent/config/config-files#kv_max_value_size)
 are usually sufficient.
 
-Keys, like objects are not restricted by type and can include any character.
-However, we recommend using URL-safe chars - `[a-zA-Z0-9-._~]` with the
-exception of `/`, which can be used to help organize data. Note, `/` will be
-treated like any other character and is not fixed to the file system. Meaning,
-including `/` in a key does not fix it to a directory structure. This model is
-similar to Amazon S3 buckets. However, `/` is still useful for organizing data
-and when recursively searching within the data store. We also recommend that
-you avoid the use of `*`, `?`, `'`, and `%` because they can cause issues when
-using the API and in shell scripts.
+Keys are opaque strings. Prefer URL-safe characters such as `[a-zA-Z0-9-._~]`,
+and use `/` to organize data into prefixes (similar to Amazon S3). `/` is not
+tied to a real filesystem path; it is still useful for grouping keys and for
+recursive queries.
+
+Do **not** rely on empty path segments. Repeated slashes (`//`) are collapsed
+when keys are processed (for example `foo//bar` is treated like `foo/bar`), so
+a key that literally depends on `//` cannot be stored as a distinct name.
+
+Keys must not begin with `/`. We also recommend avoiding `*`, `?`, `'`, and `%`
+because they can cause issues in the API and in shell scripts.
 
 ## Using Sentinel to apply policies for Consul KV 
 

--- a/content/consul/v1.21.x/content/api-docs/kv.mdx
+++ b/content/consul/v1.21.x/content/api-docs/kv.mdx
@@ -22,6 +22,11 @@ replication between datacenters, please view the
 
 ~> Values in the KV store cannot be larger than 512kb.
 
+~> Key names are path-cleaned by the HTTP API. Repeated slashes (`//`) collapse
+to a single `/` (so `foo//bar` becomes `foo/bar`). Keys must not begin with `/`.
+Unless `disable_kv_key_validation` is enabled, keys also cannot have leading or
+trailing spaces or `..` path segments.
+
 In order to perform atomic operations on multiple KV pairs (up to a limit of 64)
 please consider using [transactions](/consul/api-docs/txn) instead.
 

--- a/content/consul/v1.21.x/content/docs/automate/kv/index.mdx
+++ b/content/consul/v1.21.x/content/docs/automate/kv/index.mdx
@@ -55,15 +55,24 @@ not need extra storage. The general [sizing
 recommendations](/consul/docs/reference/agent#kv_max_value_size) are usually
 sufficient.
 
-Keys, like objects, are not restricted by type and can include any character.
-However, we recommend using URL-safe chars such as `[a-zA-Z0-9-._~]` with the
-exception of `/`, which can be used to help organize data. Note, `/` is
-treated like any other character and is not fixed to the file system. This means
-that including `/` in a key does not fix it to a directory structure. This model is
-similar to Amazon S3 buckets. However, `/` is still useful for organizing data
-and when recursively searching within the data store. We also recommend that you
-avoid the use of `*`, `?`, `'`, and `%` because they can cause issues when using
-the API and in shell scripts.
+Keys are opaque strings. Prefer URL-safe characters such as `[a-zA-Z0-9-._~]`,
+and use `/` to organize data into prefixes (similar to Amazon S3). `/` is not
+tied to a real filesystem path; it is still useful for grouping keys and for
+recursive queries.
+
+Do **not** rely on empty path segments. Repeated slashes (`//`) are collapsed
+when keys are processed (for example `foo//bar` is treated like `foo/bar`), so
+a key that literally depends on `//` cannot be stored as a distinct name.
+
+Unless [`disable_kv_key_validation`](/consul/docs/reference/agent/configuration-file/general#disable_kv_key_validation)
+is enabled (not recommended), the agent also rejects keys that:
+
+- begin with `/`
+- have leading or trailing spaces
+- contain `..` path segments (path traversal)
+
+We also recommend avoiding `*`, `?`, `'`, and `%` because they can cause issues
+in the API and in shell scripts.
 
 ## Using Sentinel to apply policies for Consul KV
 

--- a/content/consul/v1.21.x/content/partials/text/limitations/kv.mdx
+++ b/content/consul/v1.21.x/content/partials/text/limitations/kv.mdx
@@ -1,3 +1,5 @@
 If you experience errors when using the Consul KV store, refer to the following list of technical constraints.
 
 - The Consul KV and its API, CLI, and UI controls are considered feature complete. New feature development is not planned for future Consul releases.
+- Key names cannot start with `/`, and must not include leading or trailing spaces or `..` path segments (unless `disable_kv_key_validation` is set).
+- Repeated slashes (`//`) are collapsed; empty key segments are not preserved as distinct names.

--- a/content/consul/v1.22.x/content/api-docs/kv.mdx
+++ b/content/consul/v1.22.x/content/api-docs/kv.mdx
@@ -22,6 +22,11 @@ replication between datacenters, please view the
 
 ~> Values in the KV store cannot be larger than 512kb.
 
+~> Key names are path-cleaned by the HTTP API. Repeated slashes (`//`) collapse
+to a single `/` (so `foo//bar` becomes `foo/bar`). Keys must not begin with `/`.
+Unless `disable_kv_key_validation` is enabled, keys also cannot have leading or
+trailing spaces or `..` path segments.
+
 In order to perform atomic operations on multiple KV pairs (up to a limit of 64)
 please consider using [transactions](/consul/api-docs/txn) instead.
 

--- a/content/consul/v1.22.x/content/docs/automate/kv/index.mdx
+++ b/content/consul/v1.22.x/content/docs/automate/kv/index.mdx
@@ -55,15 +55,24 @@ not need extra storage. The general [sizing
 recommendations](/consul/docs/reference/agent#kv_max_value_size) are usually
 sufficient.
 
-Keys, like objects, are not restricted by type and can include any character.
-However, we recommend using URL-safe chars such as `[a-zA-Z0-9-._~]` with the
-exception of `/`, which can be used to help organize data. Note, `/` is
-treated like any other character and is not fixed to the file system. This means
-that including `/` in a key does not fix it to a directory structure. This model is
-similar to Amazon S3 buckets. However, `/` is still useful for organizing data
-and when recursively searching within the data store. We also recommend that you
-avoid the use of `*`, `?`, `'`, and `%` because they can cause issues when using
-the API and in shell scripts.
+Keys are opaque strings. Prefer URL-safe characters such as `[a-zA-Z0-9-._~]`,
+and use `/` to organize data into prefixes (similar to Amazon S3). `/` is not
+tied to a real filesystem path; it is still useful for grouping keys and for
+recursive queries.
+
+Do **not** rely on empty path segments. Repeated slashes (`//`) are collapsed
+when keys are processed (for example `foo//bar` is treated like `foo/bar`), so
+a key that literally depends on `//` cannot be stored as a distinct name.
+
+Unless [`disable_kv_key_validation`](/consul/docs/reference/agent/configuration-file/general#disable_kv_key_validation)
+is enabled (not recommended), the agent also rejects keys that:
+
+- begin with `/`
+- have leading or trailing spaces
+- contain `..` path segments (path traversal)
+
+We also recommend avoiding `*`, `?`, `'`, and `%` because they can cause issues
+in the API and in shell scripts.
 
 ## Using Sentinel to apply policies for Consul KV
 

--- a/content/consul/v1.22.x/content/partials/text/limitations/kv.mdx
+++ b/content/consul/v1.22.x/content/partials/text/limitations/kv.mdx
@@ -1,3 +1,5 @@
 If you experience errors when using the Consul KV store, refer to the following list of technical constraints.
 
 - The Consul KV and its API, CLI, and UI controls are considered feature complete. New feature development is not planned for future Consul releases.
+- Key names cannot start with `/`, and must not include leading or trailing spaces or `..` path segments (unless `disable_kv_key_validation` is set).
+- Repeated slashes (`//`) are collapsed; empty key segments are not preserved as distinct names.

--- a/content/consul/v2.0.x/content/api-docs/kv.mdx
+++ b/content/consul/v2.0.x/content/api-docs/kv.mdx
@@ -22,6 +22,11 @@ replication between datacenters, please view the
 
 ~> Values in the KV store cannot be larger than 512kb.
 
+~> Key names are path-cleaned by the HTTP API. Repeated slashes (`//`) collapse
+to a single `/` (so `foo//bar` becomes `foo/bar`). Keys must not begin with `/`.
+Unless `disable_kv_key_validation` is enabled, keys also cannot have leading or
+trailing spaces or `..` path segments.
+
 In order to perform atomic operations on multiple KV pairs (up to a limit of 64)
 please consider using [transactions](/consul/api-docs/txn) instead.
 

--- a/content/consul/v2.0.x/content/docs/automate/kv/index.mdx
+++ b/content/consul/v2.0.x/content/docs/automate/kv/index.mdx
@@ -55,15 +55,24 @@ not need extra storage. The general [sizing
 recommendations](/consul/docs/reference/agent#kv_max_value_size) are usually
 sufficient.
 
-Keys, like objects, are not restricted by type and can include any character.
-However, we recommend using URL-safe chars such as `[a-zA-Z0-9-._~]` with the
-exception of `/`, which can be used to help organize data. Note, `/` is
-treated like any other character and is not fixed to the file system. This means
-that including `/` in a key does not fix it to a directory structure. This model is
-similar to Amazon S3 buckets. However, `/` is still useful for organizing data
-and when recursively searching within the data store. We also recommend that you
-avoid the use of `*`, `?`, `'`, and `%` because they can cause issues when using
-the API and in shell scripts.
+Keys are opaque strings. Prefer URL-safe characters such as `[a-zA-Z0-9-._~]`,
+and use `/` to organize data into prefixes (similar to Amazon S3). `/` is not
+tied to a real filesystem path; it is still useful for grouping keys and for
+recursive queries.
+
+Do **not** rely on empty path segments. Repeated slashes (`//`) are collapsed
+when keys are processed (for example `foo//bar` is treated like `foo/bar`), so
+a key that literally depends on `//` cannot be stored as a distinct name.
+
+Unless [`disable_kv_key_validation`](/consul/docs/reference/agent/configuration-file/general#disable_kv_key_validation)
+is enabled (not recommended), the agent also rejects keys that:
+
+- begin with `/`
+- have leading or trailing spaces
+- contain `..` path segments (path traversal)
+
+We also recommend avoiding `*`, `?`, `'`, and `%` because they can cause issues
+in the API and in shell scripts.
 
 ## Using Sentinel to apply policies for Consul KV
 

--- a/content/consul/v2.0.x/content/partials/text/limitations/kv.mdx
+++ b/content/consul/v2.0.x/content/partials/text/limitations/kv.mdx
@@ -1,3 +1,5 @@
 If you experience errors when using the Consul KV store, refer to the following list of technical constraints.
 
 - The Consul KV and its API, CLI, and UI controls are considered feature complete. New feature development is not planned for future Consul releases.
+- Key names cannot start with `/`, and must not include leading or trailing spaces or `..` path segments (unless `disable_kv_key_validation` is set).
+- Repeated slashes (`//`) are collapsed; empty key segments are not preserved as distinct names.


### PR DESCRIPTION
The KV overview still said keys could include any character. In practice empty segments from `//` get collapsed (so `foo//bar` is not a distinct key), keys must not start with `/`, and with key validation enabled the agent also rejects leading/trailing spaces and `..` segments.

Updated the overview, API notes, and limitations partial on recent Consul versions.

Fixes hashicorp/consul#15933