### PR TITLE
docs(vault): fix autopilot automated-upgrades anchor typo

### DIFF
--- a/content/vault/v1.13.x/content/docs/upgrading/vault-ha-upgrade.mdx
+++ b/content/vault/v1.13.x/content/docs/upgrading/vault-ha-upgrade.mdx
@@ -14,7 +14,7 @@ last_modified: 2023-09-27T00:00:00.000Z
 This is our recommended upgrade procedure if **one** of the following applies:
 
 - Running Vault version earlier than 1.11
-- Opt-out the [Autopilot automated upgrade](/vault/docs/concepts/integrated-storage/autopilot#automated-upgrade) features with Vault 1.11 or later
+- Opt-out the [Autopilot automated upgrade](/vault/docs/concepts/integrated-storage/autopilot#automated-upgrades) features with Vault 1.11 or later
 - Running Vault with external storage backend such as Consul
 
 You should consider how to apply the steps described in this document to your

--- a/content/vault/v1.14.x/content/docs/upgrading/vault-ha-upgrade.mdx
+++ b/content/vault/v1.14.x/content/docs/upgrading/vault-ha-upgrade.mdx
@@ -14,7 +14,7 @@ last_modified: 2023-09-27T00:00:00.000Z
 This is our recommended upgrade procedure if **one** of the following applies:
 
 - Running Vault version earlier than 1.11
-- Opt-out the [Autopilot automated upgrade](/vault/docs/concepts/integrated-storage/autopilot#automated-upgrade) features with Vault 1.11 or later
+- Opt-out the [Autopilot automated upgrade](/vault/docs/concepts/integrated-storage/autopilot#automated-upgrades) features with Vault 1.11 or later
 - Running Vault with external storage backend such as Consul
 
 You should consider how to apply the steps described in this document to your

--- a/content/vault/v1.15.x/content/docs/upgrading/vault-ha-upgrade.mdx
+++ b/content/vault/v1.15.x/content/docs/upgrading/vault-ha-upgrade.mdx
@@ -14,7 +14,7 @@ last_modified: 2023-09-27T00:00:00.000Z
 This is our recommended upgrade procedure if **one** of the following applies:
 
 - Running Vault version earlier than 1.11
-- Opt-out the [Autopilot automated upgrade](/vault/docs/concepts/integrated-storage/autopilot#automated-upgrade) features with Vault 1.11 or later
+- Opt-out the [Autopilot automated upgrade](/vault/docs/concepts/integrated-storage/autopilot#automated-upgrades) features with Vault 1.11 or later
 - Running Vault with external storage backend such as Consul
 
 You should consider how to apply the steps described in this document to your

--- a/content/vault/v1.16.x/content/docs/upgrading/vault-ha-upgrade.mdx
+++ b/content/vault/v1.16.x/content/docs/upgrading/vault-ha-upgrade.mdx
@@ -14,7 +14,7 @@ last_modified: 2025-07-02T11:30:26-05:00
 This is our recommended upgrade procedure if **one** of the following applies:
 
 - Running Vault version earlier than 1.11
-- Opt-out the [Autopilot automated upgrade](/vault/docs/concepts/integrated-storage/autopilot#automated-upgrade) features with Vault 1.11 or later
+- Opt-out the [Autopilot automated upgrade](/vault/docs/concepts/integrated-storage/autopilot#automated-upgrades) features with Vault 1.11 or later
 - Running Vault with external storage backend such as Consul
 
 You should consider how to apply the steps described in this document to your

--- a/content/vault/v1.17.x/content/docs/upgrading/vault-ha-upgrade.mdx
+++ b/content/vault/v1.17.x/content/docs/upgrading/vault-ha-upgrade.mdx
@@ -14,7 +14,7 @@ last_modified: 2025-07-02T11:30:26-05:00
 This is our recommended upgrade procedure if **one** of the following applies:
 
 - Running Vault version earlier than 1.11
-- Opt-out the [Autopilot automated upgrade](/vault/docs/concepts/integrated-storage/autopilot#automated-upgrade) features with Vault 1.11 or later
+- Opt-out the [Autopilot automated upgrade](/vault/docs/concepts/integrated-storage/autopilot#automated-upgrades) features with Vault 1.11 or later
 - Running Vault with external storage backend such as Consul
 
 You should consider how to apply the steps described in this document to your

--- a/content/vault/v1.18.x/content/docs/upgrading/vault-ha-upgrade.mdx
+++ b/content/vault/v1.18.x/content/docs/upgrading/vault-ha-upgrade.mdx
@@ -14,7 +14,7 @@ last_modified: 2025-07-02T11:30:26-05:00
 This is our recommended upgrade procedure if **one** of the following applies:
 
 - Running Vault version earlier than 1.11
-- Opt-out the [Autopilot automated upgrade](/vault/docs/concepts/integrated-storage/autopilot#automated-upgrade) features with Vault 1.11 or later
+- Opt-out the [Autopilot automated upgrade](/vault/docs/concepts/integrated-storage/autopilot#automated-upgrades) features with Vault 1.11 or later
 - Running Vault with external storage backend such as Consul
 
 You should consider how to apply the steps described in this document to your

--- a/content/vault/v1.20.x/content/docs/upgrade/vault-ha-upgrade.mdx
+++ b/content/vault/v1.20.x/content/docs/upgrade/vault-ha-upgrade.mdx
@@ -14,7 +14,7 @@ last_modified: 2025-07-18T10:33:02-04:00
 This is our recommended upgrade procedure if **one** of the following applies:
 
 - Running Vault version earlier than 1.11
-- Opt-out the [Autopilot automated upgrade](/vault/docs/concepts/integrated-storage/autopilot#automated-upgrade) features with Vault 1.11 or later
+- Opt-out the [Autopilot automated upgrade](/vault/docs/concepts/integrated-storage/autopilot#automated-upgrades) features with Vault 1.11 or later
 - Running Vault with external storage backend such as Consul
 
 You should consider how to apply the steps described in this document to your

--- a/content/vault/v1.21.x/content/docs/upgrade/vault-ha-upgrade.mdx
+++ b/content/vault/v1.21.x/content/docs/upgrade/vault-ha-upgrade.mdx
@@ -14,7 +14,7 @@ last_modified: 2025-10-22T13:53:42-07:00
 This is our recommended upgrade procedure if **one** of the following applies:
 
 - Running Vault version earlier than 1.11
-- Opt-out the [Autopilot automated upgrade](/vault/docs/concepts/integrated-storage/autopilot#automated-upgrade) features with Vault 1.11 or later
+- Opt-out the [Autopilot automated upgrade](/vault/docs/concepts/integrated-storage/autopilot#automated-upgrades) features with Vault 1.11 or later
 - Running Vault with external storage backend such as Consul
 
 You should consider how to apply the steps described in this document to your

--- a/content/vault/v2.x/content/docs/upgrade/vault-ha-upgrade.mdx
+++ b/content/vault/v2.x/content/docs/upgrade/vault-ha-upgrade.mdx
@@ -14,7 +14,7 @@ last_modified: 2026-04-15T00:16:00.000Z
 This is our recommended upgrade procedure if **one** of the following applies:
 
 - Running Vault version earlier than 1.11
-- Opt-out the [Autopilot automated upgrade](/vault/docs/concepts/integrated-storage/autopilot#automated-upgrade) features with Vault 1.11 or later
+- Opt-out the [Autopilot automated upgrade](/vault/docs/concepts/integrated-storage/autopilot#automated-upgrades) features with Vault 1.11 or later
 - Running Vault with external storage backend such as Consul
 
 You should consider how to apply the steps described in this document to your


### PR DESCRIPTION
A few HA upgrade pages linked to `#automated-upgrade` (singular). The Autopilot page heading is **Automated upgrades**, so the anchor is `#automated-upgrades`. Fixed the typo so those links land on the right section.

Related to hashicorp/vault#31161 (broken upgrade docs path).