### PR TITLE
docs(vault): PKI role ttl accepts full duration strings including days

### DIFF
--- a/content/vault/v1.19.x/content/api-docs/secret/pki/index.mdx
+++ b/content/vault/v1.19.x/content/api-docs/secret/pki/index.mdx
@@ -3189,13 +3189,13 @@ request is denied.
 
 - `ttl` `(string: "")` - Specifies the Time To Live value to be used for the
   validity period of the requested certificate, provided as a string duration
-  with time suffix. Hour is the largest suffix. The value specified is strictly
+  using [duration format strings](/vault/docs/concepts/duration-format) (hours, days, etc.). The value specified is strictly
   used for future validity. If not set, uses the system default value or the
   value of `max_ttl`, whichever is shorter. See `not_after` as an alternative
   for setting an absolute end date (rather than a relative one).
 
 - `max_ttl` `(string: "")` - Specifies the maximum Time To Live provided as a
-  string duration with time suffix. Hour is the largest suffix. If not set,
+  string duration using [duration format strings](/vault/docs/concepts/duration-format) (hours, days, etc.). If not set,
   defaults to the system maximum lease TTL.
 
 - `allow_localhost` `(bool: true)` - Specifies if clients can request

--- a/content/vault/v1.19.x/content/api-docs/secret/pki/issuance.mdx
+++ b/content/vault/v1.19.x/content/api-docs/secret/pki/issuance.mdx
@@ -338,7 +338,7 @@ mount.
    ACME is disabled, all requests to ACME directory URLs will return 404.
 
  - `max_ttl` `(string: "")` - Specifies the maximum Time To Live provided as a
-   string duration with time suffix. Hour is the largest suffix. If not set,
+   string duration using [duration format strings](/vault/docs/concepts/duration-format) (hours, days, etc.). If not set,
    defaults to the previous hard-coded behavior of 90 days (2160 hours).
 
  - `challenge_permitted_ip_ranges` `(list: [])` - List of CIDR blocks that are

--- a/content/vault/v1.20.x/content/api-docs/secret/pki/index.mdx
+++ b/content/vault/v1.20.x/content/api-docs/secret/pki/index.mdx
@@ -3196,13 +3196,13 @@ request is denied.
 
 - `ttl` `(string: "")` - Specifies the Time To Live value to be used for the
   validity period of the requested certificate, provided as a string duration
-  with time suffix. Hour is the largest suffix. The value specified is strictly
+  using [duration format strings](/vault/docs/concepts/duration-format) (hours, days, etc.). The value specified is strictly
   used for future validity. If not set, uses the system default value or the
   value of `max_ttl`, whichever is shorter. See `not_after` as an alternative
   for setting an absolute end date (rather than a relative one).
 
 - `max_ttl` `(string: "")` - Specifies the maximum Time To Live provided as a
-  string duration with time suffix. Hour is the largest suffix. If not set,
+  string duration using [duration format strings](/vault/docs/concepts/duration-format) (hours, days, etc.). If not set,
   defaults to the system maximum lease TTL.
 
 - `allow_localhost` `(bool: true)` - Specifies if clients can request

--- a/content/vault/v1.20.x/content/api-docs/secret/pki/issuance.mdx
+++ b/content/vault/v1.20.x/content/api-docs/secret/pki/issuance.mdx
@@ -342,7 +342,7 @@ mount.
    ACME is disabled, all requests to ACME directory URLs will return 404.
 
  - `max_ttl` `(string: "")` - Specifies the maximum Time To Live provided as a
-   string duration with time suffix. Hour is the largest suffix. If not set,
+   string duration using [duration format strings](/vault/docs/concepts/duration-format) (hours, days, etc.). If not set,
    defaults to the previous hard-coded behavior of 90 days (2160 hours).
 
  - `challenge_permitted_ip_ranges` `(list: [])` - List of CIDR blocks that are

--- a/content/vault/v1.21.x/content/api-docs/secret/pki/index.mdx
+++ b/content/vault/v1.21.x/content/api-docs/secret/pki/index.mdx
@@ -3244,13 +3244,13 @@ request is denied.
 
 - `ttl` `(string: "")` - Specifies the Time To Live value to be used for the
   validity period of the requested certificate, provided as a string duration
-  with time suffix. Hour is the largest suffix. The value specified is strictly
+  using [duration format strings](/vault/docs/concepts/duration-format) (hours, days, etc.). The value specified is strictly
   used for future validity. If not set, uses the system default value or the
   value of `max_ttl`, whichever is shorter. See `not_after` as an alternative
   for setting an absolute end date (rather than a relative one).
 
 - `max_ttl` `(string: "")` - Specifies the maximum Time To Live provided as a
-  string duration with time suffix. Hour is the largest suffix. If not set,
+  string duration using [duration format strings](/vault/docs/concepts/duration-format) (hours, days, etc.). If not set,
   defaults to the system maximum lease TTL.
 
 - `allow_localhost` `(bool: true)` - Specifies if clients can request

--- a/content/vault/v1.21.x/content/api-docs/secret/pki/issuance.mdx
+++ b/content/vault/v1.21.x/content/api-docs/secret/pki/issuance.mdx
@@ -342,7 +342,7 @@ mount.
    ACME is disabled, all requests to ACME directory URLs will return 404.
 
  - `max_ttl` `(string: "")` - Specifies the maximum Time To Live provided as a
-   string duration with time suffix. Hour is the largest suffix. If not set,
+   string duration using [duration format strings](/vault/docs/concepts/duration-format) (hours, days, etc.). If not set,
    defaults to the previous hard-coded behavior of 90 days (2160 hours).
 
  - `challenge_permitted_ip_ranges` `(list: [])` - List of CIDR blocks that are

--- a/content/vault/v2.x/content/api-docs/secret/pki/index.mdx
+++ b/content/vault/v2.x/content/api-docs/secret/pki/index.mdx
@@ -3244,13 +3244,13 @@ request is denied.
 
 - `ttl` `(string: "")` - Specifies the Time To Live value to be used for the
   validity period of the requested certificate, provided as a string duration
-  with time suffix. Hour is the largest suffix. The value specified is strictly
+  using [duration format strings](/vault/docs/concepts/duration-format) (hours, days, etc.). The value specified is strictly
   used for future validity. If not set, uses the system default value or the
   value of `max_ttl`, whichever is shorter. See `not_after` as an alternative
   for setting an absolute end date (rather than a relative one).
 
 - `max_ttl` `(string: "")` - Specifies the maximum Time To Live provided as a
-  string duration with time suffix. Hour is the largest suffix. If not set,
+  string duration using [duration format strings](/vault/docs/concepts/duration-format) (hours, days, etc.). If not set,
   defaults to the system maximum lease TTL.
 
 - `allow_localhost` `(bool: true)` - Specifies if clients can request

--- a/content/vault/v2.x/content/api-docs/secret/pki/issuance.mdx
+++ b/content/vault/v2.x/content/api-docs/secret/pki/issuance.mdx
@@ -342,7 +342,7 @@ mount.
    ACME is disabled, all requests to ACME directory URLs will return 404.
 
  - `max_ttl` `(string: "")` - Specifies the maximum Time To Live provided as a
-   string duration with time suffix. Hour is the largest suffix. If not set,
+   string duration using [duration format strings](/vault/docs/concepts/duration-format) (hours, days, etc.). If not set,
    defaults to the previous hard-coded behavior of 90 days (2160 hours).
 
  - `challenge_permitted_ip_ranges` `(list: [])` - List of CIDR blocks that are


### PR DESCRIPTION
Create/Update Role still said hour was the largest suffix for `ttl` / `max_ttl`. That is wrong — Vault's duration format supports `d` (days) and the other units on the duration-format page (and people commonly set 90d cert lifetimes).

Replaced the old wording with a pointer to that page on recent PKI API docs.

Fixes hashicorp/vault#31404