### PR TITLE
docs(vault): clarify sign-intermediate TTL vs issuer expiry

### DIFF
--- a/content/vault/v1.19.x/content/api-docs/secret/pki/index.mdx
+++ b/content/vault/v1.19.x/content/api-docs/secret/pki/index.mdx
@@ -734,9 +734,18 @@ intermediary goes beyond the prescribed length.
 
 - `ttl` `(string: "")` - Specifies the requested Time To Live (after which the
   certificate will be expired). This cannot be larger than the engine's max (or,
-  if not set, the system max). However, this can be after the expiration of the
-  signing CA. See `not_after` as an alternative for setting an absolute end date
-  (rather than a relative one).
+  if not set, the system max). See `not_after` as an alternative for setting an
+  absolute end date (rather than a relative one).
+
+  By default, if the requested `NotAfter` would extend past the signing
+  issuer's expiry, Vault **truncates** it to the issuer's `NotAfter` rather
+  than allowing a longer intermediate. To control that behavior, set
+  [`enforce_leaf_not_after_behavior`](#enforce_leaf_not_after_behavior) and
+  configure the issuer's
+  [`leaf_not_after_behavior`](#leaf_not_after_behavior) (`truncate`, `err`,
+  `permit`, or `always_enforce_err`). Only with `permit` (or equivalent issuer
+  settings) can the signed intermediate outlive the signing CA; that is rarely
+  useful for intermediate CAs in a trust chain.
 
 - `format` `(string: "pem")` - Specifies the format for returned data. Can be
   `pem`, `der`, or `pem_bundle`. If `der`, the output is base64 encoded. If

--- a/content/vault/v1.20.x/content/api-docs/secret/pki/index.mdx
+++ b/content/vault/v1.20.x/content/api-docs/secret/pki/index.mdx
@@ -735,9 +735,18 @@ intermediary goes beyond the prescribed length.
 
 - `ttl` `(string: "")` - Specifies the requested Time To Live (after which the
   certificate will be expired). This cannot be larger than the engine's max (or,
-  if not set, the system max). However, this can be after the expiration of the
-  signing CA. See `not_after` as an alternative for setting an absolute end date
-  (rather than a relative one).
+  if not set, the system max). See `not_after` as an alternative for setting an
+  absolute end date (rather than a relative one).
+
+  By default, if the requested `NotAfter` would extend past the signing
+  issuer's expiry, Vault **truncates** it to the issuer's `NotAfter` rather
+  than allowing a longer intermediate. To control that behavior, set
+  [`enforce_leaf_not_after_behavior`](#enforce_leaf_not_after_behavior) and
+  configure the issuer's
+  [`leaf_not_after_behavior`](#leaf_not_after_behavior) (`truncate`, `err`,
+  `permit`, or `always_enforce_err`). Only with `permit` (or equivalent issuer
+  settings) can the signed intermediate outlive the signing CA; that is rarely
+  useful for intermediate CAs in a trust chain.
 
 - `format` `(string: "pem")` - Specifies the format for returned data. Can be
   `pem`, `der`, or `pem_bundle`. If `der`, the output is base64 encoded. If

--- a/content/vault/v1.21.x/content/api-docs/secret/pki/index.mdx
+++ b/content/vault/v1.21.x/content/api-docs/secret/pki/index.mdx
@@ -736,9 +736,18 @@ intermediary goes beyond the prescribed length.
 
 - `ttl` `(string: "")` - Specifies the requested Time To Live (after which the
   certificate will be expired). This cannot be larger than the engine's max (or,
-  if not set, the system max). However, this can be after the expiration of the
-  signing CA. See `not_after` as an alternative for setting an absolute end date
-  (rather than a relative one).
+  if not set, the system max). See `not_after` as an alternative for setting an
+  absolute end date (rather than a relative one).
+
+  By default, if the requested `NotAfter` would extend past the signing
+  issuer's expiry, Vault **truncates** it to the issuer's `NotAfter` rather
+  than allowing a longer intermediate. To control that behavior, set
+  [`enforce_leaf_not_after_behavior`](#enforce_leaf_not_after_behavior) and
+  configure the issuer's
+  [`leaf_not_after_behavior`](#leaf_not_after_behavior) (`truncate`, `err`,
+  `permit`, or `always_enforce_err`). Only with `permit` (or equivalent issuer
+  settings) can the signed intermediate outlive the signing CA; that is rarely
+  useful for intermediate CAs in a trust chain.
 
 - `format` `(string: "pem")` - Specifies the format for returned data. Can be
   `pem`, `der`, or `pem_bundle`. If `der`, the output is base64 encoded. If

--- a/content/vault/v2.x/content/api-docs/secret/pki/index.mdx
+++ b/content/vault/v2.x/content/api-docs/secret/pki/index.mdx
@@ -736,9 +736,18 @@ intermediary goes beyond the prescribed length.
 
 - `ttl` `(string: "")` - Specifies the requested Time To Live (after which the
   certificate will be expired). This cannot be larger than the engine's max (or,
-  if not set, the system max). However, this can be after the expiration of the
-  signing CA. See `not_after` as an alternative for setting an absolute end date
-  (rather than a relative one).
+  if not set, the system max). See `not_after` as an alternative for setting an
+  absolute end date (rather than a relative one).
+
+  By default, if the requested `NotAfter` would extend past the signing
+  issuer's expiry, Vault **truncates** it to the issuer's `NotAfter` rather
+  than allowing a longer intermediate. To control that behavior, set
+  [`enforce_leaf_not_after_behavior`](#enforce_leaf_not_after_behavior) and
+  configure the issuer's
+  [`leaf_not_after_behavior`](#leaf_not_after_behavior) (`truncate`, `err`,
+  `permit`, or `always_enforce_err`). Only with `permit` (or equivalent issuer
+  settings) can the signed intermediate outlive the signing CA; that is rarely
+  useful for intermediate CAs in a trust chain.
 
 - `format` `(string: "pem")` - Specifies the format for returned data. Can be
   `pem`, `der`, or `pem_bundle`. If `der`, the output is base64 encoded. If


### PR DESCRIPTION
`sign-intermediate`'s `ttl` docs said the cert can live past the signing CA without much nuance. By default Vault still truncates `NotAfter` to the issuer; you only get a longer intermediate if you wire up `enforce_leaf_not_after_behavior` and the issuer's `leaf_not_after_behavior` (`permit`, etc.).

Updated the parameter text to match that.

Fixes hashicorp/vault#31403