### PR TITLE
docs(consul): OSService checks are Windows-only

### DIFF
--- a/content/consul/v1.14.x/content/docs/services/usage/checks.mdx
+++ b/content/consul/v1.14.x/content/docs/services/usage/checks.mdx
@@ -319,7 +319,7 @@ check = {
 By default, UDP checks timeout at 10 seconds, but you can specify a custom timeout in the `timeout` field. If any timeout on read exists, the check is still considered healthy.
 
 ## OSService check
-OSService checks if an OS service is running on the host. OSService checks support Windows services on Windows hosts or SystemD services on Unix hosts. The check logs the service as `healthy` if it is running. If the service is not running, the status is logged as `critical`. All other results are logged with `warning`. A `warning` status indicates that the check is not reliable because an issue is preventing it from determining the health of the service.
+OSService checks if an OS service is running on the host. **Windows only:** this check type is implemented for Windows services. On Linux and other Unix systems the agent returns "not implemented", so do not rely on OSService checks outside Windows. On Windows, the check logs the service as `healthy` if it is running. If the service is not running, the status is logged as `critical`. All other results are logged with `warning`. A `warning` status indicates that the check is not reliable because an issue is preventing it from determining the health of the service.
 
 ### OSService check configurations
 Add an `os_service` field to the `check` block in your service definition file and specify the name of the service to check. All other fields are optional. Refer to [Health Checks Configuration Reference](/consul/docs/services/configuration/checks-configuration-reference] for information about all health check configurations. 

--- a/content/consul/v1.15.x/content/docs/services/usage/checks.mdx
+++ b/content/consul/v1.15.x/content/docs/services/usage/checks.mdx
@@ -319,7 +319,7 @@ check = {
 By default, UDP checks timeout at 10 seconds, but you can specify a custom timeout in the `timeout` field. If any timeout on read exists, the check is still considered healthy.
 
 ## OSService check
-OSService checks if an OS service is running on the host. OSService checks support Windows services on Windows hosts or SystemD services on Unix hosts. The check logs the service as `healthy` if it is running. If the service is not running, the status is logged as `critical`. All other results are logged with `warning`. A `warning` status indicates that the check is not reliable because an issue is preventing it from determining the health of the service.
+OSService checks if an OS service is running on the host. **Windows only:** this check type is implemented for Windows services. On Linux and other Unix systems the agent returns "not implemented", so do not rely on OSService checks outside Windows. On Windows, the check logs the service as `healthy` if it is running. If the service is not running, the status is logged as `critical`. All other results are logged with `warning`. A `warning` status indicates that the check is not reliable because an issue is preventing it from determining the health of the service.
 
 ### OSService check configurations
 Add an `os_service` field to the `check` block in your service definition file and specify the name of the service to check. All other fields are optional. Refer to [Health Checks Configuration Reference](/consul/docs/services/configuration/checks-configuration-reference) for information about all health check configurations. 

--- a/content/consul/v1.16.x/content/docs/services/usage/checks.mdx
+++ b/content/consul/v1.16.x/content/docs/services/usage/checks.mdx
@@ -319,7 +319,7 @@ check = {
 By default, UDP checks timeout at 10 seconds, but you can specify a custom timeout in the `timeout` field. If any timeout on read exists, the check is still considered healthy.
 
 ## OSService check
-OSService checks if an OS service is running on the host. OSService checks support Windows services on Windows hosts or SystemD services on Unix hosts. The check logs the service as `healthy` if it is running. If the service is not running, the status is logged as `critical`. All other results are logged with `warning`. A `warning` status indicates that the check is not reliable because an issue is preventing it from determining the health of the service.
+OSService checks if an OS service is running on the host. **Windows only:** this check type is implemented for Windows services. On Linux and other Unix systems the agent returns "not implemented", so do not rely on OSService checks outside Windows. On Windows, the check logs the service as `healthy` if it is running. If the service is not running, the status is logged as `critical`. All other results are logged with `warning`. A `warning` status indicates that the check is not reliable because an issue is preventing it from determining the health of the service.
 
 ### OSService check configurations
 Add an `os_service` field to the `check` block in your service definition file and specify the name of the service to check. All other fields are optional. Refer to [Health Checks Configuration Reference](/consul/docs/services/configuration/checks-configuration-reference) for information about all health check configurations. 

--- a/content/consul/v1.17.x/content/docs/services/usage/checks.mdx
+++ b/content/consul/v1.17.x/content/docs/services/usage/checks.mdx
@@ -319,7 +319,7 @@ check = {
 By default, UDP checks timeout at 10 seconds, but you can specify a custom timeout in the `timeout` field. If any timeout on read exists, the check is still considered healthy.
 
 ## OSService check
-OSService checks if an OS service is running on the host. OSService checks support Windows services on Windows hosts or SystemD services on Unix hosts. The check logs the service as `healthy` if it is running. If the service is not running, the status is logged as `critical`. All other results are logged with `warning`. A `warning` status indicates that the check is not reliable because an issue is preventing it from determining the health of the service.
+OSService checks if an OS service is running on the host. **Windows only:** this check type is implemented for Windows services. On Linux and other Unix systems the agent returns "not implemented", so do not rely on OSService checks outside Windows. On Windows, the check logs the service as `healthy` if it is running. If the service is not running, the status is logged as `critical`. All other results are logged with `warning`. A `warning` status indicates that the check is not reliable because an issue is preventing it from determining the health of the service.
 
 ### OSService check configurations
 Add an `os_service` field to the `check` block in your service definition file and specify the name of the service to check. All other fields are optional. Refer to [Health Checks Configuration Reference](/consul/docs/services/configuration/checks-configuration-reference) for information about all health check configurations. 

--- a/content/consul/v1.18.x/content/docs/services/usage/checks.mdx
+++ b/content/consul/v1.18.x/content/docs/services/usage/checks.mdx
@@ -319,7 +319,7 @@ check = {
 By default, UDP checks timeout at 10 seconds, but you can specify a custom timeout in the `timeout` field. If any timeout on read exists, the check is still considered healthy.
 
 ## OSService check
-OSService checks if an OS service is running on the host. OSService checks support Windows services on Windows hosts or SystemD services on Unix hosts. The check logs the service as `healthy` if it is running. If the service is not running, the status is logged as `critical`. All other results are logged with `warning`. A `warning` status indicates that the check is not reliable because an issue is preventing it from determining the health of the service.
+OSService checks if an OS service is running on the host. **Windows only:** this check type is implemented for Windows services. On Linux and other Unix systems the agent returns "not implemented", so do not rely on OSService checks outside Windows. On Windows, the check logs the service as `healthy` if it is running. If the service is not running, the status is logged as `critical`. All other results are logged with `warning`. A `warning` status indicates that the check is not reliable because an issue is preventing it from determining the health of the service.
 
 ### OSService check configurations
 Add an `os_service` field to the `check` block in your service definition file and specify the name of the service to check. All other fields are optional. Refer to [Health Checks Configuration Reference](/consul/docs/services/configuration/checks-configuration-reference) for information about all health check configurations. 

--- a/content/consul/v1.19.x/content/docs/services/usage/checks.mdx
+++ b/content/consul/v1.19.x/content/docs/services/usage/checks.mdx
@@ -319,7 +319,7 @@ check = {
 By default, UDP checks timeout at 10 seconds, but you can specify a custom timeout in the `timeout` field. If any timeout on read exists, the check is still considered healthy.
 
 ## OSService check
-OSService checks if an OS service is running on the host. OSService checks support Windows services on Windows hosts or SystemD services on Unix hosts. The check logs the service as `healthy` if it is running. If the service is not running, the status is logged as `critical`. All other results are logged with `warning`. A `warning` status indicates that the check is not reliable because an issue is preventing it from determining the health of the service.
+OSService checks if an OS service is running on the host. **Windows only:** this check type is implemented for Windows services. On Linux and other Unix systems the agent returns "not implemented", so do not rely on OSService checks outside Windows. On Windows, the check logs the service as `healthy` if it is running. If the service is not running, the status is logged as `critical`. All other results are logged with `warning`. A `warning` status indicates that the check is not reliable because an issue is preventing it from determining the health of the service.
 
 ### OSService check configurations
 Add an `os_service` field to the `check` block in your service definition file and specify the name of the service to check. All other fields are optional. Refer to [Health Checks Configuration Reference](/consul/docs/services/configuration/checks-configuration-reference) for information about all health check configurations. 

--- a/content/consul/v1.20.x/content/docs/services/usage/checks.mdx
+++ b/content/consul/v1.20.x/content/docs/services/usage/checks.mdx
@@ -319,7 +319,7 @@ check = {
 By default, UDP checks timeout at 10 seconds, but you can specify a custom timeout in the `timeout` field. If any timeout on read exists, the check is still considered healthy.
 
 ## OSService check
-OSService checks if an OS service is running on the host. OSService checks support Windows services on Windows hosts or SystemD services on Unix hosts. The check logs the service as `healthy` if it is running. If the service is not running, the status is logged as `critical`. All other results are logged with `warning`. A `warning` status indicates that the check is not reliable because an issue is preventing it from determining the health of the service.
+OSService checks if an OS service is running on the host. **Windows only:** this check type is implemented for Windows services. On Linux and other Unix systems the agent returns "not implemented", so do not rely on OSService checks outside Windows. On Windows, the check logs the service as `healthy` if it is running. If the service is not running, the status is logged as `critical`. All other results are logged with `warning`. A `warning` status indicates that the check is not reliable because an issue is preventing it from determining the health of the service.
 
 ### OSService check configurations
 Add an `os_service` field to the `check` block in your service definition file and specify the name of the service to check. All other fields are optional. Refer to [Health Checks Configuration Reference](/consul/docs/services/configuration/checks-configuration-reference) for information about all health check configurations. 

--- a/content/consul/v1.21.x/content/docs/register/health-check/vm.mdx
+++ b/content/consul/v1.21.x/content/docs/register/health-check/vm.mdx
@@ -337,7 +337,7 @@ By default, UDP checks timeout at 10 seconds, but you can specify a custom timeo
 
 ## OSService check
 
-OSService checks if an OS service is running on the host. OSService checks support Windows services on Windows hosts or SystemD services on Unix hosts. The check logs the service as `healthy` if it is running. If the service is not running, the status is logged as `critical`. All other results are logged with `warning`. A `warning` status indicates that the check is not reliable because an issue is preventing it from determining the health of the service.
+OSService checks if an OS service is running on the host. **Windows only:** this check type is implemented for Windows services. On Linux and other Unix systems the agent returns "not implemented", so do not rely on OSService checks outside Windows. On Windows, the check logs the service as `healthy` if it is running. If the service is not running, the status is logged as `critical`. All other results are logged with `warning`. A `warning` status indicates that the check is not reliable because an issue is preventing it from determining the health of the service.
 
 ### OSService check configurations
 

--- a/content/consul/v1.22.x/content/docs/register/health-check/vm.mdx
+++ b/content/consul/v1.22.x/content/docs/register/health-check/vm.mdx
@@ -337,7 +337,7 @@ By default, UDP checks timeout at 10 seconds, but you can specify a custom timeo
 
 ## OSService check
 
-OSService checks if an OS service is running on the host. OSService checks support Windows services on Windows hosts or SystemD services on Unix hosts. The check logs the service as `healthy` if it is running. If the service is not running, the status is logged as `critical`. All other results are logged with `warning`. A `warning` status indicates that the check is not reliable because an issue is preventing it from determining the health of the service.
+OSService checks if an OS service is running on the host. **Windows only:** this check type is implemented for Windows services. On Linux and other Unix systems the agent returns "not implemented", so do not rely on OSService checks outside Windows. On Windows, the check logs the service as `healthy` if it is running. If the service is not running, the status is logged as `critical`. All other results are logged with `warning`. A `warning` status indicates that the check is not reliable because an issue is preventing it from determining the health of the service.
 
 ### OSService check configurations
 

--- a/content/consul/v2.0.x/content/docs/register/health-check/vm.mdx
+++ b/content/consul/v2.0.x/content/docs/register/health-check/vm.mdx
@@ -331,7 +331,7 @@ By default, UDP checks timeout at 10 seconds, but you can specify a custom timeo
 
 ## OSService check
 
-OSService checks if an OS service is running on the host. OSService checks support Windows services on Windows hosts or SystemD services on Unix hosts. The check logs the service as `healthy` if it is running. If the service is not running, the status is logged as `critical`. All other results are logged with `warning`. A `warning` status indicates that the check is not reliable because an issue is preventing it from determining the health of the service.
+OSService checks if an OS service is running on the host. **Windows only:** this check type is implemented for Windows services. On Linux and other Unix systems the agent returns "not implemented", so do not rely on OSService checks outside Windows. On Windows, the check logs the service as `healthy` if it is running. If the service is not running, the status is logged as `critical`. All other results are logged with `warning`. A `warning` status indicates that the check is not reliable because an issue is preventing it from determining the health of the service.
 
 ### OSService check configurations
 


### PR DESCRIPTION
OSService check docs said Windows *or* SystemD on Unix. The Unix implementation is still a stub (`not implemented`); only Windows services work. Updated the check description so people do not expect systemd coverage.

Fixes hashicorp/consul#19037