### PR TITLE
docs(vault): TLS 1.2 cipher lists do not require disabling TLS 1.3

### DIFF
--- a/content/vault/v1.19.x/content/docs/configuration/listener/tcp/index.mdx
+++ b/content/vault/v1.19.x/content/docs/configuration/listener/tcp/index.mdx
@@ -229,10 +229,12 @@ default value in the `"/sys/config/ui"` [API endpoint](/vault/api-docs/system/co
   is available in the [Golang TLS documentation][golang-tls].
 
   ~> **Note**: Go only consults the `tls_cipher_suites` list for TLSv1.2 and
-  earlier; the order of ciphers is not important. For this parameter to be
-  effective, the `tls_max_version` property must be set to `tls12` to prevent
-  negotiation of TLSv1.3, which is not recommended. For more information about
-  this and other TLS related changes, see the [Go TLS blog post][go-tls-blog].
+  earlier; the order of ciphers is not important. TLS 1.3 ignores this list and
+  uses its own fixed suites, so you can leave `tls_max_version` at `tls13`
+  (the default) and still constrain TLS 1.2 ciphers. Only set
+  `tls_max_version = "tls12"` if you want to disable TLS 1.3 entirely. For more
+  information about this and other TLS related changes, see the
+  [Go TLS blog post][go-tls-blog].
 
 - `tls_prefer_server_cipher_suites` `(string: "false")` – Specifies to prefer the
   server's ciphersuite over the client ciphersuites.

--- a/content/vault/v1.19.x/content/docs/configuration/listener/tcp/tcp-tls.mdx
+++ b/content/vault/v1.19.x/content/docs/configuration/listener/tcp/tcp-tls.mdx
@@ -49,14 +49,18 @@ Go team has already designated a select set of ciphers that align with the
 broadly-accepted Mozilla Security/Server Side TLS guidance for [modern TLS
 configuration](https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility).
 
-## Example TLS 1.2 configuration
+## Example TLS 1.2 cipher suites (TLS 1.3 still allowed)
 
-To use TLS 1.2 with a non-default set of ciphersuites, you can set 1.2 as the
-minimum and maximum allowed TLS version and explicitly define your preferred
-ciphersuites with `tls_ciper_suites` and one or more of the ciphersuite
-constants from the ciphersuite configuration parser. For example:
+`tls_cipher_suites` only applies to TLS 1.2 and earlier. TLS 1.3 always uses
+Go's fixed modern suite list and ignores that parameter. You can therefore
+restrict TLS 1.2 ciphers **without** disabling TLS 1.3: leave
+`tls_max_version` at its default (`tls13`), set `tls_min_version = "tls12"`,
+and list the TLS 1.2 suites you want. Clients that negotiate TLS 1.3 still
+work.
 
-<CodeBlockConfig hideClipboard highlight="5-7">
+For example (AES-GCM / ChaCha20 only for TLS 1.2; no CBC/`*_SHA` suites):
+
+<CodeBlockConfig hideClipboard highlight="5-6">
 
 ```plaintext
 listener "tcp" {
@@ -64,16 +68,15 @@ listener "tcp" {
   tls_cert_file = "cert.pem"
   tls_key_file  = "key.pem"
   tls_min_version = "tls12"
-  tls_max_version = "tls12"
   tls_cipher_suites = "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"
 }
 ```
 
 </CodeBlockConfig>
 
-You must set the minimum and maximum TLS version to disable TLS 1.3, which does
-not support explicit cipher selection. The priority order of the ciphersuites
-in `tls_cipher_suites` is determined by the `tls` Go package.
+Only set `tls_max_version = "tls12"` if you intentionally want to reject TLS
+1.3. The priority order of suites in `tls_cipher_suites` is determined by the
+`tls` Go package.
 
 <Note>
 

--- a/content/vault/v1.20.x/content/docs/configuration/listener/tcp/index.mdx
+++ b/content/vault/v1.20.x/content/docs/configuration/listener/tcp/index.mdx
@@ -229,10 +229,12 @@ default value in the `"/sys/config/ui"` [API endpoint](/vault/api-docs/system/co
   is available in the [Golang TLS documentation][golang-tls].
 
   ~> **Note**: Go only consults the `tls_cipher_suites` list for TLSv1.2 and
-  earlier; the order of ciphers is not important. For this parameter to be
-  effective, the `tls_max_version` property must be set to `tls12` to prevent
-  negotiation of TLSv1.3, which is not recommended. For more information about
-  this and other TLS related changes, see the [Go TLS blog post][go-tls-blog].
+  earlier; the order of ciphers is not important. TLS 1.3 ignores this list and
+  uses its own fixed suites, so you can leave `tls_max_version` at `tls13`
+  (the default) and still constrain TLS 1.2 ciphers. Only set
+  `tls_max_version = "tls12"` if you want to disable TLS 1.3 entirely. For more
+  information about this and other TLS related changes, see the
+  [Go TLS blog post][go-tls-blog].
 
 - `tls_prefer_server_cipher_suites` `(string: "false")` – Specifies to prefer the
   server's ciphersuite over the client ciphersuites.

--- a/content/vault/v1.20.x/content/docs/configuration/listener/tcp/tcp-tls.mdx
+++ b/content/vault/v1.20.x/content/docs/configuration/listener/tcp/tcp-tls.mdx
@@ -49,14 +49,18 @@ Go team has already designated a select set of ciphers that align with the
 broadly-accepted Mozilla Security/Server Side TLS guidance for [modern TLS
 configuration](https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility).
 
-## Example TLS 1.2 configuration
+## Example TLS 1.2 cipher suites (TLS 1.3 still allowed)
 
-To use TLS 1.2 with a non-default set of ciphersuites, you can set 1.2 as the
-minimum and maximum allowed TLS version and explicitly define your preferred
-ciphersuites with `tls_ciper_suites` and one or more of the ciphersuite
-constants from the ciphersuite configuration parser. For example:
+`tls_cipher_suites` only applies to TLS 1.2 and earlier. TLS 1.3 always uses
+Go's fixed modern suite list and ignores that parameter. You can therefore
+restrict TLS 1.2 ciphers **without** disabling TLS 1.3: leave
+`tls_max_version` at its default (`tls13`), set `tls_min_version = "tls12"`,
+and list the TLS 1.2 suites you want. Clients that negotiate TLS 1.3 still
+work.
 
-<CodeBlockConfig hideClipboard highlight="5-7">
+For example (AES-GCM / ChaCha20 only for TLS 1.2; no CBC/`*_SHA` suites):
+
+<CodeBlockConfig hideClipboard highlight="5-6">
 
 ```plaintext
 listener "tcp" {
@@ -64,16 +68,15 @@ listener "tcp" {
   tls_cert_file = "cert.pem"
   tls_key_file  = "key.pem"
   tls_min_version = "tls12"
-  tls_max_version = "tls12"
   tls_cipher_suites = "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"
 }
 ```
 
 </CodeBlockConfig>
 
-You must set the minimum and maximum TLS version to disable TLS 1.3, which does
-not support explicit cipher selection. The priority order of the ciphersuites
-in `tls_cipher_suites` is determined by the `tls` Go package.
+Only set `tls_max_version = "tls12"` if you intentionally want to reject TLS
+1.3. The priority order of suites in `tls_cipher_suites` is determined by the
+`tls` Go package.
 
 <Note>
 

--- a/content/vault/v1.21.x/content/docs/configuration/listener/tcp/index.mdx
+++ b/content/vault/v1.21.x/content/docs/configuration/listener/tcp/index.mdx
@@ -229,10 +229,12 @@ default value in the `"/sys/config/ui"` [API endpoint](/vault/api-docs/system/co
   is available in the [Golang TLS documentation][golang-tls].
 
   ~> **Note**: Go only consults the `tls_cipher_suites` list for TLSv1.2 and
-  earlier; the order of ciphers is not important. For this parameter to be
-  effective, the `tls_max_version` property must be set to `tls12` to prevent
-  negotiation of TLSv1.3, which is not recommended. For more information about
-  this and other TLS related changes, see the [Go TLS blog post][go-tls-blog].
+  earlier; the order of ciphers is not important. TLS 1.3 ignores this list and
+  uses its own fixed suites, so you can leave `tls_max_version` at `tls13`
+  (the default) and still constrain TLS 1.2 ciphers. Only set
+  `tls_max_version = "tls12"` if you want to disable TLS 1.3 entirely. For more
+  information about this and other TLS related changes, see the
+  [Go TLS blog post][go-tls-blog].
 
 - `tls_prefer_server_cipher_suites` `(string: "false")` – Specifies to prefer the
   server's ciphersuite over the client ciphersuites.

--- a/content/vault/v1.21.x/content/docs/configuration/listener/tcp/tcp-tls.mdx
+++ b/content/vault/v1.21.x/content/docs/configuration/listener/tcp/tcp-tls.mdx
@@ -49,14 +49,18 @@ Go team has already designated a select set of ciphers that align with the
 broadly-accepted Mozilla Security/Server Side TLS guidance for [modern TLS
 configuration](https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility).
 
-## Example TLS 1.2 configuration
+## Example TLS 1.2 cipher suites (TLS 1.3 still allowed)
 
-To use TLS 1.2 with a non-default set of ciphersuites, you can set 1.2 as the
-minimum and maximum allowed TLS version and explicitly define your preferred
-ciphersuites with `tls_ciper_suites` and one or more of the ciphersuite
-constants from the ciphersuite configuration parser. For example:
+`tls_cipher_suites` only applies to TLS 1.2 and earlier. TLS 1.3 always uses
+Go's fixed modern suite list and ignores that parameter. You can therefore
+restrict TLS 1.2 ciphers **without** disabling TLS 1.3: leave
+`tls_max_version` at its default (`tls13`), set `tls_min_version = "tls12"`,
+and list the TLS 1.2 suites you want. Clients that negotiate TLS 1.3 still
+work.
 
-<CodeBlockConfig hideClipboard highlight="5-7">
+For example (AES-GCM / ChaCha20 only for TLS 1.2; no CBC/`*_SHA` suites):
+
+<CodeBlockConfig hideClipboard highlight="5-6">
 
 ```plaintext
 listener "tcp" {
@@ -64,16 +68,15 @@ listener "tcp" {
   tls_cert_file = "cert.pem"
   tls_key_file  = "key.pem"
   tls_min_version = "tls12"
-  tls_max_version = "tls12"
   tls_cipher_suites = "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"
 }
 ```
 
 </CodeBlockConfig>
 
-You must set the minimum and maximum TLS version to disable TLS 1.3, which does
-not support explicit cipher selection. The priority order of the ciphersuites
-in `tls_cipher_suites` is determined by the `tls` Go package.
+Only set `tls_max_version = "tls12"` if you intentionally want to reject TLS
+1.3. The priority order of suites in `tls_cipher_suites` is determined by the
+`tls` Go package.
 
 <Note>
 

--- a/content/vault/v2.x/content/docs/configuration/listener/tcp/index.mdx
+++ b/content/vault/v2.x/content/docs/configuration/listener/tcp/index.mdx
@@ -265,10 +265,12 @@ default value in the `"/sys/config/ui"` [API endpoint](/vault/api-docs/system/co
   is available in the [Golang TLS documentation][golang-tls].
 
   ~> **Note**: Go only consults the `tls_cipher_suites` list for TLSv1.2 and
-  earlier; the order of ciphers is not important. For this parameter to be
-  effective, the `tls_max_version` property must be set to `tls12` to prevent
-  negotiation of TLSv1.3, which is not recommended. For more information about
-  this and other TLS related changes, see the [Go TLS blog post][go-tls-blog].
+  earlier; the order of ciphers is not important. TLS 1.3 ignores this list and
+  uses its own fixed suites, so you can leave `tls_max_version` at `tls13`
+  (the default) and still constrain TLS 1.2 ciphers. Only set
+  `tls_max_version = "tls12"` if you want to disable TLS 1.3 entirely. For more
+  information about this and other TLS related changes, see the
+  [Go TLS blog post][go-tls-blog].
 
 - `tls_prefer_server_cipher_suites` `(string: "false")` – Specifies to prefer the
   server's ciphersuite over the client ciphersuites.

--- a/content/vault/v2.x/content/docs/configuration/listener/tcp/tcp-tls.mdx
+++ b/content/vault/v2.x/content/docs/configuration/listener/tcp/tcp-tls.mdx
@@ -49,14 +49,18 @@ Go team has already designated a select set of ciphers that align with the
 broadly-accepted Mozilla Security/Server Side TLS guidance for [modern TLS
 configuration](https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility).
 
-## Example TLS 1.2 configuration
+## Example TLS 1.2 cipher suites (TLS 1.3 still allowed)
 
-To use TLS 1.2 with a non-default set of ciphersuites, you can set 1.2 as the
-minimum and maximum allowed TLS version and explicitly define your preferred
-ciphersuites with `tls_ciper_suites` and one or more of the ciphersuite
-constants from the ciphersuite configuration parser. For example:
+`tls_cipher_suites` only applies to TLS 1.2 and earlier. TLS 1.3 always uses
+Go's fixed modern suite list and ignores that parameter. You can therefore
+restrict TLS 1.2 ciphers **without** disabling TLS 1.3: leave
+`tls_max_version` at its default (`tls13`), set `tls_min_version = "tls12"`,
+and list the TLS 1.2 suites you want. Clients that negotiate TLS 1.3 still
+work.
 
-<CodeBlockConfig hideClipboard highlight="5-7">
+For example (AES-GCM / ChaCha20 only for TLS 1.2; no CBC/`*_SHA` suites):
+
+<CodeBlockConfig hideClipboard highlight="5-6">
 
 ```plaintext
 listener "tcp" {
@@ -64,16 +68,15 @@ listener "tcp" {
   tls_cert_file = "cert.pem"
   tls_key_file  = "key.pem"
   tls_min_version = "tls12"
-  tls_max_version = "tls12"
   tls_cipher_suites = "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"
 }
 ```
 
 </CodeBlockConfig>
 
-You must set the minimum and maximum TLS version to disable TLS 1.3, which does
-not support explicit cipher selection. The priority order of the ciphersuites
-in `tls_cipher_suites` is determined by the `tls` Go package.
+Only set `tls_max_version = "tls12"` if you intentionally want to reject TLS
+1.3. The priority order of suites in `tls_cipher_suites` is determined by the
+`tls` Go package.
 
 <Note>
 


### PR DESCRIPTION
The TCP TLS guide and listener reference implied you had to set `tls_max_version = "tls12"` for `tls_cipher_suites` to matter. Go only uses that list for TLS 1.2; TLS 1.3 ignores it and keeps its own suites, so you can keep 1.3 enabled and still drop weak 1.2 ciphers.

Updated the example and the parameter note (and fixed a `tls_ciper_suites` typo in the guide).

Fixes hashicorp/vault#30858