### PR TITLE
docs(vault): document LDAP auto-auth password file format

### DIFF
--- a/content/vault/v1.19.x/content/docs/agent-and-proxy/autoauth/methods/ldap.mdx
+++ b/content/vault/v1.19.x/content/docs/agent-and-proxy/autoauth/methods/ldap.mdx
@@ -16,7 +16,12 @@ method](/vault/docs/auth/ldap).
 
 ## Configuration
 
-- `password_file_path` `(string: required)` - The path to the password file
+- `password_file_path` `(string: required)` - Path to a regular file (or
+  symlink to a file) whose **entire contents** are used as the LDAP password.
+  There is no special encoding: no JSON, no key=value wrapper—just the raw
+  password bytes as text. A trailing newline is included if present, so prefer
+  writing the file without one (for example `printf '%s' 'secret' > /path/to/pass`).
+  The path must point at a file, not a directory.
 
 - `username` `(string: required)` - The username to authenticate against on Vault
 
@@ -35,3 +40,19 @@ auto-auth will attempt to read the password stored at `password_file_path`.
 Defaults to `1m` if `remove_password_after_reading` is set to `true`, or `0.5s`
 otherwise. Uses [duration format
 strings](/vault/docs/concepts/duration-format).
+
+## Example
+
+```hcl
+auto_auth {
+  method {
+    type = "ldap"
+    config = {
+      username           = "agent"
+      password_file_path = "/run/vault-agent/ldap-password"
+      # file contents: the password only, no trailing newline preferred
+    }
+  }
+}
+```
+

--- a/content/vault/v1.20.x/content/docs/agent-and-proxy/autoauth/methods/ldap.mdx
+++ b/content/vault/v1.20.x/content/docs/agent-and-proxy/autoauth/methods/ldap.mdx
@@ -16,7 +16,12 @@ method](/vault/docs/auth/ldap).
 
 ## Configuration
 
-- `password_file_path` `(string: required)` - The path to the password file
+- `password_file_path` `(string: required)` - Path to a regular file (or
+  symlink to a file) whose **entire contents** are used as the LDAP password.
+  There is no special encoding: no JSON, no key=value wrapper—just the raw
+  password bytes as text. A trailing newline is included if present, so prefer
+  writing the file without one (for example `printf '%s' 'secret' > /path/to/pass`).
+  The path must point at a file, not a directory.
 
 - `username` `(string: required)` - The username to authenticate against on Vault
 
@@ -35,3 +40,19 @@ auto-auth will attempt to read the password stored at `password_file_path`.
 Defaults to `1m` if `remove_password_after_reading` is set to `true`, or `0.5s`
 otherwise. Uses [duration format
 strings](/vault/docs/concepts/duration-format).
+
+## Example
+
+```hcl
+auto_auth {
+  method {
+    type = "ldap"
+    config = {
+      username           = "agent"
+      password_file_path = "/run/vault-agent/ldap-password"
+      # file contents: the password only, no trailing newline preferred
+    }
+  }
+}
+```
+

--- a/content/vault/v1.21.x/content/docs/agent-and-proxy/autoauth/methods/ldap.mdx
+++ b/content/vault/v1.21.x/content/docs/agent-and-proxy/autoauth/methods/ldap.mdx
@@ -16,7 +16,12 @@ method](/vault/docs/auth/ldap).
 
 ## Configuration
 
-- `password_file_path` `(string: required)` - The path to the password file
+- `password_file_path` `(string: required)` - Path to a regular file (or
+  symlink to a file) whose **entire contents** are used as the LDAP password.
+  There is no special encoding: no JSON, no key=value wrapper—just the raw
+  password bytes as text. A trailing newline is included if present, so prefer
+  writing the file without one (for example `printf '%s' 'secret' > /path/to/pass`).
+  The path must point at a file, not a directory.
 
 - `username` `(string: required)` - The username to authenticate against on Vault
 
@@ -35,3 +40,19 @@ auto-auth will attempt to read the password stored at `password_file_path`.
 Defaults to `1m` if `remove_password_after_reading` is set to `true`, or `0.5s`
 otherwise. Uses [duration format
 strings](/vault/docs/concepts/duration-format).
+
+## Example
+
+```hcl
+auto_auth {
+  method {
+    type = "ldap"
+    config = {
+      username           = "agent"
+      password_file_path = "/run/vault-agent/ldap-password"
+      # file contents: the password only, no trailing newline preferred
+    }
+  }
+}
+```
+

--- a/content/vault/v2.x/content/docs/agent-and-proxy/autoauth/methods/ldap.mdx
+++ b/content/vault/v2.x/content/docs/agent-and-proxy/autoauth/methods/ldap.mdx
@@ -16,7 +16,12 @@ method](/vault/docs/auth/ldap).
 
 ## Configuration
 
-- `password_file_path` `(string: required)` - The path to the password file
+- `password_file_path` `(string: required)` - Path to a regular file (or
+  symlink to a file) whose **entire contents** are used as the LDAP password.
+  There is no special encoding: no JSON, no key=value wrapper—just the raw
+  password bytes as text. A trailing newline is included if present, so prefer
+  writing the file without one (for example `printf '%s' 'secret' > /path/to/pass`).
+  The path must point at a file, not a directory.
 
 - `username` `(string: required)` - The username to authenticate against on Vault
 
@@ -35,3 +40,19 @@ auto-auth will attempt to read the password stored at `password_file_path`.
 Defaults to `1m` if `remove_password_after_reading` is set to `true`, or `0.5s`
 otherwise. Uses [duration format
 strings](/vault/docs/concepts/duration-format).
+
+## Example
+
+```hcl
+auto_auth {
+  method {
+    type = "ldap"
+    config = {
+      username           = "agent"
+      password_file_path = "/run/vault-agent/ldap-password"
+      # file contents: the password only, no trailing newline preferred
+    }
+  }
+}
+```
+


### PR DESCRIPTION
`password_file_path` did not say what goes in the file. Agent reads the whole file as the password (plain text, no JSON), and a trailing newline counts as part of it.

Clarified that and added a tiny example.

Fixes hashicorp/vault#29901