### PR TITLE
docs(vault): cert auth needs enable_identity_alias_metadata for ACL templates

### DIFF
--- a/content/vault/v1.19.x/content/api-docs/auth/cert.mdx
+++ b/content/vault/v1.19.x/content/api-docs/auth/cert.mdx
@@ -366,7 +366,9 @@ Configuration options for the method.
   login.
 - `enable_identity_alias_metadata` `(boolean: false)` - If set, metadata of
   the certificate including the metadata corresponding to
-  `allowed_metadata_extensions` will be stored in the alias
+  `allowed_metadata_extensions` will be stored on the identity alias so it can
+  be used in [ACL policy templates](/vault/docs/concepts/policies#templated-policies)
+  (for example `identity.entity.aliases.<mount accessor>.metadata.<key>`). Off by default.
 - `ocsp_cache_size` `(int: 100)` - The size of the OCSP response LRU cache.  Note
   that this cache is used for all configured certificates.
 - `role_cache_size` `(int: 200)` - The size of the role cache.  Use `-1` to disable

--- a/content/vault/v1.19.x/content/docs/auth/cert.mdx
+++ b/content/vault/v1.19.x/content/docs/auth/cert.mdx
@@ -156,6 +156,34 @@ In this mode, the security of authentication depends on the load balancer perfor
 full TLS verification to the client, and that the connection between the load
 balancer and Vault is secured, ideally with Mutual TLS.
 
+
+## Certificate metadata and ACL policy templates
+
+By default, certificate fields are **not** stored on the identity alias, so
+ACL policy templates such as
+`{{identity.entity.aliases.<mount accessor>.metadata.<key>}}` will not see
+client certificate metadata.
+
+To make certificate metadata available for [ACL policy
+templating](/vault/docs/concepts/policies#templated-policies):
+
+1. Configure the cert auth method with `enable_identity_alias_metadata=true`:
+
+   ```text
+   $ vault write auth/cert/config enable_identity_alias_metadata=true
+   ```
+
+1. Optionally set `allowed_metadata_extensions` on the certificate role if you
+   need OID extension values as metadata (see the
+   [cert auth API](/vault/api-docs/auth/cert)).
+
+1. Use the mount accessor from `vault auth list` in template paths, for example
+   `identity.entity.aliases.auth_cert_XXXX.metadata.common_name`.
+
+Without `enable_identity_alias_metadata`, login still works and assigned
+`policies` on the role apply, but alias metadata-based templates will not
+resolve certificate fields.
+
 ## API
 
 The TLS Certificate auth method has a full HTTP API. Please see the

--- a/content/vault/v1.20.x/content/api-docs/auth/cert.mdx
+++ b/content/vault/v1.20.x/content/api-docs/auth/cert.mdx
@@ -366,7 +366,9 @@ Configuration options for the method.
   login.
 - `enable_identity_alias_metadata` `(boolean: false)` - If set, metadata of
   the certificate including the metadata corresponding to
-  `allowed_metadata_extensions` will be stored in the alias
+  `allowed_metadata_extensions` will be stored on the identity alias so it can
+  be used in [ACL policy templates](/vault/docs/concepts/policies#templated-policies)
+  (for example `identity.entity.aliases.<mount accessor>.metadata.<key>`). Off by default.
 - `ocsp_cache_size` `(int: 100)` - The size of the OCSP response LRU cache.  Note
   that this cache is used for all configured certificates.
 - `role_cache_size` `(int: 200)` - The size of the role cache.  Use `-1` to disable

--- a/content/vault/v1.20.x/content/docs/auth/cert.mdx
+++ b/content/vault/v1.20.x/content/docs/auth/cert.mdx
@@ -156,6 +156,34 @@ In this mode, the security of authentication depends on the load balancer perfor
 full TLS verification to the client, and that the connection between the load
 balancer and Vault is secured, ideally with Mutual TLS.
 
+
+## Certificate metadata and ACL policy templates
+
+By default, certificate fields are **not** stored on the identity alias, so
+ACL policy templates such as
+`{{identity.entity.aliases.<mount accessor>.metadata.<key>}}` will not see
+client certificate metadata.
+
+To make certificate metadata available for [ACL policy
+templating](/vault/docs/concepts/policies#templated-policies):
+
+1. Configure the cert auth method with `enable_identity_alias_metadata=true`:
+
+   ```text
+   $ vault write auth/cert/config enable_identity_alias_metadata=true
+   ```
+
+1. Optionally set `allowed_metadata_extensions` on the certificate role if you
+   need OID extension values as metadata (see the
+   [cert auth API](/vault/api-docs/auth/cert)).
+
+1. Use the mount accessor from `vault auth list` in template paths, for example
+   `identity.entity.aliases.auth_cert_XXXX.metadata.common_name`.
+
+Without `enable_identity_alias_metadata`, login still works and assigned
+`policies` on the role apply, but alias metadata-based templates will not
+resolve certificate fields.
+
 ## API
 
 The TLS Certificate auth method has a full HTTP API. Please see the

--- a/content/vault/v1.21.x/content/api-docs/auth/cert.mdx
+++ b/content/vault/v1.21.x/content/api-docs/auth/cert.mdx
@@ -366,7 +366,9 @@ Configuration options for the method.
   login.
 - `enable_identity_alias_metadata` `(boolean: false)` - If set, metadata of
   the certificate including the metadata corresponding to
-  `allowed_metadata_extensions` will be stored in the alias
+  `allowed_metadata_extensions` will be stored on the identity alias so it can
+  be used in [ACL policy templates](/vault/docs/concepts/policies#templated-policies)
+  (for example `identity.entity.aliases.<mount accessor>.metadata.<key>`). Off by default.
 - `ocsp_cache_size` `(int: 100)` - The size of the OCSP response LRU cache.  Note
   that this cache is used for all configured certificates.
 - `role_cache_size` `(int: 200)` - The size of the role cache.  Use `-1` to disable

--- a/content/vault/v1.21.x/content/docs/auth/cert.mdx
+++ b/content/vault/v1.21.x/content/docs/auth/cert.mdx
@@ -156,6 +156,34 @@ In this mode, the security of authentication depends on the load balancer perfor
 full TLS verification to the client, and that the connection between the load
 balancer and Vault is secured, ideally with Mutual TLS.
 
+
+## Certificate metadata and ACL policy templates
+
+By default, certificate fields are **not** stored on the identity alias, so
+ACL policy templates such as
+`{{identity.entity.aliases.<mount accessor>.metadata.<key>}}` will not see
+client certificate metadata.
+
+To make certificate metadata available for [ACL policy
+templating](/vault/docs/concepts/policies#templated-policies):
+
+1. Configure the cert auth method with `enable_identity_alias_metadata=true`:
+
+   ```text
+   $ vault write auth/cert/config enable_identity_alias_metadata=true
+   ```
+
+1. Optionally set `allowed_metadata_extensions` on the certificate role if you
+   need OID extension values as metadata (see the
+   [cert auth API](/vault/api-docs/auth/cert)).
+
+1. Use the mount accessor from `vault auth list` in template paths, for example
+   `identity.entity.aliases.auth_cert_XXXX.metadata.common_name`.
+
+Without `enable_identity_alias_metadata`, login still works and assigned
+`policies` on the role apply, but alias metadata-based templates will not
+resolve certificate fields.
+
 ## API
 
 The TLS Certificate auth method has a full HTTP API. Please see the

--- a/content/vault/v2.x/content/api-docs/auth/cert.mdx
+++ b/content/vault/v2.x/content/api-docs/auth/cert.mdx
@@ -366,7 +366,9 @@ Configuration options for the method.
   login.
 - `enable_identity_alias_metadata` `(boolean: false)` - If set, metadata of
   the certificate including the metadata corresponding to
-  `allowed_metadata_extensions` will be stored in the alias
+  `allowed_metadata_extensions` will be stored on the identity alias so it can
+  be used in [ACL policy templates](/vault/docs/concepts/policies#templated-policies)
+  (for example `identity.entity.aliases.<mount accessor>.metadata.<key>`). Off by default.
 - `ocsp_cache_size` `(int: 100)` - The size of the OCSP response LRU cache.  Note
   that this cache is used for all configured certificates.
 - `role_cache_size` `(int: 200)` - The size of the role cache.  Use `-1` to disable

--- a/content/vault/v2.x/content/docs/auth/cert.mdx
+++ b/content/vault/v2.x/content/docs/auth/cert.mdx
@@ -156,6 +156,34 @@ In this mode, the security of authentication depends on the load balancer perfor
 full TLS verification to the client, and that the connection between the load
 balancer and Vault is secured, ideally with Mutual TLS.
 
+
+## Certificate metadata and ACL policy templates
+
+By default, certificate fields are **not** stored on the identity alias, so
+ACL policy templates such as
+`{{identity.entity.aliases.<mount accessor>.metadata.<key>}}` will not see
+client certificate metadata.
+
+To make certificate metadata available for [ACL policy
+templating](/vault/docs/concepts/policies#templated-policies):
+
+1. Configure the cert auth method with `enable_identity_alias_metadata=true`:
+
+   ```text
+   $ vault write auth/cert/config enable_identity_alias_metadata=true
+   ```
+
+1. Optionally set `allowed_metadata_extensions` on the certificate role if you
+   need OID extension values as metadata (see the
+   [cert auth API](/vault/api-docs/auth/cert)).
+
+1. Use the mount accessor from `vault auth list` in template paths, for example
+   `identity.entity.aliases.auth_cert_XXXX.metadata.common_name`.
+
+Without `enable_identity_alias_metadata`, login still works and assigned
+`policies` on the role apply, but alias metadata-based templates will not
+resolve certificate fields.
+
 ## API
 
 The TLS Certificate auth method has a full HTTP API. Please see the


### PR DESCRIPTION
Using cert auth with ACL policy templates on certificate metadata is easy to miss: you have to set `enable_identity_alias_metadata=true` on `auth/cert/config` or the alias has no metadata. Added a short section on the cert auth method page and clarified the API field.

Fixes hashicorp/vault#30363