### PR TITLE
docs(vault): warn unseal keys appear in process listings

### DIFF
--- a/content/vault/v1.19.x/content/docs/commands/operator/unseal.mdx
+++ b/content/vault/v1.19.x/content/docs/commands/operator/unseal.mdx
@@ -17,21 +17,30 @@ unseal a Vault server. Vault starts in a sealed state. It cannot perform
 operations until it is unsealed. This command accepts a portion of the master
 key (an "unseal key").
 
-The unseal key can be supplied as an argument to the command, but this is
-not recommended as the unseal key will be available in your history:
+The unseal key can be supplied as an argument to the command, but **do not
+do this in production**. Argument form is visible in shell history **and** in
+process listings (`ps`) for any local user while the command runs—including
+when the key is expanded from a subshell such as
+`vault operator unseal $(gpg --decrypt key.gpg)`.
 
 ```shell-session
 $ vault operator unseal IXyR0OJnSFobekZMMCKCoVEpT7wI6l+USMzE3IcyDyo=
 ```
 
-Instead, run the command with no arguments and it will prompt for the key:
+Prefer an interactive TTY so the key is not passed as an argument:
 
 ```shell-session
 $ vault operator unseal
-Key (will be hidden): IXyR0OJnSFobekZMMCKCoVEpT7wI6l+USMzE3IcyDyo=
+Key (will be hidden):
 ```
 
-For more information on sealing and unsealing, please the [seal concepts
+For non-interactive unseal (automation, encrypted key files), use the
+[unseal HTTP API](/vault/api-docs/system/unseal) and keep the key out of the
+process argv—for example POST JSON on stdin with a tool that does not echo
+the body into process arguments. Avoid shell command substitution that puts
+the key on the CLI.
+
+For more information on sealing and unsealing, see the [seal concepts
 page](/vault/docs/concepts/seal).
 
 ## Examples

--- a/content/vault/v1.20.x/content/docs/commands/operator/unseal.mdx
+++ b/content/vault/v1.20.x/content/docs/commands/operator/unseal.mdx
@@ -17,21 +17,30 @@ unseal a Vault server. Vault starts in a sealed state. It cannot perform
 operations until it is unsealed. This command accepts a portion of the master
 key (an "unseal key").
 
-The unseal key can be supplied as an argument to the command, but this is
-not recommended as the unseal key will be available in your history:
+The unseal key can be supplied as an argument to the command, but **do not
+do this in production**. Argument form is visible in shell history **and** in
+process listings (`ps`) for any local user while the command runs—including
+when the key is expanded from a subshell such as
+`vault operator unseal $(gpg --decrypt key.gpg)`.
 
 ```shell-session
 $ vault operator unseal IXyR0OJnSFobekZMMCKCoVEpT7wI6l+USMzE3IcyDyo=
 ```
 
-Instead, run the command with no arguments and it will prompt for the key:
+Prefer an interactive TTY so the key is not passed as an argument:
 
 ```shell-session
 $ vault operator unseal
-Key (will be hidden): IXyR0OJnSFobekZMMCKCoVEpT7wI6l+USMzE3IcyDyo=
+Key (will be hidden):
 ```
 
-For more information on sealing and unsealing, please the [seal concepts
+For non-interactive unseal (automation, encrypted key files), use the
+[unseal HTTP API](/vault/api-docs/system/unseal) and keep the key out of the
+process argv—for example POST JSON on stdin with a tool that does not echo
+the body into process arguments. Avoid shell command substitution that puts
+the key on the CLI.
+
+For more information on sealing and unsealing, see the [seal concepts
 page](/vault/docs/concepts/seal).
 
 ## Examples

--- a/content/vault/v1.21.x/content/docs/commands/operator/unseal.mdx
+++ b/content/vault/v1.21.x/content/docs/commands/operator/unseal.mdx
@@ -17,21 +17,30 @@ unseal a Vault server. Vault starts in a sealed state. It cannot perform
 operations until it is unsealed. This command accepts a portion of the master
 key (an "unseal key").
 
-The unseal key can be supplied as an argument to the command, but this is
-not recommended as the unseal key will be available in your history:
+The unseal key can be supplied as an argument to the command, but **do not
+do this in production**. Argument form is visible in shell history **and** in
+process listings (`ps`) for any local user while the command runs—including
+when the key is expanded from a subshell such as
+`vault operator unseal $(gpg --decrypt key.gpg)`.
 
 ```shell-session
 $ vault operator unseal IXyR0OJnSFobekZMMCKCoVEpT7wI6l+USMzE3IcyDyo=
 ```
 
-Instead, run the command with no arguments and it will prompt for the key:
+Prefer an interactive TTY so the key is not passed as an argument:
 
 ```shell-session
 $ vault operator unseal
-Key (will be hidden): IXyR0OJnSFobekZMMCKCoVEpT7wI6l+USMzE3IcyDyo=
+Key (will be hidden):
 ```
 
-For more information on sealing and unsealing, please the [seal concepts
+For non-interactive unseal (automation, encrypted key files), use the
+[unseal HTTP API](/vault/api-docs/system/unseal) and keep the key out of the
+process argv—for example POST JSON on stdin with a tool that does not echo
+the body into process arguments. Avoid shell command substitution that puts
+the key on the CLI.
+
+For more information on sealing and unsealing, see the [seal concepts
 page](/vault/docs/concepts/seal).
 
 ## Examples

--- a/content/vault/v2.x/content/docs/commands/operator/unseal.mdx
+++ b/content/vault/v2.x/content/docs/commands/operator/unseal.mdx
@@ -17,21 +17,30 @@ unseal a Vault server. Vault starts in a sealed state. It cannot perform
 operations until it is unsealed. This command accepts a portion of the master
 key (an "unseal key").
 
-The unseal key can be supplied as an argument to the command, but this is
-not recommended as the unseal key will be available in your history:
+The unseal key can be supplied as an argument to the command, but **do not
+do this in production**. Argument form is visible in shell history **and** in
+process listings (`ps`) for any local user while the command runs—including
+when the key is expanded from a subshell such as
+`vault operator unseal $(gpg --decrypt key.gpg)`.
 
 ```shell-session
 $ vault operator unseal IXyR0OJnSFobekZMMCKCoVEpT7wI6l+USMzE3IcyDyo=
 ```
 
-Instead, run the command with no arguments and it will prompt for the key:
+Prefer an interactive TTY so the key is not passed as an argument:
 
 ```shell-session
 $ vault operator unseal
-Key (will be hidden): IXyR0OJnSFobekZMMCKCoVEpT7wI6l+USMzE3IcyDyo=
+Key (will be hidden):
 ```
 
-For more information on sealing and unsealing, please the [seal concepts
+For non-interactive unseal (automation, encrypted key files), use the
+[unseal HTTP API](/vault/api-docs/system/unseal) and keep the key out of the
+process argv—for example POST JSON on stdin with a tool that does not echo
+the body into process arguments. Avoid shell command substitution that puts
+the key on the CLI.
+
+For more information on sealing and unsealing, see the [seal concepts
 page](/vault/docs/concepts/seal).
 
 ## Examples


### PR DESCRIPTION
`vault operator unseal` docs only mentioned shell history. Keys on the CLI (including via `$(gpg --decrypt ...)`) also show up in `ps` for other local users. Spelled that out and pointed automation at the unseal HTTP API instead of stuffing the key into argv.

Fixes hashicorp/vault#31138