### PR TITLE
docs(nomad): expand agent -dev mode behavior

### DIFF
--- a/content/nomad/v1.10.x/content/commands/agent.mdx
+++ b/content/nomad/v1.10.x/content/commands/agent.mdx
@@ -115,8 +115,16 @@ You may, however, may pass the following configuration options as CLI arguments:
 
 - `-dev`: Start the agent in development mode. This enables a pre-configured
   dual-role agent (client + server) which is useful for developing or testing
-  Nomad. No other configuration is required to start the agent in this mode,
-  but you may pass an optional comma-separated list of mode configurations:
+  Nomad. No other configuration is required to start the agent in this mode.
+
+  Development mode is **not** required to run client and server on one host—you
+  can enable both with normal config. What `-dev` changes includes bootstrap
+  defaults suited to a laptop: for example client
+  [network fingerprinting](/nomad/docs/configuration/client#network_interface)
+  defaults to the loopback interface (`unique.network.ip-address` is often
+  `127.0.0.1`), whereas a non-dev client prefers the interface used for the
+  advertise address. Some attributes may also differ from a full agent start.
+  Do not use `-dev` for production clusters.
 
 - `-dev-connect`: Start the agent in development mode, but bind to a public
   network interface rather than localhost for using Consul service mesh. It may be

--- a/content/nomad/v1.10.x/content/commands/agent.mdx
+++ b/content/nomad/v1.10.x/content/commands/agent.mdx
@@ -115,16 +115,14 @@ You may, however, may pass the following configuration options as CLI arguments:
 
 - `-dev`: Start the agent in development mode. This enables a pre-configured
   dual-role agent (client + server) which is useful for developing or testing
-  Nomad. No other configuration is required to start the agent in this mode.
+  Nomad. No other configuration is required to start the agent in this mode,
+  but you may pass an optional comma-separated list of mode configurations:
 
-  Development mode is **not** required to run client and server on one host—you
-  can enable both with normal config. What `-dev` changes includes bootstrap
-  defaults suited to a laptop: for example client
-  [network fingerprinting](/nomad/docs/configuration/client#network_interface)
-  defaults to the loopback interface (`unique.network.ip-address` is often
-  `127.0.0.1`), whereas a non-dev client prefers the interface used for the
-  advertise address. Some attributes may also differ from a full agent start.
-  Do not use `-dev` for production clusters.
+  You can also run client and server on one host without `-dev` using normal
+  configuration. In `-dev`, client network fingerprinting often uses loopback
+  (`unique.network.ip-address` ≈ `127.0.0.1`); without `-dev` the client prefers
+  the advertise-address interface. Do not use `-dev` in production.
+
 
 - `-dev-connect`: Start the agent in development mode, but bind to a public
   network interface rather than localhost for using Consul service mesh. It may be

--- a/content/nomad/v1.11.x/content/commands/agent.mdx
+++ b/content/nomad/v1.11.x/content/commands/agent.mdx
@@ -122,8 +122,16 @@ You may, however, may pass the following configuration options as CLI arguments:
 
 - `-dev`: Start the agent in development mode. This enables a pre-configured
   dual-role agent (client + server) which is useful for developing or testing
-  Nomad. No other configuration is required to start the agent in this mode,
-  but you may pass an optional comma-separated list of mode configurations:
+  Nomad. No other configuration is required to start the agent in this mode.
+
+  Development mode is **not** required to run client and server on one host—you
+  can enable both with normal config. What `-dev` changes includes bootstrap
+  defaults suited to a laptop: for example client
+  [network fingerprinting](/nomad/docs/configuration/client#network_interface)
+  defaults to the loopback interface (`unique.network.ip-address` is often
+  `127.0.0.1`), whereas a non-dev client prefers the interface used for the
+  advertise address. Some attributes may also differ from a full agent start.
+  Do not use `-dev` for production clusters.
 
 - `-dev-connect`: Start the agent in development mode, but bind to a public
   network interface rather than localhost for using Consul service mesh. It may be

--- a/content/nomad/v1.11.x/content/commands/agent.mdx
+++ b/content/nomad/v1.11.x/content/commands/agent.mdx
@@ -122,16 +122,14 @@ You may, however, may pass the following configuration options as CLI arguments:
 
 - `-dev`: Start the agent in development mode. This enables a pre-configured
   dual-role agent (client + server) which is useful for developing or testing
-  Nomad. No other configuration is required to start the agent in this mode.
+  Nomad. No other configuration is required to start the agent in this mode,
+  but you may pass an optional comma-separated list of mode configurations:
 
-  Development mode is **not** required to run client and server on one host—you
-  can enable both with normal config. What `-dev` changes includes bootstrap
-  defaults suited to a laptop: for example client
-  [network fingerprinting](/nomad/docs/configuration/client#network_interface)
-  defaults to the loopback interface (`unique.network.ip-address` is often
-  `127.0.0.1`), whereas a non-dev client prefers the interface used for the
-  advertise address. Some attributes may also differ from a full agent start.
-  Do not use `-dev` for production clusters.
+  You can also run client and server on one host without `-dev` using normal
+  configuration. In `-dev`, client network fingerprinting often uses loopback
+  (`unique.network.ip-address` ≈ `127.0.0.1`); without `-dev` the client prefers
+  the advertise-address interface. Do not use `-dev` in production.
+
 
 - `-dev-connect`: Start the agent in development mode, but bind to a public
   network interface rather than localhost for using Consul service mesh. It may be

--- a/content/nomad/v2.0.x/content/commands/agent.mdx
+++ b/content/nomad/v2.0.x/content/commands/agent.mdx
@@ -122,8 +122,16 @@ You may, however, may pass the following configuration options as CLI arguments:
 
 - `-dev`: Start the agent in development mode. This enables a pre-configured
   dual-role agent (client + server) which is useful for developing or testing
-  Nomad. No other configuration is required to start the agent in this mode,
-  but you may pass an optional comma-separated list of mode configurations:
+  Nomad. No other configuration is required to start the agent in this mode.
+
+  Development mode is **not** required to run client and server on one host—you
+  can enable both with normal config. What `-dev` changes includes bootstrap
+  defaults suited to a laptop: for example client
+  [network fingerprinting](/nomad/docs/configuration/client#network_interface)
+  defaults to the loopback interface (`unique.network.ip-address` is often
+  `127.0.0.1`), whereas a non-dev client prefers the interface used for the
+  advertise address. Some attributes may also differ from a full agent start.
+  Do not use `-dev` for production clusters.
 
 - `-dev-connect`: Start the agent in development mode, but bind to a public
   network interface rather than localhost for using Consul service mesh. It may be

--- a/content/nomad/v2.0.x/content/commands/agent.mdx
+++ b/content/nomad/v2.0.x/content/commands/agent.mdx
@@ -122,16 +122,14 @@ You may, however, may pass the following configuration options as CLI arguments:
 
 - `-dev`: Start the agent in development mode. This enables a pre-configured
   dual-role agent (client + server) which is useful for developing or testing
-  Nomad. No other configuration is required to start the agent in this mode.
+  Nomad. No other configuration is required to start the agent in this mode,
+  but you may pass an optional comma-separated list of mode configurations:
 
-  Development mode is **not** required to run client and server on one host—you
-  can enable both with normal config. What `-dev` changes includes bootstrap
-  defaults suited to a laptop: for example client
-  [network fingerprinting](/nomad/docs/configuration/client#network_interface)
-  defaults to the loopback interface (`unique.network.ip-address` is often
-  `127.0.0.1`), whereas a non-dev client prefers the interface used for the
-  advertise address. Some attributes may also differ from a full agent start.
-  Do not use `-dev` for production clusters.
+  You can also run client and server on one host without `-dev` using normal
+  configuration. In `-dev`, client network fingerprinting often uses loopback
+  (`unique.network.ip-address` ≈ `127.0.0.1`); without `-dev` the client prefers
+  the advertise-address interface. Do not use `-dev` in production.
+
 
 - `-dev-connect`: Start the agent in development mode, but bind to a public
   network interface rather than localhost for using Consul service mesh. It may be


### PR DESCRIPTION
`-dev` was only described as a dual-role test agent. Expanded it a bit: you can run client+server without `-dev`, and in dev mode network fingerprinting tends to stick to loopback (`unique.network.ip-address` ≈ 127.0.0.1) unlike a normal client.

Fixes hashicorp/nomad#20323