### PR TITLE
docs(terraform): backend settings are not loaded from terraform.tfvars

### DIFF
--- a/content/terraform/v1.11.x/docs/language/backend/index.mdx
+++ b/content/terraform/v1.11.x/docs/language/backend/index.mdx
@@ -107,6 +107,15 @@ the arguments are omitted, we call this a _partial configuration_.
 With a partial configuration, the remaining configuration arguments must be
 provided as part of [the initialization process](/terraform/cli/init).
 
+~> **Note:** Do not put backend settings only in `terraform.tfvars` or
+  `*.auto.tfvars`. Those files are for [input variables](/terraform/language/values/variables),
+  not backend configuration. Backend arguments must live in a `terraform`
+  `backend` block and/or be supplied with `-backend-config` during
+  `terraform init`. Also avoid naming a `-backend-config` file
+  `terraform.tfvars`—use a distinct name such as `backend.hcl` or
+  `state.config` so it is not confused with variable files.
+
+
 There are several ways to supply the remaining arguments:
 
 - **File**: A configuration file may be specified via the `init` command line.

--- a/content/terraform/v1.12.x/docs/language/backend/index.mdx
+++ b/content/terraform/v1.12.x/docs/language/backend/index.mdx
@@ -107,6 +107,15 @@ the arguments are omitted, we call this a _partial configuration_.
 With a partial configuration, the remaining configuration arguments must be
 provided as part of [the initialization process](/terraform/cli/init).
 
+~> **Note:** Do not put backend settings only in `terraform.tfvars` or
+  `*.auto.tfvars`. Those files are for [input variables](/terraform/language/values/variables),
+  not backend configuration. Backend arguments must live in a `terraform`
+  `backend` block and/or be supplied with `-backend-config` during
+  `terraform init`. Also avoid naming a `-backend-config` file
+  `terraform.tfvars`—use a distinct name such as `backend.hcl` or
+  `state.config` so it is not confused with variable files.
+
+
 There are several ways to supply the remaining arguments:
 
 - **File**: A configuration file may be specified via the `init` command line.

--- a/content/terraform/v1.13.x/docs/language/backend/index.mdx
+++ b/content/terraform/v1.13.x/docs/language/backend/index.mdx
@@ -107,6 +107,15 @@ the arguments are omitted, we call this a _partial configuration_.
 With a partial configuration, the remaining configuration arguments must be
 provided as part of [the initialization process](/terraform/cli/init).
 
+~> **Note:** Do not put backend settings only in `terraform.tfvars` or
+  `*.auto.tfvars`. Those files are for [input variables](/terraform/language/values/variables),
+  not backend configuration. Backend arguments must live in a `terraform`
+  `backend` block and/or be supplied with `-backend-config` during
+  `terraform init`. Also avoid naming a `-backend-config` file
+  `terraform.tfvars`—use a distinct name such as `backend.hcl` or
+  `state.config` so it is not confused with variable files.
+
+
 There are several ways to supply the remaining arguments:
 
 - **File**: A configuration file may be specified via the `init` command line.

--- a/content/terraform/v1.14.x/docs/language/backend/index.mdx
+++ b/content/terraform/v1.14.x/docs/language/backend/index.mdx
@@ -107,6 +107,15 @@ the arguments are omitted, we call this a _partial configuration_.
 With a partial configuration, the remaining configuration arguments must be
 provided as part of [the initialization process](/terraform/cli/init).
 
+~> **Note:** Do not put backend settings only in `terraform.tfvars` or
+  `*.auto.tfvars`. Those files are for [input variables](/terraform/language/values/variables),
+  not backend configuration. Backend arguments must live in a `terraform`
+  `backend` block and/or be supplied with `-backend-config` during
+  `terraform init`. Also avoid naming a `-backend-config` file
+  `terraform.tfvars`—use a distinct name such as `backend.hcl` or
+  `state.config` so it is not confused with variable files.
+
+
 There are several ways to supply the remaining arguments:
 
 - **File**: A configuration file may be specified via the `init` command line.

--- a/content/terraform/v1.15.x/docs/language/backend/index.mdx
+++ b/content/terraform/v1.15.x/docs/language/backend/index.mdx
@@ -107,6 +107,15 @@ the arguments are omitted, we call this a _partial configuration_.
 With a partial configuration, the remaining configuration arguments must be
 provided as part of [the initialization process](/terraform/cli/init).
 
+~> **Note:** Do not put backend settings only in `terraform.tfvars` or
+  `*.auto.tfvars`. Those files are for [input variables](/terraform/language/values/variables),
+  not backend configuration. Backend arguments must live in a `terraform`
+  `backend` block and/or be supplied with `-backend-config` during
+  `terraform init`. Also avoid naming a `-backend-config` file
+  `terraform.tfvars`—use a distinct name such as `backend.hcl` or
+  `state.config` so it is not confused with variable files.
+
+
 There are several ways to supply the remaining arguments:
 
 - **File**: A configuration file may be specified via the `init` command line.

--- a/content/terraform/v1.16.x (beta)/docs/language/backend/index.mdx
+++ b/content/terraform/v1.16.x (beta)/docs/language/backend/index.mdx
@@ -107,6 +107,15 @@ the arguments are omitted, we call this a _partial configuration_.
 With a partial configuration, the remaining configuration arguments must be
 provided as part of [the initialization process](/terraform/cli/init).
 
+~> **Note:** Do not put backend settings only in `terraform.tfvars` or
+  `*.auto.tfvars`. Those files are for [input variables](/terraform/language/values/variables),
+  not backend configuration. Backend arguments must live in a `terraform`
+  `backend` block and/or be supplied with `-backend-config` during
+  `terraform init`. Also avoid naming a `-backend-config` file
+  `terraform.tfvars`—use a distinct name such as `backend.hcl` or
+  `state.config` so it is not confused with variable files.
+
+
 There are several ways to supply the remaining arguments:
 
 - **File**: A configuration file may be specified via the `init` command line.


### PR DESCRIPTION
Easy to think `terraform.tfvars` can carry backend args (or to pass that filename to `-backend-config`). Variable files are not backend config—call that out under partial configuration and suggest `backend.hcl` / `state.config` instead.

Fixes hashicorp/terraform#38720