### PR TITLE
docs(vault): seal best practices — do not put unseal keys on the CLI

### DIFF
--- a/content/vault/v1.19.x/content/docs/configuration/seal/seal-best-practices.mdx
+++ b/content/vault/v1.19.x/content/docs/configuration/seal/seal-best-practices.mdx
@@ -39,6 +39,7 @@ If this method is employed, the recommendation is to put additional operational 
 - Quarterly unseal drills to make sure all operators can respond.
 - Key shards should be stored in secure locations and further encrypted using personal encryption. Vault provides for this in the [init](/vault/docs/commands/operator/init) command with flags to PGP encrypt the unseal keys and root token.
 - Key holder key access is tied to enterprise user lifecycle management to ensure the process is responsive to staffing changes.
+- When applying a shard, do **not** put the key on the `vault operator unseal` command line (including via shell command substitution). Arguments appear in process listings. Prefer an interactive prompt, or the [unseal HTTP API](/vault/api-docs/system/unseal) for automation. See the [`operator unseal` command](/vault/docs/commands/operator/unseal) docs.
 
 ## Cloud provider
 

--- a/content/vault/v1.20.x/content/docs/configuration/seal/seal-best-practices.mdx
+++ b/content/vault/v1.20.x/content/docs/configuration/seal/seal-best-practices.mdx
@@ -39,6 +39,7 @@ If this method is employed, the recommendation is to put additional operational 
 - Quarterly unseal drills to make sure all operators can respond.
 - Key shards should be stored in secure locations and further encrypted using personal encryption. Vault provides for this in the [init](/vault/docs/commands/operator/init) command with flags to PGP encrypt the unseal keys and root token.
 - Key holder key access is tied to enterprise user lifecycle management to ensure the process is responsive to staffing changes.
+- When applying a shard, do **not** put the key on the `vault operator unseal` command line (including via shell command substitution). Arguments appear in process listings. Prefer an interactive prompt, or the [unseal HTTP API](/vault/api-docs/system/unseal) for automation. See the [`operator unseal` command](/vault/docs/commands/operator/unseal) docs.
 
 ## Cloud provider
 

--- a/content/vault/v1.21.x/content/docs/configuration/seal/seal-best-practices.mdx
+++ b/content/vault/v1.21.x/content/docs/configuration/seal/seal-best-practices.mdx
@@ -39,6 +39,7 @@ If this method is employed, the recommendation is to put additional operational 
 - Quarterly unseal drills to make sure all operators can respond.
 - Key shards should be stored in secure locations and further encrypted using personal encryption. Vault provides for this in the [init](/vault/docs/commands/operator/init) command with flags to PGP encrypt the unseal keys and root token.
 - Key holder key access is tied to enterprise user lifecycle management to ensure the process is responsive to staffing changes.
+- When applying a shard, do **not** put the key on the `vault operator unseal` command line (including via shell command substitution). Arguments appear in process listings. Prefer an interactive prompt, or the [unseal HTTP API](/vault/api-docs/system/unseal) for automation. See the [`operator unseal` command](/vault/docs/commands/operator/unseal) docs.
 
 ## Cloud provider
 

--- a/content/vault/v2.x/content/docs/configuration/seal/seal-best-practices.mdx
+++ b/content/vault/v2.x/content/docs/configuration/seal/seal-best-practices.mdx
@@ -39,6 +39,7 @@ If this method is employed, the recommendation is to put additional operational 
 - Quarterly unseal drills to make sure all operators can respond.
 - Key shards should be stored in secure locations and further encrypted using personal encryption. Vault provides for this in the [init](/vault/docs/commands/operator/init) command with flags to PGP encrypt the unseal keys and root token.
 - Key holder key access is tied to enterprise user lifecycle management to ensure the process is responsive to staffing changes.
+- When applying a shard, do **not** put the key on the `vault operator unseal` command line (including via shell command substitution). Arguments appear in process listings. Prefer an interactive prompt, or the [unseal HTTP API](/vault/api-docs/system/unseal) for automation. See the [`operator unseal` command](/vault/docs/commands/operator/unseal) docs.
 
 ## Cloud provider
 


### PR DESCRIPTION
Sealing best practices mentioned PGP-encrypting shards but not how to apply them safely. Added a bullet under operator overhead: don't put unseal keys on the CLI (argv shows up in `ps`), prefer interactive unseal or the HTTP API.

Related to hashicorp/vault#31138