### PR TITLE
docs(nomad): Windows Docker driver needs Windows containers mode

### DIFF
--- a/content/nomad/v1.10.x/content/docs/deploy/task-driver/docker.mdx
+++ b/content/nomad/v1.10.x/content/docs/deploy/task-driver/docker.mdx
@@ -36,6 +36,14 @@ The `docker` driver implements the following capabilities:
 Nomad requires Docker to be installed and running on the host alongside the
 Nomad agent.
 
+### Windows clients
+
+On Windows hosts, Nomad's Docker driver requires Docker to run in
+**Windows containers** mode. Linux containers mode is not supported for a
+Windows Nomad client. Prefer Linux Nomad clients for Linux images. See the
+[FAQ](/nomad/docs/faq#q-can-nomad-on-windows-run-linux-docker-images).
+
+
 By default Nomad communicates with the Docker daemon using the daemon's Unix
 socket. Nomad will need to be able to read/write to this socket. If you do not
 run Nomad as root, make sure you add the Nomad user to the Docker group so

--- a/content/nomad/v1.10.x/content/docs/deploy/task-driver/docker.mdx
+++ b/content/nomad/v1.10.x/content/docs/deploy/task-driver/docker.mdx
@@ -36,13 +36,6 @@ The `docker` driver implements the following capabilities:
 Nomad requires Docker to be installed and running on the host alongside the
 Nomad agent.
 
-### Windows clients
-
-On Windows hosts, Nomad's Docker driver requires Docker to run in
-**Windows containers** mode. Linux containers mode is not supported for a
-Windows Nomad client. Prefer Linux Nomad clients for Linux images. See the
-[FAQ](/nomad/docs/faq#q-can-nomad-on-windows-run-linux-docker-images).
-
 
 By default Nomad communicates with the Docker daemon using the daemon's Unix
 socket. Nomad will need to be able to read/write to this socket. If you do not
@@ -117,6 +110,8 @@ plugin "docker" {
   }
 }
 ```
+
+On Windows, the Docker driver needs Docker in Windows containers mode. Linux containers mode is not supported for a Windows Nomad client; run Linux images on a Linux client (including a Linux Nomad agent under WSL2). Windows clients should use Windows container images that match the host.
 
 ## Plugin Options
 
@@ -487,8 +482,10 @@ container ids without killing them, or disable it by setting the
 
 ### Docker for Windows
 
-Docker for Windows only supports running Windows containers. Because Docker for
-Windows is relatively new and rapidly evolving you may want to consult the
+Docker for Windows only supports running Windows containers, and Nomad's Docker
+driver on a Windows client expects that mode. Linux images need a Linux Nomad
+client (for example a Linux agent under WSL2). Because Docker for Windows is
+relatively new and rapidly evolving you may want to consult the
 [list of relevant issues on GitHub][winissues].
 
 ## Next steps

--- a/content/nomad/v1.10.x/content/docs/faq.mdx
+++ b/content/nomad/v1.10.x/content/docs/faq.mdx
@@ -100,29 +100,6 @@ machine you will need to use the network interface IP address.
 $ curl http://192.168.0.10:8080
 ```
 
-## Q: Can Nomad on Windows run Linux Docker images?
-
-On a **Windows Nomad client**, the Docker task driver expects the Docker
-engine to be in **Windows containers** mode. If Docker Desktop (or Docker
-Engine) is set to Linux containers, Nomad logs a warning such as
-`Docker is configured with Linux containers; switch to Windows Containers`
-and will not run tasks as intended.
-
-That also means a Windows Nomad agent cannot pull and run typical
-Linux-only images (for example `eclipse-mosquitto`) while Docker is in
-Windows containers mode—you will see manifest errors for `windows/amd64`.
-
-To run Linux container images with Nomad:
-
-- Use a **Linux** Nomad client (Linux VM, bare metal, or WSL2 running a
-  Linux Nomad agent against a Linux Docker engine), or
-- Use Windows container images that match your Windows host when the
-  agent runs on Windows.
-
-Docker Desktop's Linux containers mode is still useful for local Linux
-Nomad agents and networking experiments; see [How to connect to my host
-network when using Docker Desktop](#q-how-to-connect-to-my-host-network-when-using-docker-desktop-windows-and-macos).
-
 
 [consul_dc]: /consul/docs/agent/config/config-files#datacenter
 [consul_fed]: /consul/tutorials/networking/federation-gossip-wan

--- a/content/nomad/v1.10.x/content/docs/faq.mdx
+++ b/content/nomad/v1.10.x/content/docs/faq.mdx
@@ -100,6 +100,30 @@ machine you will need to use the network interface IP address.
 $ curl http://192.168.0.10:8080
 ```
 
+## Q: Can Nomad on Windows run Linux Docker images?
+
+On a **Windows Nomad client**, the Docker task driver expects the Docker
+engine to be in **Windows containers** mode. If Docker Desktop (or Docker
+Engine) is set to Linux containers, Nomad logs a warning such as
+`Docker is configured with Linux containers; switch to Windows Containers`
+and will not run tasks as intended.
+
+That also means a Windows Nomad agent cannot pull and run typical
+Linux-only images (for example `eclipse-mosquitto`) while Docker is in
+Windows containers mode—you will see manifest errors for `windows/amd64`.
+
+To run Linux container images with Nomad:
+
+- Use a **Linux** Nomad client (Linux VM, bare metal, or WSL2 running a
+  Linux Nomad agent against a Linux Docker engine), or
+- Use Windows container images that match your Windows host when the
+  agent runs on Windows.
+
+Docker Desktop's Linux containers mode is still useful for local Linux
+Nomad agents and networking experiments; see [How to connect to my host
+network when using Docker Desktop](#q-how-to-connect-to-my-host-network-when-using-docker-desktop-windows-and-macos).
+
+
 [consul_dc]: /consul/docs/agent/config/config-files#datacenter
 [consul_fed]: /consul/tutorials/networking/federation-gossip-wan
 [nomad_region]: /nomad/docs/configuration#datacenter

--- a/content/nomad/v1.10.x/content/docs/job-declare/task-driver/docker.mdx
+++ b/content/nomad/v1.10.x/content/docs/job-declare/task-driver/docker.mdx
@@ -17,7 +17,9 @@ driver handles downloading containers, mapping ports, and starting, watching,
 and cleaning up after containers.
 
 **Note:** If you are using Docker Desktop for Windows or MacOS, check
-[the FAQ][faq-win-mac].
+[the FAQ][faq-win-mac]. On a **Windows Nomad client**, Docker must run in
+Windows containers mode (Linux images need a Linux Nomad client)—see
+[Can Nomad on Windows run Linux Docker images?](/nomad/docs/faq#q-can-nomad-on-windows-run-linux-docker-images).
 
 Refer to [Configure the Docker task
 driver](/nomad/docs/deploy/task-driver/docker) for capabilities, client

--- a/content/nomad/v1.10.x/content/docs/job-declare/task-driver/docker.mdx
+++ b/content/nomad/v1.10.x/content/docs/job-declare/task-driver/docker.mdx
@@ -17,9 +17,7 @@ driver handles downloading containers, mapping ports, and starting, watching,
 and cleaning up after containers.
 
 **Note:** If you are using Docker Desktop for Windows or MacOS, check
-[the FAQ][faq-win-mac]. On a **Windows Nomad client**, Docker must run in
-Windows containers mode (Linux images need a Linux Nomad client)—see
-[Can Nomad on Windows run Linux Docker images?](/nomad/docs/faq#q-can-nomad-on-windows-run-linux-docker-images).
+[the FAQ][faq-win-mac]. On Windows Nomad clients, Docker must be in Windows containers mode; Linux images need a Linux client.
 
 Refer to [Configure the Docker task
 driver](/nomad/docs/deploy/task-driver/docker) for capabilities, client

--- a/content/nomad/v1.11.x/content/docs/deploy/task-driver/docker.mdx
+++ b/content/nomad/v1.11.x/content/docs/deploy/task-driver/docker.mdx
@@ -36,6 +36,14 @@ The `docker` driver implements the following capabilities:
 Nomad requires Docker to be installed and running on the host alongside the
 Nomad agent.
 
+### Windows clients
+
+On Windows hosts, Nomad's Docker driver requires Docker to run in
+**Windows containers** mode. Linux containers mode is not supported for a
+Windows Nomad client. Prefer Linux Nomad clients for Linux images. See the
+[FAQ](/nomad/docs/faq#q-can-nomad-on-windows-run-linux-docker-images).
+
+
 By default Nomad communicates with the Docker daemon using the daemon's Unix
 socket. Nomad will need to be able to read/write to this socket. If you do not
 run Nomad as root, make sure you add the Nomad user to the Docker group so

--- a/content/nomad/v1.11.x/content/docs/deploy/task-driver/docker.mdx
+++ b/content/nomad/v1.11.x/content/docs/deploy/task-driver/docker.mdx
@@ -36,13 +36,6 @@ The `docker` driver implements the following capabilities:
 Nomad requires Docker to be installed and running on the host alongside the
 Nomad agent.
 
-### Windows clients
-
-On Windows hosts, Nomad's Docker driver requires Docker to run in
-**Windows containers** mode. Linux containers mode is not supported for a
-Windows Nomad client. Prefer Linux Nomad clients for Linux images. See the
-[FAQ](/nomad/docs/faq#q-can-nomad-on-windows-run-linux-docker-images).
-
 
 By default Nomad communicates with the Docker daemon using the daemon's Unix
 socket. Nomad will need to be able to read/write to this socket. If you do not
@@ -117,6 +110,8 @@ plugin "docker" {
   }
 }
 ```
+
+On Windows, the Docker driver needs Docker in Windows containers mode. Linux containers mode is not supported for a Windows Nomad client; run Linux images on a Linux client (including a Linux Nomad agent under WSL2). Windows clients should use Windows container images that match the host.
 
 ## Plugin Options
 
@@ -487,8 +482,10 @@ container ids without killing them, or disable it by setting the
 
 ### Docker for Windows
 
-Docker for Windows only supports running Windows containers. Because Docker for
-Windows is relatively new and rapidly evolving you may want to consult the
+Docker for Windows only supports running Windows containers, and Nomad's Docker
+driver on a Windows client expects that mode. Linux images need a Linux Nomad
+client (for example a Linux agent under WSL2). Because Docker for Windows is
+relatively new and rapidly evolving you may want to consult the
 [list of relevant issues on GitHub][winissues].
 
 ## Next steps

--- a/content/nomad/v1.11.x/content/docs/faq.mdx
+++ b/content/nomad/v1.11.x/content/docs/faq.mdx
@@ -100,29 +100,6 @@ machine you will need to use the network interface IP address.
 $ curl http://192.168.0.10:8080
 ```
 
-## Q: Can Nomad on Windows run Linux Docker images?
-
-On a **Windows Nomad client**, the Docker task driver expects the Docker
-engine to be in **Windows containers** mode. If Docker Desktop (or Docker
-Engine) is set to Linux containers, Nomad logs a warning such as
-`Docker is configured with Linux containers; switch to Windows Containers`
-and will not run tasks as intended.
-
-That also means a Windows Nomad agent cannot pull and run typical
-Linux-only images (for example `eclipse-mosquitto`) while Docker is in
-Windows containers mode—you will see manifest errors for `windows/amd64`.
-
-To run Linux container images with Nomad:
-
-- Use a **Linux** Nomad client (Linux VM, bare metal, or WSL2 running a
-  Linux Nomad agent against a Linux Docker engine), or
-- Use Windows container images that match your Windows host when the
-  agent runs on Windows.
-
-Docker Desktop's Linux containers mode is still useful for local Linux
-Nomad agents and networking experiments; see [How to connect to my host
-network when using Docker Desktop](#q-how-to-connect-to-my-host-network-when-using-docker-desktop-windows-and-macos).
-
 
 [consul_dc]: /consul/docs/agent/config/config-files#datacenter
 [consul_fed]: /consul/tutorials/networking/federation-gossip-wan

--- a/content/nomad/v1.11.x/content/docs/faq.mdx
+++ b/content/nomad/v1.11.x/content/docs/faq.mdx
@@ -100,6 +100,30 @@ machine you will need to use the network interface IP address.
 $ curl http://192.168.0.10:8080
 ```
 
+## Q: Can Nomad on Windows run Linux Docker images?
+
+On a **Windows Nomad client**, the Docker task driver expects the Docker
+engine to be in **Windows containers** mode. If Docker Desktop (or Docker
+Engine) is set to Linux containers, Nomad logs a warning such as
+`Docker is configured with Linux containers; switch to Windows Containers`
+and will not run tasks as intended.
+
+That also means a Windows Nomad agent cannot pull and run typical
+Linux-only images (for example `eclipse-mosquitto`) while Docker is in
+Windows containers mode—you will see manifest errors for `windows/amd64`.
+
+To run Linux container images with Nomad:
+
+- Use a **Linux** Nomad client (Linux VM, bare metal, or WSL2 running a
+  Linux Nomad agent against a Linux Docker engine), or
+- Use Windows container images that match your Windows host when the
+  agent runs on Windows.
+
+Docker Desktop's Linux containers mode is still useful for local Linux
+Nomad agents and networking experiments; see [How to connect to my host
+network when using Docker Desktop](#q-how-to-connect-to-my-host-network-when-using-docker-desktop-windows-and-macos).
+
+
 [consul_dc]: /consul/docs/agent/config/config-files#datacenter
 [consul_fed]: /consul/tutorials/networking/federation-gossip-wan
 [nomad_region]: /nomad/docs/configuration#datacenter

--- a/content/nomad/v1.11.x/content/docs/job-declare/task-driver/docker.mdx
+++ b/content/nomad/v1.11.x/content/docs/job-declare/task-driver/docker.mdx
@@ -17,7 +17,9 @@ driver handles downloading containers, mapping ports, and starting, watching,
 and cleaning up after containers.
 
 **Note:** If you are using Docker Desktop for Windows or MacOS, check
-[the FAQ][faq-win-mac].
+[the FAQ][faq-win-mac]. On a **Windows Nomad client**, Docker must run in
+Windows containers mode (Linux images need a Linux Nomad client)—see
+[Can Nomad on Windows run Linux Docker images?](/nomad/docs/faq#q-can-nomad-on-windows-run-linux-docker-images).
 
 Refer to [Configure the Docker task
 driver](/nomad/docs/deploy/task-driver/docker) for capabilities, client

--- a/content/nomad/v1.11.x/content/docs/job-declare/task-driver/docker.mdx
+++ b/content/nomad/v1.11.x/content/docs/job-declare/task-driver/docker.mdx
@@ -17,9 +17,7 @@ driver handles downloading containers, mapping ports, and starting, watching,
 and cleaning up after containers.
 
 **Note:** If you are using Docker Desktop for Windows or MacOS, check
-[the FAQ][faq-win-mac]. On a **Windows Nomad client**, Docker must run in
-Windows containers mode (Linux images need a Linux Nomad client)—see
-[Can Nomad on Windows run Linux Docker images?](/nomad/docs/faq#q-can-nomad-on-windows-run-linux-docker-images).
+[the FAQ][faq-win-mac]. On Windows Nomad clients, Docker must be in Windows containers mode; Linux images need a Linux client.
 
 Refer to [Configure the Docker task
 driver](/nomad/docs/deploy/task-driver/docker) for capabilities, client

--- a/content/nomad/v2.0.x/content/docs/deploy/task-driver/docker.mdx
+++ b/content/nomad/v2.0.x/content/docs/deploy/task-driver/docker.mdx
@@ -36,6 +36,14 @@ The `docker` driver implements the following capabilities:
 Nomad requires Docker to be installed and running on the host alongside the
 Nomad agent.
 
+### Windows clients
+
+On Windows hosts, Nomad's Docker driver requires Docker to run in
+**Windows containers** mode. Linux containers mode is not supported for a
+Windows Nomad client. Prefer Linux Nomad clients for Linux images. See the
+[FAQ](/nomad/docs/faq#q-can-nomad-on-windows-run-linux-docker-images).
+
+
 By default Nomad communicates with the Docker daemon using the daemon's Unix
 socket. Nomad will need to be able to read/write to this socket. If you do not
 run Nomad as root, make sure you add the Nomad user to the Docker group so

--- a/content/nomad/v2.0.x/content/docs/deploy/task-driver/docker.mdx
+++ b/content/nomad/v2.0.x/content/docs/deploy/task-driver/docker.mdx
@@ -36,13 +36,6 @@ The `docker` driver implements the following capabilities:
 Nomad requires Docker to be installed and running on the host alongside the
 Nomad agent.
 
-### Windows clients
-
-On Windows hosts, Nomad's Docker driver requires Docker to run in
-**Windows containers** mode. Linux containers mode is not supported for a
-Windows Nomad client. Prefer Linux Nomad clients for Linux images. See the
-[FAQ](/nomad/docs/faq#q-can-nomad-on-windows-run-linux-docker-images).
-
 
 By default Nomad communicates with the Docker daemon using the daemon's Unix
 socket. Nomad will need to be able to read/write to this socket. If you do not
@@ -117,6 +110,8 @@ plugin "docker" {
   }
 }
 ```
+
+On Windows, the Docker driver needs Docker in Windows containers mode. Linux containers mode is not supported for a Windows Nomad client; run Linux images on a Linux client (including a Linux Nomad agent under WSL2). Windows clients should use Windows container images that match the host.
 
 ## Plugin Options
 
@@ -487,8 +482,10 @@ container ids without killing them, or disable it by setting the
 
 ### Docker for Windows
 
-Docker for Windows only supports running Windows containers. Because Docker for
-Windows is relatively new and rapidly evolving you may want to consult the
+Docker for Windows only supports running Windows containers, and Nomad's Docker
+driver on a Windows client expects that mode. Linux images need a Linux Nomad
+client (for example a Linux agent under WSL2). Because Docker for Windows is
+relatively new and rapidly evolving you may want to consult the
 [list of relevant issues on GitHub][winissues].
 
 ## Next steps

--- a/content/nomad/v2.0.x/content/docs/faq.mdx
+++ b/content/nomad/v2.0.x/content/docs/faq.mdx
@@ -100,29 +100,6 @@ machine you will need to use the network interface IP address.
 $ curl http://192.168.0.10:8080
 ```
 
-## Q: Can Nomad on Windows run Linux Docker images?
-
-On a **Windows Nomad client**, the Docker task driver expects the Docker
-engine to be in **Windows containers** mode. If Docker Desktop (or Docker
-Engine) is set to Linux containers, Nomad logs a warning such as
-`Docker is configured with Linux containers; switch to Windows Containers`
-and will not run tasks as intended.
-
-That also means a Windows Nomad agent cannot pull and run typical
-Linux-only images (for example `eclipse-mosquitto`) while Docker is in
-Windows containers mode—you will see manifest errors for `windows/amd64`.
-
-To run Linux container images with Nomad:
-
-- Use a **Linux** Nomad client (Linux VM, bare metal, or WSL2 running a
-  Linux Nomad agent against a Linux Docker engine), or
-- Use Windows container images that match your Windows host when the
-  agent runs on Windows.
-
-Docker Desktop's Linux containers mode is still useful for local Linux
-Nomad agents and networking experiments; see [How to connect to my host
-network when using Docker Desktop](#q-how-to-connect-to-my-host-network-when-using-docker-desktop-windows-and-macos).
-
 
 [consul_dc]: /consul/docs/agent/config/config-files#datacenter
 [consul_fed]: /consul/tutorials/networking/federation-gossip-wan

--- a/content/nomad/v2.0.x/content/docs/faq.mdx
+++ b/content/nomad/v2.0.x/content/docs/faq.mdx
@@ -100,6 +100,30 @@ machine you will need to use the network interface IP address.
 $ curl http://192.168.0.10:8080
 ```
 
+## Q: Can Nomad on Windows run Linux Docker images?
+
+On a **Windows Nomad client**, the Docker task driver expects the Docker
+engine to be in **Windows containers** mode. If Docker Desktop (or Docker
+Engine) is set to Linux containers, Nomad logs a warning such as
+`Docker is configured with Linux containers; switch to Windows Containers`
+and will not run tasks as intended.
+
+That also means a Windows Nomad agent cannot pull and run typical
+Linux-only images (for example `eclipse-mosquitto`) while Docker is in
+Windows containers mode—you will see manifest errors for `windows/amd64`.
+
+To run Linux container images with Nomad:
+
+- Use a **Linux** Nomad client (Linux VM, bare metal, or WSL2 running a
+  Linux Nomad agent against a Linux Docker engine), or
+- Use Windows container images that match your Windows host when the
+  agent runs on Windows.
+
+Docker Desktop's Linux containers mode is still useful for local Linux
+Nomad agents and networking experiments; see [How to connect to my host
+network when using Docker Desktop](#q-how-to-connect-to-my-host-network-when-using-docker-desktop-windows-and-macos).
+
+
 [consul_dc]: /consul/docs/agent/config/config-files#datacenter
 [consul_fed]: /consul/tutorials/networking/federation-gossip-wan
 [nomad_region]: /nomad/docs/configuration#datacenter

--- a/content/nomad/v2.0.x/content/docs/job-declare/task-driver/docker.mdx
+++ b/content/nomad/v2.0.x/content/docs/job-declare/task-driver/docker.mdx
@@ -17,7 +17,9 @@ driver handles downloading containers, mapping ports, and starting, watching,
 and cleaning up after containers.
 
 **Note:** If you are using Docker Desktop for Windows or MacOS, check
-[the FAQ][faq-win-mac].
+[the FAQ][faq-win-mac]. On a **Windows Nomad client**, Docker must run in
+Windows containers mode (Linux images need a Linux Nomad client)—see
+[Can Nomad on Windows run Linux Docker images?](/nomad/docs/faq#q-can-nomad-on-windows-run-linux-docker-images).
 
 Refer to [Configure the Docker task
 driver](/nomad/docs/deploy/task-driver/docker) for capabilities, client

--- a/content/nomad/v2.0.x/content/docs/job-declare/task-driver/docker.mdx
+++ b/content/nomad/v2.0.x/content/docs/job-declare/task-driver/docker.mdx
@@ -17,9 +17,7 @@ driver handles downloading containers, mapping ports, and starting, watching,
 and cleaning up after containers.
 
 **Note:** If you are using Docker Desktop for Windows or MacOS, check
-[the FAQ][faq-win-mac]. On a **Windows Nomad client**, Docker must run in
-Windows containers mode (Linux images need a Linux Nomad client)—see
-[Can Nomad on Windows run Linux Docker images?](/nomad/docs/faq#q-can-nomad-on-windows-run-linux-docker-images).
+[the FAQ][faq-win-mac]. On Windows Nomad clients, Docker must be in Windows containers mode; Linux images need a Linux client.
 
 Refer to [Configure the Docker task
 driver](/nomad/docs/deploy/task-driver/docker) for capabilities, client


### PR DESCRIPTION
On Windows, Nomad's Docker driver expects Windows containers mode. Linux containers mode only yields the switch-to-Windows-containers warning, and Windows mode cannot pull Linux-only images. Documented that in the Docker driver client requirements and a FAQ entry.

Fixes hashicorp/nomad#24333