### PR TITLE
docs(nomad): Consul namespaces need Consul Enterprise

### DIFF
--- a/content/nomad/v1.10.x/content/docs/configuration/consul.mdx
+++ b/content/nomad/v1.10.x/content/docs/configuration/consul.mdx
@@ -110,12 +110,12 @@ agents.
 
 - `namespace` `(string: "")` <EnterpriseAlert inline/> - Specifies the [Consul
   namespace](/consul/docs/enterprise/namespaces) used by the Consul
-  integration. **Requires Consul Enterprise** as well as Nomad Enterprise for
-  non-default values. If non-empty, this namespace will be used on all Consul
-  API calls and for Consul service mesh configurations, unless overridden by the
-  job's [`consul.namespace`][] field. In Nomad Community Edition, only the
-  `"default"` namespace is used, so you should omit this field. Setting a
-  non-default namespace against open source Consul returns HTTP 400.
+  integration. Non-default values require Consul Enterprise (and Nomad
+  Enterprise for job-level overrides). If non-empty, this namespace will be used
+  on all Consul API calls and for Consul service mesh configurations, unless
+  overridden by the job's [`consul.namespace`][] field. In Nomad Community
+  Edition, only the `"default"` namespace is used, so you should omit this field.
+
 
 - `ssl` `(bool: false)` - Specifies if the transport scheme should use HTTPS to
   communicate with the Consul agent. Will default to the `CONSUL_HTTP_SSL`

--- a/content/nomad/v1.10.x/content/docs/configuration/consul.mdx
+++ b/content/nomad/v1.10.x/content/docs/configuration/consul.mdx
@@ -110,10 +110,12 @@ agents.
 
 - `namespace` `(string: "")` <EnterpriseAlert inline/> - Specifies the [Consul
   namespace](/consul/docs/enterprise/namespaces) used by the Consul
-  integration. If non-empty, this namespace will be used on all Consul API calls
-  and for Consul service mesh configurations, unless overridden by the job's
-  [`consul.namespace`][] field. In Nomad Community Edition, only the `"default"`
-  namespace is used, so you should omit this field.
+  integration. **Requires Consul Enterprise** as well as Nomad Enterprise for
+  non-default values. If non-empty, this namespace will be used on all Consul
+  API calls and for Consul service mesh configurations, unless overridden by the
+  job's [`consul.namespace`][] field. In Nomad Community Edition, only the
+  `"default"` namespace is used, so you should omit this field. Setting a
+  non-default namespace against open source Consul returns HTTP 400.
 
 - `ssl` `(bool: false)` - Specifies if the transport scheme should use HTTPS to
   communicate with the Consul agent. Will default to the `CONSUL_HTTP_SSL`

--- a/content/nomad/v1.10.x/content/partials/consul-namespaces.mdx
+++ b/content/nomad/v1.10.x/content/partials/consul-namespaces.mdx
@@ -1,17 +1,22 @@
-Nomad provides integration with [Consul Namespaces][consul_namespaces] for
-service registrations specified in `service` blocks and Consul KV reads in
-`template` blocks.
+Nomad can integrate with [Consul Namespaces][consul_namespaces] for service
+registrations specified in `service` blocks and Consul KV reads in `template`
+blocks.
 
-By default, Nomad will not specify a Consul namespace on service registrations
-or KV store reads, which Consul then implicitly resolves to the `"default"`
-namespace.  This default namespace behavior can be modified by setting the
-[`namespace`][consul_agent_namespace] field in the Nomad agent Consul
-configuration block.
+**Consul namespaces are a Consul Enterprise feature.** Open source Consul
+rejects the `ns` query parameter with an error such as `Namespaces are a Consul
+Enterprise feature`. Do not set a non-default Consul namespace unless both Consul
+and Nomad are running Enterprise editions that support it.
 
-For more control over Consul namespaces, Nomad Enterprise supports configuring
-the Consul [namespace][consul_jobspec_namespace] at the group or task level in
-the Nomad job spec as well as the [`-consul-namespace`][consul_run_namespace]
-command line argument for `job run`.
+By default, Nomad does not send a Consul namespace on service registrations or
+KV reads, so Consul uses the `"default"` namespace. On Nomad Enterprise with
+Consul Enterprise, you may set the agent-level
+[`namespace`][consul_agent_namespace] in the Nomad `consul` block. Nomad
+Community Edition always uses the `"default"` Consul namespace—omit the field.
+
+For finer control, Nomad Enterprise also supports configuring the Consul
+[namespace][consul_jobspec_namespace] at the group or task level in the job
+spec, as well as the [`-consul-namespace`][consul_run_namespace] option on
+`job run`.
 
 The Consul namespace used for a set of group or task service registrations
 within a group, as well as `template` KV store access is determined from the

--- a/content/nomad/v1.10.x/content/partials/consul-namespaces.mdx
+++ b/content/nomad/v1.10.x/content/partials/consul-namespaces.mdx
@@ -1,22 +1,20 @@
-Nomad can integrate with [Consul Namespaces][consul_namespaces] for service
-registrations specified in `service` blocks and Consul KV reads in `template`
-blocks.
+Nomad provides integration with [Consul Namespaces][consul_namespaces] for
+service registrations specified in `service` blocks and Consul KV reads in
+`template` blocks.
 
-**Consul namespaces are a Consul Enterprise feature.** Open source Consul
-rejects the `ns` query parameter with an error such as `Namespaces are a Consul
-Enterprise feature`. Do not set a non-default Consul namespace unless both Consul
-and Nomad are running Enterprise editions that support it.
+Consul namespaces require Consul Enterprise. Do not set a non-default Consul
+namespace unless Consul Enterprise is available.
 
-By default, Nomad does not send a Consul namespace on service registrations or
-KV reads, so Consul uses the `"default"` namespace. On Nomad Enterprise with
-Consul Enterprise, you may set the agent-level
-[`namespace`][consul_agent_namespace] in the Nomad `consul` block. Nomad
-Community Edition always uses the `"default"` Consul namespace—omit the field.
+By default, Nomad will not specify a Consul namespace on service registrations
+or KV store reads, which Consul then implicitly resolves to the `"default"`
+namespace.  This default namespace behavior can be modified by setting the
+[`namespace`][consul_agent_namespace] field in the Nomad agent Consul
+configuration block.
 
-For finer control, Nomad Enterprise also supports configuring the Consul
-[namespace][consul_jobspec_namespace] at the group or task level in the job
-spec, as well as the [`-consul-namespace`][consul_run_namespace] option on
-`job run`.
+For more control over Consul namespaces, Nomad Enterprise supports configuring
+the Consul [namespace][consul_jobspec_namespace] at the group or task level in
+the Nomad job spec as well as the [`-consul-namespace`][consul_run_namespace]
+command line argument for `job run`.
 
 The Consul namespace used for a set of group or task service registrations
 within a group, as well as `template` KV store access is determined from the

--- a/content/nomad/v1.11.x/content/docs/configuration/consul.mdx
+++ b/content/nomad/v1.11.x/content/docs/configuration/consul.mdx
@@ -110,12 +110,12 @@ agents.
 
 - `namespace` `(string: "")` <EnterpriseAlert inline/> - Specifies the [Consul
   namespace](/consul/docs/enterprise/namespaces) used by the Consul
-  integration. **Requires Consul Enterprise** as well as Nomad Enterprise for
-  non-default values. If non-empty, this namespace will be used on all Consul
-  API calls and for Consul service mesh configurations, unless overridden by the
-  job's [`consul.namespace`][] field. In Nomad Community Edition, only the
-  `"default"` namespace is used, so you should omit this field. Setting a
-  non-default namespace against open source Consul returns HTTP 400.
+  integration. Non-default values require Consul Enterprise (and Nomad
+  Enterprise for job-level overrides). If non-empty, this namespace will be used
+  on all Consul API calls and for Consul service mesh configurations, unless
+  overridden by the job's [`consul.namespace`][] field. In Nomad Community
+  Edition, only the `"default"` namespace is used, so you should omit this field.
+
 
 - `ssl` `(bool: false)` - Specifies if the transport scheme should use HTTPS to
   communicate with the Consul agent. Will default to the `CONSUL_HTTP_SSL`

--- a/content/nomad/v1.11.x/content/docs/configuration/consul.mdx
+++ b/content/nomad/v1.11.x/content/docs/configuration/consul.mdx
@@ -110,10 +110,12 @@ agents.
 
 - `namespace` `(string: "")` <EnterpriseAlert inline/> - Specifies the [Consul
   namespace](/consul/docs/enterprise/namespaces) used by the Consul
-  integration. If non-empty, this namespace will be used on all Consul API calls
-  and for Consul service mesh configurations, unless overridden by the job's
-  [`consul.namespace`][] field. In Nomad Community Edition, only the `"default"`
-  namespace is used, so you should omit this field.
+  integration. **Requires Consul Enterprise** as well as Nomad Enterprise for
+  non-default values. If non-empty, this namespace will be used on all Consul
+  API calls and for Consul service mesh configurations, unless overridden by the
+  job's [`consul.namespace`][] field. In Nomad Community Edition, only the
+  `"default"` namespace is used, so you should omit this field. Setting a
+  non-default namespace against open source Consul returns HTTP 400.
 
 - `ssl` `(bool: false)` - Specifies if the transport scheme should use HTTPS to
   communicate with the Consul agent. Will default to the `CONSUL_HTTP_SSL`

--- a/content/nomad/v1.11.x/content/partials/consul-namespaces.mdx
+++ b/content/nomad/v1.11.x/content/partials/consul-namespaces.mdx
@@ -1,17 +1,22 @@
-Nomad provides integration with [Consul Namespaces][consul_namespaces] for
-service registrations specified in `service` blocks and Consul KV reads in
-`template` blocks.
+Nomad can integrate with [Consul Namespaces][consul_namespaces] for service
+registrations specified in `service` blocks and Consul KV reads in `template`
+blocks.
 
-By default, Nomad will not specify a Consul namespace on service registrations
-or KV store reads, which Consul then implicitly resolves to the `"default"`
-namespace.  This default namespace behavior can be modified by setting the
-[`namespace`][consul_agent_namespace] field in the Nomad agent Consul
-configuration block.
+**Consul namespaces are a Consul Enterprise feature.** Open source Consul
+rejects the `ns` query parameter with an error such as `Namespaces are a Consul
+Enterprise feature`. Do not set a non-default Consul namespace unless both Consul
+and Nomad are running Enterprise editions that support it.
 
-For more control over Consul namespaces, Nomad Enterprise supports configuring
-the Consul [namespace][consul_jobspec_namespace] at the group or task level in
-the Nomad job spec as well as the [`-consul-namespace`][consul_run_namespace]
-command line argument for `job run`.
+By default, Nomad does not send a Consul namespace on service registrations or
+KV reads, so Consul uses the `"default"` namespace. On Nomad Enterprise with
+Consul Enterprise, you may set the agent-level
+[`namespace`][consul_agent_namespace] in the Nomad `consul` block. Nomad
+Community Edition always uses the `"default"` Consul namespace—omit the field.
+
+For finer control, Nomad Enterprise also supports configuring the Consul
+[namespace][consul_jobspec_namespace] at the group or task level in the job
+spec, as well as the [`-consul-namespace`][consul_run_namespace] option on
+`job run`.
 
 The Consul namespace used for a set of group or task service registrations
 within a group, as well as `template` KV store access is determined from the

--- a/content/nomad/v1.11.x/content/partials/consul-namespaces.mdx
+++ b/content/nomad/v1.11.x/content/partials/consul-namespaces.mdx
@@ -1,22 +1,20 @@
-Nomad can integrate with [Consul Namespaces][consul_namespaces] for service
-registrations specified in `service` blocks and Consul KV reads in `template`
-blocks.
+Nomad provides integration with [Consul Namespaces][consul_namespaces] for
+service registrations specified in `service` blocks and Consul KV reads in
+`template` blocks.
 
-**Consul namespaces are a Consul Enterprise feature.** Open source Consul
-rejects the `ns` query parameter with an error such as `Namespaces are a Consul
-Enterprise feature`. Do not set a non-default Consul namespace unless both Consul
-and Nomad are running Enterprise editions that support it.
+Consul namespaces require Consul Enterprise. Do not set a non-default Consul
+namespace unless Consul Enterprise is available.
 
-By default, Nomad does not send a Consul namespace on service registrations or
-KV reads, so Consul uses the `"default"` namespace. On Nomad Enterprise with
-Consul Enterprise, you may set the agent-level
-[`namespace`][consul_agent_namespace] in the Nomad `consul` block. Nomad
-Community Edition always uses the `"default"` Consul namespace—omit the field.
+By default, Nomad will not specify a Consul namespace on service registrations
+or KV store reads, which Consul then implicitly resolves to the `"default"`
+namespace.  This default namespace behavior can be modified by setting the
+[`namespace`][consul_agent_namespace] field in the Nomad agent Consul
+configuration block.
 
-For finer control, Nomad Enterprise also supports configuring the Consul
-[namespace][consul_jobspec_namespace] at the group or task level in the job
-spec, as well as the [`-consul-namespace`][consul_run_namespace] option on
-`job run`.
+For more control over Consul namespaces, Nomad Enterprise supports configuring
+the Consul [namespace][consul_jobspec_namespace] at the group or task level in
+the Nomad job spec as well as the [`-consul-namespace`][consul_run_namespace]
+command line argument for `job run`.
 
 The Consul namespace used for a set of group or task service registrations
 within a group, as well as `template` KV store access is determined from the

--- a/content/nomad/v2.0.x/content/docs/configuration/consul.mdx
+++ b/content/nomad/v2.0.x/content/docs/configuration/consul.mdx
@@ -110,12 +110,12 @@ agents.
 
 - `namespace` `(string: "")` <EnterpriseAlert inline/> - Specifies the [Consul
   namespace](/consul/docs/enterprise/namespaces) used by the Consul
-  integration. **Requires Consul Enterprise** as well as Nomad Enterprise for
-  non-default values. If non-empty, this namespace will be used on all Consul
-  API calls and for Consul service mesh configurations, unless overridden by the
-  job's [`consul.namespace`][] field. In Nomad Community Edition, only the
-  `"default"` namespace is used, so you should omit this field. Setting a
-  non-default namespace against open source Consul returns HTTP 400.
+  integration. Non-default values require Consul Enterprise (and Nomad
+  Enterprise for job-level overrides). If non-empty, this namespace will be used
+  on all Consul API calls and for Consul service mesh configurations, unless
+  overridden by the job's [`consul.namespace`][] field. In Nomad Community
+  Edition, only the `"default"` namespace is used, so you should omit this field.
+
 
 - `ssl` `(bool: false)` - Specifies if the transport scheme should use HTTPS to
   communicate with the Consul agent. Will default to the `CONSUL_HTTP_SSL`

--- a/content/nomad/v2.0.x/content/docs/configuration/consul.mdx
+++ b/content/nomad/v2.0.x/content/docs/configuration/consul.mdx
@@ -110,10 +110,12 @@ agents.
 
 - `namespace` `(string: "")` <EnterpriseAlert inline/> - Specifies the [Consul
   namespace](/consul/docs/enterprise/namespaces) used by the Consul
-  integration. If non-empty, this namespace will be used on all Consul API calls
-  and for Consul service mesh configurations, unless overridden by the job's
-  [`consul.namespace`][] field. In Nomad Community Edition, only the `"default"`
-  namespace is used, so you should omit this field.
+  integration. **Requires Consul Enterprise** as well as Nomad Enterprise for
+  non-default values. If non-empty, this namespace will be used on all Consul
+  API calls and for Consul service mesh configurations, unless overridden by the
+  job's [`consul.namespace`][] field. In Nomad Community Edition, only the
+  `"default"` namespace is used, so you should omit this field. Setting a
+  non-default namespace against open source Consul returns HTTP 400.
 
 - `ssl` `(bool: false)` - Specifies if the transport scheme should use HTTPS to
   communicate with the Consul agent. Will default to the `CONSUL_HTTP_SSL`

--- a/content/nomad/v2.0.x/content/partials/consul-namespaces.mdx
+++ b/content/nomad/v2.0.x/content/partials/consul-namespaces.mdx
@@ -1,17 +1,22 @@
-Nomad provides integration with [Consul Namespaces][consul_namespaces] for
-service registrations specified in `service` blocks and Consul KV reads in
-`template` blocks.
+Nomad can integrate with [Consul Namespaces][consul_namespaces] for service
+registrations specified in `service` blocks and Consul KV reads in `template`
+blocks.
 
-By default, Nomad will not specify a Consul namespace on service registrations
-or KV store reads, which Consul then implicitly resolves to the `"default"`
-namespace.  This default namespace behavior can be modified by setting the
-[`namespace`][consul_agent_namespace] field in the Nomad agent Consul
-configuration block.
+**Consul namespaces are a Consul Enterprise feature.** Open source Consul
+rejects the `ns` query parameter with an error such as `Namespaces are a Consul
+Enterprise feature`. Do not set a non-default Consul namespace unless both Consul
+and Nomad are running Enterprise editions that support it.
 
-For more control over Consul namespaces, Nomad Enterprise supports configuring
-the Consul [namespace][consul_jobspec_namespace] at the group or task level in
-the Nomad job spec as well as the [`-consul-namespace`][consul_run_namespace]
-command line argument for `job run`.
+By default, Nomad does not send a Consul namespace on service registrations or
+KV reads, so Consul uses the `"default"` namespace. On Nomad Enterprise with
+Consul Enterprise, you may set the agent-level
+[`namespace`][consul_agent_namespace] in the Nomad `consul` block. Nomad
+Community Edition always uses the `"default"` Consul namespace—omit the field.
+
+For finer control, Nomad Enterprise also supports configuring the Consul
+[namespace][consul_jobspec_namespace] at the group or task level in the job
+spec, as well as the [`-consul-namespace`][consul_run_namespace] option on
+`job run`.
 
 The Consul namespace used for a set of group or task service registrations
 within a group, as well as `template` KV store access is determined from the

--- a/content/nomad/v2.0.x/content/partials/consul-namespaces.mdx
+++ b/content/nomad/v2.0.x/content/partials/consul-namespaces.mdx
@@ -1,22 +1,20 @@
-Nomad can integrate with [Consul Namespaces][consul_namespaces] for service
-registrations specified in `service` blocks and Consul KV reads in `template`
-blocks.
+Nomad provides integration with [Consul Namespaces][consul_namespaces] for
+service registrations specified in `service` blocks and Consul KV reads in
+`template` blocks.
 
-**Consul namespaces are a Consul Enterprise feature.** Open source Consul
-rejects the `ns` query parameter with an error such as `Namespaces are a Consul
-Enterprise feature`. Do not set a non-default Consul namespace unless both Consul
-and Nomad are running Enterprise editions that support it.
+Consul namespaces require Consul Enterprise. Do not set a non-default Consul
+namespace unless Consul Enterprise is available.
 
-By default, Nomad does not send a Consul namespace on service registrations or
-KV reads, so Consul uses the `"default"` namespace. On Nomad Enterprise with
-Consul Enterprise, you may set the agent-level
-[`namespace`][consul_agent_namespace] in the Nomad `consul` block. Nomad
-Community Edition always uses the `"default"` Consul namespace—omit the field.
+By default, Nomad will not specify a Consul namespace on service registrations
+or KV store reads, which Consul then implicitly resolves to the `"default"`
+namespace.  This default namespace behavior can be modified by setting the
+[`namespace`][consul_agent_namespace] field in the Nomad agent Consul
+configuration block.
 
-For finer control, Nomad Enterprise also supports configuring the Consul
-[namespace][consul_jobspec_namespace] at the group or task level in the job
-spec, as well as the [`-consul-namespace`][consul_run_namespace] option on
-`job run`.
+For more control over Consul namespaces, Nomad Enterprise supports configuring
+the Consul [namespace][consul_jobspec_namespace] at the group or task level in
+the Nomad job spec as well as the [`-consul-namespace`][consul_run_namespace]
+command line argument for `job run`.
 
 The Consul namespace used for a set of group or task service registrations
 within a group, as well as `template` KV store access is determined from the


### PR DESCRIPTION
Setting `consul.namespace` against open source Consul returns HTTP 400 (`Namespaces are a Consul Enterprise feature`). Docs already marked Nomad Enterprise in places but read as if agent-level namespace always works. Clarified that non-default namespaces need Consul Enterprise too, and that CE Nomad stays on `default`.

Fixes hashicorp/consul#17610