### PR TITLE
docs(nomad): clarify job ID uniqueness vs optional name

### DIFF
--- a/content/nomad/v1.10.x/content/docs/job-specification/job.mdx
+++ b/content/nomad/v1.10.x/content/docs/job-specification/job.mdx
@@ -17,7 +17,7 @@ last_modified: 2025-10-10T11:41:43-05:00
 The `job` block is the top-most configuration option in the job specification.
 A job is a declarative specification of tasks that Nomad should run. Jobs have
 one or more task groups, which are themselves collections of one or more tasks.
-Job names are unique per [region][region] or [namespace][namespace].
+Job IDs are unique per [region][region] or [namespace][namespace].
 
 ```hcl
 job "docs" {

--- a/content/nomad/v1.11.x/content/docs/job-specification/job.mdx
+++ b/content/nomad/v1.11.x/content/docs/job-specification/job.mdx
@@ -17,7 +17,7 @@ last_modified: 2026-02-09T15:13:53-06:00
 The `job` block is the top-most configuration option in the job specification.
 A job is a declarative specification of tasks that Nomad should run. Jobs have
 one or more task groups, which are themselves collections of one or more tasks.
-Job names are unique per [region][region] or [namespace][namespace].
+The label in `job "…"` is the **job ID**. Job IDs are unique per [namespace][namespace] within a [region][region]. The optional [`name`](#name) parameter is only a display name (it defaults to the job ID); different jobs may share the same `name` as long as their job IDs differ.
 
 ```hcl
 job "docs" {

--- a/content/nomad/v1.11.x/content/docs/job-specification/job.mdx
+++ b/content/nomad/v1.11.x/content/docs/job-specification/job.mdx
@@ -17,7 +17,7 @@ last_modified: 2026-02-09T15:13:53-06:00
 The `job` block is the top-most configuration option in the job specification.
 A job is a declarative specification of tasks that Nomad should run. Jobs have
 one or more task groups, which are themselves collections of one or more tasks.
-The label in `job "…"` is the **job ID**. Job IDs are unique per [namespace][namespace] within a [region][region]. The optional [`name`](#name) parameter is only a display name (it defaults to the job ID); different jobs may share the same `name` as long as their job IDs differ.
+Job IDs are unique per [region][region] or [namespace][namespace].
 
 ```hcl
 job "docs" {

--- a/content/nomad/v2.0.x/content/docs/job-specification/job.mdx
+++ b/content/nomad/v2.0.x/content/docs/job-specification/job.mdx
@@ -17,7 +17,7 @@ last_modified: 2026-02-16T16:53:52.000Z
 The `job` block is the top-most configuration option in the job specification.
 A job is a declarative specification of tasks that Nomad should run. Jobs have
 one or more task groups, which are themselves collections of one or more tasks.
-Job names are unique per [region][region] or [namespace][namespace].
+The label in `job "…"` is the **job ID**. Job IDs are unique per [namespace][namespace] within a [region][region]. The optional [`name`](#name) parameter is only a display name (it defaults to the job ID); different jobs may share the same `name` as long as their job IDs differ.
 
 ```hcl
 job "docs" {

--- a/content/nomad/v2.0.x/content/docs/job-specification/job.mdx
+++ b/content/nomad/v2.0.x/content/docs/job-specification/job.mdx
@@ -17,7 +17,7 @@ last_modified: 2026-02-16T16:53:52.000Z
 The `job` block is the top-most configuration option in the job specification.
 A job is a declarative specification of tasks that Nomad should run. Jobs have
 one or more task groups, which are themselves collections of one or more tasks.
-The label in `job "…"` is the **job ID**. Job IDs are unique per [namespace][namespace] within a [region][region]. The optional [`name`](#name) parameter is only a display name (it defaults to the job ID); different jobs may share the same `name` as long as their job IDs differ.
+Job IDs are unique per [region][region] or [namespace][namespace].
 
 ```hcl
 job "docs" {


### PR DESCRIPTION
The intro on the job block page said job *names* are unique per region/namespace. That mixes up the job ID (`job "…"`) with the optional `name` field.

Job IDs are what must be unique. `name` is just a display string and can be the same on different jobs.

Fixes hashicorp/nomad#20149