### PR TITLE
docs(nomad): explain 4647 RPC vs 4648 Serf for cluster join

### DIFF
--- a/content/nomad/v1.11.x/content/docs/deploy/clusters/connect-nodes.mdx
+++ b/content/nomad/v1.11.x/content/docs/deploy/clusters/connect-nodes.mdx
@@ -47,7 +47,7 @@ server {
   enabled          = true
   bootstrap_expect = 3
 
-  # This is the IP address of the first server provisioned
+  # First server address; :4648 is the Serf (gossip) port for server membership
   server_join {
     retry_join = ["<known-address>:4648"]
   }
@@ -81,13 +81,23 @@ The client node's server list can be updated at run time using the
 $ nomad node config -update-servers <IP>:4647
 ```
 
-The port corresponds to the RPC port. If no port is specified with the IP
-address, the default RPC port of `4647` is assumed.
+Servers and clients use different default ports when joining:
 
-As servers are added or removed from the cluster, this information is pushed to
-the client. This means only one server must be specified because, after initial
-contact, the full set of servers in the client's region are shared with the
-client.
+- **Server-to-server** `retry_join` / `nomad server join` uses Nomad's
+  [Serf](/nomad/docs/configuration#ports) (gossip) port, default **`4648`**
+  (`ports.serf`). That is how servers form membership with each other.
+- **Client-to-server** `retry_join` / `nomad node config -update-servers` uses
+  the [RPC](/nomad/docs/configuration#ports) port, default **`4647`**
+  (`ports.rpc`). Clients talk to servers over RPC, not Serf.
+
+If you omit the port on a client join address, Nomad assumes `4647`. On
+server join addresses the default is `4648` (see
+[`server_join`](/nomad/docs/configuration/server_join)).
+
+`retry_join` is always a list so you can seed more than one address for
+resilience. Clients still only need one working server: after the first
+successful contact, Nomad pushes the full set of servers in the client's
+region as members are added or removed.
 
 ## Use cloud auto-join
 

--- a/content/nomad/v2.0.x/content/docs/deploy/clusters/connect-nodes.mdx
+++ b/content/nomad/v2.0.x/content/docs/deploy/clusters/connect-nodes.mdx
@@ -47,7 +47,7 @@ server {
   enabled          = true
   bootstrap_expect = 3
 
-  # This is the IP address of the first server provisioned
+  # First server address; :4648 is the Serf (gossip) port for server membership
   server_join {
     retry_join = ["<known-address>:4648"]
   }
@@ -82,13 +82,23 @@ The client node's server list can be updated at run time using the
 $ nomad node config -update-servers <IP>:4647
 ```
 
-The port corresponds to the RPC port. If no port is specified with the IP
-address, the default RPC port of `4647` is assumed.
+Servers and clients use different default ports when joining:
 
-As servers are added or removed from the cluster, this information is pushed to
-the client. This means only one server must be specified because, after initial
-contact, the full set of servers in the client's region are shared with the
-client.
+- **Server-to-server** `retry_join` / `nomad server join` uses Nomad's
+  [Serf](/nomad/docs/configuration#ports) (gossip) port, default **`4648`**
+  (`ports.serf`). That is how servers form membership with each other.
+- **Client-to-server** `retry_join` / `nomad node config -update-servers` uses
+  the [RPC](/nomad/docs/configuration#ports) port, default **`4647`**
+  (`ports.rpc`). Clients talk to servers over RPC, not Serf.
+
+If you omit the port on a client join address, Nomad assumes `4647`. On
+server join addresses the default is `4648` (see
+[`server_join`](/nomad/docs/configuration/server_join)).
+
+`retry_join` is always a list so you can seed more than one address for
+resilience. Clients still only need one working server: after the first
+successful contact, Nomad pushes the full set of servers in the client's
+region as members are added or removed.
 
 ## Use cloud auto-join
 


### PR DESCRIPTION
The manual clustering page showed servers on `:4648` and clients on `:4647` without saying why, and the “RPC port” note only covered the client path. Also clarified that `retry_join` is a list (multiple seeds ok) even though one working server is enough for clients.

Fixes hashicorp/nomad#20119