### PR TITLE
docs(nomad): clarify job dispatch takes a registered job ID

### DIFF
--- a/content/nomad/v1.10.x/content/commands/job/dispatch.mdx
+++ b/content/nomad/v1.10.x/content/commands/job/dispatch.mdx
@@ -27,10 +27,22 @@ programming languages.
 nomad job dispatch [options] <parameterized job> [input source]
 ```
 
-Dispatch creates an instance of a parameterized job. A data payload to the
-dispatched instance can be provided via stdin by using "-" for the input source
-or by specifying a path to a file. Metadata can be supplied by using the meta
-flag one or more times.
+`<parameterized job>` is the job ID of a parameterized job already
+registered with Nomad (not a path to a job file). Register it first with
+`nomad job run`, then dispatch:
+
+```shell-session
+$ nomad job run example.nomad.hcl
+==> 2024-01-02T03:04:05Z: Monitoring evaluation "abcd1234"
+...
+$ nomad job dispatch example
+==> 2024-01-02T03:04:10Z: Monitoring evaluation "efgh5678"
+...
+```
+
+A data payload to the dispatched instance can be provided via stdin by using
+"-" for the input source or by specifying a path to a file. Metadata can be
+supplied by using the meta flag one or more times.
 
 The payload has a **size limit of 16384 bytes (16KiB)**.
 

--- a/content/nomad/v1.11.x/content/commands/job/dispatch.mdx
+++ b/content/nomad/v1.11.x/content/commands/job/dispatch.mdx
@@ -27,11 +27,18 @@ programming languages.
 nomad job dispatch [options] <parameterized job> [input source]
 ```
 
-`<parameterized job>` is the **job ID** of a parameterized job already
-registered in Nomad (the string in `job "…"`), not a path to a job file.
-Register the parent job first with [`nomad job run`](/nomad/commands/job/run)
-(or the equivalent API). Dispatch only creates instances of that registered
-job; it does not submit a new job specification from disk.
+`<parameterized job>` is the job ID of a parameterized job already
+registered with Nomad (not a path to a job file). Register it first with
+`nomad job run`, then dispatch:
+
+```shell-session
+$ nomad job run example.nomad.hcl
+==> 2024-01-02T03:04:05Z: Monitoring evaluation "abcd1234"
+...
+$ nomad job dispatch example
+==> 2024-01-02T03:04:10Z: Monitoring evaluation "efgh5678"
+...
+```
 
 A data payload to the dispatched instance can be provided via stdin by using
 "-" for the input source or by specifying a path to a file. Metadata can be

--- a/content/nomad/v1.11.x/content/commands/job/dispatch.mdx
+++ b/content/nomad/v1.11.x/content/commands/job/dispatch.mdx
@@ -27,10 +27,15 @@ programming languages.
 nomad job dispatch [options] <parameterized job> [input source]
 ```
 
-Dispatch creates an instance of a parameterized job. A data payload to the
-dispatched instance can be provided via stdin by using "-" for the input source
-or by specifying a path to a file. Metadata can be supplied by using the meta
-flag one or more times.
+`<parameterized job>` is the **job ID** of a parameterized job already
+registered in Nomad (the string in `job "…"`), not a path to a job file.
+Register the parent job first with [`nomad job run`](/nomad/commands/job/run)
+(or the equivalent API). Dispatch only creates instances of that registered
+job; it does not submit a new job specification from disk.
+
+A data payload to the dispatched instance can be provided via stdin by using
+"-" for the input source or by specifying a path to a file. Metadata can be
+supplied by using the meta flag one or more times.
 
 The payload has a **size limit of 16384 bytes (16KiB)**.
 

--- a/content/nomad/v2.0.x/content/commands/job/dispatch.mdx
+++ b/content/nomad/v2.0.x/content/commands/job/dispatch.mdx
@@ -27,11 +27,18 @@ programming languages.
 nomad job dispatch [options] <parameterized job> [input source]
 ```
 
-`<parameterized job>` is the **job ID** of a parameterized job already
-registered in Nomad (the string in `job "…"`), not a path to a job file.
-Register the parent job first with [`nomad job run`](/nomad/commands/job/run)
-(or the equivalent API). Dispatch only creates instances of that registered
-job; it does not submit a new job specification from disk.
+`<parameterized job>` is the job ID of a parameterized job already
+registered with Nomad (not a path to a job file). Register it first with
+`nomad job run`, then dispatch:
+
+```shell-session
+$ nomad job run example.nomad.hcl
+==> 2024-01-02T03:04:05Z: Monitoring evaluation "abcd1234"
+...
+$ nomad job dispatch example
+==> 2024-01-02T03:04:10Z: Monitoring evaluation "efgh5678"
+...
+```
 
 A data payload to the dispatched instance can be provided via stdin by using
 "-" for the input source or by specifying a path to a file. Metadata can be

--- a/content/nomad/v2.0.x/content/commands/job/dispatch.mdx
+++ b/content/nomad/v2.0.x/content/commands/job/dispatch.mdx
@@ -27,10 +27,15 @@ programming languages.
 nomad job dispatch [options] <parameterized job> [input source]
 ```
 
-Dispatch creates an instance of a parameterized job. A data payload to the
-dispatched instance can be provided via stdin by using "-" for the input source
-or by specifying a path to a file. Metadata can be supplied by using the meta
-flag one or more times.
+`<parameterized job>` is the **job ID** of a parameterized job already
+registered in Nomad (the string in `job "…"`), not a path to a job file.
+Register the parent job first with [`nomad job run`](/nomad/commands/job/run)
+(or the equivalent API). Dispatch only creates instances of that registered
+job; it does not submit a new job specification from disk.
+
+A data payload to the dispatched instance can be provided via stdin by using
+"-" for the input source or by specifying a path to a file. Metadata can be
+supplied by using the meta flag one or more times.
 
 The payload has a **size limit of 16384 bytes (16KiB)**.
 


### PR DESCRIPTION
The dispatch page already used job IDs in the examples, but the usage blurb still read like you might pass a job file. Spelled out that the argument is the registered parameterized job ID and you need `nomad job run` (or the API) first.

Fixes hashicorp/nomad#16052