### PR TITLE
HVD: Update control workspaces content

### DIFF
--- a/content/validated-designs/docs/docs/terraform/administration-guide/introduction.mdx
+++ b/content/validated-designs/docs/docs/terraform/administration-guide/introduction.mdx
@@ -15,7 +15,7 @@ last_modified: 2026-07-06T12:00:00.000Z
 
 ## Audience
 
-<!-- EDITORIAL REWRITE (HVD 2.0 migration) — legacy maturity framing removed and operator scope rewritten for the shared Terraform Administration Guide. Please review. -->
+<!-- EDITORIAL REWRITE (HVD 2.0 migration) - legacy maturity framing removed and operator scope rewritten for the shared Terraform Administration Guide. Please review. -->
 
 The Terraform Administration Guide is for platform teams operating HCP Terraform or Terraform Enterprise as a shared service. It assumes the Terraform platform is already available: HCP Terraform is provided by HashiCorp as SaaS, and Terraform Enterprise self-hosted deployments have completed the [Installation Guide](/validated-designs/terraform/installation-guide/introduction).
 

--- a/content/validated-designs/docs/docs/terraform/administration-guide/organizing-resources.mdx
+++ b/content/validated-designs/docs/docs/terraform/administration-guide/organizing-resources.mdx
@@ -68,7 +68,7 @@ The organization in Terraform Enterprise serves as the highest-level construct, 
 
 We recommend centralizing core provisioning work within a single organization in HCP Terraform to ensure efficient provisioning and management.
 
-This approach is compatible with a multi-tenant environment where you have to support multiple business units (BUs) within the same organization. Our robust role-based access control system combined with projects ensures that each BU has its own set of permissions and access levels. Projects enable you to divide workspaces, Stacks, and teams within the organization. We discuss them in more detail below.
+This approach is compatible with a multi-tenant environment where you have to support multiple app teams within the same organization. Our robust role-based access control system combined with projects ensures that each app team has its own set of permissions and access levels. Projects enable you to divide workspaces, Stacks, and teams within the organization. We discuss them in more detail below.
 
 Terraform Enterprise uses workload concurrency to maintain a run queue, and a worker RAM allocation. Consider the following points.
 
@@ -152,9 +152,9 @@ Variations on the proposed delegation model are possible by creating your own cu
 
 When deploying HCP Terraform at scale, a key consideration is the effective organization of your projects to ensure maximum efficiency. Projects are typically allocated to an application team. Variable sets are either assigned at the project level (for example for cost-codes, owners, and support contacts) and at the workspace level depending on requirements.
 
-Automated onboarding is critical for the success of your project. Use either the <a href="https://registry.terraform.io/providers/hashicorp/tfe/latest/docs" target="_blank" rel="noreferrer">HCP Terraform and Terraform Enterprise provider</a> or the HCP Terraform API to automate the creation of the application team project and initial workspaces or Stacks and assign the necessary permissions to the teams (we recommend the former). This ensures that project allocation is consistent at scale. Consider this approach as a landing zone concept. <b>Avoid any manual tasks required to onboard new teams as this results in platform team toil at scale</b>.
+Automated onboarding is critical for the success of your project. Use either the <a href="https://registry.terraform.io/providers/hashicorp/tfe/latest/docs" target="_blank" rel="noreferrer">HCP Terraform and Terraform Enterprise provider</a> or the HCP Terraform API to automate the creation of the app team project and initial workspaces or Stacks and assign the necessary permissions to the teams (we recommend the former). This ensures that project allocation is consistent at scale. Consider this approach as a Terraform Landing Zone (TLZ) concept. <b>Avoid any manual tasks required to onboard new teams as this results in platform team toil at scale</b>.
 
-We recommend assigning separate projects for each application within a business unit. The suggested naming convention for projects is: `<business-unit-name>-<application-name>`.
+We recommend assigning separate projects for each application within an app team. The suggested naming convention for projects is: `<app-team-name>-<application-name>`.
 
 #### Access management and permissions
 
@@ -178,17 +178,17 @@ This separation allows for distinct configurations, variables, and provider sett
 When designing workspaces, it is important to consider the following:
 
 - **Workspace isolation**: Isolate each workspace from other workspaces to prevent unintended changes or disruptions. This isolation ensures that changes made to one workspace do not affect other workspaces.
-- **Workspace naming**: We recommend following a naming convention for workspaces to maintain consistency and clarity. The recommended format, with a maximum of 90 characters, is as follows: `<business-unit>-<app-name>-<layer>-<env>`. By incorporating the business unit, application name, layer, and environment into the workspace name, you can identify and associate workspaces with specific components of your infrastructure.
+- **Workspace naming**: We recommend following a naming convention for workspaces to maintain consistency and clarity. The recommended format, with a maximum of 90 characters, is as follows: `<app-team>-<app-name>-<layer>-<env>`. By incorporating the app team, application name, layer, and environment into the workspace name, you can identify and associate workspaces with specific components of your infrastructure.
 
 #### Naming convention
 
-We recommend following a naming convention for workspaces to maintain consistency and clarity. The recommended format is: `<business-unit>-<app-name>-<layer>-<env>` where:
-- `<business-unit>`: The business unit or team that owns the workspace.
+We recommend following a naming convention for workspaces to maintain consistency and clarity. The recommended format is: `<app-team>-<app-name>-<layer>-<env>` where:
+- `<app-team>`: The app team that owns the workspace.
 - `<app-name>`: The name of the application or service that the workspace manages.
 - `<layer>`: The layer of the infrastructure that the workspace manages (for example `network`, `compute`, `data`, `app`).
 - `<env>`: The environment that the workspace manages (for example `dev`, `test`, `prod`).
 
-By incorporating the business unit, application name, layer, and environment into the workspace name, you can identify and associate workspaces with specific components of your infrastructure. We recommend a maximum of ninety characters but this is not a hard limit.
+By incorporating the app team, application name, layer, and environment into the workspace name, you can identify and associate workspaces with specific components of your infrastructure. We recommend a maximum of ninety characters but this is not a hard limit.
 
 Many application teams do not need the `layer` component in the name as the infrastructure they need for their application is clear. However, to standardize, consider use of the string `main` or `app` in place of the `layer` component as this helps maintain consistency across the organization. This field is also useful for delineation if the team splits into two as your business grows.
 
@@ -284,7 +284,7 @@ Use dynamic provider iteration or separate deployments to manage resources acros
 
 ###### Landing zones
 
-Implement foundational infrastructure (for example networking, identity, policy) as a reusable Stack with consistent configuration across environments or business units.
+Implement foundational infrastructure (for example networking, identity, policy) as a reusable Stack with consistent configuration across environments or app teams.
 
 ###### Multi-region AWS deployments
 

--- a/content/validated-designs/docs/docs/terraform/user-guide/iac-and-cloud-provisioning.mdx
+++ b/content/validated-designs/docs/docs/terraform/user-guide/iac-and-cloud-provisioning.mdx
@@ -13,7 +13,7 @@ HCP Terraform provides you with a robust and efficient cloud provisioning workfl
 
 1. Plan your project, covering installation and configuration of HCP Terraform or Terraform Enterprise, and how you intend to provide self-service capability to your internal customers. The Terraform Administration and User Guides: Standardization HVD details this in more depth. Consideration now of how you onboard, and work with, early adopter teams, and later how to onboard gradually larger groups of teams until the platform is generally available saves a lot of time and effort.
 1. Consider the size and bandwidth of your platform team. Consider what would happen to their workload if any of the onboarding experience of your internal customers was not fully automated.
-1. Plan a landing zone provisioning workflow.
+1. Plan a Terraform Landing Zone provisioning workflow.
 1. Ensure your platform team is fully trained on IaC with Terraform and the cloud provider(s) you are using. Expect all contributors to read, understand, and adhere to the HashiCorp <a href="https://developer.hashicorp.com/terraform/language/style" target="_blank">Terraform language style guide</a>. Use your documentation to guide all developers to write Terraform code that is compliant with this style guide.
 1. Set up a Terraform Stack or workspace with cloud credentials.
 1. Store your Terraform code in your strategic version control system.
@@ -21,13 +21,13 @@ HCP Terraform provides you with a robust and efficient cloud provisioning workfl
 1. Consider the configuration required for HCP Terraform to enable the deployment end-to-end in the context of your organization's security and compliance requirements. Revisit each step in the workflow, and consider the requirements in terms of engineering content and effort, and focus on the manual steps and what you would need to do to automate each step. Also consider what would be necessary in a disaster recovery scenario.
 1. If you intend for your deployment to scale to a large number of teams, ensure to read the respective HVDs in this series.
 
-The landing zone provisioning workflow is a crucial process that you implement for your application or development teams to ensure infrastructure provisioning in the appropriate landing zones. Each cloud platform has its own recommendations for implementing these landing zones, and for Kubernetes-based teams, a Kubernetes namespace can also serve as a component of a landing zone.
+The landing zone provisioning workflow is a crucial process that you implement for your App Teams to ensure infrastructure provisioning in the appropriate landing zones. Each cloud platform has its own recommendations for implementing these landing zones, and for Kubernetes-based teams, a Kubernetes namespace can also serve as a component of a landing zone.
 
-![The cloud landing zone workspace](/img/terraform/operating-guides/adoption/iac-and-cloud-provisioning-cloud-provisioning.jpg "image_tooltip")
+![Cloud provisioning workflow](/img/terraform/operating-guides/adoption/iac-and-cloud-provisioning-cloud-provisioning.jpg "image_tooltip")
 
 To achieve end-to-end cloud provisioning, developers commit Terraform code to the designated repository, triggering a plan in HCP Terraform which uses cloud credentials to complete the plan phase. Once approved, plan/apply the Stack or workspace(s), provisioning the desired resources in the cloud.
 
-The platform team owns and implements a landing zone workflow, partnering the networking, security, and finance teams as necessary, adhering to the guidance provided by the cloud vendors' well-architected framework. Do this before any application teams can initiate infrastructure provisioning in the cloud.
+The Platform Team owns and implements the landing zone provisioning workflow, partnering with the networking, security, and finance teams as necessary, and adhering to the guidance provided by the cloud vendors' well-architected framework. Do this before any App Teams can initiate infrastructure provisioning in the cloud.
 
 ## Landing zones
 
@@ -46,35 +46,43 @@ Major cloud providers offer their own solutions for this approach:
 - Azure Landing Zone Accelerator
 - Cloud Foundation Toolkit for GCP.
 
-Landing zones are commonly deployed _by_ HCP Terraform, but the landing zone concept is also applicable _to_ HCP Terraform. The platform team deploys a control workspace during the onboarding of an internal customer using automation and which is then used to deploy the operational environment needed by that customer to support their development remit. This is akin to the equivalent CSP account and configuration needed by the same team. The recommended way to do this is as follows.
+Landing zones are commonly deployed _by_ HCP Terraform, but the concept is also applicable _to_ HCP Terraform itself. A separate but related construct - the _Terraform Landing Zone (TLZ)_ - defines how the Platform Team structures HCP Terraform or Terraform Enterprise to support App Teams at scale. The TLZ maps the same principles as a cloud landing zone to the platform layer: a standardized, automated environment that every App Team receives when they onboard to Terraform.
 
-- **Complete preparative reading**: Read about cloud landing zone patterns applicable to the cloud service providers with whom you partner.
-- **Define the HCP Terraform landing zone**: There are a number of ways to apply the LZ concept, but core requirements include:
-  - Use of the <a href="https://registry.terraform.io/providers/hashicorp/tfe/latest/docs" target="_blank" rel="noreferrer">Terraform Enterprise provider</a> so that there is state representation for the configuration - this applies to both HCP Terraform and Terraform Enterprise.
-  - Definition of a VCS template which contains boilerplate Terraform code for the LZ and a directory structure designed and managed by the platform team.
-  - Creation of a Terraform module for your private registry - The platform team calls this through its automated onboarding process when an application team wants to onboard. This module nominally creates the following:
-    - A control workspace for the application team.
-    - A VCS repository for the application team to store the code which runs in the control workspace.
-    - Variables/sets as needed for efficient deployment.
-    - Public and private cloud resources for the team to use as necessary.
+### Terraform Landing Zone
+
+The Terraform Landing Zone (TLZ) pattern applies to both HCP Terraform and Terraform Enterprise. The TLZ uses a three-tier hierarchy of workspaces.
+
+![Terraform Landing Zone workspace hierarchy](/img/terraform/operating-guides/adoption/hvd-terraform-oga-control-workspace-hierarchy.svg "Terraform Landing Zone workspace hierarchy")
+
+- **Platform Management workspace** - Owned and operated by the Platform Team. This is the top-level workspace that manages the lifecycle of all control workspaces beneath it. There may be many Platform Management workspaces in an organization, but they are independent of each other; there is no relationship or shared state between separate Platform Management workspaces. The state of a Platform Management workspace contains all the control workspaces it manages.
+- **Control workspace** - The Platform Management workspace vends one control workspace per App Team, using the HCP Terraform and Terraform Enterprise provider. The control workspace holds the Terraform configuration that the App Team (or Platform Team) uses to deploy and manage the App Team's resources. The Platform Team may delegate management of a control workspace to the App Team, or retain it, depending on your governance model.
+- **App workspaces** - The workspaces that hold the App Team's actual cloud resources. The control workspace vends and manages these workspaces.
+
+The recommended way to implement the TLZ is as follows.
+
+- **Complete preparatory reading**: Read about cloud landing zone patterns applicable to the cloud service providers with whom you partner.
+- **Define the Terraform Landing Zone**: There are a number of ways to apply the TLZ concept, but core requirements include:
+  - Use of the <a href="https://registry.terraform.io/providers/hashicorp/tfe/latest/docs" target="_blank" rel="noreferrer">HCP Terraform and Terraform Enterprise provider</a> so that there is state representation for the configuration - this applies to both HCP Terraform and Terraform Enterprise.
+  - Use the <a href="https://github.com/hashicorp-validated-designs/terraform-tfe-platform-management" target="_blank" rel="noreferrer">`terraform-tfe-platform-management`</a> module as the foundation for your Platform Management workspace. For each App Team, a single call to this module creates the HCP Terraform project, team, control workspace, and team token.
+  - Use the <a href="https://github.com/hashicorp-validated-designs/control-workspace-template" target="_blank" rel="noreferrer">`control-workspace-template`</a> repository as the VCS template for new control workspaces. This template contains the boilerplate Terraform code and directory structure for the control workspace, designed and maintained by the Platform Team.
   - Augment your onboarding pipeline to make use of the module. Hook the process into other organizational platforms for credential generation and observability and so on.
-  - Dedicate a HCP Terraform project to house the landing zone control workspaces separately from others the platform team own. Use the Terraform Enterprise provider or HCP Terraform API to deploy this. The onboarding process directs creation of control workspaces into this project.
-- **Test**: Create landing zones using the process.
-- **Update the module and VCS template**: **Expect to do this a number of times to refine the process** as you scale. Do not underestimate this key area. Depending on the onboarding design, if you onboard ten internal customers using the process, then need to change the process, this applies from that point on for the next set of customers. Depending on the implementation, you may need retrospective updates to refine the pipeline. This is also why it is important to funnel sets of early adopters onto the platform as you develop the solution using stepwise refinement.
-- **Ensure smooth onboarding**: Work to ensure the onboarding process is as smooth as possible for the application teams. If using ServiceNow as front door to the onboarding process, liaise with the ServiceNow team _as early as possible_ as we find there is always a lead time for remediation.
+  - Dedicate an HCP Terraform project to house the control workspaces separately from others the Platform Team owns. Use the HCP Terraform and Terraform Enterprise provider or HCP Terraform API to deploy this. The onboarding process directs creation of control workspaces into this project.
+- **Test**: Create Terraform Landing Zones using the process.
+- **Update the module and VCS template**: **Expect to do this a number of times to refine the process** as you scale. Do not underestimate this key area. Depending on the onboarding design, if you onboard ten App Teams using the process and then need to change the process, those changes only apply from that point on for the next set of teams. Depending on the implementation, you may need retrospective updates to refine the pipeline. This is also why it is important to funnel sets of early adopters onto the platform as you develop the solution using stepwise refinement.
+- **Ensure smooth onboarding**: Work to ensure the onboarding process is as smooth as possible for App Teams. If using ServiceNow as the front door to the onboarding process, liaise with the ServiceNow team _as early as possible_ as we find there is always a lead time for remediation.
 
-#### Summary of landing zone workflow
+#### Summary of Terraform Landing Zone workflow
 
 - **Ticket raised**: Audit trail created, approval acquired as appropriate.
-- **Landing zone child module call code added**: The top-level workspace and its VCS repository is where the platform team collect and manage onboarded teams.
+- **Landing Zone child module call code added**: The Platform Management workspace and its VCS repository is where the Platform Team collects and manages onboarded App Teams.
   - We recommend automating the addition of this child module call to ensure the solution is scalable. Use your strategic orchestration technology to manage this automation.
-  - If your business expects to onboard thousands of teams, then avoid performance issues with the workspace run as discussed at the end of the previous section by placing significant consideration on prior planning of the platform team landing zone deployment workspace(s).
-- **Run the top-level workspace**: This creates the control workspace for the application team using the Terraform landing zone module.
-- **Application team control workspace created**: The template VCS contains Terraform code to use child modules to create the application team's Stacks or workspaces. In a franchise model, the application team would have write access to this repository so that they can configure it to deploy all the required Stacks or workspaces to support their needs. In a service catalog model, run the control workspace to create the application team's Stacks or workspaces to hook into subsequent request processes for pre-canned infrastructure requests.
+  - If your business expects to onboard thousands of teams, avoid performance issues with the workspace run as discussed at the end of the previous section by placing significant consideration on prior planning of the Platform Management workspace(s).
+- **Run the Platform Management workspace**: This creates the control workspace for the App Team using the `terraform-tfe-platform-management` module.
+- **App Team control workspace created**: The template VCS contains Terraform code to use child modules to create the App Team's Stacks or workspaces. In a franchise model, the App Team would have write access to this repository so that they can configure it to deploy all the required Stacks or workspaces to support their needs. In a service catalog model, run the control workspace to create the App Team's Stacks or workspaces to hook into subsequent request processes for pre-canned infrastructure requests.
 
 <Note>
 
-While we have found many of our scaled customers have derived significant success scaling Terraform onboarding through the use of the landing zone concept, each customer implements them differently, and the preceding advice is a generalization of the process. We recommend that you engage with a HashiCorp Solution Architect to discuss your specific requirements.
+While many scaled customers derive significant success scaling Terraform onboarding through the Terraform Landing Zone pattern, each customer implements it differently and the preceding advice is a generalization of the process. We recommend that you engage with a HashiCorp Solution Architect to discuss your specific requirements.
 
 </Note>
 

--- a/content/validated-designs/img/terraform/operating-guides/adoption/hvd-terraform-oga-control-workspace-hierarchy.svg
+++ b/content/validated-designs/img/terraform/operating-guides/adoption/hvd-terraform-oga-control-workspace-hierarchy.svg
@@ -1,0 +1,66 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 335" width="800" height="335" font-family="Inter, ui-sans-serif, system-ui, sans-serif" role="img" aria-label="Terraform Landing Zone workspace hierarchy diagram showing Platform Management Workspace at top, Control Workspaces per App Team in the middle tier, and App Workspaces at the bottom tier">
+  <title>Terraform Landing Zone - Workspace Hierarchy</title>
+
+  <rect width="800" height="335" fill="#F8FAFC" rx="8"/>
+
+  <text x="16" y="26" font-size="12" font-weight="600" fill="#374151">Platform Team</text>
+  <text x="16" y="43" font-size="11" fill="#6B7280">manages</text>
+  <line x1="35" y1="47" x2="35" y2="55" stroke="#9CA3AF" stroke-width="1.5"/>
+  <polygon points="29,55 35,63 41,55" fill="#9CA3AF"/>
+
+  <rect x="15" y="65" width="770" height="56" rx="6" fill="#1563FF"/>
+  <text x="400" y="87" text-anchor="middle" font-size="14" font-weight="600" fill="#FFFFFF">Platform Management Workspace</text>
+  <text x="400" y="107" text-anchor="middle" font-size="11" fill="rgba(255,255,255,0.82)">Vends one control workspace per App Team - all control workspace state is tracked here</text>
+
+  <line x1="135" y1="121" x2="135" y2="153" stroke="#94A3B8" stroke-width="1.5"/>
+  <line x1="400" y1="121" x2="400" y2="153" stroke="#94A3B8" stroke-width="1.5"/>
+  <line x1="665" y1="121" x2="665" y2="153" stroke="#94A3B8" stroke-width="1.5"/>
+  <line x1="135" y1="153" x2="665" y2="153" stroke="#94A3B8" stroke-width="1.5"/>
+
+  <rect x="20" y="153" width="230" height="52" rx="5" fill="#0F9B8E"/>
+  <text x="135" y="175" text-anchor="middle" font-size="12" font-weight="600" fill="#FFFFFF">Control Workspace</text>
+  <text x="135" y="193" text-anchor="middle" font-size="11" fill="rgba(255,255,255,0.85)">App Team A</text>
+
+  <rect x="285" y="153" width="230" height="52" rx="5" fill="#0F9B8E"/>
+  <text x="400" y="175" text-anchor="middle" font-size="12" font-weight="600" fill="#FFFFFF">Control Workspace</text>
+  <text x="400" y="193" text-anchor="middle" font-size="11" fill="rgba(255,255,255,0.85)">App Team B</text>
+
+  <rect x="550" y="153" width="230" height="52" rx="5" fill="#0F9B8E" opacity="0.40"/>
+  <text x="665" y="184" text-anchor="middle" font-size="18" fill="rgba(255,255,255,0.80)" font-style="italic">more...</text>
+
+  <line x1="55" y1="205" x2="55" y2="240" stroke="#94A3B8" stroke-width="1.5"/>
+  <line x1="135" y1="205" x2="135" y2="240" stroke="#94A3B8" stroke-width="1.5"/>
+  <line x1="215" y1="205" x2="215" y2="240" stroke="#94A3B8" stroke-width="1.5"/>
+  <line x1="55" y1="240" x2="215" y2="240" stroke="#94A3B8" stroke-width="1.5"/>
+
+  <rect x="17" y="240" width="76" height="44" rx="4" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="1.5"/>
+  <text x="55" y="258" text-anchor="middle" font-size="9" font-weight="600" fill="#374151">App Workspace</text>
+  <text x="55" y="273" text-anchor="middle" font-size="10" fill="#6B7280">dev</text>
+
+  <rect x="97" y="240" width="76" height="44" rx="4" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="1.5"/>
+  <text x="135" y="258" text-anchor="middle" font-size="9" font-weight="600" fill="#374151">App Workspace</text>
+  <text x="135" y="273" text-anchor="middle" font-size="10" fill="#6B7280">staging</text>
+
+  <rect x="177" y="240" width="76" height="44" rx="4" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="1.5"/>
+  <text x="215" y="258" text-anchor="middle" font-size="9" font-weight="600" fill="#374151">App Workspace</text>
+  <text x="215" y="273" text-anchor="middle" font-size="10" fill="#6B7280">prod</text>
+
+  <line x1="360" y1="205" x2="360" y2="240" stroke="#94A3B8" stroke-width="1.5"/>
+  <line x1="440" y1="205" x2="440" y2="240" stroke="#94A3B8" stroke-width="1.5"/>
+  <line x1="360" y1="240" x2="440" y2="240" stroke="#94A3B8" stroke-width="1.5"/>
+
+  <rect x="322" y="240" width="76" height="44" rx="4" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="1.5"/>
+  <text x="360" y="258" text-anchor="middle" font-size="9" font-weight="600" fill="#374151">App Workspace</text>
+  <text x="360" y="273" text-anchor="middle" font-size="10" fill="#6B7280">dev</text>
+
+  <rect x="402" y="240" width="76" height="44" rx="4" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="1.5"/>
+  <text x="440" y="258" text-anchor="middle" font-size="9" font-weight="600" fill="#374151">App Workspace</text>
+  <text x="440" y="273" text-anchor="middle" font-size="10" fill="#6B7280">prod</text>
+
+  <rect x="20" y="302" width="14" height="14" rx="2" fill="#1563FF"/>
+  <text x="40" y="313" font-size="11" fill="#374151">Platform Management Workspace</text>
+  <rect x="230" y="302" width="14" height="14" rx="2" fill="#0F9B8E"/>
+  <text x="250" y="313" font-size="11" fill="#374151">Control Workspace (one per App Team)</text>
+  <rect x="470" y="302" width="14" height="14" rx="2" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="1.5"/>
+  <text x="490" y="313" font-size="11" fill="#374151">App Workspace</text>
+</svg>


### PR DESCRIPTION
## Summary

Rewrite the control workspaces section in the HVD Terraform Operating Guide to reflect updated terminology and guidance agreed between CDL, PS, and SA. The work was delayed by module publication blockers (doormat/passport IT permissions) and gaps in implementation understanding. The agreed terminology and hierarchy is now fully understood and the supporting module has been published.

Source PR being migrated: https://github.com/hashicorp/hvd-docs/pull/402

## Changes

**Updated files:**
- `content/validated-designs/docs/docs/terraform/administration-guide/introduction.mdx`
- `content/validated-designs/docs/docs/terraform/administration-guide/organizing-resources.mdx`
- `content/validated-designs/docs/docs/terraform/user-guide/iac-and-cloud-provisioning.mdx`
- `content/validated-designs/img/terraform/operating-guides/adoption/hvd-terraform-oga-control-workspace-hierarchy.svg`

Main guidance themes migrated:
- terminology updates from business-unit language to app-team language
- Terraform Landing Zone (TLZ) framing and hierarchy
- revised control workspace guidance spanning Platform Management, Control, and App workspaces
- new hierarchy diagram asset

## Open items for human attention

> ℹ️ **Needs-human:** Confirm whether "the landing zone provisioning workflow" should remain general in the introductory sentence or be made explicitly "the Terraform Landing Zone provisioning workflow".
> ℹ️ **Needs-human:** Consider whether the control workspace bullet should add a cross-reference clarifying that the provider guidance applies equally to HCP Terraform and Terraform Enterprise.
> ℹ️ **Needs-human:** Module links currently point to GitHub source for `terraform-tfe-platform-management`; update them to the registry URL once published.

## Notes

This is a draft PR created as part of the HVD migration from `hashicorp/hvd-docs` into `hashicorp/web-unified-docs`. The content is being moved as-is in draft form so any follow-up review and cleanup can happen in the correct repository.
