### PR TITLE
Terraform Docs

### DIFF
--- a/content/terraform/v1.12.x/docs/language/block/moved.mdx
+++ b/content/terraform/v1.12.x/docs/language/block/moved.mdx
@@ -38,7 +38,7 @@ This section provides details about the fields you can configure in the `moved` 
 
 The `moved` block specifies the previous address and the new address for the resource. The following table describes the arguments you can set in the `moved` block.
 
-| Arbument | Description | Type | Required |
+| Argument | Description | Type | Required |
 | ---   | ---         | ---  | ---      |
 | `from` | Specifies a resource's previous address. The syntax allows Terraform to select modules, resources, and resources inside child modules. | string | required |
 | `to` | Specifies the new address to relocate the resource to. The syntax allows Terraform to select modules, resources, and resources inside child modules. | string | required |

--- a/content/terraform/v1.15.x/docs/language/block/moved.mdx
+++ b/content/terraform/v1.15.x/docs/language/block/moved.mdx
@@ -38,7 +38,7 @@ This section provides details about the fields you can configure in the `moved` 
 
 The `moved` block specifies the previous address and the new address for the resource. The following table describes the arguments you can set in the `moved` block.
 
-| Arbument | Description | Type | Required |
+| Argument | Description | Type | Required |
 | ---   | ---         | ---  | ---      |
 | `from` | Specifies a resource's previous address. The syntax allows Terraform to select modules, resources, and resources inside child modules. | string | required |
 | `to` | Specifies the new address to relocate the resource to. The syntax allows Terraform to select modules, resources, and resources inside child modules. | string | required |

--- a/content/terraform/v1.16.x (beta)/docs/language/block/moved.mdx
+++ b/content/terraform/v1.16.x (beta)/docs/language/block/moved.mdx
@@ -38,7 +38,7 @@ This section provides details about the fields you can configure in the `moved` 
 
 The `moved` block specifies the previous address and the new address for the resource. The following table describes the arguments you can set in the `moved` block.
 
-| Arbument | Description | Type | Required |
+| Argument | Description | Type | Required |
 | ---   | ---         | ---  | ---      |
 | `from` | Specifies a resource's previous address. The syntax allows Terraform to select modules, resources, and resources inside child modules. | string | required |
 | `to` | Specifies the new address to relocate the resource to. The syntax allows Terraform to select modules, resources, and resources inside child modules. | string | required |


### PR DESCRIPTION
### What

Corrects a misspelled table header in the `moved` block reference: **"Arbument" → "Argument"**.

Changed pages:

- Terraform v1.12.x — [Language / Blocks / `moved`](https://developer.hashicorp.com/terraform/language/block/moved)
- Terraform v1.15.x — Language / Blocks / `moved`
- Terraform v1.16.x (beta) — Language / Blocks / `moved`

### Why

The first column header of the argument reference table read "Arbument" instead
of "Argument". This looks unpolished on a reference page and prevents readers
from finding the column with an in-page search for "Argument".

The v1.13.x and v1.14.x copies of this page already had the correct spelling,
so this change brings the remaining three versions in line with them. There are
no remaining occurrences of "Arbument" in the repository.

### Screenshots

N/A — text-only correction, with no sidebar additions or formatting changes.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] Description links to related pull requests or issues, if any. (N/A)

#### Content
- [x] You added redirects to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages **across all affected versions**. Refer to [Redirects](https://github.com/hashicorp/web-unified-docs/blob/main/docs/content-guide/redirects.md#example-redirects) for examples and guidance. (N/A)
- [x] Links to related content where appropriate (e.g., CLI, language, API endpoints, permissions, etc.). (N/A)
- [x] Pages with related content are updated and link to this content when appropriate. (N/A)
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages. (N/A)
- [x] New pages have metadata (page name and description) at the top. (N/A)
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility. (N/A)
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars. (N/A)
- [x] UI elements (button names, page names, etc.) are bolded. (N/A)
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
