### PR TITLE
Vault Docs: Fix autopilot gradual failure explaination

### DIFF
--- a/content/vault/v1.17.x/content/partials/autopilot/redundancy-zones.mdx
+++ b/content/vault/v1.17.x/content/partials/autopilot/redundancy-zones.mdx
@@ -21,5 +21,5 @@ to take the place of voters.
 For example, consider a cluster that is configured to have 3 redundancy zones
 with 2 nodes in each zone. If a voting node becomes unreachable, the zone standby
 in that zone is promoted. The cluster then maintains 3 voting nodes with 2 remaining
-standbys. The cluster can handle an additional 2 gradual failures before it loses
+standbys. The cluster can handle an additional 3 gradual failures before it loses
 quorum.

--- a/content/vault/v1.19.x/content/partials/autopilot/redundancy-zones.mdx
+++ b/content/vault/v1.19.x/content/partials/autopilot/redundancy-zones.mdx
@@ -21,5 +21,5 @@ to take the place of voters.
 For example, consider a cluster that is configured to have 3 redundancy zones
 with 2 nodes in each zone. If a voting node becomes unreachable, the zone standby
 in that zone is promoted. The cluster then maintains 3 voting nodes with 2 remaining
-standbys. The cluster can handle an additional 2 gradual failures before it loses
+standbys. The cluster can handle an additional 3 gradual failures before it loses
 quorum.

--- a/content/vault/v1.20.x/content/partials/autopilot/redundancy-zones.mdx
+++ b/content/vault/v1.20.x/content/partials/autopilot/redundancy-zones.mdx
@@ -21,5 +21,5 @@ to take the place of voters.
 For example, consider a cluster that is configured to have 3 redundancy zones
 with 2 nodes in each zone. If a voting node becomes unreachable, the zone standby
 in that zone is promoted. The cluster then maintains 3 voting nodes with 2 remaining
-standbys. The cluster can handle an additional 2 gradual failures before it loses
+standbys. The cluster can handle an additional 3 gradual failures before it loses
 quorum.

--- a/content/vault/v1.21.x/content/partials/autopilot/redundancy-zones.mdx
+++ b/content/vault/v1.21.x/content/partials/autopilot/redundancy-zones.mdx
@@ -21,5 +21,5 @@ to take the place of voters.
 For example, consider a cluster that is configured to have 3 redundancy zones
 with 2 nodes in each zone. If a voting node becomes unreachable, the zone standby
 in that zone is promoted. The cluster then maintains 3 voting nodes with 2 remaining
-standbys. The cluster can handle an additional 2 gradual failures before it loses
+standbys. The cluster can handle an additional 3 gradual failures before it loses
 quorum.

--- a/content/vault/v2.x/content/partials/autopilot/redundancy-zones.mdx
+++ b/content/vault/v2.x/content/partials/autopilot/redundancy-zones.mdx
@@ -21,5 +21,5 @@ to take the place of voters.
 For example, consider a cluster that is configured to have 3 redundancy zones
 with 2 nodes in each zone. If a voting node becomes unreachable, the zone standby
 in that zone is promoted. The cluster then maintains 3 voting nodes with 2 remaining
-standbys. The cluster can handle an additional 2 gradual failures before it loses
+standbys. The cluster can handle an additional 3 gradual failures before it loses
 quorum.


### PR DESCRIPTION
Follow up to https://github.com/hashicorp/web-unified-docs/pull/3073

Ensure that the explaination on the redundancy zone gradual failure is in line with the optimistic failure tolerance table that was updated earlier