### PR TITLE
VAULT-49253: add newly implemented fields to oauth resource server config docs

### DIFF
--- a/content/vault/v2.x/content/api-docs/system/config-oauth-resource-server.mdx
+++ b/content/vault/v2.x/content/api-docs/system/config-oauth-resource-server.mdx
@@ -303,6 +303,10 @@ Create a new OAuth Resource Server configuration profile.
 - `enabled` `(bool: true)` – Whether the profile is active. Disabled profiles
   are not evaluated during JWT validation.
 
+- `unique_id_claim` `(string: "jti")` - The claim that uniquely identifies a specific JWT.
+
+- `actor_claim` `(string: "act.sub")` - The claim that Vault should use to resolve an actor's entity.
+
 ### Sample payload (JWKS mode)
 
 ```json


### PR DESCRIPTION
This PR adds the two newly added fields `actor_claim` and `unique_id_claim` to the OAuth Resource Server Config API configuration docs.
