### PR TITLE
VAULT-47169: Fixes misleading use of `version: 2` in `VaultStaticSecret` KV v2 examples

### DIFF
--- a/content/vault/v2.x/content/docs/deploy/kubernetes/vso/api-reference.mdx
+++ b/content/vault/v2.x/content/docs/deploy/kubernetes/vso/api-reference.mdx
@@ -982,7 +982,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `mount` _string_ | Mount for the secret in Vault |  |  |
 | `path` _string_ | Path of the secret in Vault, corresponds to the `path` parameter for:<br />kv-v1: https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v1#read-secret<br />kv-v2: https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#read-secret-version |  |  |
-| `version` _integer_ | Version of the secret to fetch. Only valid for type kv-v2. Corresponds to version query parameter:<br />https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#version |  | Minimum: 0 <br /> |
+| `version` _integer_ | Version of the secret to fetch. Only valid for type kv-v2. Corresponds to version query parameter:<br />https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#version<br />**Warning:** Omit this field in most cases. Setting a version locks the sync to that specific version of the secret and VSO will not pick up newer versions when the secret is updated. Only set this field if you explicitly want to pin to a specific secret version. |  | Minimum: 0 <br /> |
 | `type` _string_ | Type of the Vault static secret |  | Enum: [kv-v1 kv-v2] <br /> |
 | `transformation` _[Transformation](#transformation)_ | Transformation provides configuration for transforming the secret data before<br />it is stored in the CSI volume. |  |  |
 
@@ -998,7 +998,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `mount` _string_ | Mount for the secret in Vault |  |  |
 | `path` _string_ | Path of the secret in Vault, corresponds to the `path` parameter for:<br />kv-v1: https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v1#read-secret<br />kv-v2: https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#read-secret-version |  |  |
-| `version` _integer_ | Version of the secret to fetch. Only valid for type kv-v2. Corresponds to version query parameter:<br />https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#version |  | Minimum: 0 <br /> |
+| `version` _integer_ | Version of the secret to fetch. Only valid for type kv-v2. Corresponds to version query parameter:<br />https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#version<br />**Warning:** Omit this field in most cases. Setting a version locks the sync to that specific version of the secret and VSO will not pick up newer versions when the secret is updated. Only set this field if you explicitly want to pin to a specific secret version. |  | Minimum: 0 <br /> |
 | `type` _string_ | Type of the Vault static secret |  | Enum: [kv-v1 kv-v2] <br /> |
 
 
@@ -1036,7 +1036,7 @@ _Appears in:_
 | `syncConfig` _[SyncConfig](#syncconfig)_ | SyncConfig configures sync behavior from Vault to VSO |  |  |
 | `mount` _string_ | Mount for the secret in Vault |  |  |
 | `path` _string_ | Path of the secret in Vault, corresponds to the `path` parameter for:<br />kv-v1: https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v1#read-secret<br />kv-v2: https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#read-secret-version |  |  |
-| `version` _integer_ | Version of the secret to fetch. Only valid for type kv-v2. Corresponds to version query parameter:<br />https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#version |  | Minimum: 0 <br /> |
+| `version` _integer_ | Version of the secret to fetch. Only valid for type kv-v2. Corresponds to version query parameter:<br />https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#version<br />**Warning:** Omit this field in most cases. Setting a version locks the sync to that specific version of the secret and VSO will not pick up newer versions when the secret is updated. Only set this field if you explicitly want to pin to a specific secret version. |  | Minimum: 0 <br /> |
 | `type` _string_ | Type of the Vault static secret |  | Enum: [kv-v1 kv-v2] <br /> |
 
 

--- a/content/vault/v2.x/content/docs/deploy/kubernetes/vso/api-reference.mdx
+++ b/content/vault/v2.x/content/docs/deploy/kubernetes/vso/api-reference.mdx
@@ -982,7 +982,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `mount` _string_ | Mount for the secret in Vault |  |  |
 | `path` _string_ | Path of the secret in Vault, corresponds to the `path` parameter for:<br />kv-v1: https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v1#read-secret<br />kv-v2: https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#read-secret-version |  |  |
-| `version` _integer_ | Version of the secret to fetch. Only valid for type kv-v2. Corresponds to version query parameter:<br />https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#version<br />**Warning:** Omit this field in most cases. Setting a version locks the sync to that specific version of the secret and VSO will not pick up newer versions when the secret is updated. Only set this field if you explicitly want to pin to a specific secret version. |  | Minimum: 0 <br /> |
+| `version` _integer_ | Version of the secret to fetch. Only valid for type kv-v2. Corresponds to version query parameter:<br />https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#version<br />This field should normally be omitted, unless you want to lock the sync to a specific version of the secret and ignore updates. |  | Minimum: 0 <br /> |
 | `type` _string_ | Type of the Vault static secret |  | Enum: [kv-v1 kv-v2] <br /> |
 | `transformation` _[Transformation](#transformation)_ | Transformation provides configuration for transforming the secret data before<br />it is stored in the CSI volume. |  |  |
 
@@ -998,7 +998,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `mount` _string_ | Mount for the secret in Vault |  |  |
 | `path` _string_ | Path of the secret in Vault, corresponds to the `path` parameter for:<br />kv-v1: https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v1#read-secret<br />kv-v2: https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#read-secret-version |  |  |
-| `version` _integer_ | Version of the secret to fetch. Only valid for type kv-v2. Corresponds to version query parameter:<br />https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#version<br />**Warning:** Omit this field in most cases. Setting a version locks the sync to that specific version of the secret and VSO will not pick up newer versions when the secret is updated. Only set this field if you explicitly want to pin to a specific secret version. |  | Minimum: 0 <br /> |
+| `version` _integer_ | Version of the secret to fetch. Only valid for type kv-v2. Corresponds to version query parameter:<br />https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#version<br />This field should normally be omitted, unless you want to lock the sync to a specific version of the secret and ignore updates. |  | Minimum: 0 <br /> |
 | `type` _string_ | Type of the Vault static secret |  | Enum: [kv-v1 kv-v2] <br /> |
 
 
@@ -1036,7 +1036,7 @@ _Appears in:_
 | `syncConfig` _[SyncConfig](#syncconfig)_ | SyncConfig configures sync behavior from Vault to VSO |  |  |
 | `mount` _string_ | Mount for the secret in Vault |  |  |
 | `path` _string_ | Path of the secret in Vault, corresponds to the `path` parameter for:<br />kv-v1: https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v1#read-secret<br />kv-v2: https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#read-secret-version |  |  |
-| `version` _integer_ | Version of the secret to fetch. Only valid for type kv-v2. Corresponds to version query parameter:<br />https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#version<br />**Warning:** Omit this field in most cases. Setting a version locks the sync to that specific version of the secret and VSO will not pick up newer versions when the secret is updated. Only set this field if you explicitly want to pin to a specific secret version. |  | Minimum: 0 <br /> |
+| `version` _integer_ | Version of the secret to fetch. Only valid for type kv-v2. Corresponds to version query parameter:<br />https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#version<br />This field should normally be omitted, unless you want to lock the sync to a specific version of the secret and ignore updates. |  | Minimum: 0 <br /> |
 | `type` _string_ | Type of the Vault static secret |  | Enum: [kv-v1 kv-v2] <br /> |
 
 

--- a/content/vault/v2.x/content/docs/deploy/kubernetes/vso/sources/vault/index.mdx
+++ b/content/vault/v2.x/content/docs/deploy/kubernetes/vso/sources/vault/index.mdx
@@ -246,7 +246,6 @@ spec:
   mount: kvv2
   type: kv-v2
   path: eng/apikey/google
-  version: 2
   refreshAfter: 60s
   destination:
     create: true

--- a/content/vault/v2.x/content/docs/deploy/kubernetes/vso/sources/vault/instant-updates.mdx
+++ b/content/vault/v2.x/content/docs/deploy/kubernetes/vso/sources/vault/instant-updates.mdx
@@ -57,7 +57,6 @@ spec:
   mount: <kv mount>
   type: kv-v2
   path: <kv secret path>
-  version: 2
   refreshAfter: 1h
   destination:
     create: true


### PR DESCRIPTION
Description:

Fixes misleading `version: 2` field in the `VaultStaticSecret` KV v2 examples.
Users who copy-paste these examples would unknowingly lock their secret sync to
version 2 of a KV secret, causing them to miss updates when the secret is rotated.

## Changes

- **sources/vault/index.mdx**: Removed `version: 2` from the KV version 2 `VaultStaticSecret` example
- **sources/vault/instant-updates.mdx**: Removed `version: 2` from the `VaultStaticSecret` instant updates example
- **api-reference.mdx**: Added a warning to the `version` field description in `VaultStaticSecretCollectable`, `VaultStaticSecretCommon`, and `VaultStaticSecretSpec` to clarify that this field should normally be omitted unless the user explicitly wants to pin to a specific secret version