### PR TITLE
Update setup.mdx with licensing requirements for VSO

### DIFF
--- a/content/vault/v2.x/content/docs/deploy/kubernetes/vso/csi/setup.mdx
+++ b/content/vault/v2.x/content/docs/deploy/kubernetes/vso/csi/setup.mdx
@@ -77,6 +77,10 @@ path "sys/license/status" {
 }
 ```
 
+When using VSO with Vault Enterprise or HCP Vault Dedicated, you must grant `read` 
+on `sys/license/status` otherwise the plugin will fail to properly identify the cluster's
+license.
+
 To generate AppRole secret IDs with the CSI driver so application Pods can 
 log into Vault and fetch secrets independently, your Vault policy must grant the CSI driver 
 permissions for the associated role. 


### PR DESCRIPTION
Added note about granting 'read' permission on sys/license/status for VSO with Vault Enterprise or HCP Vault Dedicated.

## Description

<!-- ID for Jira ticket e.g [SPE-1234] -->

:ticket: [Jira ticket]

<!-- Add a brief description of changes here. Include any other necessary relevant links -->
- From a troubleshooting discussion with Michael Kosir, we both missed the license in the example policy, and assume you can validate a cluster is CE or ENT from unauthed endpoint /v1/sys/seal-status
<!-- Help your reviewer understand the type of review you need by selecting the scope and urgency. -->

### Requested review scope:

- [x] Content touched by the PR _only_ (typos, clarifications, tips)
- [ ] Code test (command and code block changes)
- [ ] Flow and language near changes (new/rearranged steps)
- [ ] Review everything (rewrites, major changes)

### Review urgency:

- [ ] ASAP (bug fixes, broken content, imminent releases)
- [ ] 3 days (small changes, easy reviews)
- [ ] 1 week (default)
- [x] Best effort (very non-urgent)

<!-- Fill out only the appropriate checklist for your type of feature (or both if necessary) and delete the other one! -->

## All updates:

<!-- This section is mandatory for all PRs: -->

I have:

- [ ] Verified that all status checks have passed
- [ ] Verified that preview environment has successfully deployed
- [ ] Verified appropriate `label` applied (`hcp` + `product name`)
- [ ] Added all required reviewers (code owners and external)


[SPE-1234]: https://hashicorp.atlassian.net/browse/SPE-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ