### PR TITLE
docs(nomad): list PUT and POST where both methods are supported

### DIFF
--- a/content/nomad/v1.11.x/content/api-docs/agent.mdx
+++ b/content/nomad/v1.11.x/content/api-docs/agent.mdx
@@ -113,7 +113,7 @@ This endpoint updates the list of known servers to the provided list. This
 
 | Method | Path             | Produces       |
 | ------ | ---------------- | -------------- |
-| `POST` | `/v1/agent/servers` | `(empty body)` |
+| `POST` / `PUT` | `/v1/agent/servers` | `(empty body)` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -391,7 +391,7 @@ eligible for servers.
 
 | Method | Path          | Produces           |
 | ------ | ------------- | ------------------ |
-| `POST` | `/v1/agent/join` | `application/json` |
+| `POST` / `PUT` | `/v1/agent/join` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -432,7 +432,7 @@ stop attempting replication. This is only applicable for servers.
 
 | Method | Path                 | Produces           |
 | ------ | -------------------- | ------------------ |
-| `POST` | `/v1/agent/force-leave` | `application/json` |
+| `POST` / `PUT` | `/v1/agent/force-leave` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -882,7 +882,7 @@ to apply the provided values. This is only applicable for servers.
 
 | Method | Path                       | Produces           |
 | ------ | -------------------------- | ------------------ |
-| `PUT`  | `/v1/agent/schedulers/config` | `application/json` |
+| `PUT` / `POST`  | `/v1/agent/schedulers/config` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and

--- a/content/nomad/v1.11.x/content/api-docs/deployments.mdx
+++ b/content/nomad/v1.11.x/content/api-docs/deployments.mdx
@@ -299,7 +299,7 @@ the job being reverted.
 
 | Method | Path                                 | Produces           |
 | ------ | ------------------------------------ | ------------------ |
-| `POST` | `/v1/deployment/fail/:deployment_id` | `application/json` |
+| `POST` / `PUT` | `/v1/deployment/fail/:deployment_id` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -342,7 +342,7 @@ a rolling upgrade or resume it.
 
 | Method | Path                                  | Produces           |
 | ------ | ------------------------------------- | ------------------ |
-| `POST` | `/v1/deployment/pause/:deployment_id` | `application/json` |
+| `POST` / `PUT` | `/v1/deployment/pause/:deployment_id` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -396,7 +396,7 @@ rolling upgrade of the remaining allocations should begin.
 
 | Method | Path                                    | Produces           |
 | ------ | --------------------------------------- | ------------------ |
-| `POST` | `/v1/deployment/promote/:deployment_id` | `application/json` |
+| `POST` / `PUT` | `/v1/deployment/promote/:deployment_id` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -465,7 +465,7 @@ version of the job has a different specification than the job being reverted.
 
 | Method | Path                                              | Produces           |
 | ------ | ------------------------------------------------- | ------------------ |
-| `POST` | `/v1/deployment/allocation-health/:deployment_id` | `application/json` |
+| `POST` / `PUT` | `/v1/deployment/allocation-health/:deployment_id` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -530,7 +530,7 @@ deployment to complete.
 
 | Method | Path                                    | Produces           |
 | ------ | --------------------------------------- | ------------------ |
-| `POST` | `/v1/deployment/unblock/:deployment_id` | `application/json` |
+| `POST` / `PUT` | `/v1/deployment/unblock/:deployment_id` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and

--- a/content/nomad/v1.11.x/content/api-docs/jobs.mdx
+++ b/content/nomad/v1.11.x/content/api-docs/jobs.mdx
@@ -112,7 +112,7 @@ This endpoint creates (aka "registers") a new job in the system.
 
 | Method | Path       | Produces           |
 | ------ | ---------- | ------------------ |
-| `POST` | `/v1/jobs` | `application/json` |
+| `POST` / `PUT` | `/v1/jobs` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -225,7 +225,7 @@ job.
 
 | Method | Path             | Produces           |
 | ------ | ---------------- | ------------------ |
-| `POST` | `/v1/jobs/parse` | `application/json` |
+| `POST` / `PUT` | `/v1/jobs/parse` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -1676,7 +1676,7 @@ This endpoint registers a new job or updates an existing job.
 
 | Method | Path              | Produces           |
 | ------ | ----------------- | ------------------ |
-| `POST` | `/v1/job/:job_id` | `application/json` |
+| `POST` / `PUT` | `/v1/job/:job_id` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -1754,7 +1754,7 @@ This endpoint dispatches a new instance of a parameterized job.
 
 | Method | Path                       | Produces           |
 | ------ | -------------------------- | ------------------ |
-| `POST` | `/v1/job/:job_id/dispatch` | `application/json` |
+| `POST` / `PUT` | `/v1/job/:job_id/dispatch` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -1825,7 +1825,7 @@ request body as the `Payload` as described in [Dispatch Job](#dispatch-job).
 
 | Method | Path                               | Produces           |
 | ------ | ---------------------------------- | ------------------ |
-| `POST` | `/v1/job/:job_id/dispatch/payload` | `application/json` |
+| `POST` / `PUT` | `/v1/job/:job_id/dispatch/payload` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -1873,7 +1873,7 @@ This endpoint reverts the job to an older version.
 
 | Method | Path                     | Produces           |
 | ------ | ------------------------ | ------------------ |
-| `POST` | `/v1/job/:job_id/revert` | `application/json` |
+| `POST` / `PUT` | `/v1/job/:job_id/revert` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -1947,7 +1947,7 @@ This endpoint sets the job's stability.
 
 | Method | Path                     | Produces           |
 | ------ | ------------------------ | ------------------ |
-| `POST` | `/v1/job/:job_id/stable` | `application/json` |
+| `POST` / `PUT` | `/v1/job/:job_id/stable` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -2007,7 +2007,7 @@ without a JSON payload will be removed in Nomad 0.9.
 
 | Method | Path                       | Produces           |
 | ------ | -------------------------- | ------------------ |
-| `POST` | `/v1/job/:job_id/evaluate` | `application/json` |
+| `POST` / `PUT` | `/v1/job/:job_id/evaluate` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -2069,7 +2069,7 @@ This endpoint invokes a dry-run of the scheduler for the job.
 
 | Method | Path                   | Produces           |
 | ------ | ---------------------- | ------------------ |
-| `POST` | `/v1/job/:job_id/plan` | `application/json` |
+| `POST` / `PUT` | `/v1/job/:job_id/plan` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -2280,7 +2280,7 @@ settings. As such, this should be only used to immediately run a periodic job.
 
 | Method | Path                             | Produces           |
 | ------ | -------------------------------- | ------------------ |
-| `POST` | `/v1/job/:job_id/periodic/force` | `application/json` |
+| `POST` / `PUT` | `/v1/job/:job_id/periodic/force` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -2433,7 +2433,7 @@ This will return a 400 error if the job has an active deployment.
 
 | Method | Path                    | Produces           |
 | ------ | ----------------------- | ------------------ |
-| `POST` | `/v1/job/:job_id/scale` | `application/json` |
+| `POST` / `PUT` | `/v1/job/:job_id/scale` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and

--- a/content/nomad/v1.11.x/content/api-docs/nodes.mdx
+++ b/content/nomad/v1.11.x/content/api-docs/nodes.mdx
@@ -852,7 +852,7 @@ force a run of the scheduling logic.
 
 | Method | Path                         | Produces           |
 | ------ | ---------------------------- | ------------------ |
-| `POST` | `/v1/node/:node_id/evaluate` | `application/json` |
+| `POST` / `PUT` | `/v1/node/:node_id/evaluate` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -921,7 +921,7 @@ Guide](/nomad/docs/manage/migrate-workloads) for suggested usage.
 
 | Method | Path                      | Produces           |
 | ------ | ------------------------- | ------------------ |
-| `POST` | `/v1/node/:node_id/drain` | `application/json` |
+| `POST` / `PUT` | `/v1/node/:node_id/drain` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -996,7 +996,7 @@ they are alive.
 
 | Method | Path                      | Produces           |
 | ------ | ------------------------- | ------------------ |
-| `POST` | `/v1/node/:node_id/purge` | `application/json` |
+| `POST` / `PUT` | `/v1/node/:node_id/purge` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -1042,7 +1042,7 @@ This endpoint toggles the scheduling eligibility of the node.
 
 | Method | Path                            | Produces           |
 | ------ | ------------------------------- | ------------------ |
-| `POST` | `/v1/node/:node_id/eligibility` | `application/json` |
+| `POST` / `PUT` | `/v1/node/:node_id/eligibility` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and

--- a/content/nomad/v1.11.x/content/api-docs/nodes.mdx
+++ b/content/nomad/v1.11.x/content/api-docs/nodes.mdx
@@ -917,7 +917,7 @@ $ curl \
 This endpoint toggles the drain mode of the node. When draining is enabled, no
 further allocations will be assigned to this node, and existing allocations will
 be migrated to new nodes. See the [Workload Migration
-Guide](/nomad/docs/manage/migrate-workloads) for suggested usage.
+Guide](/nomad/tutorials/manage-clusters/node-drain) for suggested usage.
 
 | Method | Path                      | Produces           |
 | ------ | ------------------------- | ------------------ |

--- a/content/nomad/v1.11.x/content/api-docs/search.mdx
+++ b/content/nomad/v1.11.x/content/api-docs/search.mdx
@@ -20,7 +20,7 @@ every context.
 
 | Method | Path         | Produces           |
 | ------ | ------------ | ------------------ |
-| `POST` | `/v1/search` | `application/json` |
+| `POST` / `PUT` | `/v1/search` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -140,7 +140,7 @@ a name that exactly matches the search term are listed first.
 
 | Method | Path               | Produces           |
 | ------ | ------------------ | ------------------ |
-| `POST` | `/v1/search/fuzzy` | `application/json` |
+| `POST` / `PUT` | `/v1/search/fuzzy` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and

--- a/content/nomad/v1.11.x/content/api-docs/validate.mdx
+++ b/content/nomad/v1.11.x/content/api-docs/validate.mdx
@@ -25,7 +25,7 @@ the job file locally but skips validating driver configurations.
 
 | Method | Path               | Produces           |
 | ------ | ------------------ | ------------------ |
-| `POST` | `/v1/validate/job` | `application/json` |
+| `POST` / `PUT` | `/v1/validate/job` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and

--- a/content/nomad/v2.0.x/content/api-docs/agent.mdx
+++ b/content/nomad/v2.0.x/content/api-docs/agent.mdx
@@ -113,7 +113,7 @@ This endpoint updates the list of known servers to the provided list. This
 
 | Method | Path             | Produces       |
 | ------ | ---------------- | -------------- |
-| `POST` | `/v1/agent/servers` | `(empty body)` |
+| `POST` / `PUT` | `/v1/agent/servers` | `(empty body)` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -405,7 +405,7 @@ eligible for servers.
 
 | Method | Path          | Produces           |
 | ------ | ------------- | ------------------ |
-| `POST` | `/v1/agent/join` | `application/json` |
+| `POST` / `PUT` | `/v1/agent/join` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -446,7 +446,7 @@ stop attempting replication. This is only applicable for servers.
 
 | Method | Path                 | Produces           |
 | ------ | -------------------- | ------------------ |
-| `POST` | `/v1/agent/force-leave` | `application/json` |
+| `POST` / `PUT` | `/v1/agent/force-leave` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -924,7 +924,7 @@ to apply the provided values. This is only applicable for servers.
 
 | Method | Path                       | Produces           |
 | ------ | -------------------------- | ------------------ |
-| `PUT`  | `/v1/agent/schedulers/config` | `application/json` |
+| `PUT` / `POST`  | `/v1/agent/schedulers/config` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and

--- a/content/nomad/v2.0.x/content/api-docs/deployments.mdx
+++ b/content/nomad/v2.0.x/content/api-docs/deployments.mdx
@@ -299,7 +299,7 @@ the job being reverted.
 
 | Method | Path                                 | Produces           |
 | ------ | ------------------------------------ | ------------------ |
-| `POST` | `/v1/deployment/fail/:deployment_id` | `application/json` |
+| `POST` / `PUT` | `/v1/deployment/fail/:deployment_id` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -342,7 +342,7 @@ a rolling upgrade or resume it.
 
 | Method | Path                                  | Produces           |
 | ------ | ------------------------------------- | ------------------ |
-| `POST` | `/v1/deployment/pause/:deployment_id` | `application/json` |
+| `POST` / `PUT` | `/v1/deployment/pause/:deployment_id` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -396,7 +396,7 @@ rolling upgrade of the remaining allocations should begin.
 
 | Method | Path                                    | Produces           |
 | ------ | --------------------------------------- | ------------------ |
-| `POST` | `/v1/deployment/promote/:deployment_id` | `application/json` |
+| `POST` / `PUT` | `/v1/deployment/promote/:deployment_id` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -465,7 +465,7 @@ version of the job has a different specification than the job being reverted.
 
 | Method | Path                                              | Produces           |
 | ------ | ------------------------------------------------- | ------------------ |
-| `POST` | `/v1/deployment/allocation-health/:deployment_id` | `application/json` |
+| `POST` / `PUT` | `/v1/deployment/allocation-health/:deployment_id` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -530,7 +530,7 @@ deployment to complete.
 
 | Method | Path                                    | Produces           |
 | ------ | --------------------------------------- | ------------------ |
-| `POST` | `/v1/deployment/unblock/:deployment_id` | `application/json` |
+| `POST` / `PUT` | `/v1/deployment/unblock/:deployment_id` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and

--- a/content/nomad/v2.0.x/content/api-docs/jobs.mdx
+++ b/content/nomad/v2.0.x/content/api-docs/jobs.mdx
@@ -112,7 +112,7 @@ This endpoint creates (aka "registers") a new job in the system.
 
 | Method | Path       | Produces           |
 | ------ | ---------- | ------------------ |
-| `POST` | `/v1/jobs` | `application/json` |
+| `POST` / `PUT` | `/v1/jobs` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -225,7 +225,7 @@ job.
 
 | Method | Path             | Produces           |
 | ------ | ---------------- | ------------------ |
-| `POST` | `/v1/jobs/parse` | `application/json` |
+| `POST` / `PUT` | `/v1/jobs/parse` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -1676,7 +1676,7 @@ This endpoint registers a new job or updates an existing job.
 
 | Method | Path              | Produces           |
 | ------ | ----------------- | ------------------ |
-| `POST` | `/v1/job/:job_id` | `application/json` |
+| `POST` / `PUT` | `/v1/job/:job_id` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -1754,7 +1754,7 @@ This endpoint dispatches a new instance of a parameterized job.
 
 | Method | Path                       | Produces           |
 | ------ | -------------------------- | ------------------ |
-| `POST` | `/v1/job/:job_id/dispatch` | `application/json` |
+| `POST` / `PUT` | `/v1/job/:job_id/dispatch` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -1825,7 +1825,7 @@ request body as the `Payload` as described in [Dispatch Job](#dispatch-job).
 
 | Method | Path                               | Produces           |
 | ------ | ---------------------------------- | ------------------ |
-| `POST` | `/v1/job/:job_id/dispatch/payload` | `application/json` |
+| `POST` / `PUT` | `/v1/job/:job_id/dispatch/payload` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -1873,7 +1873,7 @@ This endpoint reverts the job to an older version.
 
 | Method | Path                     | Produces           |
 | ------ | ------------------------ | ------------------ |
-| `POST` | `/v1/job/:job_id/revert` | `application/json` |
+| `POST` / `PUT` | `/v1/job/:job_id/revert` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -1947,7 +1947,7 @@ This endpoint sets the job's stability.
 
 | Method | Path                     | Produces           |
 | ------ | ------------------------ | ------------------ |
-| `POST` | `/v1/job/:job_id/stable` | `application/json` |
+| `POST` / `PUT` | `/v1/job/:job_id/stable` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -2007,7 +2007,7 @@ without a JSON payload will be removed in Nomad 0.9.
 
 | Method | Path                       | Produces           |
 | ------ | -------------------------- | ------------------ |
-| `POST` | `/v1/job/:job_id/evaluate` | `application/json` |
+| `POST` / `PUT` | `/v1/job/:job_id/evaluate` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -2069,7 +2069,7 @@ This endpoint invokes a dry-run of the scheduler for the job.
 
 | Method | Path                   | Produces           |
 | ------ | ---------------------- | ------------------ |
-| `POST` | `/v1/job/:job_id/plan` | `application/json` |
+| `POST` / `PUT` | `/v1/job/:job_id/plan` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -2280,7 +2280,7 @@ settings. As such, this should be only used to immediately run a periodic job.
 
 | Method | Path                             | Produces           |
 | ------ | -------------------------------- | ------------------ |
-| `POST` | `/v1/job/:job_id/periodic/force` | `application/json` |
+| `POST` / `PUT` | `/v1/job/:job_id/periodic/force` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -2433,7 +2433,7 @@ This will return a 400 error if the job has an active deployment.
 
 | Method | Path                    | Produces           |
 | ------ | ----------------------- | ------------------ |
-| `POST` | `/v1/job/:job_id/scale` | `application/json` |
+| `POST` / `PUT` | `/v1/job/:job_id/scale` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and

--- a/content/nomad/v2.0.x/content/api-docs/nodes.mdx
+++ b/content/nomad/v2.0.x/content/api-docs/nodes.mdx
@@ -852,7 +852,7 @@ force a run of the scheduling logic.
 
 | Method | Path                         | Produces           |
 | ------ | ---------------------------- | ------------------ |
-| `POST` | `/v1/node/:node_id/evaluate` | `application/json` |
+| `POST` / `PUT` | `/v1/node/:node_id/evaluate` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -921,7 +921,7 @@ Guide](/nomad/docs/manage/migrate-workloads) for suggested usage.
 
 | Method | Path                      | Produces           |
 | ------ | ------------------------- | ------------------ |
-| `POST` | `/v1/node/:node_id/drain` | `application/json` |
+| `POST` / `PUT` | `/v1/node/:node_id/drain` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -996,7 +996,7 @@ they are alive.
 
 | Method | Path                      | Produces           |
 | ------ | ------------------------- | ------------------ |
-| `POST` | `/v1/node/:node_id/purge` | `application/json` |
+| `POST` / `PUT` | `/v1/node/:node_id/purge` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -1042,7 +1042,7 @@ This endpoint toggles the scheduling eligibility of the node.
 
 | Method | Path                            | Produces           |
 | ------ | ------------------------------- | ------------------ |
-| `POST` | `/v1/node/:node_id/eligibility` | `application/json` |
+| `POST` / `PUT` | `/v1/node/:node_id/eligibility` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and

--- a/content/nomad/v2.0.x/content/api-docs/nodes.mdx
+++ b/content/nomad/v2.0.x/content/api-docs/nodes.mdx
@@ -917,7 +917,7 @@ $ curl \
 This endpoint toggles the drain mode of the node. When draining is enabled, no
 further allocations will be assigned to this node, and existing allocations will
 be migrated to new nodes. See the [Workload Migration
-Guide](/nomad/docs/manage/migrate-workloads) for suggested usage.
+Guide](/nomad/tutorials/manage-clusters/node-drain) for suggested usage.
 
 | Method | Path                      | Produces           |
 | ------ | ------------------------- | ------------------ |

--- a/content/nomad/v2.0.x/content/api-docs/search.mdx
+++ b/content/nomad/v2.0.x/content/api-docs/search.mdx
@@ -20,7 +20,7 @@ every context.
 
 | Method | Path         | Produces           |
 | ------ | ------------ | ------------------ |
-| `POST` | `/v1/search` | `application/json` |
+| `POST` / `PUT` | `/v1/search` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -140,7 +140,7 @@ a name that exactly matches the search term are listed first.
 
 | Method | Path               | Produces           |
 | ------ | ------------------ | ------------------ |
-| `POST` | `/v1/search/fuzzy` | `application/json` |
+| `POST` / `PUT` | `/v1/search/fuzzy` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and

--- a/content/nomad/v2.0.x/content/api-docs/validate.mdx
+++ b/content/nomad/v2.0.x/content/api-docs/validate.mdx
@@ -25,7 +25,7 @@ the job file locally but skips validating driver configurations.
 
 | Method | Path               | Produces           |
 | ------ | ------------------ | ------------------ |
-| `POST` | `/v1/validate/job` | `application/json` |
+| `POST` / `PUT` | `/v1/validate/job` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and


### PR DESCRIPTION
## Summary
- Updates Nomad API docs (`v1.11.x` and `v2.0.x`) so endpoints that accept both PUT and POST in the HTTP agent document both methods (using the existing `POST` / `PUT` convention).
- Covers jobs, nodes, agent, deployments, validate, and search endpoints.

Docs now live in this repo under `content/nomad/` (formerly `website/content/api-docs` in `hashicorp/nomad`).

Fixes hashicorp/nomad#15243

**CLA:** Happy to sign the HashiCorp CLA if required for this contribution.

## Test plan
- [ ] Spot-check Create Job / Update Job / node drain tables show `POST` / `PUT`
- [ ] Cross-check a sample of updated paths against `command/agent/*_endpoint.go` method switches