### PR TITLE
Updated documentation for namespace scoped entity alias creation (VAULT-48944)

### DIFF
--- a/content/vault/v2.x/content/api-docs/secret/identity/entity-alias.mdx
+++ b/content/vault/v2.x/content/api-docs/secret/identity/entity-alias.mdx
@@ -5,8 +5,8 @@ description: >-
   This is the API documentation for managing entity aliases in the identity
   store.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2026-04-15T00:13:50.000Z
-last_modified: 2026-04-15T00:13:50.000Z
+created_at: 2026-04-14T17:13:42-07:00
+last_modified: 2026-08-18T14:16:58.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -46,8 +46,13 @@ This endpoint creates a new alias for an entity.
   alias should belong to. You can omit `mount_accessor` during creation when you
   set `issuer`. If you omit `mount_accessor`, Vault automatically generates a
   synthetic value for aliases bound to an OAuth resource-server configuration in
-  the format `oauth-resource-server_<namespace_id>_<config_id>`, where `<config_id>`
-  is the UUID of the matching configuration.
+  the format `oauth-resource-server_<namespace_id>_<config_id>`, where
+  `<namespace_id>` is either the internal UUID or the human-readable path of the
+  namespace, and `<config_id>` is the UUID of the matching configuration. For
+  nested namespaces, use the full path joined with `/`
+  (e.g. `parent/child` -> `oauth-resource-server_parent/child_<config_id>`).
+  We recommend omitting `mount_accessor` and letting Vault generate this value
+  automatically when creating aliases for OAuth resource-server configurations.
 
 - `custom_metadata` `(map<string|string>: <optional>)` - A map of arbitrary string to string valued 
   user-provided metadata meant to describe the alias.

--- a/content/vault/v2.x/content/api-docs/secret/identity/entity-alias.mdx
+++ b/content/vault/v2.x/content/api-docs/secret/identity/entity-alias.mdx
@@ -48,7 +48,9 @@ This endpoint creates a new alias for an entity.
   synthetic value for aliases bound to an OAuth resource-server configuration in
   the format `oauth-resource-server_<namespace_id>_<config_id>`, where `<config_id>`
   is the UUID of the matching configuration. You can also use a namespace path
-  in place of `<namespace_id>`: `oauth-resource-server_<namespace_path>_<config_id>`.
+  is the UUID of the matching configuration. You may also specify the mount 
+  accessor in the format `oauth-resource-server_<namespace_id>_<config_id>` or
+  `oauth-resource-server_<namespace_path>_<config_id>`.
 
   **We recommend omitting `mount_accessor` and letting Vault generate this value
   automatically when using [Vault as an OAuth resource server](/vault/docs/ai/oauth-server).**

--- a/content/vault/v2.x/content/api-docs/secret/identity/entity-alias.mdx
+++ b/content/vault/v2.x/content/api-docs/secret/identity/entity-alias.mdx
@@ -50,7 +50,8 @@ This endpoint creates a new alias for an entity.
   is the UUID of the matching configuration. You can also use a namespace path
   in place of `<namespace_id>`: `oauth-resource-server_<namespace_path>_<config_id>`.
 
-  **We recommend omitting `mount_accessor` and letting Vault generate this value automatically.**
+  **We recommend omitting `mount_accessor` and letting Vault generate this value
+  automatically when using [Vault as an OAuth resource server](/vault/docs/ai/oauth-server).**
 
 - `custom_metadata` `(map<string|string>: <optional>)` - A map of arbitrary string to string valued 
   user-provided metadata meant to describe the alias.

--- a/content/vault/v2.x/content/api-docs/secret/identity/entity-alias.mdx
+++ b/content/vault/v2.x/content/api-docs/secret/identity/entity-alias.mdx
@@ -6,7 +6,7 @@ description: >-
   store.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2026-04-14T17:13:42-07:00
-last_modified: 2026-08-19T19:44:02.000Z
+last_modified: 2026-08-20T14:35:42.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -47,7 +47,6 @@ This endpoint creates a new alias for an entity.
   set `issuer`. If you omit `mount_accessor`, Vault automatically generates a
   synthetic value for aliases bound to an OAuth resource-server configuration in
   the format `oauth-resource-server_<namespace_id>_<config_id>`, where `<config_id>`
-  is the UUID of the matching configuration. You can also use a namespace path
   is the UUID of the matching configuration. You may also specify the mount 
   accessor in the format `oauth-resource-server_<namespace_id>_<config_id>` or
   `oauth-resource-server_<namespace_path>_<config_id>`.

--- a/content/vault/v2.x/content/api-docs/secret/identity/entity-alias.mdx
+++ b/content/vault/v2.x/content/api-docs/secret/identity/entity-alias.mdx
@@ -6,7 +6,7 @@ description: >-
   store.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2026-04-14T17:13:42-07:00
-last_modified: 2026-08-18T14:16:58.000Z
+last_modified: 2026-08-19T19:44:02.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -46,13 +46,11 @@ This endpoint creates a new alias for an entity.
   alias should belong to. You can omit `mount_accessor` during creation when you
   set `issuer`. If you omit `mount_accessor`, Vault automatically generates a
   synthetic value for aliases bound to an OAuth resource-server configuration in
-  the format `oauth-resource-server_<namespace_id>_<config_id>`, where
-  `<namespace_id>` is either the internal UUID or the human-readable path of the
-  namespace, and `<config_id>` is the UUID of the matching configuration. For
-  nested namespaces, use the full path joined with `/`
-  (e.g. `parent/child` -> `oauth-resource-server_parent/child_<config_id>`).
-  We recommend omitting `mount_accessor` and letting Vault generate this value
-  automatically when creating aliases for OAuth resource-server configurations.
+  the format `oauth-resource-server_<namespace_id>_<config_id>`, where `<config_id>`
+  is the UUID of the matching configuration. You can also use a namespace path
+  in place of `<namespace_id>`: `oauth-resource-server_<namespace_path>_<config_id>`.
+
+  **We recommend omitting `mount_accessor` and letting Vault generate this value automatically.**
 
 - `custom_metadata` `(map<string|string>: <optional>)` - A map of arbitrary string to string valued 
   user-provided metadata meant to describe the alias.

--- a/content/vault/v2.x/content/api-docs/secret/identity/entity-alias.mdx
+++ b/content/vault/v2.x/content/api-docs/secret/identity/entity-alias.mdx
@@ -51,8 +51,13 @@ This endpoint creates a new alias for an entity.
   accessor in the format `oauth-resource-server_<namespace_id>_<config_id>` or
   `oauth-resource-server_<namespace_path>_<config_id>`.
 
-  **We recommend omitting `mount_accessor` and letting Vault generate this value
-  automatically when using [Vault as an OAuth resource server](/vault/docs/ai/oauth-server).**
+<Tip>
+
+  When using Vault as an [Vault as an OAuth resource server](/vault/docs/ai/oauth-server),
+  we recommend omitting `mount_accessor` so Vault automatically generates the
+  accessor value.
+
+</Tip>
 
 - `custom_metadata` `(map<string|string>: <optional>)` - A map of arbitrary string to string valued 
   user-provided metadata meant to describe the alias.


### PR DESCRIPTION
### Update
- clarify that both namespace path and id are valid for mount accessor and the convention of nested namespaces (e.g. `parent/child` -> `oauth-resource-server_parent/child_<config_id>`)
- highlight that the user should let Vault handle the creation of synthetic mount accessor when it can get a little problematic

Please go to the `Preview` tab and select the appropriate template:

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
