### PR TITLE
feat: add HVD feedback GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/hvd-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/hvd-feedback.yml
@@ -1,0 +1,53 @@
+# Copyright IBM Corp. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+name: HashiCorp Validated Design Feedback
+description: Provide feedback on a HashiCorp Validated Design guide.
+title: "Short summary of your feedback"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form to provide feedback on a HashiCorp Validated Design guide.
+  - type: dropdown
+    id: guide
+    attributes:
+      label: Product / Guide
+      description: Which validated design guide is your feedback for?
+      options:
+        - Boundary — Installation Guide
+        - Boundary — Administration Guide
+        - Boundary — User Guide
+        - Consul — Installation Guide
+        - Consul — Administration Guide
+        - Consul — User Guide
+        - Nomad — Installation Guide
+        - Nomad — Administration Guide
+        - Nomad — User Guide
+        - Terraform — Installation Guide
+        - Terraform — Administration Guide
+        - Terraform — User Guide
+        - Vault — Installation Guide
+        - Vault — Administration Guide
+        - Vault — User Guide
+        - Vault Radar — Administration Guide
+        - Vault Radar — User Guide
+        - Not applicable
+    validations:
+      required: true
+  - type: input
+    id: page_url
+    attributes:
+      label: Page URL
+      description: URL of the specific page your feedback relates to.
+      placeholder: "https://developer.hashicorp.com/validated-designs/..."
+    validations:
+      required: true
+  - type: textarea
+    id: feedback
+    attributes:
+      label: Feedback
+      description: Describe your feedback in as much detail as possible.
+      placeholder: "On this page..."
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/hvd-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/hvd-feedback.yml
@@ -1,14 +1,14 @@
 # Copyright IBM Corp. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
-name: HashiCorp Validated Design Feedback
-description: Provide feedback on a HashiCorp Validated Design guide.
+name: HashiCorp Validated Designs Feedback
+description: Provide feedback on a HashiCorp Validated Design
 title: "Short summary of your feedback"
 body:
   - type: markdown
     attributes:
       value: |
-        Use this form to provide feedback on a HashiCorp Validated Design guide.
+        Use this form to provide feedback on content within the HashiCorp Validated Designs section of the developer portal.
   - type: dropdown
     id: guide
     attributes:
@@ -32,7 +32,7 @@ body:
         - Vault — User Guide
         - Vault Radar — Administration Guide
         - Vault Radar — User Guide
-        - Not applicable
+        - Not applicable (for pages outside of a specific guide)
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/hvd-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/hvd-feedback.yml
@@ -4,6 +4,8 @@
 name: HashiCorp Validated Designs Feedback
 description: Provide feedback on a HashiCorp Validated Design
 title: "Short summary of your feedback"
+labels:
+  - Validated Designs
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
Adds a dedicated GitHub issue template for HashiCorp Validated Design (HVD) guide feedback.

## What

New file: `.github/ISSUE_TEMPLATE/hvd-feedback.yml`

The template includes:
- A **Product / Guide** dropdown with all 17 product+guide combinations derived from the `content/validated-designs/docs/docs/` directory structure, plus a **Not applicable** option. Options are ordered alphabetically by product, then Installation → Administration → User Guide within each product.
- A required **Page URL** field for the specific developer.hashicorp.com page the feedback relates to.
- A required **Feedback** textarea.

## Why

Implementing a custom form to collect specific information we need. This replaces the JIRA form we used in the past, which is now to onerous to manage.