### PR TITLE
Update metrics documentation for Vault cluster behavior

### DIFF
--- a/content/vault/v2.x/content/api-docs/system/metrics.mdx
+++ b/content/vault/v2.x/content/api-docs/system/metrics.mdx
@@ -37,10 +37,10 @@ $ curl \
   --header "X-Vault-Token: ..." \
     'http://127.0.0.1:8200/v1/sys/metrics?format=prometheus'
 ```
-When requesting metric information, only the active node in a Vault cluster
-responds with data. Follower nodes ignore metric requests, which typically
-results in a timeout response. For example, `curl` command returns with the
-error code `0` and no output.
+When requesting metric information, only the active & the performance standby nodes in a Vault cluster
+respond with data. Just a standby node will ignore the metric requests, which typically
+will result in a timeout. For example, the `curl` command returns with the
+error code `0`, and no output; however, the CLI call to 'sys/metrics' from a standby node will be forwarded to the active node.
 
 
 ### Sample response


### PR DESCRIPTION
Clarified behavior of metric requests in Vault clusters regarding active and standby nodes.