### PR TITLE
Vault: Fix typo in Verify doc

### DIFF
--- a/content/vault/v2.x/content/docs/ai/iam/providers/verify.mdx
+++ b/content/vault/v2.x/content/docs/ai/iam/providers/verify.mdx
@@ -26,7 +26,7 @@ agentic IAM.
   [sign up for a free trial](https://docs.verify.ibm.com/verify/docs/getting-started-signing-up-for-a-free-trial)
   to evaluate the integration process.
 
-- **You must have the [`oauth2c`](https://github.com/SecureAuthCorp/oauth2c) CLI**. 
+- **You must have the [`oauth2c`](https://github.com/SecureAuthCorp/oauth2c) CLI**.
   You need `oauth2c` installed and in your system `PATH` to interact with OAuth
   2.0 authorization servers.
 
@@ -114,7 +114,7 @@ application that performs operations on behalf of the user.
 1. In the **Application URL** field, enter the main URL or home page of the app
    to add as the resource server. The application URL is the entry point of the
    user to interact with the application. You can configure the application URL
-   to be appropriate for your AI application UI or chat interface. 
+   to be appropriate for your AI application UI or chat interface.
 
 1. Enable the necessary grant types. Browser driven flows use the Authorization
    code grant, and the resource server needs Client Credentials to
@@ -194,7 +194,7 @@ the configured OIDC application introspection endpoints.
 8. Click **Add custom rule**.
 
 9. Within the **Request rule** text area, enter the following JSON which
-   uses the client ID of then OIDC application. Paste the client ID value you
+   uses the client ID of the OIDC application. Paste the client ID value you
    just copied to replace the "CLIENT_ID" placeholder text.
 
    ```json
@@ -427,7 +427,7 @@ and the addition of an `authorization_details` Rich Authorization Requests
    1. In the **Target attribute** field, enter `actor-token`.
 
    1. Click **OK**.
-      
+
    </Tab>
    </Tabs>
 
@@ -550,7 +550,7 @@ for AI agents.
 
 Vault requires the following information for setup:
 
-Variable         | Purpose 
+Variable         | Purpose
 ---------------- | -------------------------------------------------------------
 `DELEGATED_JWT`  | The OBO with authorization details JWT as obtained after token exchange via the STS client.
 `ISSUER`         | The issuer retrieved from the Well known Open ID configuration of the JWT issuer.


### PR DESCRIPTION
Fixed a typo (then -> the) in Verify documentation.