### PR TITLE
docs: clarify generate-config-out limitation with for_each resources

### DIFF
--- a/content/terraform/v1.14.x/docs/language/import/generating-configuration.mdx
+++ b/content/terraform/v1.14.x/docs/language/import/generating-configuration.mdx
@@ -3,14 +3,12 @@ page_title: Import - Generating Configuration
 description: >-
   Generate configuration and manage existing resources with Terraform using configuration-driven import.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-11-19T13:27:46Z
-last_modified: 2025-11-19T08:59:09-08:00
+created_at: 2023-01-01T00:00:00.000Z
+last_modified: 2023-01-01T00:00:00.000Z
 # END AUTO GENERATED METADATA
 ---
 
 # Generating configuration
-
-This topic describes how to generate code for single resources or small batches of resources defined in [`import` blocks](/terraform/language/block/import). For instructions querying your existing infrastructure for resources and generating `import` configuration based on search results, refer to the [Import existing resources in bulk](/terraform/language/import/bulk). 
 
 ~> **Experimental:** Configuration generation is available in Terraform v1.5 as an experimental feature. Later minor versions may contain changes to the formatting of generated configuration and behavior of the `terraform plan` command using the `-generate-config-out` flag.
 
@@ -21,7 +19,7 @@ Starting with Terraform's generated HCL, we recommend iterating to find your ide
 To generate configuration, run `terraform plan` with the `-generate-config-out` flag and supply a new file path. Do not supply a path to an existing file, or Terraform throws an error.
 
 ```shell
-$ terraform plan -generate-config-out="generated_resources.tf"
+$ terraform plan -generate-config-out=generated_resources.tf
 ```
 
 If any resources targeted by an `import` block do not exist in your configuration, Terraform then generates and writes configuration for those resources in `generated_resources.tf`.
@@ -89,7 +87,7 @@ Terraform has generated configuration and written it to generated.tf. Please rev
 The example above instructs Terraform to generate configuration in a file named `generated.tf`. The below code is an example of a `generated.tf` file.
 
 ```hcl
-resource "aws_iot_thing" "bar" {
+resource aws_iot_thing "bar" {
   name = "foo"
 }
 ```
@@ -123,6 +121,7 @@ aws_iot_thing.bar: Importing... [id=foo]
 aws_iot_thing.bar: Import complete [id=foo]
 
 Apply complete! Resources: 1 imported, 0 added, 0 changed, 0 destroyed.
+
 ```
 
 Commit your new resource configuration to your version control system.
@@ -136,7 +135,7 @@ Terraform generates configuration for importable resources during a plan by requ
 Terraform will display an error like the one below if it does not receive values for resource attributes while generating configuration.
 
 ```shell
-$ terraform plan -generate-config-out="generated.tf"
+$ terraform plan -generate-config-out=generated.tf
 ╷
 │ Error: Conflicting configuration arguments
 │ 
@@ -149,3 +148,7 @@ $ terraform plan -generate-config-out="generated.tf"
 ```
 
 In the example above, Terraform still generates configuration and writes it to `generated.tf`. This error stems from a conflict between the `ipv6_address_count` and `ipv6_addresses` arguments. The resource supports both of these arguments, but you must choose only one when configuring the resource. You could fix the error by removing one of these two arguments, then running `terraform plan` again to check that there are no further issues.
+
+### Importing resources with `for_each`
+
+~> **Note:** When importing a resource that will ultimately be managed with `for_each`, `-generate-config-out` cannot generate configuration directly against a `for_each`-keyed address (for example, `aws_s3_bucket.this["my-bucket"]`). Instead, generate the configuration against a temporary, non-indexed resource address first, then manually refactor the generated block into your `for_each` structure afterward. See [hashicorp/terraform#38032](https://github.com/hashicorp/terraform/issues/38032) for further context and discussion.

--- a/content/terraform/v1.5.x/docs/language/import/generating-configuration.mdx
+++ b/content/terraform/v1.5.x/docs/language/import/generating-configuration.mdx
@@ -148,3 +148,7 @@ $ terraform plan -generate-config-out=generated.tf
 ```
 
 In the example above, Terraform still generates configuration and writes it to `generated.tf`. This error stems from a conflict between the `ipv6_address_count` and `ipv6_addresses` arguments. The resource supports both of these arguments, but you must choose only one when configuring the resource. You could fix the error by removing one of these two arguments, then running `terraform plan` again to check that there are no further issues.
+
+### Importing resources with `for_each`
+
+~> **Note:** When importing a resource that will ultimately be managed with `for_each`, `-generate-config-out` cannot generate configuration directly against a `for_each`-keyed address (for example, `aws_s3_bucket.this["my-bucket"]`). Instead, generate the configuration against a temporary, non-indexed resource address first, then manually refactor the generated block into your `for_each` structure afterward. See [hashicorp/terraform#38032](https://github.com/hashicorp/terraform/issues/38032) for further context and discussion.


### PR DESCRIPTION
Context: hashicorp/terraform#38032

While importing an existing Aurora cluster into a for_each-managed Terraform module, I found that -generate-config-out produces isolated, single-resource configuration blocks rather than a consolidated for_each block, with no documented workaround. This PR adds a note explaining the temporary-address workaround, referencing the related discussion in #38032 for further context.