### PR TITLE
Add http_read_timeout note to large raft snapshots section

### DIFF
--- a/content/vault/v1.10.x/content/partials/raft-large-snapshots.mdx
+++ b/content/vault/v1.10.x/content/partials/raft-large-snapshots.mdx
@@ -1,6 +1,9 @@
-### Large Raft Snapshots
+### Large raft snapshots
 
 Taking and restoring Raft snapshots can exceed Vault's default and recommended
 timeout settings. The
 [`VAULT_CLIENT_TIMEOUT`](/vault/docs/commands#vault_client_timeout) environment variable can
-be used to allow for more time to take or restore a snapshot.
+be used to allow for more time to take or restore a snapshot. You may also need
+to increase the
+[`http_read_timeout`](/vault/docs/configuration/listener/tcp#http_read_timeout)
+parameter in your TCP listener configuration.

--- a/content/vault/v1.11.x/content/partials/raft-large-snapshots.mdx
+++ b/content/vault/v1.11.x/content/partials/raft-large-snapshots.mdx
@@ -3,4 +3,7 @@
 Taking and restoring Raft snapshots can exceed Vault's default and recommended
 timeout settings. The
 [`VAULT_CLIENT_TIMEOUT`](/vault/docs/commands#vault_client_timeout) environment variable can
-be used to allow for more time to take or restore a snapshot.
+be used to allow for more time to take or restore a snapshot. You may also need
+to increase the
+[`http_read_timeout`](/vault/docs/configuration/listener/tcp#http_read_timeout)
+parameter in your TCP listener configuration.

--- a/content/vault/v1.12.x/content/partials/raft-large-snapshots.mdx
+++ b/content/vault/v1.12.x/content/partials/raft-large-snapshots.mdx
@@ -3,4 +3,7 @@
 Taking and restoring Raft snapshots can exceed Vault's default and recommended
 timeout settings. The
 [`VAULT_CLIENT_TIMEOUT`](/vault/docs/commands#vault_client_timeout) environment variable can
-be used to allow for more time to take or restore a snapshot.
+be used to allow for more time to take or restore a snapshot. You may also need
+to increase the
+[`http_read_timeout`](/vault/docs/configuration/listener/tcp#http_read_timeout)
+parameter in your TCP listener configuration.

--- a/content/vault/v1.13.x/content/partials/raft-large-snapshots.mdx
+++ b/content/vault/v1.13.x/content/partials/raft-large-snapshots.mdx
@@ -3,4 +3,7 @@
 Taking and restoring Raft snapshots can exceed Vault's default and recommended
 timeout settings. The
 [`VAULT_CLIENT_TIMEOUT`](/vault/docs/commands#vault_client_timeout) environment variable can
-be used to allow for more time to take or restore a snapshot.
+be used to allow for more time to take or restore a snapshot. You may also need
+to increase the
+[`http_read_timeout`](/vault/docs/configuration/listener/tcp#http_read_timeout)
+parameter in your TCP listener configuration.

--- a/content/vault/v1.14.x/content/partials/raft-large-snapshots.mdx
+++ b/content/vault/v1.14.x/content/partials/raft-large-snapshots.mdx
@@ -3,4 +3,7 @@
 Taking and restoring Raft snapshots can exceed Vault's default and recommended
 timeout settings. The
 [`VAULT_CLIENT_TIMEOUT`](/vault/docs/commands#vault_client_timeout) environment variable can
-be used to allow for more time to take or restore a snapshot.
+be used to allow for more time to take or restore a snapshot. You may also need
+to increase the
+[`http_read_timeout`](/vault/docs/configuration/listener/tcp#http_read_timeout)
+parameter in your TCP listener configuration.

--- a/content/vault/v1.15.x/content/partials/raft-large-snapshots.mdx
+++ b/content/vault/v1.15.x/content/partials/raft-large-snapshots.mdx
@@ -3,4 +3,7 @@
 Taking and restoring Raft snapshots can exceed Vault's default and recommended
 timeout settings. The
 [`VAULT_CLIENT_TIMEOUT`](/vault/docs/commands#vault_client_timeout) environment variable can
-be used to allow for more time to take or restore a snapshot.
+be used to allow for more time to take or restore a snapshot. You may also need
+to increase the
+[`http_read_timeout`](/vault/docs/configuration/listener/tcp#http_read_timeout)
+parameter in your TCP listener configuration.

--- a/content/vault/v1.16.x/content/partials/raft-large-snapshots.mdx
+++ b/content/vault/v1.16.x/content/partials/raft-large-snapshots.mdx
@@ -3,4 +3,7 @@
 Taking and restoring Raft snapshots can exceed Vault's default and recommended
 timeout settings. The
 [`VAULT_CLIENT_TIMEOUT`](/vault/docs/commands#vault_client_timeout) environment variable can
-be used to allow for more time to take or restore a snapshot.
+be used to allow for more time to take or restore a snapshot. You may also need
+to increase the
+[`http_read_timeout`](/vault/docs/configuration/listener/tcp#http_read_timeout)
+parameter in your TCP listener configuration.

--- a/content/vault/v1.17.x/content/partials/raft-large-snapshots.mdx
+++ b/content/vault/v1.17.x/content/partials/raft-large-snapshots.mdx
@@ -3,4 +3,7 @@
 Taking and restoring Raft snapshots can exceed Vault's default and recommended
 timeout settings. The
 [`VAULT_CLIENT_TIMEOUT`](/vault/docs/commands#vault_client_timeout) environment variable can
-be used to allow for more time to take or restore a snapshot.
+be used to allow for more time to take or restore a snapshot. You may also need
+to increase the
+[`http_read_timeout`](/vault/docs/configuration/listener/tcp#http_read_timeout)
+parameter in your TCP listener configuration.

--- a/content/vault/v1.18.x/content/partials/raft-large-snapshots.mdx
+++ b/content/vault/v1.18.x/content/partials/raft-large-snapshots.mdx
@@ -3,4 +3,7 @@
 Taking and restoring Raft snapshots can exceed Vault's default and recommended
 timeout settings. The
 [`VAULT_CLIENT_TIMEOUT`](/vault/docs/commands#vault_client_timeout) environment variable can
-be used to allow for more time to take or restore a snapshot.
+be used to allow for more time to take or restore a snapshot. You may also need
+to increase the
+[`http_read_timeout`](/vault/docs/configuration/listener/tcp#http_read_timeout)
+parameter in your TCP listener configuration.

--- a/content/vault/v1.19.x/content/partials/raft-large-snapshots.mdx
+++ b/content/vault/v1.19.x/content/partials/raft-large-snapshots.mdx
@@ -3,4 +3,7 @@
 Taking and restoring Raft snapshots can exceed Vault's default and recommended
 timeout settings. The
 [`VAULT_CLIENT_TIMEOUT`](/vault/docs/commands#vault_client_timeout) environment variable can
-be used to allow for more time to take or restore a snapshot.
+be used to allow for more time to take or restore a snapshot. You may also need
+to increase the
+[`http_read_timeout`](/vault/docs/configuration/listener/tcp#http_read_timeout)
+parameter in your TCP listener configuration.

--- a/content/vault/v1.20.x/content/partials/raft-large-snapshots.mdx
+++ b/content/vault/v1.20.x/content/partials/raft-large-snapshots.mdx
@@ -3,4 +3,7 @@
 Taking and restoring Raft snapshots can exceed Vault's default and recommended
 timeout settings. The
 [`VAULT_CLIENT_TIMEOUT`](/vault/docs/commands#vault_client_timeout) environment variable can
-be used to allow for more time to take or restore a snapshot.
+be used to allow for more time to take or restore a snapshot. You may also need
+to increase the
+[`http_read_timeout`](/vault/docs/configuration/listener/tcp#http_read_timeout)
+parameter in your TCP listener configuration.

--- a/content/vault/v1.21.x/content/partials/raft-large-snapshots.mdx
+++ b/content/vault/v1.21.x/content/partials/raft-large-snapshots.mdx
@@ -3,4 +3,7 @@
 Taking and restoring Raft snapshots can exceed Vault's default and recommended
 timeout settings. The
 [`VAULT_CLIENT_TIMEOUT`](/vault/docs/commands#vault_client_timeout) environment variable can
-be used to allow for more time to take or restore a snapshot.
+be used to allow for more time to take or restore a snapshot. You may also need
+to increase the
+[`http_read_timeout`](/vault/docs/configuration/listener/tcp#http_read_timeout)
+parameter in your TCP listener configuration.

--- a/content/vault/v1.9.x/content/partials/raft-large-snapshots.mdx
+++ b/content/vault/v1.9.x/content/partials/raft-large-snapshots.mdx
@@ -1,6 +1,9 @@
-### Large Raft Snapshots
+### Large raft snapshots
 
 Taking and restoring Raft snapshots can exceed Vault's default and recommended
 timeout settings. The
 [`VAULT_CLIENT_TIMEOUT`](/vault/docs/commands#vault_client_timeout) environment variable can
-be used to allow for more time to take or restore a snapshot.
+be used to allow for more time to take or restore a snapshot. You may also need
+to increase the
+[`http_read_timeout`](/vault/docs/configuration/listener/tcp#http_read_timeout)
+parameter in your TCP listener configuration.

--- a/content/vault/v2.x/content/partials/raft-large-snapshots.mdx
+++ b/content/vault/v2.x/content/partials/raft-large-snapshots.mdx
@@ -3,4 +3,7 @@
 Taking and restoring Raft snapshots can exceed Vault's default and recommended
 timeout settings. The
 [`VAULT_CLIENT_TIMEOUT`](/vault/docs/commands#vault_client_timeout) environment variable can
-be used to allow for more time to take or restore a snapshot.
+be used to allow for more time to take or restore a snapshot. You may also need
+to increase the
+[`http_read_timeout`](/vault/docs/configuration/listener/tcp#http_read_timeout)
+parameter in your TCP listener configuration.


### PR DESCRIPTION
## Description

Adds a note to the "Large raft snapshots" section (/sys/storage/raft/snapshot) that http_read_timeout in the TCP listener config may also need to be increased for large snapshots. Existing text only mentioned VAULT_CLIENT_TIMEOUT. Applied to all versions (v1.9.x–v1.21.x and v2.x) via the raft-large-snapshots.mdx partial. Also corrects a sentence-case heading in v1.9.x and v1.10.x.



