### PR TITLE
fix: replace remote image URL with local path in vault DR guide

### DIFF
--- a/content/validated-designs/docs/docs/vault/administration-guide/disaster-recovery-operations.mdx
+++ b/content/validated-designs/docs/docs/vault/administration-guide/disaster-recovery-operations.mdx
@@ -31,7 +31,7 @@ When Vault is deployed inline with the architecture outlined in the HashiCorp Va
 
 In the diagram below, the Vault leader node (voter) is in Availability Zone B. If it fails, the follower node (non-voter) in Availability Zone B will be elected as the new leader node (voter) and continue operation. The specifics of how active node step-down, leadership lost, and Raft election are outside the scope of this document.
 
-[![Vault DR Failover](https://developer.hashicorp.com/.extracted/hvd/img/vault/solution-design-guides/vault-enterprise/030-hvd-vault-cluster-architecture-diagram.png)](https://developer.hashicorp.com/.extracted/hvd/img/vault/solution-design-guides/vault-enterprise/030-hvd-vault-cluster-architecture-diagram.png)
+![Vault DR Failover](/img/vault/solution-design-guides/vault-enterprise/030-hvd-vault-cluster-architecture-diagram.png)
 
 Vault operators should have a runbook to handle every combination of losing a node or nodes in the above architecture. For example, if a node in Zone C fails overnight it might be acceptable to wait until the next day to replace it in the cluster. However, a loss of connectivity entirely to Zone B and C might trigger action to replace those lost nodes immediately in Zone A, as once 4 nodes are lost the cluster has no more redundancy for maintaining quorum.
 


### PR DESCRIPTION
## Summary

Replaces a remote `https://developer.hashicorp.com/.extracted/hvd/img/...` image URL in the Vault Administration Guide disaster recovery page with the correct local `/img/...` path.

## Problem

The image in `vault/administration-guide/disaster-recovery-operations.mdx` was referencing an absolute remote URL rather than the local asset path used throughout the rest of the HVD content. This caused failures in the PDF generation toolchain — pandoc cannot resolve remote image URLs during the XeLaTeX build step, producing an opaque TeX error about a missing PNG file.

## Change

- Replaced the remote URL with the local `/img/vault/solution-design-guides/vault-enterprise/030-hvd-vault-cluster-architecture-diagram.png` path
- Removed the redundant linked-image construct (image wrapped in a hyperlink pointing to itself), which has no effect on the website and is meaningless in PDF output

## Testing

The image asset already exists locally under `public/assets/validated-designs/img/` — no asset changes required.
