### PR TITLE
Boundary: fix config encrypt and decrypt examples

### DIFF
--- a/content/boundary/v0.13.x/content/docs/commands/config/decrypt.mdx
+++ b/content/boundary/v0.13.x/content/docs/commands/config/decrypt.mdx
@@ -35,11 +35,11 @@ kms "aead" {
 }
 ```
 
-You can define the "kms" block in the configuration file or in a separate file
+You can define the `kms` block in the configuration file or in a separate file
 that you pass using the `-config-kms` flag. If you define it in the
 configuration file, only string parameters are supported, and the markers must
 be inside the quotation marks that delimit the string. Additionally, if you
-define the block inline, do not use an "aead" block with the key defined in the
+define the block inline, do not use an `aead` block with the key defined in the
 configuration file, as it provides no protection.
 
 ## Usage

--- a/content/boundary/v0.13.x/content/docs/commands/config/decrypt.mdx
+++ b/content/boundary/v0.13.x/content/docs/commands/config/decrypt.mdx
@@ -22,7 +22,7 @@ appropriate, for example: `key = {{decrypt(encrypted_value)}}`.
 The following command overwrites the existing configuration file using the `-overwrite` flag:
 
 ```shell-session
-$ boundary config decrypt -overwrite config.hcl
+$ boundary config decrypt -config config.hcl -overwrite
 ```
 
 In order for this command to perform its task, you must define a "kms" block within the configuration file:
@@ -35,18 +35,19 @@ kms "aead" {
 }
 ```
 
-You can define the "kms" block in the configuration file or using the `-config`
-flag. If you define it in the configuration file, only string parameters are
-supported, and the markers must be inside the quotation marks that delimit the string.
-Additionally, if you define the block inline, do not use an "aead" block with
-the key defined in the configuration file, as it provides no protection.
+You can define the "kms" block in the configuration file or in a separate file
+that you pass using the `-config-kms` flag. If you define it in the
+configuration file, only string parameters are supported, and the markers must
+be inside the quotation marks that delimit the string. Additionally, if you
+define the block inline, do not use an "aead" block with the key defined in the
+configuration file, as it provides no protection.
 
 ## Usage
 
 <CodeBlockConfig hideClipboard>
 
 ```shell-session
-$ boundary config decrypt [options] [args]
+$ boundary config decrypt [options]
 ```
 
 </CodeBlockConfig>
@@ -54,7 +55,7 @@ $ boundary config decrypt [options] [args]
 
 ### Command options
 
-- `-config` `(string: "")` - The configuration file to decrypt.
+- `-config` `(string: "")` - The configuration file to decrypt (required).
 
 - `-config-kms` `(string: "")` - If set, the given file is parsed for
    a "kms" block with purpose `config` to determine whether it should be used to perform the command.

--- a/content/boundary/v0.13.x/content/docs/commands/config/encrypt.mdx
+++ b/content/boundary/v0.13.x/content/docs/commands/config/encrypt.mdx
@@ -20,10 +20,10 @@ appropriate, for example: `key = {{encrypt(key_value)}}`.
 
 ## Examples
 
-The following command overwrites the existing configuration file use the `-overwrite` flag:
+The following command overwrites the existing configuration file using the `-overwrite` flag:
 
 ```shell-session
-$ boundary config encrypt -overwrite config.hcl
+$ boundary config encrypt -config config.hcl -overwrite
 ```
 
 In order for this command to perform its task, you must define a "kms" block within a configuration file:
@@ -36,18 +36,19 @@ kms "aead" {
 }
 ```
 
-You can define the "kms" block in the configuration file or using the `-config`
-flag. If you define it in the configuration file, only string parameters are
-supported, and the markers must be inside the quotation marks that delimit the string.
-Additionally, if you define the block inline, do not use an "aead" block with
-the key defined in the configuration file as it provides no protection.
+You can define the "kms" block in the configuration file or in a separate file
+that you pass using the `-config-kms` flag. If you define it in the
+configuration file, only string parameters are supported, and the markers must
+be inside the quotation marks that delimit the string. Additionally, if you
+define the block inline, do not use an "aead" block with the key defined in the
+configuration file as it provides no protection.
 
 ## Usage
 
 <CodeBlockConfig hideClipboard>
 
 ```shell-session
-$ boundary config encrypt [options] [args]
+$ boundary config encrypt [options]
 ```
 
 </CodeBlockConfig>
@@ -55,7 +56,7 @@ $ boundary config encrypt [options] [args]
 
 ### Command options
 
-- `-config` `(string: "")` - The configuration file to encrypt.
+- `-config` `(string: "")` - The configuration file to encrypt (required).
 
 - `-config-kms` `(string: "")` - If set, the given file is parsed for
    a "kms" block with purpose `config` to determine whether it should be used to perform the command.

--- a/content/boundary/v0.13.x/content/docs/commands/config/encrypt.mdx
+++ b/content/boundary/v0.13.x/content/docs/commands/config/encrypt.mdx
@@ -36,11 +36,11 @@ kms "aead" {
 }
 ```
 
-You can define the "kms" block in the configuration file or in a separate file
+You can define the `kms` block in the configuration file or in a separate file
 that you pass using the `-config-kms` flag. If you define it in the
 configuration file, only string parameters are supported, and the markers must
 be inside the quotation marks that delimit the string. Additionally, if you
-define the block inline, do not use an "aead" block with the key defined in the
+define the block inline, do not use an `aead` block with the key defined in the
 configuration file as it provides no protection.
 
 ## Usage

--- a/content/boundary/v0.14.x/content/docs/commands/config/decrypt.mdx
+++ b/content/boundary/v0.14.x/content/docs/commands/config/decrypt.mdx
@@ -35,11 +35,11 @@ kms "aead" {
 }
 ```
 
-You can define the "kms" block in the configuration file or in a separate file
+You can define the `kms` block in the configuration file or in a separate file
 that you pass using the `-config-kms` flag. If you define it in the
 configuration file, only string parameters are supported, and the markers must
 be inside the quotation marks that delimit the string. Additionally, if you
-define the block inline, do not use an "aead" block with the key defined in the
+define the block inline, do not use an `aead` block with the key defined in the
 configuration file, as it provides no protection.
 
 ## Usage

--- a/content/boundary/v0.14.x/content/docs/commands/config/decrypt.mdx
+++ b/content/boundary/v0.14.x/content/docs/commands/config/decrypt.mdx
@@ -22,7 +22,7 @@ appropriate, for example: `key = {{decrypt(encrypted_value)}}`.
 The following command overwrites the existing configuration file using the `-overwrite` flag:
 
 ```shell-session
-$ boundary config decrypt -overwrite config.hcl
+$ boundary config decrypt -config config.hcl -overwrite
 ```
 
 In order for this command to perform its task, you must define a "kms" block within the configuration file:
@@ -35,18 +35,19 @@ kms "aead" {
 }
 ```
 
-You can define the "kms" block in the configuration file or using the `-config`
-flag. If you define it in the configuration file, only string parameters are
-supported, and the markers must be inside the quotation marks that delimit the string.
-Additionally, if you define the block inline, do not use an "aead" block with
-the key defined in the configuration file, as it provides no protection.
+You can define the "kms" block in the configuration file or in a separate file
+that you pass using the `-config-kms` flag. If you define it in the
+configuration file, only string parameters are supported, and the markers must
+be inside the quotation marks that delimit the string. Additionally, if you
+define the block inline, do not use an "aead" block with the key defined in the
+configuration file, as it provides no protection.
 
 ## Usage
 
 <CodeBlockConfig hideClipboard>
 
 ```shell-session
-$ boundary config decrypt [options] [args]
+$ boundary config decrypt [options]
 ```
 
 </CodeBlockConfig>
@@ -54,7 +55,7 @@ $ boundary config decrypt [options] [args]
 
 ### Command options
 
-- `-config` `(string: "")` - The configuration file to decrypt.
+- `-config` `(string: "")` - The configuration file to decrypt (required).
 
 - `-config-kms` `(string: "")` - If set, the given file is parsed for
    a "kms" block with purpose `config` to determine whether it should be used to perform the command.

--- a/content/boundary/v0.14.x/content/docs/commands/config/encrypt.mdx
+++ b/content/boundary/v0.14.x/content/docs/commands/config/encrypt.mdx
@@ -20,10 +20,10 @@ appropriate, for example: `key = {{encrypt(key_value)}}`.
 
 ## Examples
 
-The following command overwrites the existing configuration file use the `-overwrite` flag:
+The following command overwrites the existing configuration file using the `-overwrite` flag:
 
 ```shell-session
-$ boundary config encrypt -overwrite config.hcl
+$ boundary config encrypt -config config.hcl -overwrite
 ```
 
 In order for this command to perform its task, you must define a "kms" block within a configuration file:
@@ -36,18 +36,19 @@ kms "aead" {
 }
 ```
 
-You can define the "kms" block in the configuration file or using the `-config`
-flag. If you define it in the configuration file, only string parameters are
-supported, and the markers must be inside the quotation marks that delimit the string.
-Additionally, if you define the block inline, do not use an "aead" block with
-the key defined in the configuration file as it provides no protection.
+You can define the "kms" block in the configuration file or in a separate file
+that you pass using the `-config-kms` flag. If you define it in the
+configuration file, only string parameters are supported, and the markers must
+be inside the quotation marks that delimit the string. Additionally, if you
+define the block inline, do not use an "aead" block with the key defined in the
+configuration file as it provides no protection.
 
 ## Usage
 
 <CodeBlockConfig hideClipboard>
 
 ```shell-session
-$ boundary config encrypt [options] [args]
+$ boundary config encrypt [options]
 ```
 
 </CodeBlockConfig>
@@ -55,7 +56,7 @@ $ boundary config encrypt [options] [args]
 
 ### Command options
 
-- `-config` `(string: "")` - The configuration file to encrypt.
+- `-config` `(string: "")` - The configuration file to encrypt (required).
 
 - `-config-kms` `(string: "")` - If set, the given file is parsed for
    a "kms" block with purpose `config` to determine whether it should be used to perform the command.

--- a/content/boundary/v0.14.x/content/docs/commands/config/encrypt.mdx
+++ b/content/boundary/v0.14.x/content/docs/commands/config/encrypt.mdx
@@ -36,11 +36,11 @@ kms "aead" {
 }
 ```
 
-You can define the "kms" block in the configuration file or in a separate file
+You can define the `kms` block in the configuration file or in a separate file
 that you pass using the `-config-kms` flag. If you define it in the
 configuration file, only string parameters are supported, and the markers must
 be inside the quotation marks that delimit the string. Additionally, if you
-define the block inline, do not use an "aead" block with the key defined in the
+define the block inline, do not use an `aead` block with the key defined in the
 configuration file as it provides no protection.
 
 ## Usage

--- a/content/boundary/v0.15.x/content/docs/commands/config/decrypt.mdx
+++ b/content/boundary/v0.15.x/content/docs/commands/config/decrypt.mdx
@@ -35,11 +35,11 @@ kms "aead" {
 }
 ```
 
-You can define the "kms" block in the configuration file or in a separate file
+You can define the `kms` block in the configuration file or in a separate file
 that you pass using the `-config-kms` flag. If you define it in the
 configuration file, only string parameters are supported, and the markers must
 be inside the quotation marks that delimit the string. Additionally, if you
-define the block inline, do not use an "aead" block with the key defined in the
+define the block inline, do not use an `aead` block with the key defined in the
 configuration file, as it provides no protection.
 
 ## Usage

--- a/content/boundary/v0.15.x/content/docs/commands/config/decrypt.mdx
+++ b/content/boundary/v0.15.x/content/docs/commands/config/decrypt.mdx
@@ -22,7 +22,7 @@ appropriate, for example: `key = {{decrypt(encrypted_value)}}`.
 The following command overwrites the existing configuration file using the `-overwrite` flag:
 
 ```shell-session
-$ boundary config decrypt -overwrite config.hcl
+$ boundary config decrypt -config config.hcl -overwrite
 ```
 
 In order for this command to perform its task, you must define a "kms" block within the configuration file:
@@ -35,18 +35,19 @@ kms "aead" {
 }
 ```
 
-You can define the "kms" block in the configuration file or using the `-config`
-flag. If you define it in the configuration file, only string parameters are
-supported, and the markers must be inside the quotation marks that delimit the string.
-Additionally, if you define the block inline, do not use an "aead" block with
-the key defined in the configuration file, as it provides no protection.
+You can define the "kms" block in the configuration file or in a separate file
+that you pass using the `-config-kms` flag. If you define it in the
+configuration file, only string parameters are supported, and the markers must
+be inside the quotation marks that delimit the string. Additionally, if you
+define the block inline, do not use an "aead" block with the key defined in the
+configuration file, as it provides no protection.
 
 ## Usage
 
 <CodeBlockConfig hideClipboard>
 
 ```shell-session
-$ boundary config decrypt [options] [args]
+$ boundary config decrypt [options]
 ```
 
 </CodeBlockConfig>
@@ -54,7 +55,7 @@ $ boundary config decrypt [options] [args]
 
 ### Command options
 
-- `-config` `(string: "")` - The configuration file to decrypt.
+- `-config` `(string: "")` - The configuration file to decrypt (required).
 
 - `-config-kms` `(string: "")` - If set, the given file is parsed for
    a "kms" block with purpose `config` to determine whether it should be used to perform the command.

--- a/content/boundary/v0.15.x/content/docs/commands/config/encrypt.mdx
+++ b/content/boundary/v0.15.x/content/docs/commands/config/encrypt.mdx
@@ -20,10 +20,10 @@ appropriate, for example: `key = {{encrypt(key_value)}}`.
 
 ## Examples
 
-The following command overwrites the existing configuration file use the `-overwrite` flag:
+The following command overwrites the existing configuration file using the `-overwrite` flag:
 
 ```shell-session
-$ boundary config encrypt -overwrite config.hcl
+$ boundary config encrypt -config config.hcl -overwrite
 ```
 
 In order for this command to perform its task, you must define a "kms" block within a configuration file:
@@ -36,18 +36,19 @@ kms "aead" {
 }
 ```
 
-You can define the "kms" block in the configuration file or using the `-config`
-flag. If you define it in the configuration file, only string parameters are
-supported, and the markers must be inside the quotation marks that delimit the string.
-Additionally, if you define the block inline, do not use an "aead" block with
-the key defined in the configuration file as it provides no protection.
+You can define the "kms" block in the configuration file or in a separate file
+that you pass using the `-config-kms` flag. If you define it in the
+configuration file, only string parameters are supported, and the markers must
+be inside the quotation marks that delimit the string. Additionally, if you
+define the block inline, do not use an "aead" block with the key defined in the
+configuration file as it provides no protection.
 
 ## Usage
 
 <CodeBlockConfig hideClipboard>
 
 ```shell-session
-$ boundary config encrypt [options] [args]
+$ boundary config encrypt [options]
 ```
 
 </CodeBlockConfig>
@@ -55,7 +56,7 @@ $ boundary config encrypt [options] [args]
 
 ### Command options
 
-- `-config` `(string: "")` - The configuration file to encrypt.
+- `-config` `(string: "")` - The configuration file to encrypt (required).
 
 - `-config-kms` `(string: "")` - If set, the given file is parsed for
    a "kms" block with purpose `config` to determine whether it should be used to perform the command.

--- a/content/boundary/v0.15.x/content/docs/commands/config/encrypt.mdx
+++ b/content/boundary/v0.15.x/content/docs/commands/config/encrypt.mdx
@@ -36,11 +36,11 @@ kms "aead" {
 }
 ```
 
-You can define the "kms" block in the configuration file or in a separate file
+You can define the `kms` block in the configuration file or in a separate file
 that you pass using the `-config-kms` flag. If you define it in the
 configuration file, only string parameters are supported, and the markers must
 be inside the quotation marks that delimit the string. Additionally, if you
-define the block inline, do not use an "aead" block with the key defined in the
+define the block inline, do not use an `aead` block with the key defined in the
 configuration file as it provides no protection.
 
 ## Usage

--- a/content/boundary/v0.16.x/content/docs/commands/config/decrypt.mdx
+++ b/content/boundary/v0.16.x/content/docs/commands/config/decrypt.mdx
@@ -35,11 +35,11 @@ kms "aead" {
 }
 ```
 
-You can define the "kms" block in the configuration file or in a separate file
+You can define the `kms` block in the configuration file or in a separate file
 that you pass using the `-config-kms` flag. If you define it in the
 configuration file, only string parameters are supported, and the markers must
 be inside the quotation marks that delimit the string. Additionally, if you
-define the block inline, do not use an "aead" block with the key defined in the
+define the block inline, do not use an `aead` block with the key defined in the
 configuration file, as it provides no protection.
 
 ## Usage

--- a/content/boundary/v0.16.x/content/docs/commands/config/decrypt.mdx
+++ b/content/boundary/v0.16.x/content/docs/commands/config/decrypt.mdx
@@ -22,7 +22,7 @@ appropriate, for example: `key = {{decrypt(encrypted_value)}}`.
 The following command overwrites the existing configuration file using the `-overwrite` flag:
 
 ```shell-session
-$ boundary config decrypt -overwrite config.hcl
+$ boundary config decrypt -config config.hcl -overwrite
 ```
 
 In order for this command to perform its task, you must define a "kms" block within the configuration file:
@@ -35,18 +35,19 @@ kms "aead" {
 }
 ```
 
-You can define the "kms" block in the configuration file or using the `-config`
-flag. If you define it in the configuration file, only string parameters are
-supported, and the markers must be inside the quotation marks that delimit the string.
-Additionally, if you define the block inline, do not use an "aead" block with
-the key defined in the configuration file, as it provides no protection.
+You can define the "kms" block in the configuration file or in a separate file
+that you pass using the `-config-kms` flag. If you define it in the
+configuration file, only string parameters are supported, and the markers must
+be inside the quotation marks that delimit the string. Additionally, if you
+define the block inline, do not use an "aead" block with the key defined in the
+configuration file, as it provides no protection.
 
 ## Usage
 
 <CodeBlockConfig hideClipboard>
 
 ```shell-session
-$ boundary config decrypt [options] [args]
+$ boundary config decrypt [options]
 ```
 
 </CodeBlockConfig>
@@ -54,7 +55,7 @@ $ boundary config decrypt [options] [args]
 
 ### Command options
 
-- `-config` `(string: "")` - The configuration file to decrypt.
+- `-config` `(string: "")` - The configuration file to decrypt (required).
 
 - `-config-kms` `(string: "")` - If set, the given file is parsed for
    a "kms" block with purpose `config` to determine whether it should be used to perform the command.

--- a/content/boundary/v0.16.x/content/docs/commands/config/encrypt.mdx
+++ b/content/boundary/v0.16.x/content/docs/commands/config/encrypt.mdx
@@ -20,10 +20,10 @@ appropriate, for example: `key = {{encrypt(key_value)}}`.
 
 ## Examples
 
-The following command overwrites the existing configuration file use the `-overwrite` flag:
+The following command overwrites the existing configuration file using the `-overwrite` flag:
 
 ```shell-session
-$ boundary config encrypt -overwrite config.hcl
+$ boundary config encrypt -config config.hcl -overwrite
 ```
 
 In order for this command to perform its task, you must define a "kms" block within a configuration file:
@@ -36,18 +36,19 @@ kms "aead" {
 }
 ```
 
-You can define the "kms" block in the configuration file or using the `-config`
-flag. If you define it in the configuration file, only string parameters are
-supported, and the markers must be inside the quotation marks that delimit the string.
-Additionally, if you define the block inline, do not use an "aead" block with
-the key defined in the configuration file as it provides no protection.
+You can define the "kms" block in the configuration file or in a separate file
+that you pass using the `-config-kms` flag. If you define it in the
+configuration file, only string parameters are supported, and the markers must
+be inside the quotation marks that delimit the string. Additionally, if you
+define the block inline, do not use an "aead" block with the key defined in the
+configuration file as it provides no protection.
 
 ## Usage
 
 <CodeBlockConfig hideClipboard>
 
 ```shell-session
-$ boundary config encrypt [options] [args]
+$ boundary config encrypt [options]
 ```
 
 </CodeBlockConfig>
@@ -55,7 +56,7 @@ $ boundary config encrypt [options] [args]
 
 ### Command options
 
-- `-config` `(string: "")` - The configuration file to encrypt.
+- `-config` `(string: "")` - The configuration file to encrypt (required).
 
 - `-config-kms` `(string: "")` - If set, the given file is parsed for
    a "kms" block with purpose `config` to determine whether it should be used to perform the command.

--- a/content/boundary/v0.16.x/content/docs/commands/config/encrypt.mdx
+++ b/content/boundary/v0.16.x/content/docs/commands/config/encrypt.mdx
@@ -36,11 +36,11 @@ kms "aead" {
 }
 ```
 
-You can define the "kms" block in the configuration file or in a separate file
+You can define the `kms` block in the configuration file or in a separate file
 that you pass using the `-config-kms` flag. If you define it in the
 configuration file, only string parameters are supported, and the markers must
 be inside the quotation marks that delimit the string. Additionally, if you
-define the block inline, do not use an "aead" block with the key defined in the
+define the block inline, do not use an `aead` block with the key defined in the
 configuration file as it provides no protection.
 
 ## Usage

--- a/content/boundary/v0.17.x/content/docs/commands/config/decrypt.mdx
+++ b/content/boundary/v0.17.x/content/docs/commands/config/decrypt.mdx
@@ -35,11 +35,11 @@ kms "aead" {
 }
 ```
 
-You can define the "kms" block in the configuration file or in a separate file
+You can define the `kms` block in the configuration file or in a separate file
 that you pass using the `-config-kms` flag. If you define it in the
 configuration file, only string parameters are supported, and the markers must
 be inside the quotation marks that delimit the string. Additionally, if you
-define the block inline, do not use an "aead" block with the key defined in the
+define the block inline, do not use an `aead` block with the key defined in the
 configuration file, as it provides no protection.
 
 ## Usage

--- a/content/boundary/v0.17.x/content/docs/commands/config/decrypt.mdx
+++ b/content/boundary/v0.17.x/content/docs/commands/config/decrypt.mdx
@@ -22,7 +22,7 @@ appropriate, for example: `key = {{decrypt(encrypted_value)}}`.
 The following command overwrites the existing configuration file using the `-overwrite` flag:
 
 ```shell-session
-$ boundary config decrypt -overwrite config.hcl
+$ boundary config decrypt -config config.hcl -overwrite
 ```
 
 In order for this command to perform its task, you must define a "kms" block within the configuration file:
@@ -35,18 +35,19 @@ kms "aead" {
 }
 ```
 
-You can define the "kms" block in the configuration file or using the `-config`
-flag. If you define it in the configuration file, only string parameters are
-supported, and the markers must be inside the quotation marks that delimit the string.
-Additionally, if you define the block inline, do not use an "aead" block with
-the key defined in the configuration file, as it provides no protection.
+You can define the "kms" block in the configuration file or in a separate file
+that you pass using the `-config-kms` flag. If you define it in the
+configuration file, only string parameters are supported, and the markers must
+be inside the quotation marks that delimit the string. Additionally, if you
+define the block inline, do not use an "aead" block with the key defined in the
+configuration file, as it provides no protection.
 
 ## Usage
 
 <CodeBlockConfig hideClipboard>
 
 ```shell-session
-$ boundary config decrypt [options] [args]
+$ boundary config decrypt [options]
 ```
 
 </CodeBlockConfig>
@@ -54,7 +55,7 @@ $ boundary config decrypt [options] [args]
 
 ### Command options
 
-- `-config` `(string: "")` - The configuration file to decrypt.
+- `-config` `(string: "")` - The configuration file to decrypt (required).
 
 - `-config-kms` `(string: "")` - If set, the given file is parsed for
    a "kms" block with purpose `config` to determine whether it should be used to perform the command.

--- a/content/boundary/v0.17.x/content/docs/commands/config/encrypt.mdx
+++ b/content/boundary/v0.17.x/content/docs/commands/config/encrypt.mdx
@@ -20,10 +20,10 @@ appropriate, for example: `key = {{encrypt(key_value)}}`.
 
 ## Examples
 
-The following command overwrites the existing configuration file use the `-overwrite` flag:
+The following command overwrites the existing configuration file using the `-overwrite` flag:
 
 ```shell-session
-$ boundary config encrypt -overwrite config.hcl
+$ boundary config encrypt -config config.hcl -overwrite
 ```
 
 In order for this command to perform its task, you must define a "kms" block within a configuration file:
@@ -36,18 +36,19 @@ kms "aead" {
 }
 ```
 
-You can define the "kms" block in the configuration file or using the `-config`
-flag. If you define it in the configuration file, only string parameters are
-supported, and the markers must be inside the quotation marks that delimit the string.
-Additionally, if you define the block inline, do not use an "aead" block with
-the key defined in the configuration file as it provides no protection.
+You can define the "kms" block in the configuration file or in a separate file
+that you pass using the `-config-kms` flag. If you define it in the
+configuration file, only string parameters are supported, and the markers must
+be inside the quotation marks that delimit the string. Additionally, if you
+define the block inline, do not use an "aead" block with the key defined in the
+configuration file as it provides no protection.
 
 ## Usage
 
 <CodeBlockConfig hideClipboard>
 
 ```shell-session
-$ boundary config encrypt [options] [args]
+$ boundary config encrypt [options]
 ```
 
 </CodeBlockConfig>
@@ -55,7 +56,7 @@ $ boundary config encrypt [options] [args]
 
 ### Command options
 
-- `-config` `(string: "")` - The configuration file to encrypt.
+- `-config` `(string: "")` - The configuration file to encrypt (required).
 
 - `-config-kms` `(string: "")` - If set, the given file is parsed for
    a "kms" block with purpose `config` to determine whether it should be used to perform the command.

--- a/content/boundary/v0.17.x/content/docs/commands/config/encrypt.mdx
+++ b/content/boundary/v0.17.x/content/docs/commands/config/encrypt.mdx
@@ -36,11 +36,11 @@ kms "aead" {
 }
 ```
 
-You can define the "kms" block in the configuration file or in a separate file
+You can define the `kms` block in the configuration file or in a separate file
 that you pass using the `-config-kms` flag. If you define it in the
 configuration file, only string parameters are supported, and the markers must
 be inside the quotation marks that delimit the string. Additionally, if you
-define the block inline, do not use an "aead" block with the key defined in the
+define the block inline, do not use an `aead` block with the key defined in the
 configuration file as it provides no protection.
 
 ## Usage

--- a/content/boundary/v0.18.x/content/docs/commands/config/decrypt.mdx
+++ b/content/boundary/v0.18.x/content/docs/commands/config/decrypt.mdx
@@ -35,11 +35,11 @@ kms "aead" {
 }
 ```
 
-You can define the "kms" block in the configuration file or in a separate file
+You can define the `kms` block in the configuration file or in a separate file
 that you pass using the `-config-kms` flag. If you define it in the
 configuration file, only string parameters are supported, and the markers must
 be inside the quotation marks that delimit the string. Additionally, if you
-define the block inline, do not use an "aead" block with the key defined in the
+define the block inline, do not use an `aead` block with the key defined in the
 configuration file, as it provides no protection.
 
 ## Usage

--- a/content/boundary/v0.18.x/content/docs/commands/config/decrypt.mdx
+++ b/content/boundary/v0.18.x/content/docs/commands/config/decrypt.mdx
@@ -22,7 +22,7 @@ appropriate, for example: `key = {{decrypt(encrypted_value)}}`.
 The following command overwrites the existing configuration file using the `-overwrite` flag:
 
 ```shell-session
-$ boundary config decrypt -overwrite config.hcl
+$ boundary config decrypt -config config.hcl -overwrite
 ```
 
 In order for this command to perform its task, you must define a "kms" block within the configuration file:
@@ -35,18 +35,19 @@ kms "aead" {
 }
 ```
 
-You can define the "kms" block in the configuration file or using the `-config`
-flag. If you define it in the configuration file, only string parameters are
-supported, and the markers must be inside the quotation marks that delimit the string.
-Additionally, if you define the block inline, do not use an "aead" block with
-the key defined in the configuration file, as it provides no protection.
+You can define the "kms" block in the configuration file or in a separate file
+that you pass using the `-config-kms` flag. If you define it in the
+configuration file, only string parameters are supported, and the markers must
+be inside the quotation marks that delimit the string. Additionally, if you
+define the block inline, do not use an "aead" block with the key defined in the
+configuration file, as it provides no protection.
 
 ## Usage
 
 <CodeBlockConfig hideClipboard>
 
 ```shell-session
-$ boundary config decrypt [options] [args]
+$ boundary config decrypt [options]
 ```
 
 </CodeBlockConfig>
@@ -54,7 +55,7 @@ $ boundary config decrypt [options] [args]
 
 ### Command options
 
-- `-config` `(string: "")` - The configuration file to decrypt.
+- `-config` `(string: "")` - The configuration file to decrypt (required).
 
 - `-config-kms` `(string: "")` - If set, the given file is parsed for
    a "kms" block with purpose `config` to determine whether it should be used to perform the command.

--- a/content/boundary/v0.18.x/content/docs/commands/config/encrypt.mdx
+++ b/content/boundary/v0.18.x/content/docs/commands/config/encrypt.mdx
@@ -20,10 +20,10 @@ appropriate, for example: `key = {{encrypt(key_value)}}`.
 
 ## Examples
 
-The following command overwrites the existing configuration file use the `-overwrite` flag:
+The following command overwrites the existing configuration file using the `-overwrite` flag:
 
 ```shell-session
-$ boundary config encrypt -overwrite config.hcl
+$ boundary config encrypt -config config.hcl -overwrite
 ```
 
 In order for this command to perform its task, you must define a "kms" block within a configuration file:
@@ -36,18 +36,19 @@ kms "aead" {
 }
 ```
 
-You can define the "kms" block in the configuration file or using the `-config`
-flag. If you define it in the configuration file, only string parameters are
-supported, and the markers must be inside the quotation marks that delimit the string.
-Additionally, if you define the block inline, do not use an "aead" block with
-the key defined in the configuration file as it provides no protection.
+You can define the "kms" block in the configuration file or in a separate file
+that you pass using the `-config-kms` flag. If you define it in the
+configuration file, only string parameters are supported, and the markers must
+be inside the quotation marks that delimit the string. Additionally, if you
+define the block inline, do not use an "aead" block with the key defined in the
+configuration file as it provides no protection.
 
 ## Usage
 
 <CodeBlockConfig hideClipboard>
 
 ```shell-session
-$ boundary config encrypt [options] [args]
+$ boundary config encrypt [options]
 ```
 
 </CodeBlockConfig>
@@ -55,7 +56,7 @@ $ boundary config encrypt [options] [args]
 
 ### Command options
 
-- `-config` `(string: "")` - The configuration file to encrypt.
+- `-config` `(string: "")` - The configuration file to encrypt (required).
 
 - `-config-kms` `(string: "")` - If set, the given file is parsed for
    a "kms" block with purpose `config` to determine whether it should be used to perform the command.

--- a/content/boundary/v0.18.x/content/docs/commands/config/encrypt.mdx
+++ b/content/boundary/v0.18.x/content/docs/commands/config/encrypt.mdx
@@ -36,11 +36,11 @@ kms "aead" {
 }
 ```
 
-You can define the "kms" block in the configuration file or in a separate file
+You can define the `kms` block in the configuration file or in a separate file
 that you pass using the `-config-kms` flag. If you define it in the
 configuration file, only string parameters are supported, and the markers must
 be inside the quotation marks that delimit the string. Additionally, if you
-define the block inline, do not use an "aead" block with the key defined in the
+define the block inline, do not use an `aead` block with the key defined in the
 configuration file as it provides no protection.
 
 ## Usage

--- a/content/boundary/v0.19.x/content/docs/commands/config/decrypt.mdx
+++ b/content/boundary/v0.19.x/content/docs/commands/config/decrypt.mdx
@@ -35,11 +35,11 @@ kms "aead" {
 }
 ```
 
-You can define the "kms" block in the configuration file or in a separate file
+You can define the `kms` block in the configuration file or in a separate file
 that you pass using the `-config-kms` flag. If you define it in the
 configuration file, only string parameters are supported, and the markers must
 be inside the quotation marks that delimit the string. Additionally, if you
-define the block inline, do not use an "aead" block with the key defined in the
+define the block inline, do not use an `aead` block with the key defined in the
 configuration file, as it provides no protection.
 
 ## Usage

--- a/content/boundary/v0.19.x/content/docs/commands/config/decrypt.mdx
+++ b/content/boundary/v0.19.x/content/docs/commands/config/decrypt.mdx
@@ -22,7 +22,7 @@ appropriate, for example: `key = {{decrypt(encrypted_value)}}`.
 The following command overwrites the existing configuration file using the `-overwrite` flag:
 
 ```shell-session
-$ boundary config decrypt -overwrite config.hcl
+$ boundary config decrypt -config config.hcl -overwrite
 ```
 
 In order for this command to perform its task, you must define a "kms" block within the configuration file:
@@ -35,18 +35,19 @@ kms "aead" {
 }
 ```
 
-You can define the "kms" block in the configuration file or using the `-config`
-flag. If you define it in the configuration file, only string parameters are
-supported, and the markers must be inside the quotation marks that delimit the string.
-Additionally, if you define the block inline, do not use an "aead" block with
-the key defined in the configuration file, as it provides no protection.
+You can define the "kms" block in the configuration file or in a separate file
+that you pass using the `-config-kms` flag. If you define it in the
+configuration file, only string parameters are supported, and the markers must
+be inside the quotation marks that delimit the string. Additionally, if you
+define the block inline, do not use an "aead" block with the key defined in the
+configuration file, as it provides no protection.
 
 ## Usage
 
 <CodeBlockConfig hideClipboard>
 
 ```shell-session
-$ boundary config decrypt [options] [args]
+$ boundary config decrypt [options]
 ```
 
 </CodeBlockConfig>
@@ -54,7 +55,7 @@ $ boundary config decrypt [options] [args]
 
 ### Command options
 
-- `-config` `(string: "")` - The configuration file to decrypt.
+- `-config` `(string: "")` - The configuration file to decrypt (required).
 
 - `-config-kms` `(string: "")` - If set, the given file is parsed for
    a "kms" block with purpose `config` to determine whether it should be used to perform the command.

--- a/content/boundary/v0.19.x/content/docs/commands/config/encrypt.mdx
+++ b/content/boundary/v0.19.x/content/docs/commands/config/encrypt.mdx
@@ -20,10 +20,10 @@ appropriate, for example: `key = {{encrypt(key_value)}}`.
 
 ## Examples
 
-The following command overwrites the existing configuration file use the `-overwrite` flag:
+The following command overwrites the existing configuration file using the `-overwrite` flag:
 
 ```shell-session
-$ boundary config encrypt -overwrite config.hcl
+$ boundary config encrypt -config config.hcl -overwrite
 ```
 
 In order for this command to perform its task, you must define a "kms" block within a configuration file:
@@ -36,18 +36,19 @@ kms "aead" {
 }
 ```
 
-You can define the "kms" block in the configuration file or using the `-config`
-flag. If you define it in the configuration file, only string parameters are
-supported, and the markers must be inside the quotation marks that delimit the string.
-Additionally, if you define the block inline, do not use an "aead" block with
-the key defined in the configuration file as it provides no protection.
+You can define the "kms" block in the configuration file or in a separate file
+that you pass using the `-config-kms` flag. If you define it in the
+configuration file, only string parameters are supported, and the markers must
+be inside the quotation marks that delimit the string. Additionally, if you
+define the block inline, do not use an "aead" block with the key defined in the
+configuration file as it provides no protection.
 
 ## Usage
 
 <CodeBlockConfig hideClipboard>
 
 ```shell-session
-$ boundary config encrypt [options] [args]
+$ boundary config encrypt [options]
 ```
 
 </CodeBlockConfig>
@@ -55,7 +56,7 @@ $ boundary config encrypt [options] [args]
 
 ### Command options
 
-- `-config` `(string: "")` - The configuration file to encrypt.
+- `-config` `(string: "")` - The configuration file to encrypt (required).
 
 - `-config-kms` `(string: "")` - If set, the given file is parsed for
    a "kms" block with purpose `config` to determine whether it should be used to perform the command.

--- a/content/boundary/v0.19.x/content/docs/commands/config/encrypt.mdx
+++ b/content/boundary/v0.19.x/content/docs/commands/config/encrypt.mdx
@@ -36,11 +36,11 @@ kms "aead" {
 }
 ```
 
-You can define the "kms" block in the configuration file or in a separate file
+You can define the `kms` block in the configuration file or in a separate file
 that you pass using the `-config-kms` flag. If you define it in the
 configuration file, only string parameters are supported, and the markers must
 be inside the quotation marks that delimit the string. Additionally, if you
-define the block inline, do not use an "aead" block with the key defined in the
+define the block inline, do not use an `aead` block with the key defined in the
 configuration file as it provides no protection.
 
 ## Usage

--- a/content/boundary/v0.20.x/content/docs/commands/config/decrypt.mdx
+++ b/content/boundary/v0.20.x/content/docs/commands/config/decrypt.mdx
@@ -35,11 +35,11 @@ kms "aead" {
 }
 ```
 
-You can define the "kms" block in the configuration file or in a separate file
+You can define the `kms` block in the configuration file or in a separate file
 that you pass using the `-config-kms` flag. If you define it in the
 configuration file, only string parameters are supported, and the markers must
 be inside the quotation marks that delimit the string. Additionally, if you
-define the block inline, do not use an "aead" block with the key defined in the
+define the block inline, do not use an `aead` block with the key defined in the
 configuration file, as it provides no protection.
 
 ## Usage

--- a/content/boundary/v0.20.x/content/docs/commands/config/decrypt.mdx
+++ b/content/boundary/v0.20.x/content/docs/commands/config/decrypt.mdx
@@ -22,7 +22,7 @@ appropriate, for example: `key = {{decrypt(encrypted_value)}}`.
 The following command overwrites the existing configuration file using the `-overwrite` flag:
 
 ```shell-session
-$ boundary config decrypt -overwrite config.hcl
+$ boundary config decrypt -config config.hcl -overwrite
 ```
 
 In order for this command to perform its task, you must define a "kms" block within the configuration file:
@@ -35,18 +35,19 @@ kms "aead" {
 }
 ```
 
-You can define the "kms" block in the configuration file or using the `-config`
-flag. If you define it in the configuration file, only string parameters are
-supported, and the markers must be inside the quotation marks that delimit the string.
-Additionally, if you define the block inline, do not use an "aead" block with
-the key defined in the configuration file, as it provides no protection.
+You can define the "kms" block in the configuration file or in a separate file
+that you pass using the `-config-kms` flag. If you define it in the
+configuration file, only string parameters are supported, and the markers must
+be inside the quotation marks that delimit the string. Additionally, if you
+define the block inline, do not use an "aead" block with the key defined in the
+configuration file, as it provides no protection.
 
 ## Usage
 
 <CodeBlockConfig hideClipboard>
 
 ```shell-session
-$ boundary config decrypt [options] [args]
+$ boundary config decrypt [options]
 ```
 
 </CodeBlockConfig>
@@ -54,7 +55,7 @@ $ boundary config decrypt [options] [args]
 
 ### Command options
 
-- `-config` `(string: "")` - The configuration file to decrypt.
+- `-config` `(string: "")` - The configuration file to decrypt (required).
 
 - `-config-kms` `(string: "")` - If set, the given file is parsed for
    a "kms" block with purpose `config` to determine whether it should be used to perform the command.

--- a/content/boundary/v0.20.x/content/docs/commands/config/encrypt.mdx
+++ b/content/boundary/v0.20.x/content/docs/commands/config/encrypt.mdx
@@ -20,10 +20,10 @@ appropriate, for example: `key = {{encrypt(key_value)}}`.
 
 ## Examples
 
-The following command overwrites the existing configuration file use the `-overwrite` flag:
+The following command overwrites the existing configuration file using the `-overwrite` flag:
 
 ```shell-session
-$ boundary config encrypt -overwrite config.hcl
+$ boundary config encrypt -config config.hcl -overwrite
 ```
 
 In order for this command to perform its task, you must define a "kms" block within a configuration file:
@@ -36,18 +36,19 @@ kms "aead" {
 }
 ```
 
-You can define the "kms" block in the configuration file or using the `-config`
-flag. If you define it in the configuration file, only string parameters are
-supported, and the markers must be inside the quotation marks that delimit the string.
-Additionally, if you define the block inline, do not use an "aead" block with
-the key defined in the configuration file as it provides no protection.
+You can define the "kms" block in the configuration file or in a separate file
+that you pass using the `-config-kms` flag. If you define it in the
+configuration file, only string parameters are supported, and the markers must
+be inside the quotation marks that delimit the string. Additionally, if you
+define the block inline, do not use an "aead" block with the key defined in the
+configuration file as it provides no protection.
 
 ## Usage
 
 <CodeBlockConfig hideClipboard>
 
 ```shell-session
-$ boundary config encrypt [options] [args]
+$ boundary config encrypt [options]
 ```
 
 </CodeBlockConfig>
@@ -55,7 +56,7 @@ $ boundary config encrypt [options] [args]
 
 ### Command options
 
-- `-config` `(string: "")` - The configuration file to encrypt.
+- `-config` `(string: "")` - The configuration file to encrypt (required).
 
 - `-config-kms` `(string: "")` - If set, the given file is parsed for
    a "kms" block with purpose `config` to determine whether it should be used to perform the command.

--- a/content/boundary/v0.20.x/content/docs/commands/config/encrypt.mdx
+++ b/content/boundary/v0.20.x/content/docs/commands/config/encrypt.mdx
@@ -36,11 +36,11 @@ kms "aead" {
 }
 ```
 
-You can define the "kms" block in the configuration file or in a separate file
+You can define the `kms` block in the configuration file or in a separate file
 that you pass using the `-config-kms` flag. If you define it in the
 configuration file, only string parameters are supported, and the markers must
 be inside the quotation marks that delimit the string. Additionally, if you
-define the block inline, do not use an "aead" block with the key defined in the
+define the block inline, do not use an `aead` block with the key defined in the
 configuration file as it provides no protection.
 
 ## Usage

--- a/content/boundary/v0.21.x/content/docs/commands/config/decrypt.mdx
+++ b/content/boundary/v0.21.x/content/docs/commands/config/decrypt.mdx
@@ -35,11 +35,11 @@ kms "aead" {
 }
 ```
 
-You can define the "kms" block in the configuration file or in a separate file
+You can define the `kms` block in the configuration file or in a separate file
 that you pass using the `-config-kms` flag. If you define it in the
 configuration file, only string parameters are supported, and the markers must
 be inside the quotation marks that delimit the string. Additionally, if you
-define the block inline, do not use an "aead" block with the key defined in the
+define the block inline, do not use an `aead` block with the key defined in the
 configuration file, as it provides no protection.
 
 ## Usage

--- a/content/boundary/v0.21.x/content/docs/commands/config/decrypt.mdx
+++ b/content/boundary/v0.21.x/content/docs/commands/config/decrypt.mdx
@@ -22,7 +22,7 @@ appropriate, for example: `key = {{decrypt(encrypted_value)}}`.
 The following command overwrites the existing configuration file using the `-overwrite` flag:
 
 ```shell-session
-$ boundary config decrypt -overwrite config.hcl
+$ boundary config decrypt -config config.hcl -overwrite
 ```
 
 In order for this command to perform its task, you must define a "kms" block within the configuration file:
@@ -35,18 +35,19 @@ kms "aead" {
 }
 ```
 
-You can define the "kms" block in the configuration file or using the `-config`
-flag. If you define it in the configuration file, only string parameters are
-supported, and the markers must be inside the quotation marks that delimit the string.
-Additionally, if you define the block inline, do not use an "aead" block with
-the key defined in the configuration file, as it provides no protection.
+You can define the "kms" block in the configuration file or in a separate file
+that you pass using the `-config-kms` flag. If you define it in the
+configuration file, only string parameters are supported, and the markers must
+be inside the quotation marks that delimit the string. Additionally, if you
+define the block inline, do not use an "aead" block with the key defined in the
+configuration file, as it provides no protection.
 
 ## Usage
 
 <CodeBlockConfig hideClipboard>
 
 ```shell-session
-$ boundary config decrypt [options] [args]
+$ boundary config decrypt [options]
 ```
 
 </CodeBlockConfig>
@@ -54,7 +55,7 @@ $ boundary config decrypt [options] [args]
 
 ### Command options
 
-- `-config` `(string: "")` - The configuration file to decrypt.
+- `-config` `(string: "")` - The configuration file to decrypt (required).
 
 - `-config-kms` `(string: "")` - If set, the given file is parsed for
    a "kms" block with purpose `config` to determine whether it should be used to perform the command.

--- a/content/boundary/v0.21.x/content/docs/commands/config/encrypt.mdx
+++ b/content/boundary/v0.21.x/content/docs/commands/config/encrypt.mdx
@@ -20,10 +20,10 @@ appropriate, for example: `key = {{encrypt(key_value)}}`.
 
 ## Examples
 
-The following command overwrites the existing configuration file use the `-overwrite` flag:
+The following command overwrites the existing configuration file using the `-overwrite` flag:
 
 ```shell-session
-$ boundary config encrypt -overwrite config.hcl
+$ boundary config encrypt -config config.hcl -overwrite
 ```
 
 In order for this command to perform its task, you must define a "kms" block within a configuration file:
@@ -36,18 +36,19 @@ kms "aead" {
 }
 ```
 
-You can define the "kms" block in the configuration file or using the `-config`
-flag. If you define it in the configuration file, only string parameters are
-supported, and the markers must be inside the quotation marks that delimit the string.
-Additionally, if you define the block inline, do not use an "aead" block with
-the key defined in the configuration file as it provides no protection.
+You can define the "kms" block in the configuration file or in a separate file
+that you pass using the `-config-kms` flag. If you define it in the
+configuration file, only string parameters are supported, and the markers must
+be inside the quotation marks that delimit the string. Additionally, if you
+define the block inline, do not use an "aead" block with the key defined in the
+configuration file as it provides no protection.
 
 ## Usage
 
 <CodeBlockConfig hideClipboard>
 
 ```shell-session
-$ boundary config encrypt [options] [args]
+$ boundary config encrypt [options]
 ```
 
 </CodeBlockConfig>
@@ -55,7 +56,7 @@ $ boundary config encrypt [options] [args]
 
 ### Command options
 
-- `-config` `(string: "")` - The configuration file to encrypt.
+- `-config` `(string: "")` - The configuration file to encrypt (required).
 
 - `-config-kms` `(string: "")` - If set, the given file is parsed for
    a "kms" block with purpose `config` to determine whether it should be used to perform the command.

--- a/content/boundary/v0.21.x/content/docs/commands/config/encrypt.mdx
+++ b/content/boundary/v0.21.x/content/docs/commands/config/encrypt.mdx
@@ -36,11 +36,11 @@ kms "aead" {
 }
 ```
 
-You can define the "kms" block in the configuration file or in a separate file
+You can define the `kms` block in the configuration file or in a separate file
 that you pass using the `-config-kms` flag. If you define it in the
 configuration file, only string parameters are supported, and the markers must
 be inside the quotation marks that delimit the string. Additionally, if you
-define the block inline, do not use an "aead" block with the key defined in the
+define the block inline, do not use an `aead` block with the key defined in the
 configuration file as it provides no protection.
 
 ## Usage

--- a/content/boundary/v1.0.x/content/docs/commands/config/decrypt.mdx
+++ b/content/boundary/v1.0.x/content/docs/commands/config/decrypt.mdx
@@ -35,11 +35,11 @@ kms "aead" {
 }
 ```
 
-You can define the "kms" block in the configuration file or in a separate file
+You can define the `kms` block in the configuration file or in a separate file
 that you pass using the `-config-kms` flag. If you define it in the
 configuration file, only string parameters are supported, and the markers must
 be inside the quotation marks that delimit the string. Additionally, if you
-define the block inline, do not use an "aead" block with the key defined in the
+define the block inline, do not use an `aead` block with the key defined in the
 configuration file, as it provides no protection.
 
 ## Usage

--- a/content/boundary/v1.0.x/content/docs/commands/config/decrypt.mdx
+++ b/content/boundary/v1.0.x/content/docs/commands/config/decrypt.mdx
@@ -22,7 +22,7 @@ appropriate, for example: `key = {{decrypt(encrypted_value)}}`.
 The following command overwrites the existing configuration file using the `-overwrite` flag:
 
 ```shell-session
-$ boundary config decrypt -overwrite config.hcl
+$ boundary config decrypt -config config.hcl -overwrite
 ```
 
 In order for this command to perform its task, you must define a "kms" block within the configuration file:
@@ -35,18 +35,19 @@ kms "aead" {
 }
 ```
 
-You can define the "kms" block in the configuration file or using the `-config`
-flag. If you define it in the configuration file, only string parameters are
-supported, and the markers must be inside the quotation marks that delimit the string.
-Additionally, if you define the block inline, do not use an "aead" block with
-the key defined in the configuration file, as it provides no protection.
+You can define the "kms" block in the configuration file or in a separate file
+that you pass using the `-config-kms` flag. If you define it in the
+configuration file, only string parameters are supported, and the markers must
+be inside the quotation marks that delimit the string. Additionally, if you
+define the block inline, do not use an "aead" block with the key defined in the
+configuration file, as it provides no protection.
 
 ## Usage
 
 <CodeBlockConfig hideClipboard>
 
 ```shell-session
-$ boundary config decrypt [options] [args]
+$ boundary config decrypt [options]
 ```
 
 </CodeBlockConfig>
@@ -54,7 +55,7 @@ $ boundary config decrypt [options] [args]
 
 ### Command options
 
-- `-config` `(string: "")` - The configuration file to decrypt.
+- `-config` `(string: "")` - The configuration file to decrypt (required).
 
 - `-config-kms` `(string: "")` - If set, the given file is parsed for
    a "kms" block with purpose `config` to determine whether it should be used to perform the command.

--- a/content/boundary/v1.0.x/content/docs/commands/config/encrypt.mdx
+++ b/content/boundary/v1.0.x/content/docs/commands/config/encrypt.mdx
@@ -20,10 +20,10 @@ appropriate, for example: `key = {{encrypt(key_value)}}`.
 
 ## Examples
 
-The following command overwrites the existing configuration file use the `-overwrite` flag:
+The following command overwrites the existing configuration file using the `-overwrite` flag:
 
 ```shell-session
-$ boundary config encrypt -overwrite config.hcl
+$ boundary config encrypt -config config.hcl -overwrite
 ```
 
 In order for this command to perform its task, you must define a "kms" block within a configuration file:
@@ -36,18 +36,19 @@ kms "aead" {
 }
 ```
 
-You can define the "kms" block in the configuration file or using the `-config`
-flag. If you define it in the configuration file, only string parameters are
-supported, and the markers must be inside the quotation marks that delimit the string.
-Additionally, if you define the block inline, do not use an "aead" block with
-the key defined in the configuration file as it provides no protection.
+You can define the "kms" block in the configuration file or in a separate file
+that you pass using the `-config-kms` flag. If you define it in the
+configuration file, only string parameters are supported, and the markers must
+be inside the quotation marks that delimit the string. Additionally, if you
+define the block inline, do not use an "aead" block with the key defined in the
+configuration file as it provides no protection.
 
 ## Usage
 
 <CodeBlockConfig hideClipboard>
 
 ```shell-session
-$ boundary config encrypt [options] [args]
+$ boundary config encrypt [options]
 ```
 
 </CodeBlockConfig>
@@ -55,7 +56,7 @@ $ boundary config encrypt [options] [args]
 
 ### Command options
 
-- `-config` `(string: "")` - The configuration file to encrypt.
+- `-config` `(string: "")` - The configuration file to encrypt (required).
 
 - `-config-kms` `(string: "")` - If set, the given file is parsed for
    a "kms" block with purpose `config` to determine whether it should be used to perform the command.

--- a/content/boundary/v1.0.x/content/docs/commands/config/encrypt.mdx
+++ b/content/boundary/v1.0.x/content/docs/commands/config/encrypt.mdx
@@ -36,11 +36,11 @@ kms "aead" {
 }
 ```
 
-You can define the "kms" block in the configuration file or in a separate file
+You can define the `kms` block in the configuration file or in a separate file
 that you pass using the `-config-kms` flag. If you define it in the
 configuration file, only string parameters are supported, and the markers must
 be inside the quotation marks that delimit the string. Additionally, if you
-define the block inline, do not use an "aead" block with the key defined in the
+define the block inline, do not use an `aead` block with the key defined in the
 configuration file as it provides no protection.
 
 ## Usage


### PR DESCRIPTION
## Description

The `config encrypt` and `config decrypt` reference pages document an interface the commands do not implement. The example they give **fails when you run it**, and three other statements are inaccurate.

All four errors trace to one cause: the pages were written from the commands' `Help()` text, which does not match what `Run()` actually does. Verified against `hashicorp/boundary-enterprise` at `v1.0.0+ent`.

### What was wrong

**1. The example fails.** Both pages showed:

```shell-session
$ boundary config encrypt -overwrite config.hcl
```

`Run()` requires `-config` and ignores positional arguments, so this exits with `Missing required parameter -config`. The command's own tests only ever invoke it as `-config <file>`. Anyone copying this example got an error with no hint at the fix.

**2. The usage line advertised `[options] [args]`.** Positional arguments are parsed and then discarded. Documenting `[args]` is what produced the broken example in item 1, so leaving it would preserve the trap.

**3. The `kms` block paragraph named the wrong flag.** It read "you can define the block in the configuration file or using the `-config` flag" — but `-config` *is* the configuration file, so it described one option twice. The flag that points at a separate file is `-config-kms`. This matters beyond wording: `-config-kms` is what lifts the quoted-string-only restriction described in the same sentence.

**4. `-config` was documented as optional,** shown with a `(string: "")` default. It is required.

Also fixed a grammar slip on the encrypt pages ("configuration file use the `-overwrite` flag" → "using").

### Scope

Applied to **v0.13.x through v1.0.x** — 20 files, every documented version.

I checked whether the older versions were ever correct before changing them. Positional-argument handling was removed in `hashicorp/boundary#309` (`28df6eb7b`, 2020-08-27), **before v0.1.0**, so `-config` has been required since before the first release. No version-specific handling was needed; the fix is uniform.

### Out of scope

`get-token`, `autocomplete`, and the config `index` page still show `[options] [args]`. Those are different commands that may legitimately accept arguments — I did not verify them and did not touch them.

## Links

Code PR:
Jira:
GitHub issue: <!-- upstream Help() issue in hashicorp/boundary-enterprise -->
RFC/PRD:

## Contributor checklists

Review urgency:

- [x] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [ ] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [ ] Verify that all status checks passed
- [ ] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [x] I added redirects for any moved or removed pages — not applicable, no pages moved or removed
- [x] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [ ] I looked at the local or Vercel build to make sure the content rendered correctly
