### PR TITLE
[VAULT-6860] added documentation for disable_goroutine_trace_dump

### DIFF
--- a/content/vault/v1.19.x/content/docs/commands/server.mdx
+++ b/content/vault/v1.19.x/content/docs/commands/server.mdx
@@ -109,6 +109,30 @@ flags](/vault/docs/commands) included on all commands.
   and a downgrade must be performed in order to remove the offending engines. For
   more information, refer to the [deprecation notices](/vault/docs/updates/deprecation).
 
+- `VAULT_STACKTRACE_WRITE_TO_FILE` `(non-empty string)` - (environment variable)
+  Enables writing a goroutine dump file when Vault receives a **SIGUSR2** signal.
+  When set to any non-empty value and Vault receives SIGUSR2, Vault writes a file
+  named `goroutine` in addition to logging goroutine stacks to the log. This
+  variable has no effect on the automatic shutdown dump. Must be set before Vault starts; it is not
+  reloadable.
+
+- `VAULT_STACKTRACE_FILE_PATH` `(directory path)` - (environment variable)
+  Overrides the output directory for goroutine dump files. Applies to both the
+  SIGUSR2 dump (when `VAULT_STACKTRACE_WRITE_TO_FILE` is set) and the automatic
+  shutdown dump. The path must point to an existing directory — Vault does not
+  create it. If the path is invalid or the directory does not exist, Vault logs a
+  warning and skips the dump. When unset, Vault creates a randomly named temporary
+  directory inside [`os.TempDir()`](https://pkg.go.dev/os#TempDir) for each dump.
+
+  <Note>
+
+  SIGUSR2 also unconditionally writes a full pprof bundle (goroutine, heap,
+  allocs, threadcreate, and CPU profile) to `$TMPDIR/vault-pprof/`. This bundle
+  is not affected by `VAULT_STACKTRACE_FILE_PATH` or
+  `VAULT_STACKTRACE_WRITE_TO_FILE`.
+
+  </Note>
+
 ### Dev options
 
 - `-dev` `(bool: false)` - Enable development mode. In this mode, Vault runs

--- a/content/vault/v1.19.x/content/docs/configuration/index.mdx
+++ b/content/vault/v1.19.x/content/docs/configuration/index.mdx
@@ -278,6 +278,27 @@ can have a negative effect on performance due to the tracking of each lock attem
   [os.TempDir()](https://pkg.go.dev/os#TempDir) (usually `/tmp` on Unix systems). This can be updated on a running Vault process
   with a SIGHUP signal.
 
+- `disable_goroutine_trace_dump` `(bool: false)` - When set to `true`, suppresses
+  the goroutine pprof dump that Vault automatically writes during a normal shutdown
+  (SIGTERM or SIGINT). You can update `disable_goroutine_trace_dump` on a running
+  Vault process with a SIGHUP signal.
+
+  The dump writes a file named `goroutine` (a pprof goroutine profile readable by
+  `go tool pprof`) to a randomly named directory inside
+  [`os.TempDir()`](https://pkg.go.dev/os#TempDir) (for example,
+  `/tmp/vault-goroutine-dump-2738451092` on Linux). Set
+  `VAULT_STACKTRACE_FILE_PATH` to an existing directory path to redirect the file
+  there instead.
+
+  <Note>
+
+  A separate goroutine dump can also be triggered on demand by sending SIGUSR2 to
+  the Vault process. The SIGUSR2 dump requires the additional environment variable
+  `VAULT_STACKTRACE_WRITE_TO_FILE` to be set to any non-empty value before Vault
+  starts. `disable_goroutine_trace_dump` does not affect the SIGUSR2 dump.
+
+  </Note>
+
 - `allow_audit_log_prefixing` `(bool: false)` - Enable to allow prefixes on audit log entries for
   [file sinks](/vault/docs/audit/file).
 

--- a/content/vault/v1.20.x/content/docs/commands/server.mdx
+++ b/content/vault/v1.20.x/content/docs/commands/server.mdx
@@ -109,6 +109,30 @@ flags](/vault/docs/commands) included on all commands.
   and a downgrade must be performed in order to remove the offending engines. For
   more information, refer to the [deprecation notices](/vault/docs/updates/deprecation).
 
+- `VAULT_STACKTRACE_WRITE_TO_FILE` `(non-empty string)` - (environment variable)
+  Enables writing a goroutine dump file when Vault receives a **SIGUSR2** signal.
+  When set to any non-empty value and Vault receives SIGUSR2, Vault writes a file
+  named `goroutine` in addition to logging goroutine stacks to the log. This
+  variable has no effect on the automatic shutdown dump. Must be set before Vault starts; it is not
+  reloadable.
+
+- `VAULT_STACKTRACE_FILE_PATH` `(directory path)` - (environment variable)
+  Overrides the output directory for goroutine dump files. Applies to both the
+  SIGUSR2 dump (when `VAULT_STACKTRACE_WRITE_TO_FILE` is set) and the automatic
+  shutdown dump. The path must point to an existing directory — Vault does not
+  create it. If the path is invalid or the directory does not exist, Vault logs a
+  warning and skips the dump. When unset, Vault creates a randomly named temporary
+  directory inside [`os.TempDir()`](https://pkg.go.dev/os#TempDir) for each dump.
+
+  <Note>
+
+  SIGUSR2 also unconditionally writes a full pprof bundle (goroutine, heap,
+  allocs, threadcreate, and CPU profile) to `$TMPDIR/vault-pprof/`. This bundle
+  is not affected by `VAULT_STACKTRACE_FILE_PATH` or
+  `VAULT_STACKTRACE_WRITE_TO_FILE`.
+
+  </Note>
+
 ### Dev options
 
 - `-dev` `(bool: false)` - Enable development mode. In this mode, Vault runs

--- a/content/vault/v1.20.x/content/docs/configuration/index.mdx
+++ b/content/vault/v1.20.x/content/docs/configuration/index.mdx
@@ -281,6 +281,27 @@ can have a negative effect on performance due to the tracking of each lock attem
   [os.TempDir()](https://pkg.go.dev/os#TempDir) (usually `/tmp` on Unix systems). This can be updated on a running Vault process
   with a SIGHUP signal.
 
+- `disable_goroutine_trace_dump` `(bool: false)` - When set to `true`, suppresses
+  the goroutine pprof dump that Vault automatically writes during a normal shutdown
+  (SIGTERM or SIGINT). You can update `disable_goroutine_trace_dump` on a running
+  Vault process with a SIGHUP signal.
+
+  The dump writes a file named `goroutine` (a pprof goroutine profile readable by
+  `go tool pprof`) to a randomly named directory inside
+  [`os.TempDir()`](https://pkg.go.dev/os#TempDir) (for example,
+  `/tmp/vault-goroutine-dump-2738451092` on Linux). Set
+  `VAULT_STACKTRACE_FILE_PATH` to an existing directory path to redirect the file
+  there instead.
+
+  <Note>
+
+  A separate goroutine dump can also be triggered on demand by sending SIGUSR2 to
+  the Vault process. The SIGUSR2 dump requires the additional environment variable
+  `VAULT_STACKTRACE_WRITE_TO_FILE` to be set to any non-empty value before Vault
+  starts. `disable_goroutine_trace_dump` does not affect the SIGUSR2 dump.
+
+  </Note>
+
 - `allow_audit_log_prefixing` `(bool: false)` - Enable to allow prefixes on audit log entries for
   [file sinks](/vault/docs/audit/file).
 

--- a/content/vault/v1.21.x/content/docs/commands/server.mdx
+++ b/content/vault/v1.21.x/content/docs/commands/server.mdx
@@ -109,6 +109,30 @@ flags](/vault/docs/commands) included on all commands.
   and a downgrade must be performed in order to remove the offending engines. For
   more information, refer to the [deprecation notices](/vault/docs/updates/deprecation).
 
+- `VAULT_STACKTRACE_WRITE_TO_FILE` `(non-empty string)` - (environment variable)
+  Enables writing a goroutine dump file when Vault receives a **SIGUSR2** signal.
+  When set to any non-empty value and Vault receives SIGUSR2, Vault writes a file
+  named `goroutine` in addition to logging goroutine stacks to the log. This
+  variable has no effect on the automatic shutdown dump. Must be set before Vault starts; it is not
+  reloadable.
+
+- `VAULT_STACKTRACE_FILE_PATH` `(directory path)` - (environment variable)
+  Overrides the output directory for goroutine dump files. Applies to both the
+  SIGUSR2 dump (when `VAULT_STACKTRACE_WRITE_TO_FILE` is set) and the automatic
+  shutdown dump. The path must point to an existing directory — Vault does not
+  create it. If the path is invalid or the directory does not exist, Vault logs a
+  warning and skips the dump. When unset, Vault creates a randomly named temporary
+  directory inside [`os.TempDir()`](https://pkg.go.dev/os#TempDir) for each dump.
+
+  <Note>
+
+  SIGUSR2 also unconditionally writes a full pprof bundle (goroutine, heap,
+  allocs, threadcreate, and CPU profile) to `$TMPDIR/vault-pprof/`. This bundle
+  is not affected by `VAULT_STACKTRACE_FILE_PATH` or
+  `VAULT_STACKTRACE_WRITE_TO_FILE`.
+
+  </Note>
+
 ### Dev options
 
 - `-dev` `(bool: false)` - Enable development mode. In this mode, Vault runs

--- a/content/vault/v1.21.x/content/docs/configuration/index.mdx
+++ b/content/vault/v1.21.x/content/docs/configuration/index.mdx
@@ -281,6 +281,27 @@ can have a negative effect on performance due to the tracking of each lock attem
   [os.TempDir()](https://pkg.go.dev/os#TempDir) (usually `/tmp` on Unix systems). This can be updated on a running Vault process
   with a SIGHUP signal.
 
+- `disable_goroutine_trace_dump` `(bool: false)` - When set to `true`, suppresses
+  the goroutine pprof dump that Vault automatically writes during a normal shutdown
+  (SIGTERM or SIGINT). You can update `disable_goroutine_trace_dump` on a running
+  Vault process with a SIGHUP signal.
+
+  The dump writes a file named `goroutine` (a pprof goroutine profile readable by
+  `go tool pprof`) to a randomly named directory inside
+  [`os.TempDir()`](https://pkg.go.dev/os#TempDir) (for example,
+  `/tmp/vault-goroutine-dump-2738451092` on Linux). Set
+  `VAULT_STACKTRACE_FILE_PATH` to an existing directory path to redirect the file
+  there instead.
+
+  <Note>
+
+  A separate goroutine dump can also be triggered on demand by sending SIGUSR2 to
+  the Vault process. The SIGUSR2 dump requires the additional environment variable
+  `VAULT_STACKTRACE_WRITE_TO_FILE` to be set to any non-empty value before Vault
+  starts. `disable_goroutine_trace_dump` does not affect the SIGUSR2 dump.
+
+  </Note>
+
 - `allow_audit_log_prefixing` `(bool: false)` - Enable to allow prefixes on audit log entries for
   [file sinks](/vault/docs/audit/file).
 

--- a/content/vault/v2.x/content/docs/commands/server.mdx
+++ b/content/vault/v2.x/content/docs/commands/server.mdx
@@ -109,6 +109,30 @@ flags](/vault/docs/commands) included on all commands.
   and a downgrade must be performed in order to remove the offending engines. For
   more information, refer to the [deprecation notices](/vault/docs/updates/deprecation).
 
+- `VAULT_STACKTRACE_WRITE_TO_FILE` `(non-empty string)` - (environment variable)
+  Enables writing a goroutine dump file when Vault receives a **SIGUSR2** signal.
+  When set to any non-empty value and Vault receives SIGUSR2, Vault writes a file
+  named `goroutine` in addition to logging goroutine stacks to the log. This
+  variable has no effect on the automatic shutdown dump. Must be set before Vault starts; it is not
+  reloadable.
+
+- `VAULT_STACKTRACE_FILE_PATH` `(directory path)` - (environment variable)
+  Overrides the output directory for goroutine dump files. Applies to both the
+  SIGUSR2 dump (when `VAULT_STACKTRACE_WRITE_TO_FILE` is set) and the automatic
+  shutdown dump. The path must point to an existing directory — Vault does not
+  create it. If the path is invalid or the directory does not exist, Vault logs a
+  warning and skips the dump. When unset, Vault creates a randomly named temporary
+  directory inside [`os.TempDir()`](https://pkg.go.dev/os#TempDir) for each dump.
+
+  <Note>
+
+  SIGUSR2 also unconditionally writes a full pprof bundle (goroutine, heap,
+  allocs, threadcreate, and CPU profile) to `$TMPDIR/vault-pprof/`. This bundle
+  is not affected by `VAULT_STACKTRACE_FILE_PATH` or
+  `VAULT_STACKTRACE_WRITE_TO_FILE`.
+
+  </Note>
+
 ### Dev options
 
 - `-dev` `(bool: false)` - Enable development mode. In this mode, Vault runs

--- a/content/vault/v2.x/content/docs/configuration/index.mdx
+++ b/content/vault/v2.x/content/docs/configuration/index.mdx
@@ -287,6 +287,27 @@ to specify where the configuration is.
   [os.TempDir()](https://pkg.go.dev/os#TempDir) (usually `/tmp` on Unix systems). This can be updated on a running Vault process
   with a SIGHUP signal.
 
+- `disable_goroutine_trace_dump` `(bool: false)` - When set to `true`, suppresses
+  the goroutine pprof dump that Vault automatically writes during a normal shutdown
+  (SIGTERM or SIGINT). You can update `disable_goroutine_trace_dump` on a running
+  Vault process with a SIGHUP signal.
+
+  The dump writes a file named `goroutine` (a pprof goroutine profile readable by
+  `go tool pprof`) to a randomly named directory inside
+  [`os.TempDir()`](https://pkg.go.dev/os#TempDir) (for example,
+  `/tmp/vault-goroutine-dump-2738451092` on Linux). Set
+  `VAULT_STACKTRACE_FILE_PATH` to an existing directory path to redirect the file
+  there instead.
+
+  <Note>
+
+  A separate goroutine dump can also be triggered on demand by sending SIGUSR2 to
+  the Vault process. The SIGUSR2 dump requires the additional environment variable
+  `VAULT_STACKTRACE_WRITE_TO_FILE` to be set to any non-empty value before Vault
+  starts. `disable_goroutine_trace_dump` does not affect the SIGUSR2 dump.
+
+  </Note>
+
 - `allow_audit_log_prefixing` `(bool: false)` - Enable to allow prefixes on audit log entries for
   [file sinks](/vault/docs/audit/file).
 


### PR DESCRIPTION
## Summary

Vault gained a new `disable_goroutine_trace_dump` configuration field and two
previously undocumented environment variables (`VAULT_STACKTRACE_WRITE_TO_FILE`,
`VAULT_STACKTRACE_FILE_PATH`) that control where and whether goroutine pprof dump
files are written. This PR adds the missing documentation to both the configuration reference and the environment variables across all four affected versions (1.19, 1.20, 1.21, 2.x).

- `disable_goroutine_trace_dump` config field documented in all four `configuration/index.mdx` files
- `VAULT_STACKTRACE_WRITE_TO_FILE` and `VAULT_STACKTRACE_FILE_PATH` env vars documented in all four
  `commands/server.mdx` files under the existing `### Command options` section
  
  