### PR TITLE
docs: add connectInject.cni.tolerations field to Helm reference

### DIFF
--- a/content/consul/v2.0.x/content/docs/reference/k8s/helm.mdx
+++ b/content/consul/v2.0.x/content/docs/reference/k8s/helm.mdx
@@ -2181,6 +2181,37 @@ Use these links to navigate to a particular top-level stanza.
       Note: if running on OpenShift, this setting is ignored because the user and group are set automatically
       by the OpenShift platform.
 
+    - `tolerations` ((#v-connectinject-cni-tolerations)) (`string: null`) - Toleration settings for the CNI installer DaemonSet pods.
+      This should be a multi-line string matching the
+      [Tolerations](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
+      array in a Pod spec. Tolerations control whether the CNI DaemonSet pod can be scheduled on a
+      node with a matching taint, preventing deployment on nodes where workloads
+      should not run, such as control plane nodes.
+      If not set, the CNI DaemonSet defaults to tolerating `CriticalAddonsOnly`
+      and `NoExecute` taints.
+
+      Example:
+
+      ```yaml
+      tolerations: |
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
+      ```
+
+      To override the defaults, set `tolerations` in your `values.yaml` file:
+
+      ```yaml
+      connectInject:
+        cni:
+          tolerations: |
+            - key: dd
+              operator: Exists
+            - effect: bb
+              operator: Exists
+      ```
+
   - `consulNode` ((#v-connectinject-consulnode))
 
     - `meta` ((#v-connectinject-consulnode-meta)) (`map`) - meta specifies an arbitrary metadata key/value pair to associate with the node.


### PR DESCRIPTION
### Changes proposed in this PR ###

Added the `tolerations` entry under `connectInject.cni` in `content/consul/v2.0.x/content/docs/reference/k8s/helm.mdx`. The field was present in the chart's `values.yaml` but undocumented on the reference page.

### Why

The CNI installer runs as a DaemonSet. Without documented toleration support, users had no reference for how to control which nodes the DaemonSet is scheduled on. By default the DaemonSet tolerates `CriticalAddonsOnly` and `NoExecute` taints, but this was invisible to users. Users who need to restrict scheduling (e.g. exclude control plane nodes) or broaden it had no guidance on how to override the defaults via `values.yaml`.

### What the new entry covers

- What tolerations do in the context of the CNI DaemonSet
- The out-of-the-box default tolerations (`CriticalAddonsOnly`, `NoExecute`)
- The correct multi-line string format required when setting custom tolerations in `values.yaml`

### Changes

Below content added under `helm.mdx` → `connectInject` → `cni`:
https://developer.hashicorp.com/consul/docs/reference/k8s/helm#v-connectinject-cni

    - `tolerations` ((#v-connectinject-cni-tolerations)) (`string: null`) - Toleration settings for the CNI installer DaemonSet pods.
      This should be a multi-line string matching the
      [Tolerations](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
      array in a Pod spec. Tolerations control whether the CNI DaemonSet pod can be scheduled on a
      node with a matching taint, preventing deployment on nodes where workloads
      should not run, such as control plane nodes.
      If not set, the CNI DaemonSet defaults to tolerating `CriticalAddonsOnly`
      and `NoExecute` taints.

      Example:

      ```yaml
      tolerations: |
        - key: CriticalAddonsOnly
          operator: Exists
        - effect: NoExecute
          operator: Exists
      ```

      To override the defaults, set `tolerations` in your `values.yaml` file:

      ```yaml
      connectInject:
        cni:
          tolerations: |
            - key: dd
              operator: Exists
            - effect: bb
              operator: Exists
      ```

### How I've tested this PR ###

Manually verified:
- Helm template rendered with and without the new value produces the expected \`tolerations\` block in the generated DaemonSet YAML.

### How I expect reviewers to test this PR ###
This is a documentation and values-file change. No automated test is required.

1. Manually verify the \`connectInject.cni.tolerations\` entry added to \`charts/consul/values.yaml\` — confirm the description, default (\`null\`), and inline YAML example are accurate and clearly worded.
2. Manually verify the conditional block in \`charts/consul/templates/cni-daemonset.yaml\` — confirm that when the value is unset the hardcoded defaults are preserved, and when set the custom string is rendered correctly.

### Checklist ###
- [ ] Tests added
- [ ] [CHANGELOG entry added](https://github.com/hashicorp/consul-k8s/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)

## PCI review checklist

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.