### PR TITLE
docs: Style guide updates

### DIFF
--- a/docs/style-guide/general/language.md
+++ b/docs/style-guide/general/language.md
@@ -47,14 +47,14 @@ Refer to general roles, such as a "developer", "engineer", or "administrator", i
 - **keywords**: writing, word choice, pronouns, ambiguity
 - **content sets**: docs, tutorials, WAF, certifications
 
-Using “this” in place of a noun can create ambiguous sentences that confuse users about who or what is performing the action.
+Using “this” in place of a noun can create ambiguous sentences that confuse users about who or what is performing the action. If you use "this", make sure it has a clear noun referent.
 
 ### Examples
 
 **Do:**
 
 - `Update the worker configuration file and restart the worker. Restarting the worker ensures that the new authentication settings take effect.`
-- `Create a user account and assign the user to an administrator role. The administrator role grants access to manage targets.`
+- `Create a user account and assign the user to an administrator role. This role grants access to manage targets.`
 
 **Don't:**
 

--- a/docs/style-guide/general/language.md
+++ b/docs/style-guide/general/language.md
@@ -47,14 +47,14 @@ Refer to general roles, such as a "developer", "engineer", or "administrator", i
 - **keywords**: writing, word choice, pronouns, ambiguity
 - **content sets**: docs, tutorials, WAF, certifications
 
-Using “this” in place of a noun can create ambiguous sentences that confuse users about who or what is performing the action. If you use "this", make sure it has a clear noun referent.
+Using “this” in place of a noun can create ambiguous sentences that confuse users about who or what is performing the action.
 
 ### Examples
 
 **Do:**
 
 - `Update the worker configuration file and restart the worker. Restarting the worker ensures that the new authentication settings take effect.`
-- `Create a user account and assign the user to an administrator role. This role grants access to manage targets.`
+- `Create a user account and assign the user to an administrator role. The admin role grants access to manage targets.`
 
 **Don't:**
 

--- a/docs/style-guide/general/language.md
+++ b/docs/style-guide/general/language.md
@@ -1,21 +1,21 @@
 # Language and word choice
 
-These guideline help you choose consistent words and phrases in prose. 
+These guidelines help you choose consistent words and phrases in prose.
 
 ## Do not use ableist language
 
-- **keywords**: writing, word choice, ableist  
+- **keywords**: writing, word choice, ableist
 - **content sets**: docs, tutorials, WAF, certifications
 
 Avoid language that makes assumptions about a user's faculties or ascribes mental health conditions to processes and technologies.
 
 For many people with different abilities, the difference between asking to "see" another topic instead of being asked to "refer" to another topic is minimal. But there are people for whom "see {link}" or "sanity check" is another reminder of their "otherness" with regard to their vision or mental health. The people who are unbothered by the language will still have a good experience and the people who are more sensitive to it will definitely feel included.
 
-The discussion around ableist language is nuanced and can easily deviate from how to write content on behalf of HashiCorp to personal expression. Our goal is to be considerate and inclusive, so you should carefully weigh word choices so that we can avoid contributing to what can be an already frustrating experience. 
+The discussion around ableist language is nuanced and can easily deviate from how to write content on behalf of HashiCorp to personal expression. Our goal is to be considerate and inclusive, so you should carefully weigh word choices so that we can avoid contributing to what can be an already frustrating experience.
 
 ### Examples
 
-**Do:** 
+**Do:**
 
 - `Refer to {link} for additional information.`
 - `Perform a preliminary check to verify that the operation successfully completed.`
@@ -27,10 +27,10 @@ The discussion around ableist language is nuanced and can easily deviate from ho
 
 ## Do not use gender-specific language
 
-- **keywords**: writing, word choice, gender  
+- **keywords**: writing, word choice, gender
 - **content sets**: docs, tutorials, WAF, certifications
 
-Refer to general roles, such as a "developer", "engineer", or "administrator", instead of third-person pronouns. When you need to refer to a third-person pronoun, use the singular pronoun "they".  
+Refer to general roles, such as a "developer", "engineer", or "administrator", instead of third-person pronouns. When you need to refer to a third-person pronoun, use the singular pronoun "they".
 
 ### Examples
 
@@ -42,9 +42,28 @@ Refer to general roles, such as a "developer", "engineer", or "administrator", i
 
 - `Provide a token to the developer so that he can deploy services using the API.`
 
+## Do not use "this" as a pronoun
+
+- **keywords**: writing, word choice, pronouns, ambiguity
+- **content sets**: docs, tutorials, WAF, certifications
+
+Using “this” in place of a noun can create ambiguous sentences that confuse users about who or what is performing the action.
+
+### Examples
+
+**Do:**
+
+- `Update the worker configuration file and restart the worker. Restarting the worker ensures that the new authentication settings take effect.`
+- `Create a user account and assign the user to an administrator role. The administrator role grants access to manage targets.`
+
+**Don't:**
+
+- `Update the worker configuration file and restart the worker. This ensures the new authentication settings take effect.`
+- `Create a user account and assign the user to an administrator role. This grants access to manage targets.`
+
 ## Use non-violent language
 
-- **keywords**: writing, word choice, non-violent language  
+- **keywords**: writing, word choice, non-violent language
 - **content sets**: docs, tutorials, WAF, certifications
 
 Avoid describing actions using violent terms. Note that some words, such as "execution" to describe issuing a command, may be unavoidable. Explore alternatives whenever possible. Similarly, the `terraform destroy`command, which deletes infrastructure resources, has no alternatives.
@@ -77,7 +96,7 @@ Do not ask readers to "imagine", "suppose", "pretend", or otherwise engage in a 
 - `Suppose that we are starting with three server clusters.`
 - `Imagine that you want to use Vault commands to enable the database secrets engine.`
 
-## Use the most specific word to describe actions between entities 
+## Use the most specific word to describe actions between entities
 
 General actions such as "use" are acceptable to avoid adding long descriptions.
 
@@ -85,16 +104,16 @@ General actions such as "use" are acceptable to avoid adding long descriptions.
 
 Instead of a general action, such as "use", the preferred word is emphasized in the following examples:
 
-- {product} **consumes** the configuration file. 
+- {product} **consumes** the configuration file.
 - The flag **passes** values into the operation.
 - **Present** the token when calling the endpoint.
 
 ## Do not use figures of speech
 
-- **keywords**: diction, metaphors, similes  
+- **keywords**: diction, metaphors, similes
 - **content sets**: docs, WAF, tutorials, certifications
 
-Do not use metaphors, similes, colloquialisms, idiomatic expressions, or other figurative language. Refer to [Do not use words or phrases borrowed from other languages, scientific words, or jargon words](#do-not-use-words-or-phrases-borrowed-from-other-languages-scientific-words-or-jargon-words) for more guidance. 
+Do not use metaphors, similes, colloquialisms, idiomatic expressions, or other figurative language. Refer to [Do not use words or phrases borrowed from other languages, scientific words, or jargon words](#do-not-use-words-or-phrases-borrowed-from-other-languages-scientific-words-or-jargon-words) for more guidance.
 
 ### Examples
 
@@ -111,7 +130,7 @@ Do not use the following constructions or similar language:
 
 ## Do not editorialize about the difficulty or comprehensibility of an action or concept
 
-- **keywords**: diction, simply, easily, complexity  
+- **keywords**: diction, simply, easily, complexity
 - **content sets**: docs, WAF, tutorials, certifications
 
 Some users may be struggling with the instructions or with understanding concepts. Using language that downplays the complexity associated with our products can turn users away. Do not use the following words or similar words that imply that a task is easy:
@@ -134,7 +153,7 @@ Some users may be struggling with the instructions or with understanding concept
 
 ## Avoid unnecessary words
 
-- **keywords**: diction, extra words, fewer words  
+- **keywords**: diction, extra words, fewer words
 - **content sets**: docs, WAF, tutorials, certifications
 
 Short sentences are easier to understand than sentences that contain filler words and phrases. Avoid adding words and phrases that do not affect the meaning. When possible, replace longer expressions with shorter words that have the same meaning.
@@ -148,10 +167,10 @@ Short sentences are easier to understand than sentences that contain filler word
 
 ## Use the simplest word possible
 
-- **keywords**: diction, short words, simple words  
+- **keywords**: diction, short words, simple words
 - **content sets**: docs, WAF, tutorials, certifications
 
-Always use the shortest word that has the same meaning. 
+Always use the shortest word that has the same meaning.
 
 ### Examples
 
@@ -160,10 +179,10 @@ Always use the shortest word that has the same meaning.
 
 ## Do not use words or phrases borrowed from other languages, scientific words, or jargon words
 
-- **keywords**: diction, short words, simple words  
+- **keywords**: diction, short words, simple words
 - **content sets**: docs, WAF, tutorials, certifications
 
-Use simple, concrete words to help our global audiences understand our content. 
+Use simple, concrete words to help our global audiences understand our content.
 
 ### Examples
 
@@ -178,7 +197,7 @@ The following list contains common words and phrases that you should avoid in ed
 | carte blanche | full permission, admin access | French word that literally translates to "blank document" and means "unlimited authority". |
 | via | Choose a more concrete word to describe the relationship. | Latin word meaning "by way of". |
 | vice versa | conversely | Latin word meaning "the other way around". |
-| sanity check | preliminary check, verification, dry run | jarbon, ableist |
+| sanity check | preliminary check, verification, dry run | jargon, ableist |
 
 **Do:**
 
@@ -194,19 +213,19 @@ The following list contains common words and phrases that you should avoid in ed
 
 ## Use American English spelling
 
-- **keywords**: diction, Americn English, American spelling  
+- **keywords**: diction, American English, American spelling
 - **content sets**: docs, WAF, tutorials, certifications
 
 For consistency and cohesiveness, spell words according to American English instead of British or Australian English. Refer to the Merriam-Webster dictionary for guidance.
 
-## Examples
+### Examples
 
 - "center", not "centre"
 - "initialize", not "initialise"
 
 ## Do not use shortened or abbreviated spellings
 
-- **keywords**: writing, abbreviations  
+- **keywords**: writing, abbreviations
 - **content sets**: docs, tutorials, WAF, cert
 
 Shortened and abbreviated forms of words are common, but they may not be understandable to English as a Second Language (ESL) audiences or appropriate in formal settings. Our educational materials are friendly, but they are also professional documents. Using shortened phrases or words, even if they are widely-used and widely-understood, creates a colloquial tone that does not match our voice.  Refer to the [word list](https://docs.google.com/document/d/1MRvGd6tS5JkIwl_GssbyExkMJqOXKeUE00kSEtFi8m8/edit?tab=t.0#heading=h.7xv30zvawyfc) in the corporate style guide for additional information.
@@ -215,29 +234,29 @@ Shortened and abbreviated forms of words are common, but they may not be underst
 
 - "repository", not "repo"
 - "directory", not "dir"
-- "configuration", not "config" 
+- "configuration", not "config"
 
 ## Do not ask rhetorical questions
 
-- **keywords**: writing, questions, headings  
+- **keywords**: writing, questions, headings
 - **content sets**: docs, tutorials, WAF, certification
 
 Do not use rhetorical questions in prose, as headings, or in any other construction unless you are referring to questions that appear in the product UI or are writing content for the [What is?](https://docs.google.com/document/d/1kp5AUJaQg7Wrq472Ebad9Bvi4t5UYn5TvWtjsM2HsA8/edit?tab=t.0) content type. Instead, use descriptive headings that orient readers.
 
-Only use question marks when they are a necessary part of a code sample. 
+Only use question marks when they are a necessary part of a code sample.
 
 **Do:**
 
 ```
 ### Verify that plugins meet Packer Plugin SDK requirements
 
-The `packer init` command only installs plugins that have been upgraded to use the latest version of the [Packer Plugin SDK](https://github.com/hashicorp/packer-plugin-sdk). As a result, the plugins are compatible with Packer's API version v5.0. The plugin repository on GitHub must also follow a specific release format. Contact your repository maintainer if you are unsure that the plugin meets those requirements. 
+The `packer init` command only installs plugins that have been upgraded to use the latest version of the [Packer Plugin SDK](https://github.com/hashicorp/packer-plugin-sdk). As a result, the plugins are compatible with Packer's API version v5.0. The plugin repository on GitHub must also follow a specific release format. Contact your repository maintainer if you are unsure that the plugin meets those requirements.
 ```
 
 ```
 ## Enable your application to consume active secrets
 
-Auto-rotating secrets maintain overlapping sets of active credentials to eliminate application downtime associated with rotation. The two newest versions of your secret are always active and available for consumption. To ensure that your application continues to consume active credentials, we recommend restarting it at least once every rotation interval. 
+Auto-rotating secrets maintain overlapping sets of active credentials to eliminate application downtime associated with rotation. The two newest versions of your secret are always active and available for consumption. To ensure that your application continues to consume active credentials, we recommend restarting it at least once every rotation interval.
 ```
 
 **Don't:**
@@ -245,19 +264,19 @@ Auto-rotating secrets maintain overlapping sets of active credentials to elimina
 ```
 ### When should you upgrade your template?
 
-The `packer init` command can only install plugins that have been upgraded to use the latest version of the [Packer Plugin SDK](https://github.com/hashicorp/packer-plugin-sdk), and therefore are compatible with Packer's API version v5.0. The plugin repository on GitHub also needs to use a specific release format. If you are not sure whether the plugin you use fits those requirements, you can reach out to your maintainer to ask. 
+The `packer init` command can only install plugins that have been upgraded to use the latest version of the [Packer Plugin SDK](https://github.com/hashicorp/packer-plugin-sdk), and therefore are compatible with Packer's API version v5.0. The plugin repository on GitHub also needs to use a specific release format. If you are not sure whether the plugin you use fits those requirements, you can reach out to your maintainer to ask.
 ```
 
 ```
 ## How frequently should the secrets be consumed?
 
-Auto-rotating secrets maintain overlapping sets of active credentials to eliminate application downtime associated with rotation. At any given time, the latest two secret versions will be active and available for consumption. To ensure that your application is always consuming active credentials, we recommend restarting it at least once every rotation interval. 
+Auto-rotating secrets maintain overlapping sets of active credentials to eliminate application downtime associated with rotation. At any given time, the latest two secret versions will be active and available for consumption. To ensure that your application is always consuming active credentials, we recommend restarting it at least once every rotation interval.
 ```
 
 ## Refer to a locally addressable web services as "localhost"
 
-- **keywords**: word choice, localhost, addresses  
-- **content sets**: docs, tutorials, WAF, certifications 
+- **keywords**: word choice, localhost, addresses
+- **content sets**: docs, tutorials, WAF, certifications
 
 Refer to localhost, instead of IPv4 or IPv6 addresses, when describing a locally addressable web service. Refer to [Format IP addresses as code](../codeblocks-and-consoles/fonts-and-formats.md#format-commands-as-code) for additional guidance.
 
@@ -274,13 +293,13 @@ Refer to localhost, instead of IPv4 or IPv6 addresses, when describing a locally
 
 ## Refer to the user’s local machine as "localhost" or "your local machine"
 
-- **keywords**: word choice, localhost, addresses, local machine  
-- **content sets**: docs, tutorials, WAF, certifications 
+- **keywords**: word choice, localhost, addresses, local machine
+- **content sets**: docs, tutorials, WAF, certifications
 
 ## Spell out a phrase and place the acronym form in parentheses on first use
 
-- **keywords**: acronyms, writing, parentheses  
-- **content sets**: docs, tutorials, WAF, certifications 
+- **keywords**: acronyms, writing, parentheses
+- **content sets**: docs, tutorials, WAF, certifications
 
 Unless the spelled-out words are less common than the acronym, such as HTTP or SSH, spell out the words on first use. If a non-Hashicorp product name is commonly abbreviated, write out the name of the product before using the abbreviated form. Refer to the word list in the corporate style guide for additional information.
 
@@ -293,44 +312,42 @@ Unless the spelled-out words are less common than the acronym, such as HTTP or S
 
 ## Refer to HashiCorp products as "products" or "offerings" not “tools” or “tooling”
 
-- **keywords**: writing, word choice, products, tools  
+- **keywords**: writing, word choice, products, tools
 - **content sets**: docs, tutorials, WAF, certifications
 
 Refer to [HashiCorp Voice, Style & Language Guidelines](https://docs.google.com/document/u/0/d/1MRvGd6tS5JkIwl_GssbyExkMJqOXKeUE00kSEtFi8m8/edit) for additional guidance.
 
 ## Do not refer to “HashiStack”
 
-- **keywords**: writing, word choice, hashistack  
+- **keywords**: writing, word choice, hashistack
 - **content sets**: docs, tutorials, WAF, certifications
 
 Refer to the “HashiCorp stack", instead. Refer to [HashiCorp Voice, Style & Language Guidelines](https://docs.google.com/document/u/0/d/1MRvGd6tS5JkIwl_GssbyExkMJqOXKeUE00kSEtFi8m8/edit) for additional guidance.
 
-## Do not use unofficial product abbreviations 
+## Do not use unofficial product abbreviations
 
-- **keywords**: writing, word choice, abbreviations  
+- **keywords**: writing, word choice, abbreviations
 - **content sets**: docs, tutorials, WAF, certifications
 
 Do not use the following abbreviation: TF, TFE, TFC, TFC4B, TFCB, HCP TF, and COM. Refer to [HashiCorp Voice, Style & Language Guidelines](https://docs.google.com/document/u/0/d/1MRvGd6tS5JkIwl_GssbyExkMJqOXKeUE00kSEtFi8m8/edit) for additional guidance.
 
 ## Follow the guidance for industry terms as described in the corporate style guide
 
-- **keywords**: writing, word choice, abbreviations  
+- **keywords**: writing, word choice, abbreviations
 - **content sets**: docs, tutorials, WAF, certifications
 
 Refer to the [word list](https://docs.google.com/document/d/1MRvGd6tS5JkIwl_GssbyExkMJqOXKeUE00kSEtFi8m8/edit?tab=t.0#heading=h.7xv30zvawyfc) in the corporate style guide for guidance about industry terms.
 
 ## Refer to the documentation or website for the project
 
-- **keywords**: writing, word choice, third-party software  
+- **keywords**: writing, word choice, third-party software
 - **content sets**: docs, tutorials, WAF, certifications
 
 For guidance on words associated with a specific software project that do not appear in our style guidance, refer to the documentation or website for the project. Use the third-party’s formatting standards to differentiate between products. For example, Kubernetes Pods and Services are always capitalized.
 
 ## Follow the guidance for page titles and meta descriptions in the content types guidance
 
-- **keywords**: writing, metadata, page titles, descriptions  
+- **keywords**: writing, metadata, page titles, descriptions
 - **content sets**: docs
 
 Refer to [Appendix B: Metadata](https://hashicorp.atlassian.net/wiki/x/HICUpg) in the content types guidance for additional information.
-
-

--- a/docs/style-guide/general/links.md
+++ b/docs/style-guide/general/links.md
@@ -82,7 +82,7 @@ Refer to [Use linked text that explicitly tells readers about the destination co
 
 When readers encounter hyperlinks embedded in sentences or paragraphs, they must make a decision whether to click for more information or keep reading. Multiple hyperlinks create additional cognitive load and can cause readers to lose focus. If a reader clicks the hyperlink, they might miss important context from the original page.
 
-Additionally, some screen readers pause and announce each link, making it difficult for users to follow along the surrounding text.
+Additionally, some screen readers pause and announce each link, making it difficult for users to follow the surrounding text.
 
 As a best practice, use inline links sparingly. Put links at the end of a section or the end of the page when possible.
 
@@ -93,7 +93,7 @@ As a best practice, use inline links sparingly. Put links at the end of a sectio
 ```
 A session is a set of related connections between a user and a host. A session may include a set of credentials which define the permissions granted to the user on the host for the duration of the session.
 
-For more information about the resources related to sessions, refer to the following domain model topics:
+For more information about related resources, refer to the following domain model topics:
 
 - [credentials](/boundary/docs/domain-model/credentials)
 - [connections](/boundary/docs/domain-model/session-connections)

--- a/docs/style-guide/general/links.md
+++ b/docs/style-guide/general/links.md
@@ -7,7 +7,7 @@ These guidelines are intended to help you properly use links.
 - **keywords**: links, linking, linked text
 - **content sets**: docs, tutorial, WAF, certifications
 
-Mid-prose links can distract readers from their task or confuse readers if the linked text targets a single word that seems randomly selected. Avoid linking single words or phrases mid-sentence unless they clearly match the title of the linked topic. Instead, write a second sentence that refers users to a related topic using the title as the linked text. 
+Mid-prose links can distract readers from their task or confuse readers if the linked text targets a single word that seems randomly selected. Avoid linking single words or phrases mid-sentence unless they clearly match the title of the linked topic. Instead, write a second sentence that refers users to a related topic using the title as the linked text.
 
 
 ### Examples
@@ -27,7 +27,7 @@ You should be familiar with AWS ECS. Refer to [What is Amazon Elastic Container 
 ```
 
 ```
-For additional information about the `kill` command, refer to 
+For additional information about the `kill` command, refer to
 [Kill Signals and Commands ](https://www.linux.org/threads/kill-signals-and-commands-revised.11625/) in the Linux documentation.
 ```
 
@@ -73,5 +73,36 @@ Refer to [Use linked text that explicitly tells readers about the destination co
 
 ### Example
 
-`Refer to [Some article in PDF format (PDF)](URL) for additionl information.`
+`Refer to [Some article in PDF format (PDF)](URL) for additional information.`
 
+## Use inline links sparingly
+
+- **keywords**: writing, linking, linked text, inline links, URLs
+- **content sets**: docs, tutorial, WAF, certifications
+
+When readers encounter hyperlinks embedded in sentences or paragraphs, they must make a decision whether to click for more information or keep reading. Multiple hyperlinks create additional cognitive load and can cause readers to lose focus. If a reader clicks the hyperlink, they might miss important context from the original page.
+
+Additionally, some screen readers pause and announce each link, making it difficult for users to follow along the surrounding text.
+
+As a best practice, use inline links sparingly. Put links at the end of a section or the end of the page when possible.
+
+### Examples
+
+**Do:**
+
+```
+A session is a set of related connections between a user and a host. A session may include a set of credentials which define the permissions granted to the user on the host for the duration of the session.
+
+For more information about the resources related to sessions, refer to the following domain model topics:
+
+- [credentials](/boundary/docs/domain-model/credentials)
+- [connections](/boundary/docs/domain-model/session-connections)
+- [host](/boundary/docs/domain-model/hosts)
+- [user](/boundary/docs/domain-model/users)
+```
+
+**Don't:**
+
+```
+A session is a set of related [connections](/boundary/docs/domain-model/session-connections) between a [user](/boundary/docs/domain-model/users) and a [host](/boundary/docs/domain-model/hosts). A session may include a set of [credentials](/boundary/docs/domain-model/credentials) which define the permissions granted to the [user](/boundary/docs/domain-model/users) on the [host](/boundary/docs/domain-model/hosts) for the duration of the session.
+```


### PR DESCRIPTION
Updates the style guide with 2 new best practices:

- Do not use "this" as a pronoun
- Use inline links sparingly

It also fixes some pre-existing typos.