### PR TITLE
azure secrets engine new endpoint - access tokens

### DIFF
--- a/content/vault/v2.x/content/api-docs/secret/azure.mdx
+++ b/content/vault/v2.x/content/api-docs/secret/azure.mdx
@@ -4,7 +4,7 @@ page_title: Azure - Secrets Engines - HTTP API
 description: This is the API documentation for the Vault Azure secrets engine.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2026-04-14T17:13:42-07:00
-last_modified: 2026-08-24T22:14:16.000Z
+last_modified: 2026-08-25T16:23:41.000Z
 # END AUTO GENERATED METADATA
 ---
 

--- a/content/vault/v2.x/content/api-docs/secret/azure.mdx
+++ b/content/vault/v2.x/content/api-docs/secret/azure.mdx
@@ -3,8 +3,8 @@ layout: api
 page_title: Azure - Secrets Engines - HTTP API
 description: This is the API documentation for the Vault Azure secrets engine.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2026-04-15T00:13:47.000Z
-last_modified: 2026-04-15T00:13:47.000Z
+created_at: 2026-04-14T17:13:42-07:00
+last_modified: 2026-08-24T22:14:16.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -704,6 +704,98 @@ $ curl \
       "environment": "development"
     },
     ...
+  }
+}
+```
+
+## Generate access token
+
+@include 'alerts/enterprise-only.mdx'
+
+<Note title="Requires Vault 2.2 or later">
+
+This endpoint is available in Vault 2.2 and later.
+
+</Note>
+
+Generate an OAuth2 access token for the named static role. Vault exchanges the
+static role's stored `client_id` and `client_secret` against the Azure AD
+token endpoint using the `client_credentials` grant type and returns Azure's
+response directly. The caller supplies the scope; Vault supplies the credentials.
+
+No Vault lease is created for the returned token. Access tokens cannot be
+revoked once issued; they expire naturally (~1 hour by default, configurable in
+Azure).
+
+<Warning title="Credential must be rotated before first use">
+
+This endpoint returns a `400` error if the static role has never been rotated
+(for example, roles created with `defer_initial_creds=true` that have not yet
+been rotated). Rotate the role with the
+[`/azure/rotate-role/:name`](#manually-rotate-static-role-password) endpoint
+before calling this endpoint.
+
+</Warning>
+
+| Method | Path                   |
+| :----- | :--------------------- |
+| `POST` | `/azure/token/:name`   |
+
+### Path parameters
+
+- `name` `(string: <required>)` – Name of the static role to generate an
+  access token for.
+
+### Body parameters
+
+- `scope` `(string: <required>)` – The full Azure scope to request a token
+  for (e.g., `https://graph.microsoft.com/.default`). Passed directly to Azure
+  with no modification or validation. For `client_credentials` flows, scopes
+  must use the `.default` suffix.
+
+### Sample payload
+
+```json
+{
+  "scope": "https://graph.microsoft.com/.default"
+}
+```
+
+### Sample request
+
+<Tabs>
+<Tab heading="cURL">
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    --request POST \
+    --data '{"scope": "https://graph.microsoft.com/.default"}' \
+    http://127.0.0.1:8200/v1/azure/token/my-static-role
+```
+
+</Tab>
+<Tab heading="CLI">
+
+```shell-session
+$ vault write azure/token/my-static-role \
+    scope="https://graph.microsoft.com/.default"
+```
+
+</Tab>
+</Tabs>
+
+### Sample response
+
+The response wraps Azure's token response inside Vault's `data` envelope:
+
+```json
+{
+  "data": {
+    "token_type": "Bearer",
+    "expires_in": 3599,
+    "ext_expires_in": 3599,
+    "access_token": "eyJ0eXAiOiJKV1Q..."
   }
 }
 ```

--- a/content/vault/v2.x/content/docs/secrets/azure.mdx
+++ b/content/vault/v2.x/content/docs/secrets/azure.mdx
@@ -4,8 +4,8 @@ page_title: Azure secrets engine
 description: >-
   Dynamically generate Azure service principals and role assignments with the Azure secrets engine plugin.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2026-04-15T00:15:37.000Z
-last_modified: 2026-04-15T00:15:37.000Z
+created_at: 2026-04-14T17:13:42-07:00
+last_modified: 2026-08-24T22:14:19.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -503,6 +503,70 @@ You can import credentials in the following ways:
   secret.
 
 Refer to the [Azure plugin API documentation](/vault/api-docs/secret/azure#create-update-static-role) for more details.
+
+## Access tokens
+
+@include 'alerts/enterprise-only.mdx'
+
+<Note title="Requires Vault 2.2 or later">
+
+Access token vending is available in Vault 2.2 and later.
+
+</Note>
+
+The Azure secrets engine can generate OAuth2 access tokens directly for static
+roles, eliminating the need for callers to implement the `client_credentials`
+grant flow themselves. When a caller requests a token, Vault uses the static
+role's stored `client_id` and `client_secret` to request a bearer token from
+Azure AD and returns Azure's response directly.
+
+This allows platform teams to grant token access (`azure/token/*`) separately
+from credential access (`azure/static-creds/*`), so application developers can
+receive ready-to-use tokens without ever seeing the underlying credentials.
+
+**Key characteristics:**
+
+- **No Vault lease** is created. Access tokens cannot be revoked once issued
+  and expire naturally (approximately 1 hour by default, configurable in Azure
+  via [Configurable token lifetimes](https://learn.microsoft.com/en-us/entra/identity-platform/configure-token-lifetimes)).
+- **Scope is caller-supplied.** The `scope` parameter is passed to Azure
+  without modification. For `client_credentials` flows, Azure only allows
+  scopes with the `.default` suffix (e.g. `https://graph.microsoft.com/.default`).
+- **The static role must have been rotated at least once.** Roles using
+  `defer_initial_creds=true` that have never been rotated will return an error.
+  Use the [`rotate-role`](/vault/api-docs/secret/azure#manually-rotate-static-role-password)
+  endpoint first.
+
+### ACL policy example
+
+Grant token access to developers while denying direct credential access:
+
+```hcl
+# Allow developers to obtain access tokens
+path "azure/token/*" {
+  capabilities = ["create", "update"]
+}
+
+# Deny direct credential access
+path "azure/static-creds/*" {
+  capabilities = ["deny"]
+}
+```
+
+### Usage
+
+```shell-session
+# Get a token scoped to Microsoft Graph
+$ vault write azure/token/my-static-role \
+    scope="https://graph.microsoft.com/.default"
+
+# Get a token scoped to Azure Storage
+$ vault write azure/token/my-static-role \
+    scope="https://storage.azure.com/.default"
+```
+
+Refer to the [Azure plugin API documentation](/vault/api-docs/secret/azure#generate-access-token)
+for the full API reference, including request/response formats.
 
 ## Choosing between dynamic or existing service principals
 

--- a/content/vault/v2.x/content/docs/secrets/azure.mdx
+++ b/content/vault/v2.x/content/docs/secrets/azure.mdx
@@ -5,7 +5,7 @@ description: >-
   Dynamically generate Azure service principals and role assignments with the Azure secrets engine plugin.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2026-04-14T17:13:42-07:00
-last_modified: 2026-08-24T22:14:19.000Z
+last_modified: 2026-08-25T16:23:43.000Z
 # END AUTO GENERATED METADATA
 ---
 


### PR DESCRIPTION
This PR adds a new path to Vault azure secrets engine enterprise plugin. It is a change that will be introduced in Vault 2.2.0.

Jira: https://hashicorp.atlassian.net/jira/software/c/projects/VAULT/boards/5811?assignee=712020%3Ac16f02f8-ac9a-4fda-8355-c9c248aa44b7&selectedIssue=VAULT-46318

Please go to the `Preview` tab and select the appropriate template:

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
