### PR TITLE
docs(vault/agent): document KV version discovery via sys/internal/ui/mounts

### DIFF
--- a/content/vault/v1.14.x/content/docs/agent-and-proxy/agent/template.mdx
+++ b/content/vault/v1.14.x/content/docs/agent-and-proxy/agent/template.mdx
@@ -247,6 +247,42 @@ Unlike [Vault Agent caching](/vault/docs/agent-and-proxy/agent/caching), the beh
 templating does this depends on the type of secret or token. The following is a
 high level overview of different behaviors.
 
+### KV version discovery
+
+When Vault Agent renders a template that references a KV secret, it first
+determines whether the target mount is a KV version 1 or KV version 2 engine.
+To do this, Agent sends a preflight `GET` request to
+`/v1/sys/internal/ui/mounts/<mount-path>` before fetching the secret itself.
+
+For example, a template that reads from `kv1/my-secret` triggers a preflight
+request to:
+
+```text
+GET /v1/sys/internal/ui/mounts/kv1/my-secret
+```
+
+The response tells Agent which KV engine version is mounted at that path, so it
+can apply the correct read path and renewal behavior — the `data/` path prefix
+for KVv2, no prefix for KVv1.
+
+The preflight request uses the same token that Agent uses to read secrets. If
+the request fails, Agent uses the following fallback behavior:
+
+- **404** — the Vault server is older and does not support the endpoint; Agent
+  defaults to KVv1.
+- **No token / anonymous request** — Agent defaults to KVv1 and continues.
+- **Any other error** — Agent returns an error and the template render fails.
+
+<Note>
+
+The `vault kv` CLI command uses the same `sys/internal/ui/mounts` preflight
+request to detect the KV engine version. If Vault Agent is configured with API
+proxy and clients use `vault kv get` through it, the preflight request is
+forwarded to Vault and is not served from cache. Use `vault read` to retrieve
+KV secrets directly and avoid the preflight request.
+
+</Note>
+
 ### Renewable secrets
 
 If a secret or token is renewable, Vault Agent will renew the secret after 2/3

--- a/content/vault/v1.15.x/content/docs/agent-and-proxy/agent/template.mdx
+++ b/content/vault/v1.15.x/content/docs/agent-and-proxy/agent/template.mdx
@@ -247,6 +247,42 @@ Unlike [Vault Agent caching](/vault/docs/agent-and-proxy/agent/caching), the beh
 templating does this depends on the type of secret or token. The following is a
 high level overview of different behaviors.
 
+### KV version discovery
+
+When Vault Agent renders a template that references a KV secret, it first
+determines whether the target mount is a KV version 1 or KV version 2 engine.
+To do this, Agent sends a preflight `GET` request to
+`/v1/sys/internal/ui/mounts/<mount-path>` before fetching the secret itself.
+
+For example, a template that reads from `kv1/my-secret` triggers a preflight
+request to:
+
+```text
+GET /v1/sys/internal/ui/mounts/kv1/my-secret
+```
+
+The response tells Agent which KV engine version is mounted at that path, so it
+can apply the correct read path and renewal behavior — the `data/` path prefix
+for KVv2, no prefix for KVv1.
+
+The preflight request uses the same token that Agent uses to read secrets. If
+the request fails, Agent uses the following fallback behavior:
+
+- **404** — the Vault server is older and does not support the endpoint; Agent
+  defaults to KVv1.
+- **No token / anonymous request** — Agent defaults to KVv1 and continues.
+- **Any other error** — Agent returns an error and the template render fails.
+
+<Note>
+
+The `vault kv` CLI command uses the same `sys/internal/ui/mounts` preflight
+request to detect the KV engine version. If Vault Agent is configured with API
+proxy and clients use `vault kv get` through it, the preflight request is
+forwarded to Vault and is not served from cache. Use `vault read` to retrieve
+KV secrets directly and avoid the preflight request.
+
+</Note>
+
 ### Renewable secrets
 
 If a secret or token is renewable, Vault Agent will renew the secret after 2/3

--- a/content/vault/v1.16.x/content/docs/agent-and-proxy/agent/template.mdx
+++ b/content/vault/v1.16.x/content/docs/agent-and-proxy/agent/template.mdx
@@ -253,6 +253,42 @@ Unlike [Vault Agent caching](/vault/docs/agent-and-proxy/agent/caching), the beh
 templating does this depends on the type of secret or token. The following is a
 high level overview of different behaviors.
 
+### KV version discovery
+
+When Vault Agent renders a template that references a KV secret, it first
+determines whether the target mount is a KV version 1 or KV version 2 engine.
+To do this, Agent sends a preflight `GET` request to
+`/v1/sys/internal/ui/mounts/<mount-path>` before fetching the secret itself.
+
+For example, a template that reads from `kv1/my-secret` triggers a preflight
+request to:
+
+```text
+GET /v1/sys/internal/ui/mounts/kv1/my-secret
+```
+
+The response tells Agent which KV engine version is mounted at that path, so it
+can apply the correct read path and renewal behavior — the `data/` path prefix
+for KVv2, no prefix for KVv1.
+
+The preflight request uses the same token that Agent uses to read secrets. If
+the request fails, Agent uses the following fallback behavior:
+
+- **404** — the Vault server is older and does not support the endpoint; Agent
+  defaults to KVv1.
+- **No token / anonymous request** — Agent defaults to KVv1 and continues.
+- **Any other error** — Agent returns an error and the template render fails.
+
+<Note>
+
+The `vault kv` CLI command uses the same `sys/internal/ui/mounts` preflight
+request to detect the KV engine version. If Vault Agent is configured with API
+proxy and clients use `vault kv get` through it, the preflight request is
+forwarded to Vault and is not served from cache. Use `vault read` to retrieve
+KV secrets directly and avoid the preflight request.
+
+</Note>
+
 ### Renewable secrets
 
 If a secret or token is renewable, Vault Agent will renew the secret after 2/3

--- a/content/vault/v1.17.x/content/docs/agent-and-proxy/agent/template.mdx
+++ b/content/vault/v1.17.x/content/docs/agent-and-proxy/agent/template.mdx
@@ -257,6 +257,42 @@ Unlike [Vault Agent caching](/vault/docs/agent-and-proxy/agent/caching), the beh
 templating does this depends on the type of secret or token. The following is a
 high level overview of different behaviors.
 
+### KV version discovery
+
+When Vault Agent renders a template that references a KV secret, it first
+determines whether the target mount is a KV version 1 or KV version 2 engine.
+To do this, Agent sends a preflight `GET` request to
+`/v1/sys/internal/ui/mounts/<mount-path>` before fetching the secret itself.
+
+For example, a template that reads from `kv1/my-secret` triggers a preflight
+request to:
+
+```text
+GET /v1/sys/internal/ui/mounts/kv1/my-secret
+```
+
+The response tells Agent which KV engine version is mounted at that path, so it
+can apply the correct read path and renewal behavior — the `data/` path prefix
+for KVv2, no prefix for KVv1.
+
+The preflight request uses the same token that Agent uses to read secrets. If
+the request fails, Agent uses the following fallback behavior:
+
+- **404** — the Vault server is older and does not support the endpoint; Agent
+  defaults to KVv1.
+- **No token / anonymous request** — Agent defaults to KVv1 and continues.
+- **Any other error** — Agent returns an error and the template render fails.
+
+<Note>
+
+The `vault kv` CLI command uses the same `sys/internal/ui/mounts` preflight
+request to detect the KV engine version. If Vault Agent is configured with API
+proxy and clients use `vault kv get` through it, the preflight request is
+forwarded to Vault and is not served from cache. Use `vault read` to retrieve
+KV secrets directly and avoid the preflight request.
+
+</Note>
+
 ### Renewable secrets
 
 If a secret or token is renewable, Vault Agent will renew the secret after 2/3

--- a/content/vault/v1.18.x/content/docs/agent-and-proxy/agent/template.mdx
+++ b/content/vault/v1.18.x/content/docs/agent-and-proxy/agent/template.mdx
@@ -257,6 +257,42 @@ Unlike [Vault Agent caching](/vault/docs/agent-and-proxy/agent/caching), the beh
 templating does this depends on the type of secret or token. The following is a
 high level overview of different behaviors.
 
+### KV version discovery
+
+When Vault Agent renders a template that references a KV secret, it first
+determines whether the target mount is a KV version 1 or KV version 2 engine.
+To do this, Agent sends a preflight `GET` request to
+`/v1/sys/internal/ui/mounts/<mount-path>` before fetching the secret itself.
+
+For example, a template that reads from `kv1/my-secret` triggers a preflight
+request to:
+
+```text
+GET /v1/sys/internal/ui/mounts/kv1/my-secret
+```
+
+The response tells Agent which KV engine version is mounted at that path, so it
+can apply the correct read path and renewal behavior — the `data/` path prefix
+for KVv2, no prefix for KVv1.
+
+The preflight request uses the same token that Agent uses to read secrets. If
+the request fails, Agent uses the following fallback behavior:
+
+- **404** — the Vault server is older and does not support the endpoint; Agent
+  defaults to KVv1.
+- **No token / anonymous request** — Agent defaults to KVv1 and continues.
+- **Any other error** — Agent returns an error and the template render fails.
+
+<Note>
+
+The `vault kv` CLI command uses the same `sys/internal/ui/mounts` preflight
+request to detect the KV engine version. If Vault Agent is configured with API
+proxy and clients use `vault kv get` through it, the preflight request is
+forwarded to Vault and is not served from cache. Use `vault read` to retrieve
+KV secrets directly and avoid the preflight request.
+
+</Note>
+
 ### Renewable secrets
 
 If a secret or token is renewable, Vault Agent will renew the secret after 2/3

--- a/content/vault/v1.19.x/content/docs/agent-and-proxy/agent/template.mdx
+++ b/content/vault/v1.19.x/content/docs/agent-and-proxy/agent/template.mdx
@@ -260,6 +260,42 @@ Unlike [Vault Agent caching](/vault/docs/agent-and-proxy/agent/caching), the beh
 templating does this depends on the type of secret or token. The following is a
 high level overview of different behaviors.
 
+### KV version discovery
+
+When Vault Agent renders a template that references a KV secret, it first
+determines whether the target mount is a KV version 1 or KV version 2 engine.
+To do this, Agent sends a preflight `GET` request to
+`/v1/sys/internal/ui/mounts/<mount-path>` before fetching the secret itself.
+
+For example, a template that reads from `kv1/my-secret` triggers a preflight
+request to:
+
+```text
+GET /v1/sys/internal/ui/mounts/kv1/my-secret
+```
+
+The response tells Agent which KV engine version is mounted at that path, so it
+can apply the correct read path and renewal behavior — the `data/` path prefix
+for KVv2, no prefix for KVv1.
+
+The preflight request uses the same token that Agent uses to read secrets. If
+the request fails, Agent uses the following fallback behavior:
+
+- **404** — the Vault server is older and does not support the endpoint; Agent
+  defaults to KVv1.
+- **No token / anonymous request** — Agent defaults to KVv1 and continues.
+- **Any other error** — Agent returns an error and the template render fails.
+
+<Note>
+
+The `vault kv` CLI command uses the same `sys/internal/ui/mounts` preflight
+request to detect the KV engine version. If Vault Agent is configured with API
+proxy and clients use `vault kv get` through it, the preflight request is
+forwarded to Vault and is not served from cache. Use `vault read` to retrieve
+KV secrets directly and avoid the preflight request.
+
+</Note>
+
 ### Renewable secrets
 
 If a secret or token is renewable, Vault Agent will renew the secret after 2/3

--- a/content/vault/v1.20.x/content/docs/agent-and-proxy/agent/template.mdx
+++ b/content/vault/v1.20.x/content/docs/agent-and-proxy/agent/template.mdx
@@ -260,6 +260,42 @@ Unlike [Vault Agent caching](/vault/docs/agent-and-proxy/agent/caching), the beh
 templating does this depends on the type of secret or token. The following is a
 high level overview of different behaviors.
 
+### KV version discovery
+
+When Vault Agent renders a template that references a KV secret, it first
+determines whether the target mount is a KV version 1 or KV version 2 engine.
+To do this, Agent sends a preflight `GET` request to
+`/v1/sys/internal/ui/mounts/<mount-path>` before fetching the secret itself.
+
+For example, a template that reads from `kv1/my-secret` triggers a preflight
+request to:
+
+```text
+GET /v1/sys/internal/ui/mounts/kv1/my-secret
+```
+
+The response tells Agent which KV engine version is mounted at that path, so it
+can apply the correct read path and renewal behavior — the `data/` path prefix
+for KVv2, no prefix for KVv1.
+
+The preflight request uses the same token that Agent uses to read secrets. If
+the request fails, Agent uses the following fallback behavior:
+
+- **404** — the Vault server is older and does not support the endpoint; Agent
+  defaults to KVv1.
+- **No token / anonymous request** — Agent defaults to KVv1 and continues.
+- **Any other error** — Agent returns an error and the template render fails.
+
+<Note>
+
+The `vault kv` CLI command uses the same `sys/internal/ui/mounts` preflight
+request to detect the KV engine version. If Vault Agent is configured with API
+proxy and clients use `vault kv get` through it, the preflight request is
+forwarded to Vault and is not served from cache. Use `vault read` to retrieve
+KV secrets directly and avoid the preflight request.
+
+</Note>
+
 ### Renewable secrets
 
 If a secret or token is renewable, Vault Agent will renew the secret after 2/3

--- a/content/vault/v1.21.x/content/docs/agent-and-proxy/agent/template.mdx
+++ b/content/vault/v1.21.x/content/docs/agent-and-proxy/agent/template.mdx
@@ -278,18 +278,21 @@ The response tells Agent which KV engine version is mounted at that path, so it
 can apply the correct read path and renewal behavior — the `data/` path prefix
 for KVv2, no prefix for KVv1.
 
-The token used by Agent must have `read` capability on
-`sys/internal/ui/mounts/*` (or the specific mount path) for this discovery
-request to succeed. If the request is denied, Agent cannot determine the engine
-version for that mount.
+The preflight request uses the same token that Agent uses to read secrets. If
+the request fails, Agent uses the following fallback behavior:
+
+- **404** — the Vault server is older and does not support the endpoint; Agent
+  defaults to KVv1.
+- **No token / anonymous request** — Agent defaults to KVv1 and continues.
+- **Any other error** — Agent returns an error and the template render fails.
 
 <Note>
 
-The `vault kv` CLI command uses the same preflight request to detect the KV
-engine version. If Vault Agent is configured with API proxy and clients use
-`vault kv get` through it, the preflight request to `/sys/internal/ui/mounts`
-is forwarded to Vault and is not served from cache. Use `vault read` to
-retrieve KV secrets directly without the preflight request.
+The `vault kv` CLI command uses the same `sys/internal/ui/mounts` preflight
+request to detect the KV engine version. If Vault Agent is configured with API
+proxy and clients use `vault kv get` through it, the preflight request is
+forwarded to Vault and is not served from cache. Use `vault read` to retrieve
+KV secrets directly and avoid the preflight request.
 
 </Note>
 

--- a/content/vault/v1.21.x/content/docs/agent-and-proxy/agent/template.mdx
+++ b/content/vault/v1.21.x/content/docs/agent-and-proxy/agent/template.mdx
@@ -260,6 +260,39 @@ Unlike [Vault Agent caching](/vault/docs/agent-and-proxy/agent/caching), the beh
 templating does this depends on the type of secret or token. The following is a
 high level overview of different behaviors.
 
+### KV version discovery
+
+When Vault Agent renders a template that references a KV secret, it first
+determines whether the target mount is a KV version 1 or KV version 2 engine.
+To do this, Agent sends a preflight `GET` request to
+`/v1/sys/internal/ui/mounts/<mount-path>` before fetching the secret itself.
+
+For example, a template that reads from `kv1/my-secret` triggers a preflight
+request to:
+
+```text
+GET /v1/sys/internal/ui/mounts/kv1/my-secret
+```
+
+The response tells Agent which KV engine version is mounted at that path, so it
+can apply the correct read path and renewal behavior — the `data/` path prefix
+for KVv2, no prefix for KVv1.
+
+The token used by Agent must have `read` capability on
+`sys/internal/ui/mounts/*` (or the specific mount path) for this discovery
+request to succeed. If the request is denied, Agent cannot determine the engine
+version for that mount.
+
+<Note>
+
+The `vault kv` CLI command uses the same preflight request to detect the KV
+engine version. If Vault Agent is configured with API proxy and clients use
+`vault kv get` through it, the preflight request to `/sys/internal/ui/mounts`
+is forwarded to Vault and is not served from cache. Use `vault read` to
+retrieve KV secrets directly without the preflight request.
+
+</Note>
+
 ### Renewable secrets
 
 If a secret or token is renewable, Vault Agent will renew the secret after 2/3

--- a/content/vault/v2.x/content/docs/agent-and-proxy/agent/template.mdx
+++ b/content/vault/v2.x/content/docs/agent-and-proxy/agent/template.mdx
@@ -278,18 +278,21 @@ The response tells Agent which KV engine version is mounted at that path, so it
 can apply the correct read path and renewal behavior — the `data/` path prefix
 for KVv2, no prefix for KVv1.
 
-The token used by Agent must have `read` capability on
-`sys/internal/ui/mounts/*` (or the specific mount path) for this discovery
-request to succeed. If the request is denied, Agent cannot determine the engine
-version for that mount.
+The preflight request uses the same token that Agent uses to read secrets. If
+the request fails, Agent uses the following fallback behavior:
+
+- **404** — the Vault server is older and does not support the endpoint; Agent
+  defaults to KVv1.
+- **No token / anonymous request** — Agent defaults to KVv1 and continues.
+- **Any other error** — Agent returns an error and the template render fails.
 
 <Note>
 
-The `vault kv` CLI command uses the same preflight request to detect the KV
-engine version. If Vault Agent is configured with API proxy and clients use
-`vault kv get` through it, the preflight request to `/sys/internal/ui/mounts`
-is forwarded to Vault and is not served from cache. Use `vault read` to
-retrieve KV secrets directly without the preflight request.
+The `vault kv` CLI command uses the same `sys/internal/ui/mounts` preflight
+request to detect the KV engine version. If Vault Agent is configured with API
+proxy and clients use `vault kv get` through it, the preflight request is
+forwarded to Vault and is not served from cache. Use `vault read` to retrieve
+KV secrets directly and avoid the preflight request.
 
 </Note>
 

--- a/content/vault/v2.x/content/docs/agent-and-proxy/agent/template.mdx
+++ b/content/vault/v2.x/content/docs/agent-and-proxy/agent/template.mdx
@@ -260,6 +260,39 @@ Unlike [Vault Agent caching](/vault/docs/agent-and-proxy/agent/caching), the beh
 templating does this depends on the type of secret or token. The following is a
 high level overview of different behaviors.
 
+### KV version discovery
+
+When Vault Agent renders a template that references a KV secret, it first
+determines whether the target mount is a KV version 1 or KV version 2 engine.
+To do this, Agent sends a preflight `GET` request to
+`/v1/sys/internal/ui/mounts/<mount-path>` before fetching the secret itself.
+
+For example, a template that reads from `kv1/my-secret` triggers a preflight
+request to:
+
+```text
+GET /v1/sys/internal/ui/mounts/kv1/my-secret
+```
+
+The response tells Agent which KV engine version is mounted at that path, so it
+can apply the correct read path and renewal behavior — the `data/` path prefix
+for KVv2, no prefix for KVv1.
+
+The token used by Agent must have `read` capability on
+`sys/internal/ui/mounts/*` (or the specific mount path) for this discovery
+request to succeed. If the request is denied, Agent cannot determine the engine
+version for that mount.
+
+<Note>
+
+The `vault kv` CLI command uses the same preflight request to detect the KV
+engine version. If Vault Agent is configured with API proxy and clients use
+`vault kv get` through it, the preflight request to `/sys/internal/ui/mounts`
+is forwarded to Vault and is not served from cache. Use `vault read` to
+retrieve KV secrets directly without the preflight request.
+
+</Note>
+
 ### Renewable secrets
 
 If a secret or token is renewable, Vault Agent will renew the secret after 2/3


### PR DESCRIPTION
## Summary

**This is a test of an AI-driven docs authoring workflow.**

Adds a new "KV version discovery" subsection to the [Vault Agent templates](https://developer.hashicorp.com/vault/docs/agent-and-proxy/agent/template) page, under "Renewals and updating secrets".

Vault Agent (via consul-template's `isKVv2()`) performs a preflight `GET /v1/sys/internal/ui/mounts/<mount-path>` request each time it renders a template referencing a KV secret, to determine whether the mount is KVv1 or KVv2. This behavior was undocumented and surfaced as a customer question.

The new section explains:
- Why the request is made and what it returns
- How Agent uses the response to choose the correct read path and renewal behavior
- The error/fallback behavior when the request fails (sourced from [`consul-template/dependency/vault_common.go`](https://github.com/hashicorp/consul-template/blob/main/dependency/vault_common.go) and [`vault/command/kv_helpers.go`](https://github.com/hashicorp/vault/blob/main/command/kv_helpers.go))
- A note linking this to the same behavior in the `vault kv` CLI and its interaction with API proxy caching

## Versions

Applied to all 9 versions that contain this page: v1.14.x through v2.x. Not present in v1.4.x–v1.13.x (the file does not exist in those versions).

## Checklist

- [x] Applied to latest version (v2.x)
- [x] Backported to v1.21.x, v1.20.x, v1.19.x, v1.18.x, v1.17.x, v1.16.x, v1.15.x, v1.14.x
- [x] Verified against source code (consul-template and vault repos)
- [x] Style check: clean
- [x] AI used
- [ ] Jira/ticket link: _please add_
- [ ] Reviewer: _please assign_
