### PR TITLE
HVD: TFE and Agents on IBM Z (s390x) (HVD-2060)

### DIFF
--- a/content/validated-designs/docs/docs/terraform/administration-guide/change-log.mdx
+++ b/content/validated-designs/docs/docs/terraform/administration-guide/change-log.mdx
@@ -12,6 +12,8 @@ last_modified: 2026-07-06T12:00:00.000Z
 ## 2026-08
 
 - Restructured legacy Terraform HVD content into the HVD 2.0 Terraform Administration Guide as part of the Installation / Administration / User guide migration.
+- Added IBM Z (s390x) agent pool guidance to the Self-hosted Agents page: dedicated single-architecture pool requirement, tool version compatibility, provider availability caveat, byte-order operational note, and deployment options for IBM Z / LinuxONE environments.
+- Extended agent pool Design section with architecture isolation as a pool-design factor.
 
 ## 2026-01
 

--- a/content/validated-designs/docs/docs/terraform/administration-guide/self-hosted-agents.mdx
+++ b/content/validated-designs/docs/docs/terraform/administration-guide/self-hosted-agents.mdx
@@ -96,7 +96,7 @@ Your agent pool strategy will depend on a number of factors, the most common one
 
 HCP Terraform and Terraform Enterprise have different constraints regarding the number of HCP Terraform agents running concurrently:
 
-* HCP Terraform enforces run concurrency and self-hosted agent limits that very based on the chosen tier.
+* HCP Terraform enforces run concurrency and self-hosted agent limits that vary based on the chosen tier.
 * Terraform Enterprise imposes no limit on the number of agents running concurrently.
 
 When designing your agent pool setup, this aspect of the product must be considered, as well as the following:
@@ -104,6 +104,7 @@ When designing your agent pool setup, this aspect of the product must be conside
 * Cloud provider isolation: Dedicated agent pool(s) per cloud provider offer benefits such as a streamlined credential management process and, access to provider-specific resources that enhance security and efficiency.
 * Environment isolation: Dedicated agent pools based on environment types prevent accidental changes across development, staging, and production, facilitating focused testing and validation efforts.
 * Operations isolation: For highly privileged operations, separate pools enable granular permission management and efficient audit trail, mitigating security risks and ensuring compliance.
+* Architecture isolation: Dedicated agent pools per CPU architecture ensure runs execute on the expected platform. IBM Z (s390x / LinuxONE) agents require dedicated single-architecture pools; a pool shares one architecture, fixed by the first agent to register, and an agent of a different architecture cannot join the same pool.
 
 <Highlight>
 HashiCorp recommends dedicating an agent pool for every secured environment, such as on-premises data centers with strict controls, or cloud environments using GCP’s VPC Service Controls (or the AWS or Azure equivalent). This strategy enhances security and scalability, reduces the blast radius in case of a security incident, and aligns with the security team’s preferences for controls tailored for each environment.
@@ -147,6 +148,77 @@ Documentation and communication:
 * Communicate the naming convention to all relevant stakeholders, including teams responsible for provisioning, managing, and monitoring agent pools.
 
 By following a clear and standardized naming convention like the one outlined above, you can streamline the identification, management, and communication of agent pools across your organization's multi-cloud environments while promoting consistency and clarity. Adjust the convention as needed to align with your organization's specific requirements, preferences, and existing naming conventions.
+
+##### IBM Z (s390x) agent pools
+
+IBM Z and LinuxONE customers with "stay on the box" compliance requirements must run all software that accesses the Z environment natively on the mainframe. The HCP Terraform agent is available for s390x as a binary and Docker image, enabling these customers to run self-hosted agents inside the Z platform without crossing an architecture boundary.
+
+<Note>
+
+The HashiCorp-managed Global Agent Pool (GAP) runs on amd64 and does not include s390x workers. Terraform runs targeting IBM Z infrastructure require self-hosted agents registered against a dedicated s390x pool.
+
+</Note>
+
+###### Dedicated pools
+
+Dedicated, single-architecture pools are mandatory for s390x agents. Multi-architecture pools are not supported: a pool's architecture is permanently set by the first agent that registers against it, and an agent of a different architecture cannot join the same pool. Create a separate pool for s390x agents, isolated from any existing x86_64 or arm64 pools.
+
+When naming s390x agent pools, extend the standard naming convention with an architecture qualifier so operators can identify the pool's platform at a glance:
+
+```text
+{environment}-{cloud service provider}-z-agentpool
+```
+
+For example: `prod-ibmcloud-z-agentpool`.
+
+###### Tool version compatibility
+
+s390x agents require Terraform versions that include s390x support. Older releases do not support s390x. Customers must upgrade the Terraform version on each workspace before assigning it to an s390x pool. The platform UI blocks the assignment when the workspace uses a Terraform version that lacks s390x support. Sentinel and OPA versions on those workspaces must similarly be s390x-capable.
+
+<Highlight>
+Upgrade the Terraform version on each workspace individually before migrating it to an s390x agent pool. A workspace-by-workspace migration, validated with a plan/apply in a non-production environment first, is the safest approach.
+</Highlight>
+
+###### Provider availability
+
+Every Terraform provider used by workspaces assigned to an s390x pool must publish an s390x binary. If a provider does not supply an s390x package, Terraform runs fail with an incompatibility error:
+
+```text
+... does not have a package available for your current platform, linux_s390x
+```
+
+The provider gap on s390x is larger than on arm64. Before migrating workspaces to an s390x pool, audit every provider version in use and confirm s390x availability. The IBM Z team maintains a reference list of validated open source software at [IBM Z and LinuxONE Open Source Software](https://community.ibm.com/zsystems/oss/). Coordinate with the provider maintainer or the IBM Z team if a required provider is not yet available for s390x.
+
+###### Byte-order considerations
+
+IBM Z uses big-endian byte order, which is the opposite of x86_64 and arm64. Most Terraform configuration workflows behave correctly, but two areas carry risk when you schedule workloads across architecture boundaries:
+
+- **State files**: JSON-serialized state is generally byte-order neutral, but providers that store raw binary data inside state attributes may produce unexpected values when an agent of a different byte order reads the state.
+- **Plan files**: Terraform plan files use the Protocol Buffers binary format. Do not apply a plan generated on an amd64 or arm64 agent to an s390x agent, or in reverse.
+
+<Highlight>
+Keep plan and apply on the same architecture. Assign workspaces fully to an s390x pool or fully to an x86_64/arm64 pool. Never split a plan/apply workflow across architecture boundaries.
+</Highlight>
+
+###### Deployment
+
+HashiCorp publishes s390x agent binaries to [releases.hashicorp.com/tfc-agent](https://releases.hashicorp.com/tfc-agent/) and multi-arch Docker Hub images for the `linux/s390x` platform. The same virtual machine and container deployment guidance described in the [Deploying agents into agent pool](#deploying-agents-into-agent-pool) section applies to IBM Z and LinuxONE hosts running Linux.
+
+<!-- HUMAN-INPUT-REQUIRED: Confirm the current GA status of s390x agent support and whether the registration error / sales-routing behaviour described in the February 2026 project decision is still active before publishing this section -->
+
+<Warning>
+
+**Draft recommendation** — human review required before merging.
+
+The project decision log (February 2026) indicates that, at the time of writing, s390x agent support may not yet be generally available. If an s390x agent attempts to register before the feature reaches GA, it may receive the following error rather than completing registration:
+
+> "This agent architecture is not yet GA. Please reach out to Terraform Enterprise sales for more information."
+
+Verify the current GA and release-channel status of s390x agent support before publishing this page. If the feature is GA, remove this note. If it is in limited or controlled availability, add appropriate qualification (for example: "available to customers with a Terraform Enterprise agreement through IBM Z").
+
+*This recommendation draws on available documentation but practitioners have not validated it against the current release state. A practitioner must confirm GA status before merging this content to main.*
+
+</Warning>
 
 #### **Deploying agents into agent pool**
 


### PR DESCRIPTION
## Summary

Migrates [hashicorp/hvd-docs#400](https://github.com/hashicorp/hvd-docs/pull/400) into `web-unified-docs` now that Validated Designs content lives in this repository.

The content is ported as-is from the source PR. No substantive edits were made during migration.

---

### What's included

- **Updated file:** `content/validated-designs/docs/docs/terraform/administration-guide/self-hosted-agents.mdx`
  Adds IBM Z (s390x / LinuxONE) agent pool guidance: dedicated single-architecture pool requirement, extended naming convention with architecture qualifier, tool version compatibility (Terraform version upgrade before pool assignment), provider availability caveat (linux_s390x gap), byte-order considerations (state and plan file cross-architecture risk), and deployment options. Also adds architecture isolation as an explicit pool-design factor in the Design section, and fixes a typo (`very` → `vary`).

- **Updated file:** `content/validated-designs/docs/docs/terraform/administration-guide/change-log.mdx`
  Adds 2026-08 changelog entries for the IBM Z additions.

---

### Open items for human attention

The source PR carries one unresolved review item that must be addressed before promoting this PR from draft:

1. **GA status of s390x agent support**: The project decision log (February 2026) noted that s390x agent support may not yet be generally available. A practitioner must confirm the current GA and release-channel status. If GA, remove the `<Warning>` block in `self-hosted-agents.mdx`. If in limited availability, add appropriate qualification. See the inline `<!-- HUMAN-INPUT-REQUIRED -->` comment.

---

### Related

- Source PR: [hashicorp/hvd-docs#400](https://github.com/hashicorp/hvd-docs/pull/400)
- Jira: [HVD-2060](https://hashicorp.atlassian.net/browse/HVD-2060)


[HVD-2060]: https://hashicorp.atlassian.net/browse/HVD-2060
