### PR TITLE
Vault: Added census metrics for Secret Engines

### DIFF
--- a/content/vault/v2.x/content/docs/license/product-usage-reporting.mdx
+++ b/content/vault/v2.x/content/docs/license/product-usage-reporting.mdx
@@ -198,8 +198,10 @@ IBM collects the following product usage metrics as numerical data. Vault does n
 | `vault.secret.engine.aws.static.role.count` | Number of AWS secret engine static roles across all namespaces. |
 | `vault.secret.engine.azure.count` | Number of secret engine mounts of type Azure across all namespaces. |
 | `vault.secret.engine.azure.dynamic.role.count` | Number of Azure secret engine dynamic roles across all namespaces. |
+| `vault.secret.engine.azure.static.role.count` | Number of Azure secret engine static roles across all namespaces. |
 | `vault.secret.engine.cassandra.count` | Number of secret engine mounts of type Cassandra across all namespaces. Note that this secret engine is deprecated. |
 | `vault.secret.engine.consul.count` | Number of secret engine mounts of type Consul across all namespaces. |
+| `vault.secret.engine.consul.dynamic.role.count` | Number of Consul secret engine dynamic roles across all namespaces. |
 | `vault.secret.engine.database.count` | Number of secret engine mounts of type Database across all namespaces. Includes all databases of all types. |
 | `vault.secret.engine.database.dynamic.role.count` | Number of database secret engine dynamic roles across all namespaces. |
 | `vault.secret.engine.database.static.role.count` | Number of database secret engine static roles across all namespaces. |
@@ -220,6 +222,7 @@ IBM collects the following product usage metrics as numerical data. Vault does n
 | `vault.secret.engine.keymgmt.kms.multi.region.key.secondary.region.count` | Number of secondary region of multi region key across all namespaces in secret engine mounts of type Keymgmt. |
 | `vault.secret.engine.kmip.count` | Number of secret engine mounts of type KMIP across all namespaces. |
 | `vault.secret.engine.kubernetes.count` | Number of secret engine mounts of type Kubernetes across all namespaces. |
+| `vault.secret.engine.kubernetes.dynamic.role.count` | Number of Kubernetes secret engine dynamic roles across all namespaces. |
 | `vault.secret.engine.kv.count` | Number of secret engine mounts of type KV across all namespaces. |
 | `vault.secret.engine.ldap.count` | Number of secret engine mounts of type LDAP across all namespaces. |
 | `vault.secret.engine.ldap.dynamic.role.count` | Number of LDAP secret engine dynamic roles across all namespaces. |
@@ -230,6 +233,7 @@ IBM collects the following product usage metrics as numerical data. Vault does n
 | `vault.secret.engine.mssql.count` | Number of secret engine mounts of type MSSql across all namespaces. Note that this secret engine is deprecated. |
 | `vault.secret.engine.mysql.count` | Number of secret engine mounts of type MySQL across all namespaces. Note that this secret engine is deprecated. |
 | `vault.secret.engine.nomad.count` | Number of secret engine mounts of type Nomad across all namespaces. |
+| `vault.secret.engine.nomad.dynamic.role.count` | Number of Nomad secret engine dynamic roles across all namespaces. |
 | `vault.secret.engine.openldap.count` | Number of secret engine mounts of type OpenLDAP across all namespaces. |
 | `vault.secret.engine.openldap.dynamic.role.count` | Number of OpenLDAP secret engine dynamic roles across all namespaces. |
 | `vault.secret.engine.openldap.static.role.count` | Number of OpenLDAP secret engine static roles across all namespaces. |
@@ -239,10 +243,13 @@ IBM collects the following product usage metrics as numerical data. Vault does n
 | `vault.secret.engine.plugin.count` | Number of secret engines with unrecognized types (custom plugins) across all namespaces. |
 | `vault.secret.engine.postgresql.count` | Number of secret engine mounts of type Postgresql across all namespaces. Note that this secret engine is deprecated. |
 | `vault.secret.engine.rabbitmq.count` | Number of secret engine mounts of type RabbitMQ across all namespaces. |
+| `vault.secret.engine.rabbitmq.dynamic.role.count` | Number of RabbitMQ secret engine dynamic roles across all namespaces. |
 | `vault.secret.engine.spiffe.count` | Number of secret engine mounts of type Spiffe across all namespaces. |
 | `vault.secret.engine.ssh.count` | Number of secret engine mounts of type SSH across all namespaces. |
 | `vault.secret.engine.terraform.count` | Number of secret engine mounts of type Terraform across all namespaces. |
+| `vault.secret.engine.terraform.dynamic.role.count` | Number of Terraform Cloud secret engine dynamic roles across all namespaces. |
 | `vault.secret.engine.totp.count` | Number of secret engine mounts of type TOTP across all namespaces. |
+| `vault.secret.engine.totp.key.count` | Number of TOTP keys across all namespaces and mounts. |
 | `vault.secret.engine.transform.count` | Number of secret engine mounts of type Transform across all namespaces. |
 | `vault.secret.engine.transit.count` | Number of secret engine mounts of type Transit across all namespaces. |
 | `vault.secret.engine.transit.key.count` | Number of secret engine keys of type Transit across all namespaces and mounts. |


### PR DESCRIPTION
**Census Metrics for Secret Engines Phase 1 and 2**

Jira: 
Phase 1: https://hashicorp.atlassian.net/browse/VAULT-49100 
Phase 2: https://hashicorp.atlassian.net/browse/VAULT-49453

This PR adds census metrics for secret engines to collect the below metrics:


Secret Engine | Configuration Metric
-- | --
Azure | Static Role Count
Kubernetes | Dynamic Role Count
Consul | Dynamic Role Count
Terraform Cloud | Dynamic Role Count
RabbitMQ | Dynamic Role Count
Nomad | Dynamic Role Count
TOTP | Key Count

Please go to the `Preview` tab and select the appropriate template:

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
