### PR TITLE
Vault-49510: Adding Important Changes for default-auth config issue

### DIFF
--- a/content/vault/global/partials/important-changes/known-issue/ui-default-auth-namespace-path.mdx
+++ b/content/vault/global/partials/important-changes/known-issue/ui-default-auth-namespace-path.mdx
@@ -13,13 +13,15 @@
 <!-- END: Vault:=v1.21.x -->
 
 On affected versions, the internal lookup for root namespace default auth rules
-uses the bare string `root` as the storage key. Setting `namespace_path` to
-`root` or `root/` stores the rule under `root/`, which does not match the lookup
-key, so `GET /v1/sys/internal/ui/default-auth-methods` returns `data: null`. As
-a result, the Vault GUI login page ignores the configured default auth method and
-falls back to showing all available auth methods. The authenticated
-`vault read sys/config/ui/login/default-auth/<name>` endpoint is unaffected
-because it looks up rules by name, not namespace path.
+uses the bare string `root` as the storage key. When upgrading to 1.20.8+ent, 
+1.21.3+ent, or 2.x+ent and newer, the internal lookup is normalized to `root/`
+causing `GET /v1/sys/internal/ui/default-auth-methods` to return `data: null`
+with previously working configurations. As a result, the Vault UI login page 
+ignores the configured default auth method and falls back to showing all available 
+auth methods. 
+
+The authenticated `vault read sys/config/ui/login/default-auth/<name>` endpoint 
+is unaffected because it looks up rules by name, not namespace path.
 
 #### Recommendation
 
@@ -28,6 +30,7 @@ root namespace default auth rules:
 
 ```shell-session
 $ vault write sys/config/ui/login/default-auth/<name> \
+    namespace_path="" \
     default_auth_type="<type>" \
     backup_auth_types="<type>" \
     disable_inheritance=false

--- a/content/vault/global/partials/important-changes/known-issue/ui-default-auth-namespace-path.mdx
+++ b/content/vault/global/partials/important-changes/known-issue/ui-default-auth-namespace-path.mdx
@@ -1,4 +1,4 @@
-### UI default auth returns null after upgrade ((#ui-default-auth-namespace-path)) <EnterpriseAlert inline="true" />
+### GUI default auth returns null after upgrade ((#ui-default-auth-namespace-path)) <EnterpriseAlert inline="true" />
 
 <!-- BEGIN: Vault:=v1.20.x -->
 | Change      | Affected version         | Fixed version |
@@ -12,17 +12,30 @@
 | Known issue | 1.21.0+ent – 1.21.2+ent | 1.21.3+ent    |
 <!-- END: Vault:=v1.21.x -->
 
-Default auth rules configured for the root namespace on affected versions store
-`namespace_path` as `root` (without a trailing slash) in Raft storage. After
-upgrading to a fixed version, `GET /v1/sys/internal/ui/default-auth-methods`
-returns `data: null` because the storage key expected by the fixed binary is
-`root/`. As a result, the Vault UI login page ignores the configured default
-auth method and falls back to showing all available auth methods.
+On affected versions, the internal lookup for root namespace default auth rules
+uses the bare string `root` as the storage key. Setting `namespace_path` to
+`root` or `root/` stores the rule under `root/`, which does not match the lookup
+key, so `GET /v1/sys/internal/ui/default-auth-methods` returns `data: null`. As
+a result, the Vault GUI login page ignores the configured default auth method and
+falls back to showing all available auth methods. The authenticated
+`vault read sys/config/ui/login/default-auth/<name>` endpoint is unaffected
+because it looks up rules by name, not namespace path.
 
 #### Recommendation
 
-After upgrading, delete and recreate any default auth rules that targeted the
-root namespace:
+On affected versions, leave `namespace_path` unset when creating or updating
+root namespace default auth rules:
+
+```shell-session
+$ vault write sys/config/ui/login/default-auth/<name> \
+    default_auth_type="<type>" \
+    backup_auth_types="<type>" \
+    disable_inheritance=false
+```
+
+After upgrading to a fixed version (1.20.8+ent, 1.21.3+ent, or 2.0.x+ent),
+delete and recreate the rule with `namespace_path="root"` to migrate the stored
+key to the format the fixed binary expects:
 
 ```shell-session
 $ vault delete sys/config/ui/login/default-auth/<name>

--- a/content/vault/global/partials/important-changes/known-issue/ui-default-auth-namespace-path.mdx
+++ b/content/vault/global/partials/important-changes/known-issue/ui-default-auth-namespace-path.mdx
@@ -1,0 +1,34 @@
+### UI default auth returns null after upgrade ((#ui-default-auth-namespace-path)) <EnterpriseAlert inline="true" />
+
+<!-- BEGIN: Vault:=v1.20.x -->
+| Change      | Affected version         | Fixed version |
+| ----------- | ------------------------ | ------------- |
+| Known issue | 1.20.0+ent – 1.20.7+ent | 1.20.8+ent    |
+<!-- END: Vault:=v1.20.x -->
+
+<!-- BEGIN: Vault:=v1.21.x -->
+| Change      | Affected version         | Fixed version |
+| ----------- | ------------------------ | ------------- |
+| Known issue | 1.21.0+ent – 1.21.2+ent | 1.21.3+ent    |
+<!-- END: Vault:=v1.21.x -->
+
+Default auth rules configured for the root namespace on affected versions store
+`namespace_path` as `root` (without a trailing slash) in Raft storage. After
+upgrading to a fixed version, `GET /v1/sys/internal/ui/default-auth-methods`
+returns `data: null` because the storage key expected by the fixed binary is
+`root/`. As a result, the Vault UI login page ignores the configured default
+auth method and falls back to showing all available auth methods.
+
+#### Recommendation
+
+After upgrading, delete and recreate any default auth rules that targeted the
+root namespace:
+
+```shell-session
+$ vault delete sys/config/ui/login/default-auth/<name>
+$ vault write sys/config/ui/login/default-auth/<name> \
+    namespace_path="root" \
+    default_auth_type="<type>" \
+    backup_auth_types="<type>" \
+    disable_inheritance=false
+```

--- a/content/vault/v1.20.x/content/api-docs/system/config-ui-login-default-auth.mdx
+++ b/content/vault/v1.20.x/content/api-docs/system/config-ui-login-default-auth.mdx
@@ -4,7 +4,7 @@ page_title: /sys/config/ui/login/default-auth - HTTP API
 description: The '/sys/config/ui/login/default-auth' endpoint configures default authentication types that will display on a UI page per namespace.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-07-17T17:17:25-04:00
-last_modified: 2026-08-25T15:58:29.000Z
+last_modified: 2026-08-25T17:13:49.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -37,7 +37,8 @@ inheritance enabled.
   configuration. Names can contain letters, numbers, underscores, and dashes.
 
 - `namespace_path` `(string: "")` - Target namespace for the login configuration.
-  Leave `namespace_path` unset to target the root namespace.
+  In 1.20.0 - 1.20.7, leave `namespace_path` unset to target the root namespace.
+  In 1.20.8+, set `namespace_path` to `root` to target the root namespace.
 
 - `default_auth_type` `(string: <required>)` - The default authentication method.
   You must provide a default method if `backup_auth_types` is unset. Supported
@@ -156,7 +157,8 @@ Update the properties of a specific GUI default auth configuration.
   configuration. Names can contain letters, numbers, underscores, and dashes.
 
 - `namespace_path` `(string: "")` - Target namespace for the login configuration.
-  Leave `namespace_path` unset to target the root namespace.
+  In 1.20.0 - 1.20.7, leave `namespace_path` unset to target the root namespace.
+  In 1.20.8+, set `namespace_path` to `root` to target the root namespace.
 
 - `default_auth_type` `(string: <required>)` - The default authentication method.
   You must provide a default method if `backup_auth_types` is unset. Supported

--- a/content/vault/v1.20.x/content/api-docs/system/config-ui-login-default-auth.mdx
+++ b/content/vault/v1.20.x/content/api-docs/system/config-ui-login-default-auth.mdx
@@ -4,7 +4,7 @@ page_title: /sys/config/ui/login/default-auth - HTTP API
 description: The '/sys/config/ui/login/default-auth' endpoint configures default authentication types that will display on a UI page per namespace.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-07-17T17:17:25-04:00
-last_modified: 2026-08-25T15:25:32.000Z
+last_modified: 2026-08-25T15:58:29.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -37,7 +37,7 @@ inheritance enabled.
   configuration. Names can contain letters, numbers, underscores, and dashes.
 
 - `namespace_path` `(string: "")` - Target namespace for the login configuration.
-  Set `namespace_path` to `root` to target the root namespace.
+  Leave `namespace_path` unset to target the root namespace.
 
 - `default_auth_type` `(string: <required>)` - The default authentication method.
   You must provide a default method if `backup_auth_types` is unset. Supported
@@ -156,7 +156,7 @@ Update the properties of a specific GUI default auth configuration.
   configuration. Names can contain letters, numbers, underscores, and dashes.
 
 - `namespace_path` `(string: "")` - Target namespace for the login configuration.
-  Set `namespace_path` to `root` to target the root namespace.
+  Leave `namespace_path` unset to target the root namespace.
 
 - `default_auth_type` `(string: <required>)` - The default authentication method.
   You must provide a default method if `backup_auth_types` is unset. Supported

--- a/content/vault/v1.20.x/content/api-docs/system/config-ui-login-default-auth.mdx
+++ b/content/vault/v1.20.x/content/api-docs/system/config-ui-login-default-auth.mdx
@@ -4,7 +4,7 @@ page_title: /sys/config/ui/login/default-auth - HTTP API
 description: The '/sys/config/ui/login/default-auth' endpoint configures default authentication types that will display on a UI page per namespace.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-07-17T17:17:25-04:00
-last_modified: 2025-07-18T10:33:02-04:00
+last_modified: 2026-08-25T15:25:32.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -37,7 +37,7 @@ inheritance enabled.
   configuration. Names can contain letters, numbers, underscores, and dashes.
 
 - `namespace_path` `(string: "")` - Target namespace for the login configuration.
-  Leave `namespace_path` unset to apply the configuration to the `root` namespace.
+  Set `namespace_path` to `root` to target the root namespace.
 
 - `default_auth_type` `(string: <required>)` - The default authentication method.
   You must provide a default method if `backup_auth_types` is unset. Supported
@@ -156,8 +156,7 @@ Update the properties of a specific GUI default auth configuration.
   configuration. Names can contain letters, numbers, underscores, and dashes.
 
 - `namespace_path` `(string: "")` - Target namespace for the login configuration.
-  Leave `namespace_path` unset to update configurations under the `root`
-  namespace.
+  Set `namespace_path` to `root` to target the root namespace.
 
 - `default_auth_type` `(string: <required>)` - The default authentication method.
   You must provide a default method if `backup_auth_types` is unset. Supported

--- a/content/vault/v1.20.x/content/docs/updates/important-changes.mdx
+++ b/content/vault/v1.20.x/content/docs/updates/important-changes.mdx
@@ -12,7 +12,7 @@ valid_change_types: >-
   - Known issue --> workaround/recommendation required
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-07-01T14:39:24-05:00
-last_modified: 2026-06-09T23:33:29.000Z
+last_modified: 2026-08-25T15:26:09.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -498,4 +498,6 @@ relative to UTC in all cases.
 @include '../../../global/partials/important-changes/known-issue/sealwrap-raft-quorum-failures.mdx'
 
 @include '../../../global/partials/important-changes/known-issue/azure-static-role-self-target.mdx'
+
+@include '../../../global/partials/important-changes/known-issue/ui-default-auth-namespace-path.mdx'
 

--- a/content/vault/v1.21.x/content/api-docs/system/config-ui-login-default-auth.mdx
+++ b/content/vault/v1.21.x/content/api-docs/system/config-ui-login-default-auth.mdx
@@ -4,7 +4,7 @@ page_title: /sys/config/ui/login/default-auth - HTTP API
 description: The '/sys/config/ui/login/default-auth' endpoint configures default authentication types that will display on a UI page per namespace.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-07-22T12:58:23-07:00
-last_modified: 2026-08-25T15:25:33.000Z
+last_modified: 2026-08-25T15:58:31.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -37,7 +37,7 @@ inheritance enabled.
   configuration. Names can contain letters, numbers, underscores, and dashes.
 
 - `namespace_path` `(string: "")` - Target namespace for the login configuration.
-  Set `namespace_path` to `root` to target the root namespace.
+  Leave `namespace_path` unset to target the root namespace.
 
 - `default_auth_type` `(string: <required>)` - The default authentication method.
   You must provide a default method if `backup_auth_types` is unset. Supported
@@ -156,7 +156,7 @@ Update the properties of a specific GUI default auth configuration.
   configuration. Names can contain letters, numbers, underscores, and dashes.
 
 - `namespace_path` `(string: "")` - Target namespace for the login configuration.
-  Set `namespace_path` to `root` to target the root namespace.
+  Leave `namespace_path` unset to target the root namespace.
 
 - `default_auth_type` `(string: <required>)` - The default authentication method.
   You must provide a default method if `backup_auth_types` is unset. Supported

--- a/content/vault/v1.21.x/content/api-docs/system/config-ui-login-default-auth.mdx
+++ b/content/vault/v1.21.x/content/api-docs/system/config-ui-login-default-auth.mdx
@@ -4,7 +4,7 @@ page_title: /sys/config/ui/login/default-auth - HTTP API
 description: The '/sys/config/ui/login/default-auth' endpoint configures default authentication types that will display on a UI page per namespace.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-07-22T12:58:23-07:00
-last_modified: 2026-08-25T15:58:31.000Z
+last_modified: 2026-08-25T17:13:50.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -37,7 +37,8 @@ inheritance enabled.
   configuration. Names can contain letters, numbers, underscores, and dashes.
 
 - `namespace_path` `(string: "")` - Target namespace for the login configuration.
-  Leave `namespace_path` unset to target the root namespace.
+  In 1.21.0 - 1.21.2, leave `namespace_path` unset to target the root namespace.
+  In 1.21.3+, set `namespace_path` to `root` to target the root namespace.
 
 - `default_auth_type` `(string: <required>)` - The default authentication method.
   You must provide a default method if `backup_auth_types` is unset. Supported
@@ -156,7 +157,8 @@ Update the properties of a specific GUI default auth configuration.
   configuration. Names can contain letters, numbers, underscores, and dashes.
 
 - `namespace_path` `(string: "")` - Target namespace for the login configuration.
-  Leave `namespace_path` unset to target the root namespace.
+  In 1.21.0 - 1.21.2, leave `namespace_path` unset to target the root namespace.
+  In 1.21.3+, set `namespace_path` to `root` to target the root namespace.
 
 - `default_auth_type` `(string: <required>)` - The default authentication method.
   You must provide a default method if `backup_auth_types` is unset. Supported

--- a/content/vault/v1.21.x/content/api-docs/system/config-ui-login-default-auth.mdx
+++ b/content/vault/v1.21.x/content/api-docs/system/config-ui-login-default-auth.mdx
@@ -4,7 +4,7 @@ page_title: /sys/config/ui/login/default-auth - HTTP API
 description: The '/sys/config/ui/login/default-auth' endpoint configures default authentication types that will display on a UI page per namespace.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-07-22T12:58:23-07:00
-last_modified: 2025-10-22T13:53:42-07:00
+last_modified: 2026-08-25T15:25:33.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -37,7 +37,7 @@ inheritance enabled.
   configuration. Names can contain letters, numbers, underscores, and dashes.
 
 - `namespace_path` `(string: "")` - Target namespace for the login configuration.
-  Leave `namespace_path` unset to apply the configuration to the `root` namespace.
+  Set `namespace_path` to `root` to target the root namespace.
 
 - `default_auth_type` `(string: <required>)` - The default authentication method.
   You must provide a default method if `backup_auth_types` is unset. Supported
@@ -156,8 +156,7 @@ Update the properties of a specific GUI default auth configuration.
   configuration. Names can contain letters, numbers, underscores, and dashes.
 
 - `namespace_path` `(string: "")` - Target namespace for the login configuration.
-  Leave `namespace_path` unset to update configurations under the `root`
-  namespace.
+  Set `namespace_path` to `root` to target the root namespace.
 
 - `default_auth_type` `(string: <required>)` - The default authentication method.
   You must provide a default method if `backup_auth_types` is unset. Supported

--- a/content/vault/v1.21.x/content/docs/updates/important-changes.mdx
+++ b/content/vault/v1.21.x/content/docs/updates/important-changes.mdx
@@ -6,7 +6,7 @@ description: >-
   for upgrading Vault.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-07-22T12:58:23-07:00
-last_modified: 2026-06-09T23:33:31.000Z
+last_modified: 2026-08-25T15:26:10.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -55,6 +55,8 @@ their existing schedule until you manually update rotation with an API call.
 @include '../../../global/partials/important-changes/known-issue/azure-static-roles.mdx'
 
 @include '../../../global/partials/important-changes/known-issue/azure-static-role-self-target.mdx'
+
+@include '../../../global/partials/important-changes/known-issue/ui-default-auth-namespace-path.mdx'
 
 @include '../../../global/partials/important-changes/known-issue/secrets-engines-items-per-page-hides-results.mdx'
 

--- a/content/vault/v2.x/content/api-docs/system/config-ui-login-default-auth.mdx
+++ b/content/vault/v2.x/content/api-docs/system/config-ui-login-default-auth.mdx
@@ -3,8 +3,8 @@ layout: api
 page_title: /sys/config/ui/login/default-auth - HTTP API
 description: The '/sys/config/ui/login/default-auth' endpoint configures default authentication types that will display on a UI page per namespace.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2026-04-15T00:13:59.000Z
-last_modified: 2026-04-15T00:13:59.000Z
+created_at: 2026-04-14T17:13:42-07:00
+last_modified: 2026-08-25T15:25:34.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -37,7 +37,7 @@ inheritance enabled.
   configuration. Names can contain letters, numbers, underscores, and dashes.
 
 - `namespace_path` `(string: "")` - Target namespace for the login configuration.
-  Leave `namespace_path` unset to apply the configuration to the `root` namespace.
+  Set `namespace_path` to `root` to target the root namespace.
 
 - `default_auth_type` `(string: <required>)` - The default authentication method.
   You must provide a default method if `backup_auth_types` is unset. Supported
@@ -156,8 +156,7 @@ Update the properties of a specific GUI default auth configuration.
   configuration. Names can contain letters, numbers, underscores, and dashes.
 
 - `namespace_path` `(string: "")` - Target namespace for the login configuration.
-  Leave `namespace_path` unset to update configurations under the `root`
-  namespace.
+  Set `namespace_path` to `root` to target the root namespace.
 
 - `default_auth_type` `(string: <required>)` - The default authentication method.
   You must provide a default method if `backup_auth_types` is unset. Supported

--- a/content/vault/v2.x/content/docs/updates/important-changes.mdx
+++ b/content/vault/v2.x/content/docs/updates/important-changes.mdx
@@ -6,7 +6,7 @@ description: >-
   for upgrading Vault.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2026-04-14T17:13:42-07:00
-last_modified: 2026-07-22T16:59:44.000Z
+last_modified: 2026-08-25T15:26:10.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -219,4 +219,16 @@ corresponding Vault group with the intended membership.
 @include '../../../global/partials/important-changes/known-issue/azure-dynamic-roles.mdx'
 
 @include '../../../global/partials/important-changes/known-issue/azure-static-role-self-target.mdx'
+
+### UI default auth returns null after upgrade from 1.20.x or 1.21.x ((#ui-default-auth-namespace-path)) <EnterpriseAlert inline="true" />
+
+| Change      | Affected version                              | Fixed version |
+| ----------- | --------------------------------------------- | ------------- |
+| Known issue | Upgrading from 1.20.0–1.20.7+ent or 1.21.0–1.21.2+ent | N/A  |
+
+If you are upgrading from an affected 1.20.x or 1.21.x release, default auth
+rules targeting the root namespace may cause
+`GET /v1/sys/internal/ui/default-auth-methods` to return `data: null`. Refer to
+[Vault 1.21.x important changes](/vault/docs/v1.21.x/updates/important-changes#ui-default-auth-namespace-path)
+for the root cause and remediation steps.
 

--- a/content/vault/v2.x/content/docs/updates/important-changes.mdx
+++ b/content/vault/v2.x/content/docs/updates/important-changes.mdx
@@ -6,7 +6,7 @@ description: >-
   for upgrading Vault.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2026-04-14T17:13:42-07:00
-last_modified: 2026-08-25T15:26:10.000Z
+last_modified: 2026-08-25T17:13:50.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -220,7 +220,7 @@ corresponding Vault group with the intended membership.
 
 @include '../../../global/partials/important-changes/known-issue/azure-static-role-self-target.mdx'
 
-### UI default auth returns null after upgrade from 1.20.x or 1.21.x ((#ui-default-auth-namespace-path)) <EnterpriseAlert inline="true" />
+### GUI default auth returns null after upgrade from 1.20.x or 1.21.x ((#ui-default-auth-namespace-path)) <EnterpriseAlert inline="true" />
 
 | Change      | Affected version                              | Fixed version |
 | ----------- | --------------------------------------------- | ------------- |


### PR DESCRIPTION
### Vault

- Added important changes notice in 1.20.x, 1.21.x, and 2.x related to the default-auth config issue when upgrading Vault
- Updated language in the `update` and `create` configuration for ui default-auth to explicitly use `root` instead of leaving it blank
