### PR TITLE
fix: Stop documentation about the `postcondition` block referring to it as a `precondition` block.

### DIFF
--- a/content/terraform/v1.16.x/docs/language/meta-arguments/lifecycle.mdx
+++ b/content/terraform/v1.16.x/docs/language/meta-arguments/lifecycle.mdx
@@ -169,7 +169,7 @@ You can use `precondition` in the following Terraform configuration blocks:
 
 ### `postcondition` 
 
-Specifies a condition that Terraform evaluates after creating the resource. The following arguments in the `precondition` block are required:
+Specifies a condition that Terraform evaluates after creating the resource. The following arguments in the `postcondition` block are required:
 
 | Argument | Description | Data type |
 | --- | --- | --- |


### PR DESCRIPTION
Follow up to https://github.com/hashicorp/web-unified-docs/pull/2938 which didn't include the v1.16 docs.