### PR TITLE
fix: Update command in docker compose

### DIFF
--- a/content/consul/v2.0.x/content/docs/deploy/server/docker.mdx
+++ b/content/consul/v2.0.x/content/docs/deploy/server/docker.mdx
@@ -15,7 +15,7 @@ This topic provides an overview for deploying a Consul server when running Consu
 
 ## Deploy and run a Consul server
 
-You can start a Consul server container and configure the Consul agent from the command line. 
+You can start a Consul server container and configure the Consul agent from the command line.
 
 The following example starts the Docker container and includes a `consul agent -server` sub-command to configure the Consul server agent and enable the UI.
 
@@ -60,7 +60,7 @@ services:
       - "8500:8500"
       - "8600:8600/tcp"
       - "8600:8600/udp"
-    command: "agent -server -ui -data-dir='/consul/data' -node=consul-server1 -retry-join=consul-server2 -bootstrap-expect=3"
+    command: "agent -server -ui -client=0.0.0.0 -data-dir='/consul/data' -node=consul-server1 -retry-join=consul-server2 -bootstrap-expect=3"
   consul-server2:
     image: hashicorp/consul:1.21.3
     container_name: consul-server2


### PR DESCRIPTION
1. Container-1 needs flag of -client=0.0.0.0 so that the UI of consul can be accessed via local
2. Doc states to access the UI from the host and without this flag it won't be accessible

Fixes: https://github.com/hashicorp/web-unified-docs/issues/3119