### PR TITLE
docs: add token expiration email notification info to API tokens page

### DIFF
--- a/content/terraform-docs-common/docs/cloud-docs/users-teams-organizations/api-tokens.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/users-teams-organizations/api-tokens.mdx
@@ -204,7 +204,7 @@ The following chart illustrates the various access levels for the supported API 
 
 Each user, team, and organization token has an expiration date and time. Once the expiration time has passed, the token is no longer treated as valid and may not be used to authenticate to any API. Any API requests made with an expired token will fail.
 
-HCP Terraform sends notification emails at 30 days and 7 days before a user, team, or organization token expires, giving you sufficient time to rotate or renew tokens before they expire.
+HCP Terraform sends notification emails at 30 days and seven days before a user, team, or organization token expires. The expiration window is intended to give you sufficient time to rotate or renew tokens before they expire.
 
 We recommend creating tokens that are valid for the shortest duration possible. Tokens with a long time to live increase your security risk when, for example, you forget to delete tokens once their intended purpose is complete.
 

--- a/content/terraform-docs-common/docs/cloud-docs/users-teams-organizations/api-tokens.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/users-teams-organizations/api-tokens.mdx
@@ -204,6 +204,8 @@ The following chart illustrates the various access levels for the supported API 
 
 Each user, team, and organization token has an expiration date and time. Once the expiration time has passed, the token is no longer treated as valid and may not be used to authenticate to any API. Any API requests made with an expired token will fail.
 
+HCP Terraform sends notification emails at 30 days and 7 days before a user, team, or organization token expires, giving you sufficient time to rotate or renew tokens before they expire.
+
 We recommend creating tokens that are valid for the shortest duration possible. Tokens with a long time to live increase your security risk when, for example, you forget to delete tokens once their intended purpose is complete.
 
 You can not modify the expiration of a token once you have created it. The HCP Terraform UI displays tokens relative to the current user's timezone, but all tokens are passed and displayed in UTC in ISO 8601 format through the HCP Terraform API.


### PR DESCRIPTION

### Terraform

* Adds a note that HCP Terraform sends expiration warning emails at 30 and 7 days for user, team, and organization tokens.