### PR TITLE
Terraform Docs

### DIFF
--- a/content/terraform/v1.12.x/docs/language/block/import.mdx
+++ b/content/terraform/v1.12.x/docs/language/block/import.mdx
@@ -293,7 +293,7 @@ In the following example, Terraform imports the AWS instance with the ID `i-096f
 
 ```hcl
 provider "aws" {
-  region = "us-westl-1"
+  region = "us-west-1"
 }
 
 provider "aws" {

--- a/content/terraform/v1.12.x/docs/language/meta-arguments/for_each.mdx
+++ b/content/terraform/v1.12.x/docs/language/meta-arguments/for_each.mdx
@@ -193,9 +193,9 @@ resource "aws_instance" "server" {
 The [`count` meta-argument](#count) performs a similar operation to `for_each`. Use `for_each` when some instance arguments must have distinct values that can't be directly derived from an
 integer. Use the `count` argument when you want to create nearly identical instances.
 
-You cannot use both a `count` and ` for_each` argument in the same block.
+You cannot use both a `count` and `for_each` argument in the same block.
 
-## Supported constucts
+## Supported constructs
 
 You can use `for_each` in the following Terraform configuration blocks:
 

--- a/content/terraform/v1.12.x/docs/language/meta-arguments/index.mdx
+++ b/content/terraform/v1.12.x/docs/language/meta-arguments/index.mdx
@@ -27,7 +27,7 @@ By default, Terraform configures one infrastructure object for each `resource`, 
 
 ## `for_each`
 
-By default, Terraform configures one infrastructure object for each `resource`, `module`, and `ephemeral` block. You can add the `for_each` block to your `resource`, `data`, `module`, and `ephemeral` blocks to create and manage several similar objects, such as a fixed pool of compute instances, without writing a separate block for each instance. Refer to the [`for_each` reference](/terraform/language/meta-arguments/for_each) for details.
+By default, Terraform configures one infrastructure object for each `resource`, `module`, and `ephemeral` block. You can add the `for_each` argument to your `resource`, `data`, `module`, and `ephemeral` blocks to create and manage several similar objects, such as a fixed pool of compute instances, without writing a separate block for each instance. Refer to the [`for_each` reference](/terraform/language/meta-arguments/for_each) for details.
 
 > **Hands-on**: Complete the [Manage similar resources with for each](/terraform/tutorials/configuration-language/for-each) tutorial to learn how to create multiple instances of a resource.
 

--- a/content/terraform/v1.12.x/docs/language/meta-arguments/lifecycle.mdx
+++ b/content/terraform/v1.12.x/docs/language/meta-arguments/lifecycle.mdx
@@ -219,7 +219,7 @@ In the following example, the `precondition` block ensures that the AMI ID retri
 
 ```hcl
 data "aws_ami" "example" {
-  most_recent= true
+  most_recent = true
   owners = ["amazon"]
   filter {
     name   = "image-id"
@@ -264,7 +264,7 @@ data "aws_ebs_volume" "example" {
 }
 
 data "aws_ami" "example" {
-  most_recent= true
+  most_recent = true
   owners = ["amazon"]
   filter {
     name   = "image-id"

--- a/content/terraform/v1.12.x/docs/language/meta-arguments/lifecycle.mdx
+++ b/content/terraform/v1.12.x/docs/language/meta-arguments/lifecycle.mdx
@@ -30,7 +30,7 @@ Depending on the block you are configuring, you may be able to use one or more o
 
 ### `create_before_destroy` 
 
-By default, when Terraform must change a resource argument that cannot be updated in-place due to remote API limitations, Terraform destroys the existing object and then create a new replacement object with the new configured arguments. Use the `create_before_destroy` rule to instruct Terraform to create a replacement resource before destroying the current resource. 
+By default, when Terraform must change a resource argument that cannot be updated in-place due to remote API limitations, Terraform destroys the existing object and then creates a new replacement object with the new configured arguments. Use the `create_before_destroy` rule to instruct Terraform to create a replacement resource before destroying the current resource. 
 
 This is an opt-in behavior because many remote object types have unique name requirements or other constraints that must be accommodated for both a new and an old object to exist concurrently. Some resource types offer special options to append a random suffix onto each object name to avoid collisions, for example. Terraform CLI cannot automatically activate such features, so you must understand the constraints for each resource type before using `create_before_destroy` with it.
 

--- a/content/terraform/v1.12.x/docs/language/meta-arguments/provider.mdx
+++ b/content/terraform/v1.12.x/docs/language/meta-arguments/provider.mdx
@@ -101,7 +101,7 @@ In the following example, Terraform imports the AWS instance with the ID `i-096f
 
 ```hcl
 provider "aws" {
-  region = "us-westl-1"
+  region = "us-west-1"
 }
 
 provider "aws" {

--- a/content/terraform/v1.12.x/docs/language/meta-arguments/providers.mdx
+++ b/content/terraform/v1.12.x/docs/language/meta-arguments/providers.mdx
@@ -25,9 +25,9 @@ Within a child module, either Terraform chooses a default based on the name of t
 type, or the resource specifies an alternate configuration with the `provider`
 argument. If the module receives a `providers` map when it's called, the
 provider configuration names used within the module are effectively remapped to
-refer the specified configurations from the parent module.
+refer to the specified configurations from the parent module.
 
-In the following example, Terraform uses the default `aws` configuration for AWS resources in the root module where no explicit provider instance is selected, but the example child moduleuses the alternate configuration with the alias `usw2`. As a result, any AWS resources the module defines uses the `us-west-2` region.
+In the following example, Terraform uses the default `aws` configuration for AWS resources in the root module where no explicit provider instance is selected, but the example child module uses the alternate configuration with the alias `usw2`. As a result, any AWS resources the module defines uses the `us-west-2` region.
 
 
 ```hcl

--- a/content/terraform/v1.12.x/docs/language/meta-arguments/providers.mdx
+++ b/content/terraform/v1.12.x/docs/language/meta-arguments/providers.mdx
@@ -13,7 +13,7 @@ By default, child modules inherit the default provider configurations of their p
 
 ## Usage
 
-In a [`module` block](/terraform/language/block/module), you can add the optional `providers` meta-argument to specify which [provider configurations](/terraform/language/modules/configuration) from the parent module is available inside the child module.
+In a [`module` block](/terraform/language/block/module), you can add the optional `providers` meta-argument to specify which [provider configurations](/terraform/language/modules/configuration) from the parent module are available inside the child module.
 
 The value of `providers` is a map, where the keys are the provider configuration names used inside the child module and the values are provider configuration names from the parent module.
 
@@ -96,7 +96,7 @@ of the same provider. For example, a module that configures connectivity between
 networks in two AWS regions is likely to need both a `source` and a `destination`
 region. 
 
-In the following example, the `tunnel` module includes resources that support their own provider configuration. As a result, each resource alias maps to a different provider configurations declared in the root module:
+In the following example, the `tunnel` module includes resources that support their own provider configuration. As a result, each resource alias maps to different provider configurations declared in the root module:
 
 ```hcl
 provider "aws" {

--- a/content/terraform/v1.13.x/docs/language/meta-arguments/for_each.mdx
+++ b/content/terraform/v1.13.x/docs/language/meta-arguments/for_each.mdx
@@ -193,9 +193,9 @@ resource "aws_instance" "server" {
 The [`count` meta-argument](#count) performs a similar operation to `for_each`. Use `for_each` when some instance arguments must have distinct values that can't be directly derived from an
 integer. Use the `count` argument when you want to create nearly identical instances.
 
-You cannot use both a `count` and ` for_each` argument in the same block.
+You cannot use both a `count` and `for_each` argument in the same block.
 
-## Supported constucts
+## Supported constructs
 
 You can use `for_each` in the following Terraform configuration blocks:
 

--- a/content/terraform/v1.13.x/docs/language/meta-arguments/index.mdx
+++ b/content/terraform/v1.13.x/docs/language/meta-arguments/index.mdx
@@ -27,7 +27,7 @@ By default, Terraform configures one infrastructure object for each `resource`, 
 
 ## `for_each`
 
-By default, Terraform configures one infrastructure object for each `resource`, `module`, and `ephemeral` block. You can add the `for_each` block to your `resource`, `data`, `module`, and `ephemeral` blocks to create and manage several similar objects, such as a fixed pool of compute instances, without writing a separate block for each instance. Refer to the [`for_each` reference](/terraform/language/meta-arguments/for_each) for details.
+By default, Terraform configures one infrastructure object for each `resource`, `module`, and `ephemeral` block. You can add the `for_each` argument to your `resource`, `data`, `module`, and `ephemeral` blocks to create and manage several similar objects, such as a fixed pool of compute instances, without writing a separate block for each instance. Refer to the [`for_each` reference](/terraform/language/meta-arguments/for_each) for details.
 
 > **Hands-on**: Complete the [Manage similar resources with for each](/terraform/tutorials/configuration-language/for-each) tutorial to learn how to create multiple instances of a resource.
 

--- a/content/terraform/v1.13.x/docs/language/meta-arguments/lifecycle.mdx
+++ b/content/terraform/v1.13.x/docs/language/meta-arguments/lifecycle.mdx
@@ -219,7 +219,7 @@ In the following example, the `precondition` block ensures that the AMI ID retri
 
 ```hcl
 data "aws_ami" "example" {
-  most_recent= true
+  most_recent = true
   owners = ["amazon"]
   filter {
     name   = "image-id"
@@ -264,7 +264,7 @@ data "aws_ebs_volume" "example" {
 }
 
 data "aws_ami" "example" {
-  most_recent= true
+  most_recent = true
   owners = ["amazon"]
   filter {
     name   = "image-id"

--- a/content/terraform/v1.13.x/docs/language/meta-arguments/lifecycle.mdx
+++ b/content/terraform/v1.13.x/docs/language/meta-arguments/lifecycle.mdx
@@ -30,7 +30,7 @@ Depending on the block you are configuring, you may be able to use one or more o
 
 ### `create_before_destroy` 
 
-By default, when Terraform must change a resource argument that cannot be updated in-place due to remote API limitations, Terraform destroys the existing object and then create a new replacement object with the new configured arguments. Use the `create_before_destroy` rule to instruct Terraform to create a replacement resource before destroying the current resource. 
+By default, when Terraform must change a resource argument that cannot be updated in-place due to remote API limitations, Terraform destroys the existing object and then creates a new replacement object with the new configured arguments. Use the `create_before_destroy` rule to instruct Terraform to create a replacement resource before destroying the current resource. 
 
 This is an opt-in behavior because many remote object types have unique name requirements or other constraints that must be accommodated for both a new and an old object to exist concurrently. Some resource types offer special options to append a random suffix onto each object name to avoid collisions, for example. Terraform CLI cannot automatically activate such features, so you must understand the constraints for each resource type before using `create_before_destroy` with it.
 

--- a/content/terraform/v1.13.x/docs/language/meta-arguments/provider.mdx
+++ b/content/terraform/v1.13.x/docs/language/meta-arguments/provider.mdx
@@ -101,7 +101,7 @@ In the following example, Terraform imports the AWS instance with the ID `i-096f
 
 ```hcl
 provider "aws" {
-  region = "us-westl-1"
+  region = "us-west-1"
 }
 
 provider "aws" {

--- a/content/terraform/v1.13.x/docs/language/meta-arguments/providers.mdx
+++ b/content/terraform/v1.13.x/docs/language/meta-arguments/providers.mdx
@@ -25,9 +25,9 @@ Within a child module, either Terraform chooses a default based on the name of t
 type, or the resource specifies an alternate configuration with the `provider`
 argument. If the module receives a `providers` map when it's called, the
 provider configuration names used within the module are effectively remapped to
-refer the specified configurations from the parent module.
+refer to the specified configurations from the parent module.
 
-In the following example, Terraform uses the default `aws` configuration for AWS resources in the root module where no explicit provider instance is selected, but the example child moduleuses the alternate configuration with the alias `usw2`. As a result, any AWS resources the module defines uses the `us-west-2` region.
+In the following example, Terraform uses the default `aws` configuration for AWS resources in the root module where no explicit provider instance is selected, but the example child module uses the alternate configuration with the alias `usw2`. As a result, any AWS resources the module defines uses the `us-west-2` region.
 
 
 ```hcl

--- a/content/terraform/v1.13.x/docs/language/meta-arguments/providers.mdx
+++ b/content/terraform/v1.13.x/docs/language/meta-arguments/providers.mdx
@@ -13,7 +13,7 @@ By default, child modules inherit the default provider configurations of their p
 
 ## Usage
 
-In a [`module` block](/terraform/language/block/module), you can add the optional `providers` meta-argument to specify which [provider configurations](/terraform/language/modules/configuration) from the parent module is available inside the child module.
+In a [`module` block](/terraform/language/block/module), you can add the optional `providers` meta-argument to specify which [provider configurations](/terraform/language/modules/configuration) from the parent module are available inside the child module.
 
 The value of `providers` is a map, where the keys are the provider configuration names used inside the child module and the values are provider configuration names from the parent module.
 
@@ -96,7 +96,7 @@ of the same provider. For example, a module that configures connectivity between
 networks in two AWS regions is likely to need both a `source` and a `destination`
 region. 
 
-In the following example, the `tunnel` module includes resources that support their own provider configuration. As a result, each resource alias maps to a different provider configurations declared in the root module:
+In the following example, the `tunnel` module includes resources that support their own provider configuration. As a result, each resource alias maps to different provider configurations declared in the root module:
 
 ```hcl
 provider "aws" {

--- a/content/terraform/v1.14.x/docs/language/block/import.mdx
+++ b/content/terraform/v1.14.x/docs/language/block/import.mdx
@@ -265,7 +265,7 @@ In the following example, Terraform imports the AWS instance with the ID `i-096f
 
 ```hcl
 provider "aws" {
-  region = "us-westl-1"
+  region = "us-west-1"
 }
 
 provider "aws" {

--- a/content/terraform/v1.14.x/docs/language/meta-arguments/for_each.mdx
+++ b/content/terraform/v1.14.x/docs/language/meta-arguments/for_each.mdx
@@ -193,9 +193,9 @@ resource "aws_instance" "server" {
 The [`count` meta-argument](#count) performs a similar operation to `for_each`. Use `for_each` when some instance arguments must have distinct values that can't be directly derived from an
 integer. Use the `count` argument when you want to create nearly identical instances.
 
-You cannot use both a `count` and ` for_each` argument in the same block.
+You cannot use both a `count` and `for_each` argument in the same block.
 
-## Supported constucts
+## Supported constructs
 
 You can use `for_each` in the following Terraform configuration blocks:
 

--- a/content/terraform/v1.14.x/docs/language/meta-arguments/index.mdx
+++ b/content/terraform/v1.14.x/docs/language/meta-arguments/index.mdx
@@ -27,7 +27,7 @@ By default, Terraform configures one infrastructure object for each `resource`, 
 
 ## `for_each`
 
-By default, Terraform configures one infrastructure object for each `resource`, `module`, and `ephemeral` block. You can add the `for_each` block to your `resource`, `data`, `module`, and `ephemeral` blocks to create and manage several similar objects, such as a fixed pool of compute instances, without writing a separate block for each instance. Refer to the [`for_each` reference](/terraform/language/meta-arguments/for_each) for details.
+By default, Terraform configures one infrastructure object for each `resource`, `module`, and `ephemeral` block. You can add the `for_each` argument to your `resource`, `data`, `module`, and `ephemeral` blocks to create and manage several similar objects, such as a fixed pool of compute instances, without writing a separate block for each instance. Refer to the [`for_each` reference](/terraform/language/meta-arguments/for_each) for details.
 
 > **Hands-on**: Complete the [Manage similar resources with for each](/terraform/tutorials/configuration-language/for-each) tutorial to learn how to create multiple instances of a resource.
 

--- a/content/terraform/v1.14.x/docs/language/meta-arguments/lifecycle.mdx
+++ b/content/terraform/v1.14.x/docs/language/meta-arguments/lifecycle.mdx
@@ -49,7 +49,7 @@ You can use `action_trigger` in [`resource`](/terraform/language/block/resource)
 
 ### `create_before_destroy` 
 
-By default, when Terraform must change a resource argument that cannot be updated in-place due to remote API limitations, Terraform destroys the existing object and then create a new replacement object with the new configured arguments. Use the `create_before_destroy` rule to instruct Terraform to create a replacement resource before destroying the current resource. 
+By default, when Terraform must change a resource argument that cannot be updated in-place due to remote API limitations, Terraform destroys the existing object and then creates a new replacement object with the new configured arguments. Use the `create_before_destroy` rule to instruct Terraform to create a replacement resource before destroying the current resource. 
 
 This is an opt-in behavior because many remote object types have unique name requirements or other constraints that must be accommodated for both a new and an old object to exist concurrently. Some resource types offer special options to append a random suffix onto each object name to avoid collisions, for example. Terraform CLI cannot automatically activate such features, so you must understand the constraints for each resource type before using `create_before_destroy` with it.
 
@@ -263,7 +263,7 @@ In the following example, the `precondition` block ensures that the AMI ID retri
 
 ```hcl
 data "aws_ami" "example" {
-  most_recent= true
+  most_recent = true
   owners = ["amazon"]
   filter {
     name   = "image-id"
@@ -308,7 +308,7 @@ data "aws_ebs_volume" "example" {
 }
 
 data "aws_ami" "example" {
-  most_recent= true
+  most_recent = true
   owners = ["amazon"]
   filter {
     name   = "image-id"

--- a/content/terraform/v1.14.x/docs/language/meta-arguments/provider.mdx
+++ b/content/terraform/v1.14.x/docs/language/meta-arguments/provider.mdx
@@ -76,7 +76,7 @@ You can use `provider` in the following Terraform configuration blocks:
 - [`import` block](/terraform/language/block/import)
 - [`resource` blocks](/terraform/language/block/resource)
 
-You can use `for_each` in the following query configuration blocks:
+You can use `provider` in the following query configuration blocks:
 
 - [`list` blocks](/terraform/language/block/tfquery/list)
 
@@ -130,7 +130,7 @@ In the following example, Terraform imports the AWS instance with the ID `i-096f
 
 ```hcl
 provider "aws" {
-  region = "us-westl-1"
+  region = "us-west-1"
 }
 
 provider "aws" {

--- a/content/terraform/v1.14.x/docs/language/meta-arguments/providers.mdx
+++ b/content/terraform/v1.14.x/docs/language/meta-arguments/providers.mdx
@@ -25,9 +25,9 @@ Within a child module, either Terraform chooses a default based on the name of t
 type, or the resource specifies an alternate configuration with the `provider`
 argument. If the module receives a `providers` map when it's called, the
 provider configuration names used within the module are effectively remapped to
-refer the specified configurations from the parent module.
+refer to the specified configurations from the parent module.
 
-In the following example, Terraform uses the default `aws` configuration for AWS resources in the root module where no explicit provider instance is selected, but the example child moduleuses the alternate configuration with the alias `usw2`. As a result, any AWS resources the module defines uses the `us-west-2` region.
+In the following example, Terraform uses the default `aws` configuration for AWS resources in the root module where no explicit provider instance is selected, but the example child module uses the alternate configuration with the alias `usw2`. As a result, any AWS resources the module defines uses the `us-west-2` region.
 
 
 ```hcl

--- a/content/terraform/v1.14.x/docs/language/meta-arguments/providers.mdx
+++ b/content/terraform/v1.14.x/docs/language/meta-arguments/providers.mdx
@@ -13,7 +13,7 @@ By default, child modules inherit the default provider configurations of their p
 
 ## Usage
 
-In a [`module` block](/terraform/language/block/module), you can add the optional `providers` meta-argument to specify which [provider configurations](/terraform/language/modules/configuration) from the parent module is available inside the child module.
+In a [`module` block](/terraform/language/block/module), you can add the optional `providers` meta-argument to specify which [provider configurations](/terraform/language/modules/configuration) from the parent module are available inside the child module.
 
 The value of `providers` is a map, where the keys are the provider configuration names used inside the child module and the values are provider configuration names from the parent module.
 
@@ -101,7 +101,7 @@ of the same provider. For example, a module that configures connectivity between
 networks in two AWS regions is likely to need both a `source` and a `destination`
 region. 
 
-In the following example, the `tunnel` module includes resources that support their own provider configuration. As a result, each resource alias maps to a different provider configurations declared in the root module:
+In the following example, the `tunnel` module includes resources that support their own provider configuration. As a result, each resource alias maps to different provider configurations declared in the root module:
 
 ```hcl
 provider "aws" {

--- a/content/terraform/v1.15.x/docs/language/block/import.mdx
+++ b/content/terraform/v1.15.x/docs/language/block/import.mdx
@@ -265,7 +265,7 @@ In the following example, Terraform imports the AWS instance with the ID `i-096f
 
 ```hcl
 provider "aws" {
-  region = "us-westl-1"
+  region = "us-west-1"
 }
 
 provider "aws" {

--- a/content/terraform/v1.15.x/docs/language/meta-arguments/for_each.mdx
+++ b/content/terraform/v1.15.x/docs/language/meta-arguments/for_each.mdx
@@ -190,12 +190,12 @@ resource "aws_instance" "server" {
 
 ### How to choose between `for_each` and `count`
 
-The [`count` meta-argument](#count) performs a similar operation to `for_each`. Use `for_each` when some instance arguments must have distinct values that can't be directly derived from an
+The [`count` meta-argument](/terraform/language/meta-arguments/count) performs a similar operation to `for_each`. Use `for_each` when some instance arguments must have distinct values that can't be directly derived from an
 integer. Use the `count` argument when you want to create nearly identical instances.
 
-You cannot use both a `count` and ` for_each` argument in the same block.
+You cannot use both a `count` and `for_each` argument in the same block.
 
-## Supported constucts
+## Supported constructs
 
 You can use `for_each` in the following Terraform configuration blocks:
 

--- a/content/terraform/v1.15.x/docs/language/meta-arguments/index.mdx
+++ b/content/terraform/v1.15.x/docs/language/meta-arguments/index.mdx
@@ -27,7 +27,7 @@ By default, Terraform configures one infrastructure object for each `resource`, 
 
 ## `for_each`
 
-By default, Terraform configures one infrastructure object for each `resource`, `module`, and `ephemeral` block. You can add the `for_each` block to your `resource`, `data`, `module`, and `ephemeral` blocks to create and manage several similar objects, such as a fixed pool of compute instances, without writing a separate block for each instance. Refer to the [`for_each` reference](/terraform/language/meta-arguments/for_each) for details.
+By default, Terraform configures one infrastructure object for each `resource`, `module`, and `ephemeral` block. You can add the `for_each` argument to your `resource`, `data`, `module`, and `ephemeral` blocks to create and manage several similar objects, such as a fixed pool of compute instances, without writing a separate block for each instance. Refer to the [`for_each` reference](/terraform/language/meta-arguments/for_each) for details.
 
 > **Hands-on**: Complete the [Manage similar resources with for each](/terraform/tutorials/configuration-language/for-each) tutorial to learn how to create multiple instances of a resource.
 

--- a/content/terraform/v1.15.x/docs/language/meta-arguments/lifecycle.mdx
+++ b/content/terraform/v1.15.x/docs/language/meta-arguments/lifecycle.mdx
@@ -49,7 +49,7 @@ You can use `action_trigger` in [`resource`](/terraform/language/block/resource)
 
 ### `create_before_destroy` 
 
-By default, when Terraform must change a resource argument that cannot be updated in-place due to remote API limitations, Terraform destroys the existing object and then create a new replacement object with the new configured arguments. Use the `create_before_destroy` rule to instruct Terraform to create a replacement resource before destroying the current resource. 
+By default, when Terraform must change a resource argument that cannot be updated in-place due to remote API limitations, Terraform destroys the existing object and then creates a new replacement object with the new configured arguments. Use the `create_before_destroy` rule to instruct Terraform to create a replacement resource before destroying the current resource. 
 
 This is an opt-in behavior because many remote object types have unique name requirements or other constraints that must be accommodated for both a new and an old object to exist concurrently. Some resource types offer special options to append a random suffix onto each object name to avoid collisions, for example. Terraform CLI cannot automatically activate such features, so you must understand the constraints for each resource type before using `create_before_destroy` with it.
 
@@ -237,7 +237,7 @@ In the following example, the `precondition` block ensures that the AMI ID retri
 
 ```hcl
 data "aws_ami" "example" {
-  most_recent= true
+  most_recent = true
   owners = ["amazon"]
   filter {
     name   = "image-id"
@@ -282,7 +282,7 @@ data "aws_ebs_volume" "example" {
 }
 
 data "aws_ami" "example" {
-  most_recent= true
+  most_recent = true
   owners = ["amazon"]
   filter {
     name   = "image-id"

--- a/content/terraform/v1.15.x/docs/language/meta-arguments/provider.mdx
+++ b/content/terraform/v1.15.x/docs/language/meta-arguments/provider.mdx
@@ -53,7 +53,7 @@ You can use `provider` in the following Terraform configuration blocks:
 - [`import` blocks](/terraform/language/block/import)
 - [`resource` blocks](/terraform/language/block/resource)
 
-You can use `for_each` in the following query configuration blocks:
+You can use `provider` in the following query configuration blocks:
 
 - [`list` blocks](/terraform/language/block/tfquery/list)
 
@@ -108,7 +108,7 @@ In the following example, Terraform imports the AWS instance with the ID `i-096f
 
 ```hcl
 provider "aws" {
-  region = "us-westl-1"
+  region = "us-west-1"
 }
 
 provider "aws" {

--- a/content/terraform/v1.15.x/docs/language/meta-arguments/providers.mdx
+++ b/content/terraform/v1.15.x/docs/language/meta-arguments/providers.mdx
@@ -13,7 +13,7 @@ By default, child modules inherit the default provider configurations of their p
 
 ## Usage
 
-In a [`module` block](/terraform/language/block/module), you can add the optional `providers` meta-argument to specify which [provider configurations](/terraform/language/modules/configuration) from the parent module is available inside the child module.
+In a [`module` block](/terraform/language/block/module), you can add the optional `providers` meta-argument to specify which [provider configurations](/terraform/language/modules/configuration) from the parent module are available inside the child module.
 
 The value of `providers` is a map, where the keys are the provider configuration names used inside the child module and the values are provider configuration names from the parent module.
 
@@ -25,9 +25,9 @@ Within a child module, either Terraform chooses a default based on the name of t
 type, or the resource specifies an alternate configuration with the `provider`
 argument. If the module receives a `providers` map when it's called, the
 provider configuration names used within the module are effectively remapped to
-refer the specified configurations from the parent module.
+refer to the specified configurations from the parent module.
 
-In the following example, Terraform uses the default `aws` configuration for AWS resources in the root module where no explicit provider instance is selected, but the example child moduleuses the alternate configuration with the alias `usw2`. As a result, any AWS resources the module defines uses the `us-west-2` region.
+In the following example, Terraform uses the default `aws` configuration for AWS resources in the root module where no explicit provider instance is selected, but the example child module uses the alternate configuration with the alias `usw2`. As a result, any AWS resources the module defines uses the `us-west-2` region.
 
 
 ```hcl
@@ -99,7 +99,7 @@ The following use cases describe common patterns for the `providers` argument.
 In rare cases, a single re-usable module might require multiple configurations
 of the same provider. For example, a module that configures connectivity between networks is likely to need both a `source` and a `destination` provider configuration.
 
-In the following examples, the `tunnel` module includes resources that support their own provider configuration. As a result, each resource alias maps to a different provider configurations declared in the root module:
+In the following examples, the `tunnel` module includes resources that support their own provider configuration. As a result, each resource alias maps to different provider configurations declared in the root module:
 
 <Tabs>
 <Tab heading="AWS">

--- a/content/terraform/v1.16.x/docs/language/block/import.mdx
+++ b/content/terraform/v1.16.x/docs/language/block/import.mdx
@@ -265,7 +265,7 @@ In the following example, Terraform imports the AWS instance with the ID `i-096f
 
 ```hcl
 provider "aws" {
-  region = "us-westl-1"
+  region = "us-west-1"
 }
 
 provider "aws" {

--- a/content/terraform/v1.16.x/docs/language/meta-arguments/count.mdx
+++ b/content/terraform/v1.16.x/docs/language/meta-arguments/count.mdx
@@ -69,7 +69,7 @@ Within nested [`provisioner`](/terraform/language/block/resource#provisioner) or
 ### How to choose between `count` and `for_each`
 
 `count` and [`for_each`](/terraform/language/meta-arguments/for_each) perform a similar function. Use the `count` argument when you want to create nearly identical instances. Use `for_each` when some instance arguments must have distinct values that can't be directly derived from an
-integer index. You cannot use both a `count` and ` for_each` argument in the same `resource` or `module` block.
+integer index. You cannot use both a `count` and `for_each` argument in the same `resource` or `module` block.
 
 ## Supported constructs
 

--- a/content/terraform/v1.16.x/docs/language/meta-arguments/depends_on.mdx
+++ b/content/terraform/v1.16.x/docs/language/meta-arguments/depends_on.mdx
@@ -77,7 +77,7 @@ Instead of `depends_on`, we recommend using [expression references](/terraform/l
 
 You can use `depends_on` in the following Terraform configuration blocks:
 
-- [`check` blocks](/terraform/language/block/resource)
+- [`check` blocks](/terraform/language/block/check)
 - [`data` blocks](/terraform/language/block/data)
 - [`ephemeral` blocks](/terraform/language/block/ephemeral)
 - [`module` blocks](/terraform/language/block/module)

--- a/content/terraform/v1.16.x/docs/language/meta-arguments/for_each.mdx
+++ b/content/terraform/v1.16.x/docs/language/meta-arguments/for_each.mdx
@@ -190,12 +190,12 @@ resource "aws_instance" "server" {
 
 ### How to choose between `for_each` and `count`
 
-The [`count` meta-argument](#count) performs a similar operation to `for_each`. Use `for_each` when some instance arguments must have distinct values that can't be directly derived from an
+The [`count` meta-argument](/terraform/language/meta-arguments/count) performs a similar operation to `for_each`. Use `for_each` when some instance arguments must have distinct values that can't be directly derived from an
 integer. Use the `count` argument when you want to create nearly identical instances.
 
-You cannot use both a `count` and ` for_each` argument in the same block.
+You cannot use both a `count` and `for_each` argument in the same block.
 
-## Supported constucts
+## Supported constructs
 
 You can use `for_each` in the following Terraform configuration blocks:
 

--- a/content/terraform/v1.16.x/docs/language/meta-arguments/index.mdx
+++ b/content/terraform/v1.16.x/docs/language/meta-arguments/index.mdx
@@ -27,7 +27,7 @@ By default, Terraform configures one infrastructure object for each `resource`, 
 
 ## `for_each`
 
-By default, Terraform configures one infrastructure object for each `resource`, `module`, and `ephemeral` block. You can add the `for_each` block to your `resource`, `data`, `module`, and `ephemeral` blocks to create and manage several similar objects, such as a fixed pool of compute instances, without writing a separate block for each instance. Refer to the [`for_each` reference](/terraform/language/meta-arguments/for_each) for details.
+By default, Terraform configures one infrastructure object for each `resource`, `module`, and `ephemeral` block. You can add the `for_each` argument to your `resource`, `data`, `module`, and `ephemeral` blocks to create and manage several similar objects, such as a fixed pool of compute instances, without writing a separate block for each instance. Refer to the [`for_each` reference](/terraform/language/meta-arguments/for_each) for details.
 
 > **Hands-on**: Complete the [Manage similar resources with for each](/terraform/tutorials/configuration-language/for-each) tutorial to learn how to create multiple instances of a resource.
 

--- a/content/terraform/v1.16.x/docs/language/meta-arguments/lifecycle.mdx
+++ b/content/terraform/v1.16.x/docs/language/meta-arguments/lifecycle.mdx
@@ -50,7 +50,7 @@ You can use `action_trigger` in [`resource`](/terraform/language/block/resource)
 
 ### `create_before_destroy` 
 
-By default, when Terraform must change a resource argument that cannot be updated in-place due to remote API limitations, Terraform destroys the existing object and then create a new replacement object with the new configured arguments. Use the `create_before_destroy` rule to instruct Terraform to create a replacement resource before destroying the current resource. 
+By default, when Terraform must change a resource argument that cannot be updated in-place due to remote API limitations, Terraform destroys the existing object and then creates a new replacement object with the new configured arguments. Use the `create_before_destroy` rule to instruct Terraform to create a replacement resource before destroying the current resource. 
 
 This is an opt-in behavior because many remote object types have unique name requirements or other constraints that must be accommodated for both a new and an old object to exist concurrently. Some resource types offer special options to append a random suffix onto each object name to avoid collisions, for example. Terraform CLI cannot automatically activate such features, so you must understand the constraints for each resource type before using `create_before_destroy` with it.
 
@@ -169,7 +169,7 @@ You can use `precondition` in the following Terraform configuration blocks:
 
 ### `postcondition` 
 
-Specifies a condition that Terraform evaluates after creating the resource. The following arguments in the `precondition` block are required:
+Specifies a condition that Terraform evaluates after creating the resource. The following arguments in the `postcondition` block are required:
 
 | Argument | Description | Data type |
 | --- | --- | --- |
@@ -238,7 +238,7 @@ In the following example, the `precondition` block ensures that the AMI ID retri
 
 ```hcl
 data "aws_ami" "example" {
-  most_recent= true
+  most_recent = true
   owners = ["amazon"]
   filter {
     name   = "image-id"
@@ -283,7 +283,7 @@ data "aws_ebs_volume" "example" {
 }
 
 data "aws_ami" "example" {
-  most_recent= true
+  most_recent = true
   owners = ["amazon"]
   filter {
     name   = "image-id"

--- a/content/terraform/v1.16.x/docs/language/meta-arguments/provider.mdx
+++ b/content/terraform/v1.16.x/docs/language/meta-arguments/provider.mdx
@@ -53,7 +53,7 @@ You can use `provider` in the following Terraform configuration blocks:
 - [`import` blocks](/terraform/language/block/import)
 - [`resource` blocks](/terraform/language/block/resource)
 
-You can use `for_each` in the following query configuration blocks:
+You can use `provider` in the following query configuration blocks:
 
 - [`list` blocks](/terraform/language/block/tfquery/list)
 
@@ -108,7 +108,7 @@ In the following example, Terraform imports the AWS instance with the ID `i-096f
 
 ```hcl
 provider "aws" {
-  region = "us-westl-1"
+  region = "us-west-1"
 }
 
 provider "aws" {

--- a/content/terraform/v1.16.x/docs/language/meta-arguments/providers.mdx
+++ b/content/terraform/v1.16.x/docs/language/meta-arguments/providers.mdx
@@ -99,7 +99,7 @@ The following use cases describe common patterns for the `providers` argument.
 In rare cases, a single re-usable module might require multiple configurations
 of the same provider. For example, a module that configures connectivity between networks is likely to need both a `source` and a `destination` provider configuration.
 
-In the following examples, the `tunnel` module includes resources that support their own provider configuration. As a result, each resource alias maps to a different provider configurations declared in the root module:
+In the following examples, the `tunnel` module includes resources that support their own provider configuration. As a result, each resource alias maps to different provider configurations declared in the root module:
 
 <Tabs>
 <Tab heading="AWS">

--- a/content/terraform/v1.16.x/docs/language/meta-arguments/providers.mdx
+++ b/content/terraform/v1.16.x/docs/language/meta-arguments/providers.mdx
@@ -13,7 +13,7 @@ By default, child modules inherit the default provider configurations of their p
 
 ## Usage
 
-In a [`module` block](/terraform/language/block/module), you can add the optional `providers` meta-argument to specify which [provider configurations](/terraform/language/modules/configuration) from the parent module is available inside the child module.
+In a [`module` block](/terraform/language/block/module), you can add the optional `providers` meta-argument to specify which [provider configurations](/terraform/language/modules/configuration) from the parent module are available inside the child module.
 
 The value of `providers` is a map, where the keys are the provider configuration names used inside the child module and the values are provider configuration names from the parent module.
 
@@ -25,9 +25,9 @@ Within a child module, either Terraform chooses a default based on the name of t
 type, or the resource specifies an alternate configuration with the `provider`
 argument. If the module receives a `providers` map when it's called, the
 provider configuration names used within the module are effectively remapped to
-refer the specified configurations from the parent module.
+refer to the specified configurations from the parent module.
 
-In the following example, Terraform uses the default `aws` configuration for AWS resources in the root module where no explicit provider instance is selected, but the example child moduleuses the alternate configuration with the alias `usw2`. As a result, any AWS resources the module defines uses the `us-west-2` region.
+In the following example, Terraform uses the default `aws` configuration for AWS resources in the root module where no explicit provider instance is selected, but the example child module uses the alternate configuration with the alias `usw2`. As a result, any AWS resources the module defines uses the `us-west-2` region.
 
 
 ```hcl


### PR DESCRIPTION
Re-creating PR #2107 because of automation issues caused by it being an external person's branch, and us not having looked at it promptly.  Quicker and easier to just re-create.

Changes are under https://unified-docs-frontend-preview-l4r6ex4er-hashicorp.vercel.app/terraform/language/meta-arguments

Most of the changes occur several times across versions.

Original write-up from @neronsoda follows

### What
<!-- Explain what you changed and provide a list of changed page names. -->
Fixed multiple typos and errors in the meta-argument reference pages across versions v1.12.x, v1.13.x, v1.14.x, and v1.15.x (beta).

**v1.15.x (beta)**
- `content/terraform/v1.15.x (beta)/docs/language/meta-arguments/depends_on.mdx`
- `content/terraform/v1.15.x (beta)/docs/language/meta-arguments/for_each.mdx`
- `content/terraform/v1.15.x (beta)/docs/language/meta-arguments/provider.mdx`
- `content/terraform/v1.15.x (beta)/docs/language/meta-arguments/providers.mdx`
- `content/terraform/v1.15.x (beta)/docs/language/meta-arguments/lifecycle.mdx`
- `content/terraform/v1.15.x (beta)/docs/language/meta-arguments/index.mdx`
- `content/terraform/v1.15.x (beta)/docs/language/meta-arguments/count.mdx`

**v1.14.x**
- `content/terraform/v1.14.x/docs/language/meta-arguments/for_each.mdx`
- `content/terraform/v1.14.x/docs/language/meta-arguments/provider.mdx`
- `content/terraform/v1.14.x/docs/language/meta-arguments/providers.mdx`
- `content/terraform/v1.14.x/docs/language/meta-arguments/lifecycle.mdx`
- `content/terraform/v1.14.x/docs/language/meta-arguments/index.mdx`

**v1.13.x**
- `content/terraform/v1.13.x/docs/language/meta-arguments/for_each.mdx`
- `content/terraform/v1.13.x/docs/language/meta-arguments/provider.mdx`
- `content/terraform/v1.13.x/docs/language/meta-arguments/providers.mdx`
- `content/terraform/v1.13.x/docs/language/meta-arguments/lifecycle.mdx`
- `content/terraform/v1.13.x/docs/language/meta-arguments/index.mdx`

**v1.12.x**
- `content/terraform/v1.12.x/docs/language/meta-arguments/for_each.mdx`
- `content/terraform/v1.12.x/docs/language/meta-arguments/provider.mdx`
- `content/terraform/v1.12.x/docs/language/meta-arguments/providers.mdx`
- `content/terraform/v1.12.x/docs/language/meta-arguments/lifecycle.mdx`
- `content/terraform/v1.12.x/docs/language/meta-arguments/index.mdx`

### Why
<!-- Explain why this change is necessary and how it benefits users. -->

**depends_on.mdx** (v1.15.x beta only)
- `check` blocks were linked to `/terraform/language/block/resource` → corrected to `/terraform/language/block/check`

**for_each.mdx** (all versions)
- `constucts` → `constructs` (missing letter `r`)
- `` ` for_each` `` → `` `for_each` `` (extra leading space inside backticks)
- `[#count]` anchor link → `/terraform/language/meta-arguments/count` (invalid anchor, v1.15.x beta only)

**provider.mdx** (all versions)
- `"us-westl-1"` → `"us-west-1"` (typo in code example)
- `` `for_each` `` → `` `provider` `` in the description sentence (wrong meta-argument name, v1.14.x and v1.15.x beta only)

**providers.mdx** (all versions)
- `child moduleuses` → `child module uses` (missing space)
- `refer the specified configurations` → `refer to the specified configurations` (missing preposition)
- `provider configurations ... is available` → `are available` (subject-verb agreement, v1.15.x beta only)
- `a different provider configurations` → `different provider configurations` (article/number mismatch, v1.15.x beta only)

**lifecycle.mdx** (all versions)
- `postcondition` section incorrectly referenced `precondition` block → corrected to `postcondition` block
- `most_recent= true` → `most_recent = true` (missing space in code example)
- `then create a new replacement object` → `then creates a new replacement object` (subject-verb agreement, v1.14.x and v1.15.x beta only)

**index.mdx** (all versions)
- `` `for_each` block `` → `` `for_each` argument `` (`for_each` is a meta-argument, not a block)

**count.mdx** (v1.15.x beta only)
- `` ` for_each` `` → `` `for_each` `` (extra leading space inside backticks)

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] (N/A) Description links to related pull requests or issues, if any.

#### Content
- [x] (N/A) You added redirects to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages **across all affected versions**. Refer to [[Redirects](https://github.com/hashicorp/web-unified-docs/blob/main/docs/content-guide/redirects.md#example-redirects)](https://github.com/hashicorp/web-unified-docs/blob/main/docs/content-guide/redirects.md#example-redirects) for examples and guidance.
- [x] (N/A) Links to related content where appropriate (e.g., CLI, language, API endpoints, permissions, etc.).
- [x] (N/A) Pages with related content are updated and link to this content when appropriate.
- [x] (N/A) Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] (N/A) New pages have metadata (page name and description) at the top.
- [x] (N/A) New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] (N/A) New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] (N/A) UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.