### PR TITLE
Add linux/s390x as recommended binary to compile for TF providers

### DIFF
--- a/content/terraform-docs-common/docs/registry/providers/os-arch.mdx
+++ b/content/terraform-docs-common/docs/registry/providers/os-arch.mdx
@@ -18,6 +18,7 @@ We recommend the following operating system and architecture combinations for co
 * Linux / AMD64 (this is **required** for usage in HCP Terraform, see below)
 * Linux / ARMv8 (sometimes referred to as AArch64 or ARM64)
 * Linux / ARMv6
+* Linux / s390x
 * Windows / AMD64
 
 We also recommend shipping binaries for the following combinations, but we typically do not prioritize fixes for these:


### PR DESCRIPTION
### What
Added Linux/s390x as a recommended binary to compile for Terraform providers

### Why
Terraform providers cannot execute on s390x systems (IBM Z or LinuxONE mainframes) unless the provider is compiled for their architecture

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] (N/A) Description links to related pull requests or issues, if any.

#### Content
- [x] (N/A) You added redirects to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages **across all affected versions**. Refer to [Redirects](https://github.com/hashicorp/web-unified-docs/blob/main/docs/content-guide/redirects.md#example-redirects) for examples and guidance.
- [x] Links to related content where appropriate (e.g., CLI, language, API endpoints, permissions, etc.). The page already links to the [recommended .goreleaser.yml configuration file](https://github.com/hashicorp/terraform-provider-scaffolding-framework/blob/main/.goreleaser.yml). A companion PR to add s390x to that template is open at [hashicorp/terraform-provider-scaffolding-framework#377](https://github.com/hashicorp/terraform-provider-scaffolding-framework/pull/377).
- [x] Pages with related content are updated and link to this content when appropriate. `publishing.mdx` already links to `/terraform/registry/providers/os-arch` for the recommended OS/arch list; no further update needed.
- [x] (N/A) Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages. No pages were added, deleted, or renamed.
- [x] (N/A) New pages have metadata (page name and description) at the top. No new pages were added.
- [x] (N/A) New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility. No images were added.
- [x] (N/A) New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars. No code blocks were added.
- [x] (N/A) UI elements (button names, page names, etc.) are bolded. No UI elements referenced.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.