### PR TITLE
Edits for okta docs and OBO verify

### DIFF
--- a/content/vault/v2.x/content/ai/iam/providers/entraid.mdx
+++ b/content/vault/v2.x/content/ai/iam/providers/entraid.mdx
@@ -6,7 +6,7 @@ description: >-
    registrations, OAuth resource server profiles, and entity aliases.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2026-08-25T12:48:50-05:00
-last_modified: 2026-08-27T02:38:36.000Z
+last_modified: 2026-08-31T19:55:58.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -192,7 +192,6 @@ $ export                                 \
     JWKS_URI="<jwks_uri>"                \
     ISSUER="<issuer>"
 ```
-Application ID URI 
 
 For example:
 

--- a/content/vault/v2.x/content/ai/iam/providers/okta.mdx
+++ b/content/vault/v2.x/content/ai/iam/providers/okta.mdx
@@ -2,16 +2,20 @@
 layout: docs
 page_title: Configure Okta for agent IAM
 description: >-
-  Use Okta and Vault to secure agent permissions with the agent registry and OAuth resource server profiles.
+  Use Okta and Vault to secure agent permissions with the agent registry and
+  OAuth resource server profiles.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-08-27T15:20:32-04:00
+last_modified: 2026-08-31T19:56:02.000Z
+# END AUTO GENERATED METADATA
 ---
 
 # Configure Okta for agent IAM
 
 @include 'alerts/enterprise-and-hcp.mdx'
 
-Configure Okta to use with Vault Enterprise agentic IAM. Follow these workflows
-to configure Okta for your agents or other applications to use Okta-issued
-credentials with either authorization code or client credentials grant types.
+Use Okta with Vault Enterprise agentic IAM to secure AI workflows using
+Okta-issued credentials with authorization codes or client credential grant types.
 
 ## Before you start
 
@@ -19,10 +23,10 @@ credentials with either authorization code or client credentials grant types.
   [Okta Integrator](https://developer.okta.com/signup/) account** to configure
   the authorization server for agents.
 
-- **You must have an [Okta Platform](https://developer.okta.com/signup/)
-  account** with the non-human identities (NHI) feature available to generate
-  client credentials for agents. This feature is not available in the free
-  integrator account trial.
+- **To generate tokens from client credentials, you must have an
+  [Okta Platform](https://developer.okta.com/signup/) account** with the
+  non-human identities (NHI) feature available. The free integrator account trial
+  does not support NHI.
 
 - **You must have the [`oauth2c`](https://github.com/SecureAuthCorp/oauth2c)
   CLI**. You need `oauth2c` installed and in your system `PATH` to interact
@@ -34,129 +38,92 @@ credentials with either authorization code or client credentials grant types.
 - **You must have [`jq`](https://jqlang.org/) installed** to use the example
   commands as written.
 
-You can follow the directions below to use either an authorization code or client credentials grant type
-when defining your authorization server details.
-
-<Tabs>
-<Tab heading="Authorization code" group="authorization-code">
 
 ## Step 1: Create the OIDC service app
 
-You must first configure Okta with a Service App and customize the default
-authorization server. You then define an authorization server policy and
-default scope for reading Vault secrets.
+Create and configure Okta with a Service App and default authorization server.
 
-1. Within the Okta admin console, click **Applications and Resources**.
+![Create new App Integration](/img/agentic-ai/screenshot-okta-app000.png)
+
+1. Open the Okta admin console.
+
+1. Click **Applications and Resources**.
 
 1. Click **Create App Integration**.
 
-   ![Create new App Integration](/img/agentic-ai/screenshot-okta-app000.png)
+1. Select **OIDC - OpenID Connect**.
 
-1. Click **OIDC - OpenID Connect**.
-
-1. Click **Web Application**.
-
-   ![Application general settings](/img/agentic-ai/screenshot-okta-app001.png)
+1. Select **Web Application**.
 
 1. Click **Next**.
 
-1. Within **General Settings**, enter a name for your application
+1. Under **General Settings**, enter a name for your application
    in **App integration name**.
 
-1. Click **Client Credentials**.
+1. Select **Client Credentials**.
 
-1. Click **Refresh Token**.
+1. Select **Refresh Token**.
 
-1. Click **Token Exchange**.
+1. Select **Token Exchange**.
 
-   ![Application general settings](/img/agentic-ai/screenshot-okta-app002.png)
+1. Set **Sign-in redirect URIs** to the default callback URL for `oauth2c`:
+   `http://localhost:9876/callback`.
 
-1. Set the **Sign-in redirect URIs** to that of the `oauth2c` default value:
-   `http://localhost:9876/callback`
+1. Select **Allow everyone in your organization to access**.
 
-   ![Redirect URI settings](/img/agentic-ai/screenshot-okta-app003.png)
-
-1. Click **Allow everyone in your organization to access**.
-
-1. Click **Enable immediate access with Federation Broker Mode**.
-
-   ![Client access settings](/img/agentic-ai/screenshot-okta-app004.png)
+1. Select **Enable immediate access with Federation Broker Mode**.
 
 1. Click **Save**.
 
-### Get Client ID and Client Secret values
-
-After saving your application, you land on the application general settings
-page, where you can copy the Client ID and Client Secret values you need for
-later validation of the agent workflow. Use the browser and a terminal session
-to complete these steps.
-
-1. Click the clipboard icon next to **Client ID** to copy the value.
-
-1. In your terminal session, export the `OKTA_CLIENT_ID` environment variable
-   and paste the Client ID as the value.
+1. Save the **Client ID** and **Client secret** values from the general settings
+   page. You need the client values to validate the agent workflow later:
 
    ```shell-session
-   $ export OKTA_CLIENT_ID=`<Client ID copied from previous step>`
+   $ export \
+       OKTA_CLIENT_ID="<your_client_ID>"
+       OKTA_CLIENT_SECRET="<your_client_secret>"
    ```
 
-1. Click the clipboard icon next to **Client Secrets** to copy the value.
-
-1. In your terminal session, export the `OKTA_CLIENT_SECRET` environment
-   variable and paste the Client Secret as the value.
-
-   ```shell-session
-   $ export OKTA_CLIENT_SECRET=`<Client Secret copied from previous step>`
-   ```
-
-   ![Copy Client ID and Client Secret values](/img/agentic-ai/screenshot-okta-app005.png)
 
 ## Step 2: Configure an Authorization Server policy
 
-Follow these steps to create an Authorization Server policy and associate
-the policy with the application you created earlier. Use the browser and a
-terminal session to complete these steps.
+Create an Authorization Server policy and associate the policy with your new
+application.
+
+![Select default authorization server](/img/agentic-ai/screenshot-okta-app006.png)
 
 1. Click **Security**.
 
 1. Click **API**.
 
-1. Click **default** to select the default authorization server.
+1. Click **default** to open the setting screen for your default authorization
+   server.
 
-   ![Select default authorization server](/img/agentic-ai/screenshot-okta-app006.png)
+1. Select the **Settings** tab.
 
-1. From the **Issuer** value within **Settings**, copy the **Okta URL**
-   value (the value in parentheses).
-
-   ![Copy issuer URI](/img/agentic-ai/screenshot-okta-app007.png)
-
-1. In your terminal session, export the `OKTA_URL` environment variable
-    and paste the Okta URL as the value.
+1. Copy the **Okta URL** value in parentheses from **Issuer** and save it to an
+   environment variable for use later:
 
     ```shell-session
     $ export OKTA_URL=`<Okta URL copied from previous step>`
     ```
 
-1. Return to the Okta UI in the browser and click **Access Policies**.
+1. Select the **Access Policies** tab.
 
-1. Click **Add Policy** to add new access policy.
+1. Click **Add Policy**.
 
-   ![Add access policy](/img/agentic-ai/screenshot-okta-app008.png)
+1. Enter a name for your new policy **Name**, for example `Vault Agentic IAM`.
 
-1. Enter a name into the **Name** field.
+1. Add a useful description for the policy in the **Description** field.
 
-1. Add a description for the policy in the **Description** field.
-
-1. For **Assign to**, click **The following clients** and then enter the
+1. For **Assign to**, click **The following clients** and enter the
    name of the application you created.
-
-   ![Assign access policy](/img/agentic-ai/screenshot-okta-app009.png)
 
 1. Click **Create Policy**.
 
 1. Click **Add rule**.
 
-1. Enter a name for the rule into **Rule Name**.
+1. Enter a name for the rule into **Rule Name**, for example, `AI default access`.
 
 1. Click to enable the **Authorization Code** checkbox.
 
@@ -166,25 +133,22 @@ terminal session to complete these steps.
 
 1. Click to enable the **Token Exchange** checkbox.
 
-   ![Rule settings](/img/agentic-ai/screenshot-okta-app011.png)
-
 1. Leave all other settings at their default values.
 
 1. Click **Create rule**.
 
-You configured the application, authorization server, and rules in Okta. You
-can now configure an authorization server scope.
 
 ## Step 3: Create a Vault read scope
 
-Define a minimal scope for reading secrets from Vault and set it as the
-default scope.
+Use your application settings, authorization server, and default rules to
+configure an authorization server scope. We recommend starting with a minimal
+scope for reading secrets from Vault.
+
+![Add scope](/img/agentic-ai/screenshot-okta-app012.png)
 
 1. From the default authorization server **API** page, click **Scopes**.
 
 1. Click **Add Scope**.
-
-   ![Add scope](/img/agentic-ai/screenshot-okta-app012.png)
 
 1. Enter `vault.read` into **Name**.
 
@@ -194,18 +158,19 @@ default scope.
 
 1. Click to check **Set as default scope**.
 
-   ![Scope settings](/img/agentic-ai/screenshot-okta-app013.png)
-
 1. Click **Create**.
+
 
 ## Step 4: Validate token retrieval
 
-Use your application's Okta URL, client ID, and client secret values with the
-`oauth2c` tool to get a token from Okta as a validation step.
+Use your application URL, client ID, and client secret values with the `oauth2c`
+tool to get a token from Okta as a validation step.
 
-1. Return to the terminal where you exported the environment variables.
+<Tabs>
+<Tab heading="Authorization code" group="authz-code">
 
-1. Request an example token with the oauth2c command-line tool.
+1. Use the `oauth2c` command-line tool to request an example token using the
+   Okta authorization code workflow:
 
     ```shell-session
     $ oauth2c "${OKTA_URL}" \
@@ -219,9 +184,9 @@ Use your application's Okta URL, client ID, and client secret values with the
         --no-browser
     ```
 
-1. Note the URL under `Go to the following URL:` in the output. Visit that
-   URL in a browser to complete the authentication flow. The workflow then
-   outputs more indicators of success.
+1. Vist the URL provided under `Go to the following URL:` in a browser to
+   complete the authentication flow. Confirm Okta completed the token exchange
+   in the command line output:
 
    <CodeBlockConfig hideClipboard>
 
@@ -241,192 +206,52 @@ Use your application's Okta URL, client ID, and client secret values with the
    variable.
 
    ```shell-session
-   $ export JWT_ACCESS_TOKEN=`<access_token value from previous step>`
+   $ export JWT_ACCESS_TOKEN="<access_token_returned_by_okta>"
    ```
 
-After you configure Vault, you can use the `JWT_ACCESS_TOKEN` value to
-authenticate your agent with Vault for secret access.
 
 </Tab>
 
-<Tab heading="Client credentials" group="client-credentials">
+<Tab heading="Client credentials" group="client-creds">
 
-<Note>
-
-You must have an Okta account with the **NHI Authentication Tokens SKU**
-enabled to use client credentials. This SKU is not available in the Okta free
-trial or Okta integrator accounts.
-
-</Note>
-
-## Step 1: Create the OIDC Service App
-
-
-1. Within the Okta admin console, click **Applications and Resources**.
-
-1. Click **Create App Integration**.
-
-   ![Create new App Integration](/img/agentic-ai/screenshot-okta-app000.png)
-
-1. Click **OIDC - OpenID Connect**.
-
-1. Click **Web Application**.
-
-   ![Application general settings](/img/agentic-ai/screenshot-okta-app001.png)
-
-1. Click **Next**.
-
-1. Within **General Settings**, enter a name for your application
-   in **App integration name**.
-
-1. Click **Client Credentials**.
-
-1. Click **Refresh Token**.
-
-1. Click **Token Exchange**.
-
-   ![Application general settings](/img/agentic-ai/screenshot-okta-app002.png)
-
-1. Set the **Sign-in redirect URIs** to that of the `oauth2c` default value:
-   `http://localhost:9876/callback`
-
-   ![Redirect URI settings](/img/agentic-ai/screenshot-okta-app003.png)
-
-1. Click **Allow everyone in your organization to access**.
-
-1. Click **Enable immediate access with Federation Broker Mode**.
-
-   ![Client access settings](/img/agentic-ai/screenshot-okta-app004.png)
-
-1. Click **Save**.
-
-
-
-
-1. Click **Security**.
-
-1. Click **API**.
-
-1. Click **default** to select the default authorization server.
-
-   ![Select default authorization server](/img/agentic-ai/screenshot-okta-app006.png)
-
-1. From the **Issuer** value within **Settings**, copy the **Okta URL**
-   value (the value in parentheses).
-
-   ![Copy issuer URI](/img/agentic-ai/screenshot-okta-app007.png)
-
-1. In your terminal session, export the `OKTA_URL` environment variable
-    and paste the Okta URL as the value.
+1. Use the `oauth2c` command-line tool to request an example token using the
+   Okta client credentials workflow:
 
     ```shell-session
-    $ export OKTA_URL=`<Okta URL copied from previous step>`
-    ```
-
-1. Return to the Okta UI in the browser and click **Access Policies**.
-
-1. Click **Add Policy** to add new access policy.
-
-   ![Add access policy](/img/agentic-ai/screenshot-okta-app008.png)
-
-1. Enter a name into the **Name** field.
-
-1. Add a description for the policy in the **Description** field.
-
-1. For **Assign to**, click **The following clients** and then enter the
-   name of the application you created.
-
-   ![Assign access policy](/img/agentic-ai/screenshot-okta-app009.png)
-
-1. Click **Create Policy**.
-
-1. Click **Add rule**.
-
-1. Enter a name for the rule into **Rule Name**.
-
-1. Click to enable the **Authorization Code** checkbox.
-
-1. Click to enable the **Device Authorization** checkbox.
-
-1. Click **Advanced** to expand the options.
-
-1. Click to enable the **Token Exchange** checkbox.
-
-   ![Rule settings](/img/agentic-ai/screenshot-okta-app011.png)
-
-1. Leave all other settings at their default values.
-
-1. Click **Create rule**.
-
-You configured the application, authorization server, and rules in Okta. You
-can now configure an authorization server scope.
-
-## Step 3: Create a Vault read scope
-
-Define a minimal scope for reading secrets from Vault and set it as the
-default scope.
-
-1. From the default authorization server **API** page, click **Scopes**.
-
-1. Click **Add Scope**.
-
-   ![Add scope](/img/agentic-ai/screenshot-okta-app012.png)
-
-1. Enter `vault.read` into **Name**.
-
-1. Enter a human-friendly phrase like `Vault Read` into **Display phrase**.
-
-1. Click **Implicit**.
-
-1. Click to check **Set as default scope**.
-
-   ![Scope settings](/img/agentic-ai/screenshot-okta-app013.png)
-
-1. Click **Create**.
-
-## Step 4: Validate token retrieval
-
-Use your application's Okta URL, client ID, and client secret values with the
-`oauth2c` tool to get a token from Okta as a validation step.
-
-1. Return to the terminal where you exported the environment variables.
-
-1. Request an example token with the oauth2c command-line tool.
-
-    ```shell-session
-    $ oauth2c  ${OKTA_URL} \
-    --client-id ${OKTA_CLIENT_ID} \
+    $ oauth2c  ${OKTA_URL}                \
+    --client-id ${OKTA_CLIENT_ID}         \
     --client-secret ${OKTA_CLIENT_SECRET} \
-    --grant-type client_credentials \
-    --auth-method client_secret_basic \
-    --response-mode query \
-    --response-types code \
-    --scopes okta.myAccount.manage \
-    --pkce \
+    --grant-type client_credentials       \
+    --auth-method client_secret_basic     \
+    --response-mode query                 \
+    --response-types code                 \
+    --scopes okta.myAccount.manage        \
+    --pkce                                \
     --no-browser
     ```
 
-1. The final output string after `access_token` represents the JWT value,
-    which validates both the workflow and token issuance from Okta.
+   The final output string after `access_token` represents the JWT value,
+   which validates both the workflow and token issuance from Okta.
 
- 1. Export the `access_token` value to the `JWT_ACCESS_TOKEN` environment
-    variable.
+1. Export the `access_token` value to the `JWT_ACCESS_TOKEN` environment
+   variable.
 
-    ```shell-session
-    $ export JWT_ACCESS_TOKEN=`<access_token value from previous step>`
-    ```
-
-After you configure Vault, you can use the `JWT_ACCESS_TOKEN` value to
-authenticate your agent with Vault for secret access.
+   ```shell-session
+   $ export JWT_ACCESS_TOKEN="<access_token_returned_by_okta>"
+   ```
 
 </Tab>
 
 </Tabs>
 
-## Save your data for next steps
+After you configure Vault, you can use the `JWT_ACCESS_TOKEN` value to
+authenticate your agent with Vault for secret access.
 
-Confirm your app details from the setup process. To configure Vault agentic IAM, you must have the following information exported as environment variables
-in your terminal session before proceeding with the Vault setup.
+
+## Step 5: Save your data for next steps
+
+Confirm your app details from the setup process. To configure Vault agentic IAM,
+you must have the following information:
 
 Value                | Environment variable    | Description
 -------------------- | ----------------------- | ------------
@@ -435,7 +260,8 @@ Client ID            | EXTERNAL_ID             | Client ID value for your OIDC a
 Client secret value  | SECRET_ID               | Client secret value for your OIDC application
 Key endpoint         | JWKS_URI                | URL where clients can download public keys (JWKS). The OKTA_URL + "/v1/keys"
 
-Set the following environment variables to make Vault setup more convenient:
+We recommend setting the following environment variables to make Vault
+configuration more convenient:
 
 ```shell-session
 $ export                                 \
@@ -452,19 +278,21 @@ For example:
 <CodeBlockConfig hideClipboard>
 
 ```shell-session
-$ export                                                                                                      \
-    VAULT_ADDR="https://127.0.0.1:8200"                                                                        \
-    VAULT_TOKEN="hvs.000000000000000000000000"                                                                \
-    EXTERNAL_ID="00000000000000000000"                                                        \                                                                                \
-    SECRET_ID="3333333333333-3333-3333-333333333333"                                                          \
-    JWKS_URI="https://integrator-0000000.okta.com/oauth2/default/v1/keys"     \
+$ export                                                                  \
+    VAULT_ADDR="https://127.0.0.1:8200"                                   \
+    VAULT_TOKEN="hvs.000000000000000000000000"                            \
+    EXTERNAL_ID="00000000000000000000"                                    \
+    SECRET_ID="3333333333333-3333-3333-333333333333"                      \
+    JWKS_URI="https://integrator-0000000.okta.com/oauth2/default/v1/keys" \
     ISSUER="https://integrator-0000000.okta.com/oauth2/default"
 ```
 
 </CodeBlockConfig>
 
-You can configure Vault agent IAM with other identity providers:
 
-- [Configure IBM Verify for agent IAM](/vault/docs/ai/iam/providers/verify)
+## Next steps
 
-- [Configure Microsoft Entra ID IAM](/vault/docs/ai/iam/providers/entraid)
+- Configure Vault to [secure agentic workflows](/vault/ai/iam/setup)
+- Configure additonal identity provides and authentication servers:
+   - [Configure IBM Verify for agent IAM](/vault/ai/iam/providers/verify)
+   - [Configure Microsoft Entra ID IAM](/vault/docs/ai/iam/providers/entraid)

--- a/content/vault/v2.x/content/ai/iam/setup-agent.mdx
+++ b/content/vault/v2.x/content/ai/iam/setup-agent.mdx
@@ -5,8 +5,8 @@ description: >-
   Use Vault and your ID provider to secure agent permissions with the agent
   registry, OAuth resource server profiles, and ceiling policies.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2026-08-21T13:52:44-07:00
-last_modified: 2026-08-27T19:59:16.000Z
+created_at: 2026-08-31T19:56:05.000Z
+last_modified: 2026-08-31T19:56:05.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -15,9 +15,7 @@ last_modified: 2026-08-27T19:59:16.000Z
 @include 'alerts/enterprise-and-hcp.mdx'
 
 Use Vault Enterprise and your ID provider to implement zero trust principles
-with delegated ephemeral and narrowly scoped agent credentials. Accept JWTs with
-RAR authorization details, and OBO semantics as means to perform authorized
-operations on Vault.
+with narrowly scoped agent credentials.
 
 ## Before you start
 
@@ -27,6 +25,7 @@ operations on Vault.
 
     - [Use IBM Verify for agent IAM](/vault/ai/iam/providers/verify)
     - [Use Entra ID for agent IAM](/vault/ai/iam/providers/entraid)
+    - [Use Okta for agent IAM](/vault/ai/iam/providers/okta)
 
 - **You must have admin permissions on Vault**. You need a Vault token with
   sufficient ACL policies attached to configure and modify your Vault deployment.
@@ -39,7 +38,7 @@ operations on Vault.
 <Tab heading="Verify" group="verify">
 
 1. Create an OAuth resource server configuration file called `verify-oauth.json`
-   using the previously stored environment variables:
+   using the environment variables you saved during provider setup:
 
     ```shell-session
     $ cat > verify-oauth.json << EOF
@@ -103,7 +102,7 @@ standard `jti`. As a result, you must set `unique_id_claim` to `uti` and
 claim optional in the issued JWTs.
 
 1. Create an OAuth resource server configuration file called `entraid-oauth.json`
-   using the previously stored environment variables:
+   using the environment variables you saved during provider setup:
 
     ```shell-session
     $ cat > entraid-oauth.json << EOF
@@ -153,10 +152,8 @@ claim optional in the issued JWTs.
 
 <Tab heading="Okta" group="okta">
 
-Create an OAuth resource server configuration file called `okta-oauth.json`
-using the previously stored environment variables
-
-1. Create the OAuth resource server configuration.
+1. Create an OAuth resource server configuration file called `okta-oauth.json`
+   using the environment variables you saved during provider setup:
 
     ```shell-session
     $ cat > okta-oauth.json << EOF
@@ -207,27 +204,15 @@ using the previously stored environment variables
 </Tabs>
 
 
-## Step 2: Create Vault entities for the external users
+## Step 2: Map your external identity to a Vault entity
 
-Map your external identity to a Vault entity.
+Create a Vault entity for the external user.
 
 <Tabs>
 
 <Tab heading="Verify" group="verify">
 
-1. Create a new subject entity in for the human user.
-
-    ```shell-session
-    $ vault write identity/entity name="obo-user" external_id="${SUBJECT_EXT_ID}"
-
-    Key        Value
-    ---        -----
-    aliases    <nil>
-    id         0427b0f5-ac11-4f25-75f6-5764b85176aa
-    name       obo-user
-    ```
-
-1. Create a new actor entity for the AI agent user.
+1. Create a new entity for the AI agent user:
 
     ```shell-session
     $ vault write identity/entity name="obo-agent" external_id="${ACTOR_EXT_ID}"
@@ -244,8 +229,7 @@ Map your external identity to a Vault entity.
 
     ```shell-session
     $ export
-      OBO_USER_CANONICAL_ID="0427b0f5-ac11-4f25-75f6-5764b85176aa" \
-      OBO_AGENT_CANONICAL_ID="ef897bd9-0060-1fa4-68ba-65ae5b0747ec"
+      AGENT_CANONICAL_ID="ef897bd9-0060-1fa4-68ba-65ae5b0747ec"
     ```
 
 
@@ -253,7 +237,7 @@ Map your external identity to a Vault entity.
 
 <Tab heading="Entra" group="entra">
 
-1. Create a new actor entity for the OIDC app:
+1. Create a new entity for the OIDC app:
 
     ```shell-session
     $ vault write identity/entity name="oidc-app"
@@ -275,7 +259,7 @@ Map your external identity to a Vault entity.
 
 <Tab heading="Okta" group="okta">
 
-1. Create a new actor entity for the OIDC app:
+1. Create a new entity for the OIDC app:
 
     ```shell-session
     $ vault write identity/entity name="oidc-app"
@@ -299,7 +283,7 @@ Map your external identity to a Vault entity.
 
 ## Step 4: Create entity aliases
 
-Create aliases for the newly created Vault entities.
+Create an alias for the newly created Vault entity.
 
 Normally, creating an entity alias requires a `mount_accessor` value. If you
 provide both an external ID and an issuer that matches your OAuth resource
@@ -332,22 +316,7 @@ oauth-resource-server_root_de81dc66-e00d-23c6-7dfc-9cdbc5aaf97e
 
 <Tab heading="Verify" group="verify">
 
-1. Create an entity alias for the user entity with the issuer value included:
-
-   ```shell-session
-   $ vault write identity/entity-alias       \
-     name="jwt-binding-subject"              \
-     canonical_id="${OBO_USER_CANONICAL_ID}" \
-     issuer="${ISSUER}"                      \
-     external_id="${SUBJECT_EXT_ID}"
-
-   Key             Value
-   ---             -----
-   canonical_id    0427b0f5-ac11-4f25-75f6-5764b85176aa
-   id              e3b9d5b0-c623-1f02-b1ef-95503ad7be03
-   ```
-
-1. Create an entity alias for the agent entity with the issuer value included:
+1. Create an entity alias for the agent entity:
 
    ```shell-session
    $ vault write identity/entity-alias         \
@@ -362,11 +331,17 @@ oauth-resource-server_root_de81dc66-e00d-23c6-7dfc-9cdbc5aaf97e
    id              e929f437-f655-45c0-03e7-eb6212dba58d
    ```
 
+1. Save the alias ID to an environment variable. Do not use the canonical ID:
+
+   ```shell-session
+   $ export ALIAS_ID="e929f437-f655-45c0-03e7-eb6212dba58d"
+   ```
+
 </Tab>
 
 <Tab heading="Entra" group="entra">
 
-1. Create the entity alias for your OIDC app with the issuer value included:
+1. Create an entity alias for your OIDC app:
 
    ```shell-session
    $ vault write identity/entity-alias       \
@@ -381,16 +356,16 @@ oauth-resource-server_root_de81dc66-e00d-23c6-7dfc-9cdbc5aaf97e
    id              8268e2d2-7222-7a77-170a-e23767179c81
    ```
 
-1. Save the alias ID to an environment variable:
+1. Save the alias ID to an environment variable. Do not use the canonical ID:
 
    ```shell-session
    $ export ALIAS_ID="8268e2d2-7222-7a77-170a-e23767179c81"
    ```
 
-1. Use the canonical alias ID to double check the alias configuration:
+1. Use the alias ID to double check the alias configuration:
 
    ```shell-session
-   $ vault read identity/entity-alias/id/${ALIAS_CANONICAL_ID}
+   $ vault read identity/entity-alias/id/${ALIAS_ID}
 
    Key                          Value
    ---                          -----
@@ -413,7 +388,7 @@ oauth-resource-server_root_de81dc66-e00d-23c6-7dfc-9cdbc5aaf97e
 
 <Tab heading="Okta" group="okta">
 
-1. Create the entity alias for your OIDC app with the issuer value included:
+1. Create an entity alias for your OIDC app:
 
    ```shell-session
    $ vault write identity/entity-alias       \
@@ -428,16 +403,17 @@ oauth-resource-server_root_de81dc66-e00d-23c6-7dfc-9cdbc5aaf97e
    id              b834295b-9144-237d-0df9-1ab17842d8e6
    ```
 
-1. Save the alias ID to an environment variable:
+1. Save the alias ID to an environment variable. Do not use the canonical ID:
+
 
    ```shell-session
-   $ export ALIAS_CANONICAL_ID="b834295b-9144-237d-0df9-1ab17842d8e6"
+   $ export ALIAS_ID="b834295b-9144-237d-0df9-1ab17842d8e6"
    ```
 
-1. Use the canonical alias ID to double check the alias configuration:
+1. Use the alias ID to double check the alias configuration:
 
    ```shell-session
-   $ vault read identity/entity-alias/id/${ALIAS_CANONICAL_ID}
+   $ vault read identity/entity-alias/id/${ALIAS_ID}
 
    Key                          Value
    ---                          -----
@@ -521,8 +497,8 @@ perform.
 
 ## Step 6: Register the agent with Vault
 
-Create an entry in the Vault agent registry using the canonical ID and your
-ceiling policy:
+Create an entry in the Vault agent registry using the entity canonical ID and
+your ceiling policy:
 
 <Tabs>
 
@@ -530,8 +506,8 @@ ceiling policy:
 
 ```shell-session
 $ vault write agent-registry/register     \
-    display_name="obo-<human_user>-agent" \
-    entity_id="${OBO_AGENT_CANONICAL_ID}" \
+    display_name="<ai_agent>-iam" \
+    entity_id="${AGENT_CANONICAL_ID}"     \
     ceiling_policies='["ceiling-all"]'
 ```
 
@@ -540,14 +516,14 @@ For example:
 <CodeBlockConfig hideClipboard>
 
 ```shell-session
-$ vault write agent-registry/register     \
-    display_name="obo-danielle-agent"     \
-    entity_id="${OBO_AGENT_CANONICAL_ID}" \
+$ vault write agent-registry/register \
+    display_name="claude-iam"         \
+    entity_id="${AGENT_CANONICAL_ID}" \
     ceiling_policies='["ceiling-all"]'
 
 Key             Value
 ---             -----
-display_name    obo-danielle-agent
+display_name    claude-iam
 id              ef897bd9-0060-1fa4-68ba-65ae5b0747ec
 ```
 
@@ -648,9 +624,9 @@ Use the new agent alias to mint and validate token creation in Vault.
         --data 'authorization_details=[{{authz_request}}]' | jq -r '.access_token)
     ```
 
-1. Use the delegated token with `vault token lookup` to verify your
-   configuration. Vault validates the token against the OAuth resource server
-   config profile, resolves the entity alias, and returns the default policy:
+1. Use the minted token with `vault token lookup` to verify your configuration.
+   Vault validates the token against the OAuth resource server config profile,
+   resolves the entity alias, and returns the default policy:
 
    ```shell-session
    $ VAULT_TOKEN=${AGENT_TOKEN} vault token lookup
@@ -672,9 +648,9 @@ Use the new agent alias to mint and validate token creation in Vault.
         -d "grant_type=client_credentials"                            \
         ${TOKEN_ENDPOINT} | jq -r '.access_token')
 
-1. Use the delegated token with `vault token lookup` to verify your
-   configuration. Vault validates the token against the OAuth resource server
-   config profile, resolves the entity alias, and returns the default policy:
+1. Use the minted token with `vault token lookup` to verify your configuration.
+   Vault validates the token against the OAuth resource server config profile,
+   resolves the entity alias, and returns the default policy:
 
    ```shell-session
    $ VAULT_TOKEN=$AGENT_TOKEN vault token lookup
@@ -717,9 +693,9 @@ Use the new agent alias to mint and validate token creation in Vault.
        --data-urlencode "client_secret=${OIDC_CLIENT_SECRET}" \
        | jq -r '.access_token')
 
-1. Use the delegated token with `vault token lookup` to verify your
-   configuration. Vault validates the token against the OAuth resource server
-   config profile, resolves the entity alias, and returns the default policy:
+1. Use the minted token with `vault token lookup` to verify your configuration.
+   Vault validates the token against the OAuth resource server config profile,
+   resolves the entity alias, and returns the default policy:
 
    ```shell-session
    $ VAULT_TOKEN=$DELEGATION_TOKEN vault token lookup
@@ -752,10 +728,8 @@ Use the new agent alias to mint and validate token creation in Vault.
 
 ## Step 8: Validate Vault operations
 
-You can use KV version 2 operations with delegated RAR tokens to validate the
-ACL and ceiling policies. Vault does not consider agent policies when performing
-OBO operations. What matters is the intersection of the policies on the user, the
-policy ceiling for the agent, and RAR constraints.
+You can use KV version 2 operations with the minted tokens to validate the
+ceiling policies.
 
 1. Enable a KV version 2 secrets engine at the path `secret-v2`.
 
@@ -774,7 +748,7 @@ policy ceiling for the agent, and RAR constraints.
         secret_author="I am human"
     ```
 
-1. Try to use the original delegation token to write a `kv` secret:
+1. Try to use the original minted token to write a `kv` secret:
 
     ```shell-session
     $ VAULT_TOKEN=${AGENT_TOKEN} vault write \
@@ -791,7 +765,7 @@ policy ceiling for the agent, and RAR constraints.
 
     The write fails because the ceiling policy does not allow writes to `kv`.
 
-1. Use the original delegation token to read the `kv` secret:
+1. Use the original minted token to read the `kv` secret:
 
     ```shell-session
     $ VAULT_TOKEN=${AGENT_TOKEN} vault read secret-v2/data/shared-secret/test

--- a/content/vault/v2.x/content/ai/iam/setup-obo.mdx
+++ b/content/vault/v2.x/content/ai/iam/setup-obo.mdx
@@ -1,0 +1,462 @@
+---
+layout: docs
+page_title: Set up OBO delegation
+description: >-
+  Use Vault and your ID provider to secure OBO operations with the agent registry,
+  OAuth resource server profiles, and ceiling policies.
+# START AUTO GENERATED METADATA, DO NOT EDIT
+created_at: 2026-08-31T19:56:05.000Z
+last_modified: 2026-08-31T19:56:05.000Z
+# END AUTO GENERATED METADATA
+---
+
+# Set up OBO delegation
+
+@include 'alerts/enterprise-and-hcp.mdx'
+
+Use Vault Enterprise and your ID provider to implement zero trust principles
+with delegated ephemeral and narrowly scoped agent credentials. Accept JWTs with
+RAR authorization details, and OBO semantics as means to perform authorized
+operations on Vault.
+
+## Before you start
+
+- **You must have a Vault Enterprise or HCP Vault Dedicated server deployed**.
+
+- **You must configure an identity or OAuth provider that supports OBO**:
+
+    - [Use IBM Verify for agent IAM](/vault/ai/iam/providers/verify)
+
+- **You must have admin permissions on Vault**. You need a Vault token with
+  sufficient ACL policies attached to configure and modify your Vault deployment.
+
+
+## Step 1: Create an OAuth resource server profile
+
+1. Create an OAuth resource server configuration file called `verify-oauth.json`
+   using the environment variables you saved during provider setup:
+
+    ```shell-session
+    $ cat > verify-oauth.json << EOF
+    {
+      "issuer_id":            "${ISSUER}",
+      "use_jwks":             true,
+      "user_claim":           "sub",
+      "supported_algorithms": ["RS256"],
+      "jwks_uri":             "${JWKS_URI}"
+    }
+    EOF
+    ```
+
+    <Warning title="IBM Verify limitation">
+
+    Avoid validating with the `audiences` value with Verify STS clients as the
+    client performing the OBO token exchange with RAR authorization details
+    does not support `audience` mapping in the access token mapping.
+
+    </Warning>
+
+1. Create an OAuth resource server profile using the JSON file:
+
+    ```shell-session
+    $ vault write sys/config/oauth-resource-server/verify @verify-oauth.json
+
+    WARNING! The following warnings were returned from Vault:
+    * algorithm "RS256" is functional but consider using PS256 (RSA-PSS) for
+    better security
+    * profile supports only one algorithm family - consider supporting multiple
+    families for flexibility
+    ```
+
+1. Read the profile to check for correctness.
+
+    ```shell-session
+    $ vault read sys/config/oauth-resource-server/verify
+
+    Key                     Value
+    ---                     -----
+    audiences               [https://localhost:8200/v1]
+    clock_skew_leeway       0
+    config_id               de81dc66-e00d-23c6-7dfc-9cdbc5aaf97e
+    enabled                 true
+    issuer_id               https://mydomain.verify.ibm.com/oauth2
+    jwks_uri                https://mydomain.verify.ibm.com/oauth2/jwks
+    jwt_type                access_token
+    no_default_policy       false
+    profile_name            verify
+    supported_algorithms    [RS256]
+    use_jwks                true
+    ```
+
+## Step 2: Create Vault entities for the external users
+
+Map your external agent and human users to Vault entities.
+
+1. Create a new subject entity in for the human user.
+
+    ```shell-session
+    $ vault write identity/entity name="obo-human" external_id="${SUBJECT_EXT_ID}"
+
+    Key        Value
+    ---        -----
+    aliases    <nil>
+    id         0427b0f5-ac11-4f25-75f6-5764b85176aa
+    name       obo-human
+    ```
+
+1. Create a new actor entity for the AI agent user.
+
+    ```shell-session
+    $ vault write identity/entity name="obo-agent" external_id="${ACTOR_EXT_ID}"
+
+    Key        Value
+    ---        -----
+    aliases    <nil>
+    id         ef897bd9-0060-1fa4-68ba-65ae5b0747ec
+    name       obo-agent
+    ```
+
+1. Save the IDs created for the human and agent entities to environment
+   variables for later use:
+
+    ```shell-session
+    $ export
+      OBO_HUMAN_CANONICAL_ID="0427b0f5-ac11-4f25-75f6-5764b85176aa" \
+      OBO_AGENT_CANONICAL_ID="ef897bd9-0060-1fa4-68ba-65ae5b0747ec"
+    ```
+
+## Step 4: Create entity aliases
+
+Create aliases for the newly created Vault entities.
+
+Normally, creating an entity alias requires a `mount_accessor` value. If you
+provide both an external ID and an issuer that matches your OAuth resource
+server profile, Vault synthesizes the correct mount accessor for you when you
+create aliases for agentic IAM.
+
+Instead of associating the generated alias with an auth mount, the alias points
+to the issuer that grants access for the alias. Vault uses the following format
+for the mount accessor synthesis:
+
+<CodeBlockConfig hideClipboard>
+
+```text
+oauth-resource-server + _ + <namespace ID> + _ + <server profile config ID>
+```
+
+</CodeBlockConfig>
+
+For example, a mount accessor in the `root` namespace would be:
+
+<CodeBlockConfig hideClipboard>
+
+```
+oauth-resource-server_root_de81dc66-e00d-23c6-7dfc-9cdbc5aaf97e
+```
+
+</CodeBlockConfig>
+
+
+1. Create an entity alias for the human user entity:
+
+   ```shell-session
+   $ vault write identity/entity-alias        \
+     name="jwt-binding-subject"               \
+     canonical_id="${OBO_HUMAN_CANONICAL_ID}" \
+     issuer="${ISSUER}"                       \
+     external_id="${SUBJECT_EXT_ID}"
+
+   Key             Value
+   ---             -----
+   canonical_id    0427b0f5-ac11-4f25-75f6-5764b85176aa
+   id              e3b9d5b0-c623-1f02-b1ef-95503ad7be03
+   ```
+
+1. Create an entity alias for the agent entity:
+
+   ```shell-session
+   $ vault write identity/entity-alias         \
+     name="jwt-binding-actor"                  \
+     canonical_id="${OBO_AGENT_CANONICAL_ID}"  \
+     issuer="${ISSUER}"                        \
+     external_id="${ACTOR_EXT_ID}"
+
+   Key             Value
+   ---             -----
+   canonical_id    ef897bd9-0060-1fa4-68ba-65ae5b0747ec
+   id              e929f437-f655-45c0-03e7-eb6212dba58d
+   ```
+
+
+## Step 5: Create a ceiling policy
+
+Create a ceiling policy to encompass all the possible operations the agent might
+perform.
+
+1. Create a policy configuration file called `ceiling-policy.hcl`. For example,
+   to restrict access on the `kv`, `pki`, and `transit` plugins:
+
+    ```shell-session
+    $ cat > ceiling-policy.hcl << EOF
+    # Allow KV2 read and write
+    path "secret-v2/data/shared-secret/*" {
+      capabilities = ["read", "list"]
+    }
+
+    path "secret-v2/metadata/shared-secret/*" {
+      capabilities = ["list"]
+    }
+
+    # Allow PKI operations
+    path "pki/issue/example-dot-com" {
+      capabilities = ["create", "update"]
+    }
+
+    path "pki/cert/*" {
+      capabilities = ["read"]
+    }
+
+    path "pki/certs" {
+      capabilities = ["list"]
+    }
+
+    # Allow transit engine operations
+    path "transit/encrypt/app-key" {
+      capabilities = ["update", "create", "read"]
+    }
+
+    # Allow decrypt
+    path "transit/decrypt/app-key" {
+      capabilities = ["update", "create", "read"]
+    }
+
+    # Optional: allow key metadata read (safe)
+    path "transit/keys/app-key" {
+      capabilities = ["read"]
+    }
+    EOF
+    ```
+
+1. Write the ceiling policy to Vault:
+
+    ```shell-session
+    $ vault policy write ceiling-all ceiling-policy.hcl
+
+    Success! Uploaded policy: ceiling-all
+    ```
+
+
+## Step 6: Register the agent with Vault
+
+Create an entry in the Vault agent registry using the canonical ID of the agent
+entity and your ceiling policy:
+
+```shell-session
+$ vault write agent-registry/register     \
+    display_name="obo-<human_user>-agent" \
+    entity_id="${OBO_AGENT_CANONICAL_ID}" \
+    ceiling_policies='["ceiling-all"]'
+```
+
+For example:
+
+<CodeBlockConfig hideClipboard>
+
+```shell-session
+$ vault write agent-registry/register     \
+    display_name="obo-danielle-agent"     \
+    entity_id="${OBO_AGENT_CANONICAL_ID}" \
+    ceiling_policies='["ceiling-all"]'
+
+Key             Value
+---             -----
+display_name    obo-danielle-agent
+id              ef897bd9-0060-1fa4-68ba-65ae5b0747ec
+```
+
+</CodeBlockConfig>
+
+
+## Step 7: Validate the OBO flow
+
+You can use KV version 2 operations with delegated RAR tokens to validate the
+ACL and ceiling policies. Vault does not consider actor (agent) policies when
+performing OBO operations. Vault only uses the intersection of the ceiling policy,
+policies assigned to the human user, and RAR constraints to evaluate agent access.
+
+1. Enable a KV version 2 secrets engine at the path `secret-v2`.
+
+    ```shell-session
+    $ vault secrets enable -path=secret-v2 kv-v2
+
+    Success! Enabled the kv-v2 secrets engine at: secret-v2/
+    Create a policy to perform KV operations and link it to the subject entity.
+    ```
+
+1. Create a policy file called `kv2-policy.hcl` with full access for the human
+   (subject) entity:
+
+    ```shell-session
+    $ cat > kv2-policy.hcl <<'EOF'
+    path "secret-v2/data/shared-secret/*" {
+    capabilities = ["create", "read", "update", "delete", "list"]
+    }
+    path "secret-v2/metadata/shared-secret/*" {
+    capabilities = ["list"]
+    }
+    EOF
+    ```
+
+1. Write the new policy to Vault.
+
+    ```shell-session
+    $ vault policy write kv2-policy kv2-policy.hcl
+    Success! Uploaded policy: kv2-policy
+    ```
+
+1. Check existing policies for the human user entity. Vault should return an
+   empty list for the policy assignment:
+
+    ```shell-session
+    $ vault read identity/entity/name/obo-human
+    Key                    Value
+    ---                    -----
+    aliases                [map[canonical_id:dfee09b9-3b37-0ff3-0324-49b4909c566c creation_time:2026-06-16T12:03:12.361169Z custom_metadata:<nil> id:124d59ef-2efe-af30-bdda-c4cc9be4e184 last_update_time:2026-06-16T12:03:12.361169Z local:false merged_from_canonical_ids:<nil> metadata:<nil> mount_accessor:oauth-resource-server_root_774005a7-6e38-d8cf-37ce-9b91b2910322 name:jwt-binding-subject]]
+    creation_time          2026-06-16T12:03:12.085015Z
+    direct_group_ids       []
+    disabled               false
+    group_ids              []
+    id                     dfee09b9-3b37-0ff3-0324-49b4909c566c
+    inherited_group_ids    []
+    last_update_time       2026-06-16T12:23:59.527254Z
+    merged_entity_ids      <nil>
+    metadata               <nil>
+    mfa_secrets            map[]
+    name                   obo-human
+    namespace_id           root
+    policies               []
+    ```
+
+1. Link the `kv-policy` policy to the `obo-human` entity:
+
+    ```shell-session
+    $ vault write identity/entity/name/obo-human policies='kv2-policy'
+    ```
+
+1. Verify the policy linkage:
+
+    ```shell-session
+    $ vault read identity/entity/name/obo-human
+    Key                    Value
+    ---                    -----
+    aliases                [map[canonical_id:dfee09b9-3b37-0ff3-0324-49b4909c566c creation_time:2026-06-16T12:03:12.361169Z custom_metadata:<nil> id:124d59ef-2efe-af30-bdda-c4cc9be4e184 last_update_time:2026-06-16T12:03:12.361169Z local:false merged_from_canonical_ids:<nil> metadata:<nil> mount_accessor:oauth-resource-server_root_774005a7-6e38-d8cf-37ce-9b91b2910322 name:jwt-binding-subject]]
+    creation_time          2026-06-16T12:03:12.085015Z
+    direct_group_ids       []
+    disabled               false
+    group_ids              []
+    id                     dfee09b9-3b37-0ff3-0324-49b4909c566c
+    inherited_group_ids    []
+    last_update_time       2026-06-16T12:23:59.527254Z
+    merged_entity_ids      <nil>
+    metadata               <nil>
+    mfa_secrets            map[]
+    name                   obo-human
+    namespace_id           root
+    policies               [kv2-policy]
+    ```
+
+    <Tip>
+
+    To clear the policy from an entity, you can write a set of empty quotes:
+
+    ```shell-session
+    $ vault write identity/entity/name/obo-human policies=''
+    ```
+
+    </Tip>
+
+1. Request a delegation token with permission that only allows `create` and `read`
+   access to `kv` secrets:
+
+    ```shell-session
+    $ export DELEGATION_TOKEN=$(curl --request POST \
+      ...
+      --data 'authorization_details=[{"type":"vault:path_access","path":"secret-v2/data/shared-secret/foo", "capabilities":["create", "read"]}]' | jq -r '.access_token)
+    ```
+
+1. Use the delegation token from the token exchange to write a new secret:
+
+    ```shell-session
+    $ echo '{"data": {"foo": "bar"}}' | \
+      VAULT_TOKEN=${DELEGATION_TOKEN} vault write secret-v2/data/shared-secret/foo -
+
+    Key                Value
+    ---                -----
+    created_time       2026-06-11T07:41:13.074Z
+    custom_metadata    <nil>
+    deletion_time      n/a
+    destroyed          false
+    version            1
+    ```
+
+1. Try to perform `vault write secret` write on the same path to update the secret:
+
+    ```shell-session
+    $ echo '{"data": {"foo": "bar_new"}}' | VAULT_TOKEN=${DELEGATION_TOKEN} \
+      vault write secret-v2/data/shared-secret/foo -
+    
+    Error writing data to secret-v2/data/shared-secret/foo: Error making API request.
+    URL: PUT http://127.0.0.1:8200/v1/secret-v2/data/shared-secret/foo
+    Code: 403. Errors:
+    * 2 errors occurred:
+    	* RAR_NO_MATCH: No valid authorization_details claim found matching this request.
+    	* permission denied
+    ```
+
+   Vault prohibits the update because the current RAR policy only allows `create`
+   and `read`
+
+1. Request an updated RAR token that includes `update` permission:
+
+    ```shell-session
+    $ export DELEGATION_TOKEN=$(curl --request POST \
+      ...
+      --data 'authorization_details=[{"type":"vault:path_access","path":"secret-v2/data/shared-secret/foo", "capabilities":["create", "update", "read"]}]' | jq -r '.access_token)
+    ```
+
+1. Update the existing secret:
+
+    ```shell-session
+    $ echo '{"data": {"foo": "bar_new"}}' | VAULT_TOKEN=${DELEGATION_TOKEN} \
+      vault write secret-v2/data/shared-secret/foo -
+    Key                Value
+    ---                -----
+    created_time       2026-06-11T08:02:39.161111Z
+    custom_metadata    <nil>
+    deletion_time      n/a
+    destroyed          false
+    version            2
+    ```
+
+1. Read the new secret value with the updated token:
+
+    ```shell-session
+    $ VAULT_TOKEN=${DELEGATION_TOKEN} vault read secret-v2/data/shared-secret/foo
+    Key         Value
+    ---         -----
+    data        map[foo:bar_new]
+    metadata    map[created_time:2026-06-11T08:04:13.817972Z custom_metadata:<nil> deletion_time: destroyed:false version:2]
+    ```
+
+<Note>
+
+`vault kv put` and `vault kv get` use a special type of unauthenticated
+preflight check path (`/sys/internal/ui/mounts`) internally to determine
+whether the requested KV path is a KV version 1 or version 2 engine.
+
+The request handling flow does not recognize external tokens when routing to
+this unauthenticated endpoint and results in an error. This is a known bug,
+and you are encouraged to use `vault read` and `vault write` commands to
+work around the issue.
+
+</Note>

--- a/content/vault/v2.x/data/ai-nav-data.json
+++ b/content/vault/v2.x/data/ai-nav-data.json
@@ -41,8 +41,12 @@
     "title": "Secure agentic workflows",
     "routes": [
       {
-        "title": "Vault setup",
-        "path": "iam/setup"
+        "title": "Set up agent access",
+        "path": "iam/setup-agent"
+      },
+      {
+        "title": "Set up OBO delegation",
+        "path": "iam/setup-obo"
       },
       {
         "title": "Configure IdP + authZ servers",


### PR DESCRIPTION
- Remove tabs for steps that are identical
- Clean up text per docs style guide and content patterns
- Move OBO setup to its own guide and simplify the existing Verify instructions