### PR TITLE
fix warning syntax for sensitive outputs deprecation

### DIFF
--- a/content/terraform-docs-common/docs/cloud-docs/api-docs/state-version-outputs.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/api-docs/state-version-outputs.mdx
@@ -27,9 +27,7 @@ the name and value of the output, as well as a sensitive boolean if the value sh
 
 `GET /state-versions/:state_version_id/outputs`
 
-<Warning>
-Starting November 10, 2026, this endpoint will no longer return plaintext values for sensitive outputs. The `value` field will be `null` for any output where `sensitive` is `true`, matching the behavior of [Show Current State Version Outputs for a Workspace](/terraform/cloud-docs/api-docs/state-version-outputs#show-current-state-version-outputs-for-a-workspace). To retrieve the value of a sensitive output, use [Show a State Version Output](/terraform/cloud-docs/api-docs/state-version-outputs#show-a-state-version-output).
-</Warning>
+~> **Warning:** Starting November 10, 2026, this endpoint will no longer return plaintext values for sensitive outputs. The `value` field will be `null` for any output where `sensitive` is `true`, matching the behavior of [Show Current State Version Outputs for a Workspace](/terraform/cloud-docs/api-docs/state-version-outputs#show-current-state-version-outputs-for-a-workspace). To retrieve the value of a sensitive output, use [Show a State Version Output](/terraform/cloud-docs/api-docs/state-version-outputs#show-a-state-version-output).
 
 Listing state version outputs requires permission to read state outputs for the workspace. ([More about permissions.](/terraform/cloud-docs/users-teams-organizations/permissions))
 

--- a/content/terraform-docs-common/docs/cloud-docs/api-docs/state-version-outputs.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/api-docs/state-version-outputs.mdx
@@ -27,7 +27,11 @@ the name and value of the output, as well as a sensitive boolean if the value sh
 
 `GET /state-versions/:state_version_id/outputs`
 
-~> **Warning:** Starting November 10, 2026, this endpoint will no longer return plaintext values for sensitive outputs. The `value` field will be `null` for any output where `sensitive` is `true`, matching the behavior of [Show Current State Version Outputs for a Workspace](/terraform/cloud-docs/api-docs/state-version-outputs#show-current-state-version-outputs-for-a-workspace). To retrieve the value of a sensitive output, use [Show a State Version Output](/terraform/cloud-docs/api-docs/state-version-outputs#show-a-state-version-output).
+<Note>
+
+Starting November 10, 2026, this endpoint will no longer return plaintext values for sensitive outputs. The `value` field will be `null` for any output where `sensitive` is `true`, matching the behavior of the [`/workspaces/:workspace_id/current-state-version-outputs`](/terraform/cloud-docs/api-docs/state-version-outputs#show-current-state-version-outputs-for-a-workspace) endpoint. To retrieve the value of a sensitive output, use the [`/state-version-outputs/:state_version_output_id`](#show-a-state-version-output) endpoint.
+
+</Note>
 
 Listing state version outputs requires permission to read state outputs for the workspace. ([More about permissions.](/terraform/cloud-docs/users-teams-organizations/permissions))
 

--- a/content/terraform-docs-common/docs/cloud-docs/api-docs/state-version-outputs.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/api-docs/state-version-outputs.mdx
@@ -29,7 +29,7 @@ the name and value of the output, as well as a sensitive boolean if the value sh
 
 <Note>
 
-Starting November 10, 2026, this endpoint will no longer return plaintext values for sensitive outputs. The `value` field will be `null` for any output where `sensitive` is `true`, matching the behavior of the [`/workspaces/:workspace_id/current-state-version-outputs`](/terraform/cloud-docs/api-docs/state-version-outputs#show-current-state-version-outputs-for-a-workspace) endpoint. To retrieve the value of a sensitive output, use the [`/state-version-outputs/:state_version_output_id`](#show-a-state-version-output) endpoint.
+Starting November 10, 2026, this endpoint will no longer return plaintext values for sensitive outputs. The `value` field will be `null` for any output where `sensitive` is `true`, matching the behavior of the [`/workspaces/:workspace_id/current-state-version-outputs`](#show-current-state-version-outputs-for-a-workspace) endpoint. To retrieve the value of a sensitive output, use the [`/state-version-outputs/:state_version_output_id`](#show-a-state-version-output) endpoint.
 
 </Note>
 


### PR DESCRIPTION
### What
Fix warning syntax for deprecation

### Why
Fixing syntax error from this PR: https://github.com/hashicorp/web-unified-docs/pull/3260

----------


#### Pull Request
- Old Docs PR: https://github.com/hashicorp/web-unified-docs/pull/3260

#### Content
- [ ] Redirects have been added to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages.
- [x] API documentation and the API Changelog have been updated.
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
