### PR TITLE
Docs: Fix typo in OAuth server for Agentic AI

### DIFF
--- a/content/vault/v2.x/content/ai/iam/concepts/oauth-profiles.mdx
+++ b/content/vault/v2.x/content/ai/iam/concepts/oauth-profiles.mdx
@@ -14,7 +14,7 @@ last_modified: 2026-09-01T02:50:57.000Z
 
 Vault acts as an
 [OAuth resource server](https://datatracker.ietf.org/doc/html/rfc6749#section-1.1)
-with distinct OAuth server **profiles** for trusted IdP orauthorization servers.
+with distinct OAuth server **profiles** for trusted IdP or authorization servers.
 
 A server profile defines how Vault validates JWTs from a specific authorization
 server. Each profile represents a trust relationship with one issuer. You can


### PR DESCRIPTION
typo found in line 17 "orauthorization" -> "or authorization"
