### PR TITLE
VAULT-39263: Clarify GET and POST support for AWS creds and sts endpo…

### DIFF
--- a/content/vault/v1.21.x/content/api-docs/secret/aws.mdx
+++ b/content/vault/v1.21.x/content/api-docs/secret/aws.mdx
@@ -584,16 +584,23 @@ $ curl \
 This endpoint generates credentials based on the named role. This role must be
 created before queried.
 
+Both `/aws/creds` and `/aws/sts` accept `GET` and `POST`. `GET` is conventional
+for reads with no request body; use `POST` when passing parameters in a JSON
+body (e.g. `role_arn`, `ttl`, `role_session_name`).
+
 | Method | Path               |
 | :----- | :----------------- |
 | `GET`  | `/aws/creds/:name` |
+| `POST` | `/aws/creds/:name` |
+| `GET`  | `/aws/sts/:name`   |
 | `POST` | `/aws/sts/:name`   |
 
-The `/aws/creds` and `/aws/sts` endpoints are almost identical. The exception is
-when retrieving credentials for a role that was specified with the legacy `arn`
-or `policy` parameter. In this case, credentials retrieved through `/aws/sts`
-must be of either the `assumed_role` or `federation_token` types, and
-credentials retrieved through `/aws/creds` must be of the `iam_user` type.
+`/aws/creds` and `/aws/sts` are functionally identical for modern roles.
+`/aws/sts` is a legacy alias retained for backwards compatibility. The only
+behavioral difference applies to roles created with the legacy `arn` or
+`policy` parameter: credentials retrieved through `/aws/sts` must be of the
+`assumed_role` or `federation_token` type, and credentials retrieved through
+`/aws/creds` must be of the `iam_user` type.
 
 ### Parameters
 

--- a/content/vault/v2.x/content/api-docs/secret/aws.mdx
+++ b/content/vault/v2.x/content/api-docs/secret/aws.mdx
@@ -584,16 +584,23 @@ $ curl \
 This endpoint generates credentials based on the named role. This role must be
 created before queried.
 
+Both `/aws/creds` and `/aws/sts` accept `GET` and `POST`. `GET` is conventional
+for reads with no request body; use `POST` when passing parameters in a JSON
+body (e.g. `role_arn`, `ttl`, `role_session_name`).
+
 | Method | Path               |
 | :----- | :----------------- |
 | `GET`  | `/aws/creds/:name` |
+| `POST` | `/aws/creds/:name` |
+| `GET`  | `/aws/sts/:name`   |
 | `POST` | `/aws/sts/:name`   |
 
-The `/aws/creds` and `/aws/sts` endpoints are almost identical. The exception is
-when retrieving credentials for a role that was specified with the legacy `arn`
-or `policy` parameter. In this case, credentials retrieved through `/aws/sts`
-must be of either the `assumed_role` or `federation_token` types, and
-credentials retrieved through `/aws/creds` must be of the `iam_user` type.
+`/aws/creds` and `/aws/sts` are functionally identical for modern roles.
+`/aws/sts` is a legacy alias retained for backwards compatibility. The only
+behavioral difference applies to roles created with the legacy `arn` or
+`policy` parameter: credentials retrieved through `/aws/sts` must be of the
+`assumed_role` or `federation_token` type, and credentials retrieved through
+`/aws/creds` must be of the `iam_user` type.
 
 ### Parameters
 


### PR DESCRIPTION
Clarifies HTTP method support for the AWS secrets engine credential generation endpoints (/aws/creds/:name and /aws/sts/:name).

The existing docs only listed GET /aws/creds/:name and POST /aws/sts/:name, causing confusion about whether GET vs POST performed different operations.

Looking at path_user.go, both endpoints accept both GET and POST, and both map to the same backend callback (b.pathCredsRead). There is no functional difference between the two methods.

Updated the Generate credentials method table to document all four supported method+path combinations

Added a note explaining that GET and POST are functionally equivalent

Clarified that /aws/sts/:name is a legacy backwards-compatible alias for /aws/creds/:name

Applied to both v1.21.x and v2.x API docs

Related Issues
[Closes VAULT-39263: receiving AWS access key with both read and write API cll](https://hashicorp.atlassian.net/browse/VAULT-39263)