### PR TITLE
Nomad Docs

### DIFF
--- a/content/nomad/v2.0.x/content/docs/configuration/index.mdx
+++ b/content/nomad/v2.0.x/content/docs/configuration/index.mdx
@@ -197,6 +197,14 @@ testing.
 - `http_api_response_headers` `(map<string|string>: nil)` - Specifies
   user-defined headers to add to the HTTP API responses.
 
+- `http_disable_http2` `(bool: false)` - Disables support for the HTTP/2 protocol
+  on the HTTP server.
+  
+- `http_disable_websocket_origin_check` `(bool: false)` - Disables the origin
+  check when upgrading HTTP requests to a WebSocket. This is useful for UI
+  development when proxying requests to a development cluster. It should not
+  be used in production.
+
 - `leave_on_interrupt` `(bool: false)` - Specifies if the agent should leave
   when receiving the interrupt signal. By default, any stop signal to an agent
   (interrupt or terminate) will cause the agent to exit after ensuring its


### PR DESCRIPTION
Adds new configuration options for controlling use of HTTP/2 and allowing origin checks to be disabled for WebSocket upgrades.

<!--
**Merge branch**

Make sure you create your PR against the correct **base** branch. For instructions, refer to
GitHub's **Change the branch range and destination repository guide** (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request).

If your content is an update to:

- Currently published content

  Choose **base: main** when you are updating published documentation, and you
  want your changes published when the PR is merged. We publish Nomad content
  from the `main` branch.

- Upcoming Nomad release

  Choose the branch for the Nomad release that your content is for. Nomad
  release branches use the `nomad/<exact-release-number>` format. If you are not
  able to find the upcoming Nomad release branch that you are looking for,
  contact the tech writer that works with the Nomad team.

- Upcoming Nomad release but not sure which one

  - Choose the `main` branch.
  - Add the "do not merge" label.
  - Convert the PR to a DRAFT.
  - Put an explanation in the **Description** section.

  The tech writer coordinates with Nomad engineering and updates
  the docs PR base branch when the code is slotted into an upcoming release.

**Backports**

This repo stores previous version docs in folders instead of branches. There are
no backport labels.  If you backported your code PR to previous branches, update
the docs content in the corresponding folders. For example, if the current
release is 1.10.x and you backported your code to 1.9.x and 1.8.x, update the docs content
in the v1.10.x, v1.9.x, and v1.8.x folders. If you can't find the relevant files in previous versions,
add a note to your PR description. The tech writer will help ensure that the previous versions
receive the correct updates.
-->

## Description

Adds new configuration options for controlling use of HTTP/2 and allowing origin checks to be disabled for WebSocket upgrades.
<!-- 
Please describe why you're making this change and point out any important details the reviewers
should be aware of. A robust description helps the tech writer create a fabulous release note.
If your code PR has a splendid description, link to the code PR in the links section so that
the tech writer can update this PR's description. 

Include the target release as well as prior versions if applicable.
-->

## Links

<!--
**Please link to the related Nomad repo code PR!** if there is one. 
The tech writer does look at the code PR description, Jira ticket, and/or GH issue before reviewing docs content.

Include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a docs bug fix, please ensure related issues are linked so they will close when this PR is
merged.

// GH-Jira integration generates the link and updates the Jira ticket.
Jira: [<jira-ticket-number>]  // for example, Jira: [NMD-1234] 

GitHub Issue: <issue-link>

Deploy previews: The bot does publish a root-level link to the deploy preview, but the preview URL changes with each build.
-->

Nomad Code PR: hashicorp/nomad#28364

## Contributor checklists

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [x] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [x] Verify that all status checks passed
- [x] Verify that the preview environment deployed successfully
- [x] Add additional reviewers if they are not part of assigned groups

Content:

- [ ] I added redirects for any moved or removed pages
- [ ] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [x] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [ ] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.


[NMD-1234]: https://hashicorp.atlassian.net/browse/NMD-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ