### PR TITLE
nomad: Allow setting the reschedule delay as low as one second

### DIFF
--- a/content/nomad/v2.0.x/content/docs/job-specification/reschedule.mdx
+++ b/content/nomad/v2.0.x/content/docs/job-specification/reschedule.mdx
@@ -73,7 +73,9 @@ they run on every node.
 
 - `delay` `(string: <varies>)` - Specifies the duration to wait before attempting
   to reschedule a failed task. This is specified using a label suffix like "30s" or "1h".
-  Delay cannot be less than 5 seconds.
+  Delay cannot be less than 1 second. A lower value in combination with `unlimited=true` can cause
+  runaway rescheduling events if the underlying task in unable to start no matter where it is
+  placed.
 
 - `delay_function` `(string: <varies>)` - Specifies the function that is used to
   calculate subsequent reschedule delays. The initial delay is specified by the delay parameter.


### PR DESCRIPTION
## Description
In some situations, operators may want to set the reschedule delay lower than the existing minimum value of 5 seconds. This change therefore updates the minimum allowed value to 1 second.

When a value below 5 seconds is used in conjunction with unlimited attempts, a warning is returned to the client. This is to inform them of potential scheduling thrashing in situations where the allocation has an underlying problem and cannot start no matter what Nomad client it lands on.

Nomad Code PR: https://github.com/hashicorp/nomad/pull/28477
Jira: https://hashicorp.atlassian.net/browse/NMD-1598
GitHub Issue: https://github.com/hashicorp/nomad/issues/28185

## Contributor checklists

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [x] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [x] Verify that all status checks passed
- [x] Verify that the preview environment deployed successfully
- [x] Add additional reviewers if they are not part of assigned groups

Content:

- [x] I added redirects for any moved or removed pages
- [x] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [x] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [ ] This PR is set to merge into the correct base branch.
- [ ] The content does not contain technical inaccuracies.
- [ ] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.
