### PR TITLE
Re-create PR 2147 - Fix typos and errors in resource block pages

### DIFF
--- a/content/terraform/v1.12.x/docs/language/block/resource.mdx
+++ b/content/terraform/v1.12.x/docs/language/block/resource.mdx
@@ -1,7 +1,7 @@
 ---
 page_title: resource block reference
 description: >-
-   Learn configure `resource` block arguments in Terraform configuration language.
+   Learn how to configure `resource` block arguments in Terraform configuration language.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2023-01-01T00:00:00.000Z
 last_modified: 2023-01-01T00:00:00.000Z
@@ -407,7 +407,7 @@ The following table describes the arguments you can use in the `connection` bloc
 | `timeout` | Specifies how long to wait for the connection to become available. | string | `ssh`<p>`winrm`</p> | `"5m"` |
 | `script_path` | Specifies the path on the remote resource where Terraform copies scripts to. Refer to the [`provisioner` block reference](#provisioner) for more information. Terraform copies scripts to a path that contains random numbers depending on the `target_platform` configuration. | string | `ssh`<p>`winrm`</p> | <p>`/tmp/terraform_%RAND%.sh` when `target_platform` is `unix`</p><p>`C:/windows/temp/`<br/>`terraform_%RAND%.cmd` when `target_platform` is `windows`</p> |
 | `private_key` | Specifies the contents of an SSH key to use for the connection. `private_key` takes precedence over `password` when both are provided. | <p>string</p><p>Use a [`file` function](/terraform/language/functions/file) to load keys from file.</p> | `ssh` | none |
-| `certificate` | Specifies the contents of a signed CA certificate. You must also configure a  `private_key` arugment. | <p>string</p><p>Use a [`file` function](/terraform/language/functions/file) to load certificates from file.</p> | `ssh` | none |
+| `certificate` | Specifies the contents of a signed CA certificate. You must also configure a `private_key` argument. | <p>string</p><p>Use a [`file` function](/terraform/language/functions/file) to load certificates from file.</p> | `ssh` | none |
 | `agent` | Specifies an SSH agent for authentication. Set to `false` to disable using `ssh-agent` to authenticate. On Windows, the only supported SSH authentication agent is [Pageant](http://the.earth.li/\~sgtatham/putty/0.66/htmldoc/Chapter9.html#pageant). | string | `ssh` | `false` |
 | `agent_identity` | Specifies the preferred identity from the SSH agent to use for authentication. | string | `ssh` | none |
 | `host_key` | Specifies the public key from the remote host or the signing CA to verify the connection. | string | `ssh` | none |
@@ -652,7 +652,7 @@ resource {
 ```
 
 
-When you run the specified Terraform command, Terraform performs run the command specified in the [`command`](#command) argument. Refer to [Destroy-time provisioners](terraform/language/resources/provisioners#destroy-time-provisioners) for instructions on using the `when` argument.
+When you run the specified Terraform command, Terraform runs the command specified in the [`command`](#command) argument. Refer to [Destroy-time provisioners](/terraform/language/resources/provisioners#destroy-time-provisioners) for instructions on using the `when` argument.
 
 #### Summary
 
@@ -899,9 +899,9 @@ resource "aws_iam_role_policy" "example" {
 }
 
 resource "aws_instance" "example" {
-  ami           = "data.aws_ami.example.id"
+  ami           = data.aws_ami.example.id
   instance_type = "t2.micro"
-  iam_instance_profile = aws_iam_instance_profile.example
+  iam_instance_profile = aws_iam_instance_profile.example.name
   depends_on = [
     aws_iam_role_policy.example
   ]

--- a/content/terraform/v1.12.x/docs/language/resources/configure.mdx
+++ b/content/terraform/v1.12.x/docs/language/resources/configure.mdx
@@ -22,7 +22,7 @@ Complete the following steps to configure a resource:
 
 - Declare a `resource` block and specify its type and a name.
 - Configure provider arguments. Most arguments in your resource configuration are specific to your provider.
-- Configure Terraform meta-arguments arguments. Meta-arguments are arguments built into Terraform configuration language to control how Terraform creates and manages resources.
+- Configure Terraform meta-arguments. Meta-arguments are arguments built into Terraform configuration language to control how Terraform creates and manages resources.
 
 ## Prerequisites
 

--- a/content/terraform/v1.12.x/docs/language/resources/index.mdx
+++ b/content/terraform/v1.12.x/docs/language/resources/index.mdx
@@ -10,7 +10,7 @@ last_modified: 2023-01-01T00:00:00.000Z
 
 # Create and manage resources overview
 
-This topic describes the workflow for creating and managing resources in Terraform configuration. or a general overview of how to provision infrastructure, refer to [Core Terraform workflow](/terraform/intro/core-workflow). 
+This topic describes the workflow for creating and managing resources in Terraform configuration. For a general overview of how to provision infrastructure, refer to [Core Terraform workflow](/terraform/intro/core-workflow). 
 
 ## Introduction
 
@@ -42,8 +42,8 @@ Use the Terraform CLI to [apply the configuration](/terraform/cli/commands/apply
 As your infrastructure needs change, you may want to add or remove resources from your configuration, refactor collections of resources into reusable modules, or remove or retire resources from your cloud provider or state file. Refer to the following topics for more information about managing resources:
 
 - [Creating modules](/terraform/language/modules/develop) provides instructions on how to collect resources into reusable modules.
-- [Refactoring modules](/terraform/language/modules/develop/refactoring) provides instructions on moving and renaming sources. 
+- [Refactoring modules](/terraform/language/modules/develop/refactoring) provides instructions on moving and renaming resources. 
 - [Remove a resource from state](/terraform/language/state/remove) describes how to remove a resource from state without destroying the actual infrastructure object.
 - [Destroy a resource](/terraform/language/resources/destroy) describes how to remove a resource from state and destroy the actual infrastructure.
 
-Many providers also allow you to read data from the provider so that you can use data from exisitng infrastructure without provisioning actual infrastructure objects. Refer to [Query data sources](/terraform/language/data-sources) for more information.
+Many providers also allow you to read data from the provider so that you can use data from existing infrastructure without provisioning actual infrastructure objects. Refer to [Query data sources](/terraform/language/data-sources) for more information.

--- a/content/terraform/v1.13.x/docs/language/block/resource.mdx
+++ b/content/terraform/v1.13.x/docs/language/block/resource.mdx
@@ -1,7 +1,7 @@
 ---
 page_title: resource block reference
 description: >-
-   Learn configure `resource` block arguments in Terraform configuration language.
+   Learn how to configure `resource` block arguments in Terraform configuration language.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-09-05T15:51:39-04:00
 last_modified: 2025-11-11T15:51:39-08:00
@@ -407,7 +407,7 @@ The following table describes the arguments you can use in the `connection` bloc
 | `timeout` | Specifies how long to wait for the connection to become available. | string | `ssh`<p>`winrm`</p> | `"5m"` |
 | `script_path` | Specifies the path on the remote resource where Terraform copies scripts to. Refer to the [`provisioner` block reference](#provisioner) for more information. Terraform copies scripts to a path that contains random numbers depending on the `target_platform` configuration. | string | `ssh`<p>`winrm`</p> | <p>`/tmp/terraform_%RAND%.sh` when `target_platform` is `unix`</p><p>`C:/windows/temp/`<br/>`terraform_%RAND%.cmd` when `target_platform` is `windows`</p> |
 | `private_key` | Specifies the contents of an SSH key to use for the connection. `private_key` takes precedence over `password` when both are provided. | <p>string</p><p>Use a [`file` function](/terraform/language/functions/file) to load keys from file.</p> | `ssh` | none |
-| `certificate` | Specifies the contents of a signed CA certificate. You must also configure a  `private_key` arugment. | <p>string</p><p>Use a [`file` function](/terraform/language/functions/file) to load certificates from file.</p> | `ssh` | none |
+| `certificate` | Specifies the contents of a signed CA certificate. You must also configure a `private_key` argument. | <p>string</p><p>Use a [`file` function](/terraform/language/functions/file) to load certificates from file.</p> | `ssh` | none |
 | `agent` | Specifies an SSH agent for authentication. Set to `false` to disable using `ssh-agent` to authenticate. On Windows, the only supported SSH authentication agent is [Pageant](http://the.earth.li/\~sgtatham/putty/0.66/htmldoc/Chapter9.html#pageant). | string | `ssh` | `false` |
 | `agent_identity` | Specifies the preferred identity from the SSH agent to use for authentication. | string | `ssh` | none |
 | `host_key` | Specifies the public key from the remote host or the signing CA to verify the connection. | string | `ssh` | none |
@@ -652,7 +652,7 @@ resource {
 ```
 
 
-When you run the specified Terraform command, Terraform performs run the command specified in the [`command`](#command) argument. Refer to [Destroy-time provisioners](terraform/language/resources/provisioners#destroy-time-provisioners) for instructions on using the `when` argument.
+When you run the specified Terraform command, Terraform runs the command specified in the [`command`](#command) argument. Refer to [Destroy-time provisioners](/terraform/language/resources/provisioners#destroy-time-provisioners) for instructions on using the `when` argument.
 
 #### Summary
 

--- a/content/terraform/v1.13.x/docs/language/resources/configure.mdx
+++ b/content/terraform/v1.13.x/docs/language/resources/configure.mdx
@@ -22,7 +22,7 @@ Complete the following steps to configure a resource:
 
 - Declare a `resource` block and specify its type and a name.
 - Configure provider arguments. Most arguments in your resource configuration are specific to your provider.
-- Configure Terraform meta-arguments arguments. Meta-arguments are arguments built into Terraform configuration language to control how Terraform creates and manages resources.
+- Configure Terraform meta-arguments. Meta-arguments are arguments built into Terraform configuration language to control how Terraform creates and manages resources.
 
 ## Prerequisites
 

--- a/content/terraform/v1.13.x/docs/language/resources/index.mdx
+++ b/content/terraform/v1.13.x/docs/language/resources/index.mdx
@@ -42,7 +42,7 @@ Use the Terraform CLI to [apply the configuration](/terraform/cli/commands/apply
 As your infrastructure needs change, you may want to add or remove resources from your configuration, refactor collections of resources into reusable modules, or remove or retire resources from your cloud provider or state file. Refer to the following topics for more information about managing resources:
 
 - [Creating modules](/terraform/language/modules/develop) provides instructions on how to collect resources into reusable modules.
-- [Refactoring modules](/terraform/language/modules/develop/refactoring) provides instructions on moving and renaming sources. 
+- [Refactoring modules](/terraform/language/modules/develop/refactoring) provides instructions on moving and renaming resources. 
 - [Remove a resource from state](/terraform/language/state/remove) describes how to remove a resource from state without destroying the actual infrastructure object.
 - [Destroy a resource](/terraform/language/resources/destroy) describes how to remove a resource from state and destroy the actual infrastructure.
 

--- a/content/terraform/v1.14.x/docs/language/block/resource.mdx
+++ b/content/terraform/v1.14.x/docs/language/block/resource.mdx
@@ -1,7 +1,7 @@
 ---
 page_title: resource block reference
 description: >-
-   Learn configure `resource` block arguments in Terraform configuration language.
+   Learn how to configure `resource` block arguments in Terraform configuration language.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-11-19T13:27:46Z
 last_modified: 2025-12-03T16:22:47-08:00
@@ -110,7 +110,7 @@ resource "<TYPE>" "<LABEL>" {
         before_update,
         after_update
       ]
-      condition = <EXPRESSSION>
+      condition = <EXPRESSION>
       actions = [ action.<TYPE>.<LABEL> ]
     }
     create_before_destroy = <true || false>
@@ -265,7 +265,7 @@ You can specify the following lifecycle rules to manage how Terraform performs o
 - [`create_before_destroy`](#create_before_destroy): Terraform creates a replacement resource before destroying the current resource.
 - [`prevent_destroy`](#prevent_destroy): Terraform rejects operations to destroy the resource and returns an error. This rule doesn't prevent Terraform from destroying the resource if you remove the resource configuration. For instructions on how to remove a resource from state without destroying the actual resource, refer to [Remove a resource from state](/terraform/language/state/remove).
 - [`ignore_changes`](#ignore_changes):  Specifies a list of resource attributes that Terraform ignores changes to. Otherwise, Terraform attempts to update the actual resource to match the configuration.
-- [`replace_triggered_by`](#replace-triggered_by): Terraform replaces the resource when any of the referenced resources or specified attributes change.
+- [`replace_triggered_by`](#replace_triggered_by): Terraform replaces the resource when any of the referenced resources or specified attributes change.
 - [`precondition`](#precondition): Specifies a condition that Terraform evaluates before creating the resource. Refer to [Validate your configuration](/terraform/language/validate) for more information.
 - [`postcondition`](#postcondition): Specifies a condition that Terraform evaluates after creating the resource. Refer to [Validate your configuration](/terraform/language/validate) for more information.
 
@@ -447,7 +447,7 @@ The following table describes the arguments you can use in the `connection` bloc
 | `timeout` | Specifies how long to wait for the connection to become available. | string | `ssh`<p>`winrm`</p> | `"5m"` |
 | `script_path` | Specifies the path on the remote resource where Terraform copies scripts to. Refer to the [`provisioner` block reference](#provisioner) for more information. Terraform copies scripts to a path that contains random numbers depending on the `target_platform` configuration. | string | `ssh`<p>`winrm`</p> | <p>`/tmp/terraform_%RAND%.sh` when `target_platform` is `unix`</p><p>`C:/windows/temp/`<br/>`terraform_%RAND%.cmd` when `target_platform` is `windows`</p> |
 | `private_key` | Specifies the contents of an SSH key to use for the connection. `private_key` takes precedence over `password` when both are provided. | <p>string</p><p>Use a [`file` function](/terraform/language/functions/file) to load keys from file.</p> | `ssh` | none |
-| `certificate` | Specifies the contents of a signed CA certificate. You must also configure a  `private_key` arugment. | <p>string</p><p>Use a [`file` function](/terraform/language/functions/file) to load certificates from file.</p> | `ssh` | none |
+| `certificate` | Specifies the contents of a signed CA certificate. You must also configure a `private_key` argument. | <p>string</p><p>Use a [`file` function](/terraform/language/functions/file) to load certificates from file.</p> | `ssh` | none |
 | `agent` | Specifies an SSH agent for authentication. Set to `false` to disable using `ssh-agent` to authenticate. On Windows, the only supported SSH authentication agent is [Pageant](http://the.earth.li/\~sgtatham/putty/0.66/htmldoc/Chapter9.html#pageant). | string | `ssh` | `false` |
 | `agent_identity` | Specifies the preferred identity from the SSH agent to use for authentication. | string | `ssh` | none |
 | `host_key` | Specifies the public key from the remote host or the signing CA to verify the connection. | string | `ssh` | none |
@@ -692,7 +692,7 @@ resource {
 ```
 
 
-When you run the specified Terraform command, Terraform performs run the command specified in the [`command`](#command) argument. Refer to [Destroy-time provisioners](terraform/language/resources/provisioners#destroy-time-provisioners) for instructions on using the `when` argument.
+When you run the specified Terraform command, Terraform runs the command specified in the [`command`](#command) argument. Refer to [Destroy-time provisioners](/terraform/language/resources/provisioners#destroy-time-provisioners) for instructions on using the `when` argument.
 
 #### Summary
 
@@ -939,9 +939,9 @@ resource "aws_iam_role_policy" "example" {
 }
 
 resource "aws_instance" "example" {
-  ami           = "data.aws_ami.example.id"
+  ami           = data.aws_ami.example.id
   instance_type = "t2.micro"
-  iam_instance_profile = aws_iam_instance_profile.example
+  iam_instance_profile = aws_iam_instance_profile.example.name
   depends_on = [
     aws_iam_role_policy.example
   ]

--- a/content/terraform/v1.14.x/docs/language/resources/configure.mdx
+++ b/content/terraform/v1.14.x/docs/language/resources/configure.mdx
@@ -22,7 +22,7 @@ Complete the following steps to configure a resource:
 
 - Declare a `resource` block and specify its type and a name.
 - Configure provider arguments. Most arguments in your resource configuration are specific to your provider.
-- Configure Terraform meta-arguments arguments. Meta-arguments are arguments built into Terraform configuration language to control how Terraform creates and manages resources.
+- Configure Terraform meta-arguments. Meta-arguments are arguments built into Terraform configuration language to control how Terraform creates and manages resources.
 
 ## Prerequisites
 

--- a/content/terraform/v1.14.x/docs/language/resources/index.mdx
+++ b/content/terraform/v1.14.x/docs/language/resources/index.mdx
@@ -42,7 +42,7 @@ Use the Terraform CLI to [apply the configuration](/terraform/cli/commands/apply
 As your infrastructure needs change, you may want to add or remove resources from your configuration, refactor collections of resources into reusable modules, or remove or retire resources from your cloud provider or state file. Refer to the following topics for more information about managing resources:
 
 - [Creating modules](/terraform/language/modules/develop) provides instructions on how to collect resources into reusable modules.
-- [Refactoring modules](/terraform/language/modules/develop/refactoring) provides instructions on moving and renaming sources. 
+- [Refactoring modules](/terraform/language/modules/develop/refactoring) provides instructions on moving and renaming resources. 
 - [Remove a resource from state](/terraform/language/state/remove) describes how to remove a resource from state without destroying the actual infrastructure object.
 - [Destroy a resource](/terraform/language/resources/destroy) describes how to remove a resource from state and destroy the actual infrastructure.
 

--- a/content/terraform/v1.15.x/docs/language/block/resource.mdx
+++ b/content/terraform/v1.15.x/docs/language/block/resource.mdx
@@ -1,7 +1,7 @@
 ---
 page_title: resource block reference
 description: >-
-   Learn configure `resource` block arguments in Terraform configuration language.
+   Learn how to configure `resource` block arguments in Terraform configuration language.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2026-04-29T13:15:03Z
 last_modified: 2026-08-27T14:30:10.000Z
@@ -108,7 +108,7 @@ resource "<TYPE>" "<LABEL>" {
         before_update,
         after_update
       ]
-      condition = <EXPRESSSION>
+      condition = <EXPRESSION>
       actions = [ action.<TYPE>.<LABEL> ]
     }
     create_before_destroy = <true || false>
@@ -451,7 +451,7 @@ The following table describes the arguments you can use in the `connection` bloc
 | `timeout` | Specifies how long to wait for the connection to become available. | string | `ssh`<p>`winrm`</p> | `"5m"` |
 | `script_path` | Specifies the path on the remote resource where Terraform copies scripts to. Refer to the [`provisioner` block reference](#provisioner) for more information. Terraform copies scripts to a path that contains random numbers depending on the `target_platform` configuration. | string | `ssh`<p>`winrm`</p> | <p>`/tmp/terraform_%RAND%.sh` when `target_platform` is `unix`</p><p>`C:/windows/temp/`<br/>`terraform_%RAND%.cmd` when `target_platform` is `windows`</p> |
 | `private_key` | Specifies the contents of an SSH key to use for the connection. `private_key` takes precedence over `password` when both are provided. | <p>string</p><p>Use a [`file` function](/terraform/language/functions/file) to load keys from file.</p> | `ssh` | none |
-| `certificate` | Specifies the contents of a signed CA certificate. You must also configure a  `private_key` arugment. | <p>string</p><p>Use a [`file` function](/terraform/language/functions/file) to load certificates from file.</p> | `ssh` | none |
+| `certificate` | Specifies the contents of a signed CA certificate. You must also configure a `private_key` argument. | <p>string</p><p>Use a [`file` function](/terraform/language/functions/file) to load certificates from file.</p> | `ssh` | none |
 | `agent` | Specifies an SSH agent for authentication. Set to `false` to disable using `ssh-agent` to authenticate. On Windows, the only supported SSH authentication agent is [Pageant](http://the.earth.li/\~sgtatham/putty/0.66/htmldoc/Chapter9.html#pageant). | string | `ssh` | `false` |
 | `agent_identity` | Specifies the preferred identity from the SSH agent to use for authentication. | string | `ssh` | none |
 | `host_key` | Specifies the public key from the remote host or the signing CA to verify the connection. | string | `ssh` | none |
@@ -696,7 +696,7 @@ resource {
 ```
 
 
-When you run the specified Terraform command, Terraform performs run the command specified in the [`command`](#command) argument. Refer to [Destroy-time provisioners](terraform/language/resources/provisioners#destroy-time-provisioners) for instructions on using the `when` argument.
+When you run the specified Terraform command, Terraform runs the command specified in the [`command`](#command) argument. Refer to [Destroy-time provisioners](terraform/language/resources/provisioners#destroy-time-provisioners) for instructions on using the `when` argument.
 
 #### Summary
 
@@ -943,9 +943,9 @@ resource "aws_iam_role_policy" "example" {
 }
 
 resource "aws_instance" "example" {
-  ami           = "data.aws_ami.example.id"
+  ami           = data.aws_ami.example.id
   instance_type = "t2.micro"
-  iam_instance_profile = aws_iam_instance_profile.example
+  iam_instance_profile = aws_iam_instance_profile.example.name
   depends_on = [
     aws_iam_role_policy.example
   ]

--- a/content/terraform/v1.15.x/docs/language/resources/configure.mdx
+++ b/content/terraform/v1.15.x/docs/language/resources/configure.mdx
@@ -22,7 +22,7 @@ Complete the following steps to configure a resource:
 
 - Declare a `resource` block and specify its type and a name.
 - Configure provider arguments. Most arguments in your resource configuration are specific to your provider.
-- Configure Terraform meta-arguments arguments. Meta-arguments are arguments built into Terraform configuration language to control how Terraform creates and manages resources.
+- Configure Terraform meta-arguments. Meta-arguments are arguments built into Terraform configuration language to control how Terraform creates and manages resources.
 
 ## Prerequisites
 

--- a/content/terraform/v1.15.x/docs/language/resources/index.mdx
+++ b/content/terraform/v1.15.x/docs/language/resources/index.mdx
@@ -42,8 +42,8 @@ Use the Terraform CLI to [apply the configuration](/terraform/cli/commands/apply
 As your infrastructure needs change, you may want to add or remove resources from your configuration, refactor collections of resources into reusable modules, or remove or retire resources from your cloud provider or state file. Refer to the following topics for more information about managing resources:
 
 - [Creating modules](/terraform/language/modules/develop) provides instructions on how to collect resources into reusable modules.
-- [Refactoring modules](/terraform/language/modules/develop/refactoring) provides instructions on moving and renaming sources. 
+- [Refactoring modules](/terraform/language/modules/develop/refactoring) provides instructions on moving and renaming resources. 
 - [Remove a resource from state](/terraform/language/state/remove) describes how to remove a resource from state without destroying the actual infrastructure object.
 - [Destroy a resource](/terraform/language/resources/destroy) describes how to remove a resource from state and destroy the actual infrastructure.
 
-Many providers also allow you to read data from the provider so that you can use data from exisitng infrastructure without provisioning actual infrastructure objects. Refer to [Query data sources](/terraform/language/data-sources) for more information.
+Many providers also allow you to read data from the provider so that you can use data from existing infrastructure without provisioning actual infrastructure objects. Refer to [Query data sources](/terraform/language/data-sources) for more information.

--- a/content/terraform/v1.16.x/docs/language/block/resource.mdx
+++ b/content/terraform/v1.16.x/docs/language/block/resource.mdx
@@ -1,7 +1,7 @@
 ---
 page_title: resource block reference
 description: >-
-   Learn configure `resource` block arguments in Terraform configuration language.
+   Learn how to configure `resource` block arguments in Terraform configuration language.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2026-08-26T11:28:33Z
 last_modified: 2026-08-27T14:30:10.000Z
@@ -111,7 +111,7 @@ resource "<TYPE>" "<LABEL>" {
         before_destroy,
         after_destroy
       ]
-      condition = <EXPRESSSION>
+      condition = <EXPRESSION>
       actions = [ action.<TYPE>.<LABEL> ]
       on_failure = <halt || continue || taint>
     }
@@ -462,7 +462,7 @@ The following table describes the arguments you can use in the `connection` bloc
 | `timeout` | Specifies how long to wait for the connection to become available. | string | `ssh`<p>`winrm`</p> | `"5m"` |
 | `script_path` | Specifies the path on the remote resource where Terraform copies scripts to. Refer to the [`provisioner` block reference](#provisioner) for more information. Terraform copies scripts to a path that contains random numbers depending on the `target_platform` configuration. | string | `ssh`<p>`winrm`</p> | <p>`/tmp/terraform_%RAND%.sh` when `target_platform` is `unix`</p><p>`C:/windows/temp/`<br/>`terraform_%RAND%.cmd` when `target_platform` is `windows`</p> |
 | `private_key` | Specifies the contents of an SSH key to use for the connection. `private_key` takes precedence over `password` when both are provided. | <p>string</p><p>Use a [`file` function](/terraform/language/functions/file) to load keys from file.</p> | `ssh` | none |
-| `certificate` | Specifies the contents of a signed CA certificate. You must also configure a  `private_key` arugment. | <p>string</p><p>Use a [`file` function](/terraform/language/functions/file) to load certificates from file.</p> | `ssh` | none |
+| `certificate` | Specifies the contents of a signed CA certificate. You must also configure a `private_key` argument. | <p>string</p><p>Use a [`file` function](/terraform/language/functions/file) to load certificates from file.</p> | `ssh` | none |
 | `agent` | Specifies an SSH agent for authentication. Set to `false` to disable using `ssh-agent` to authenticate. On Windows, the only supported SSH authentication agent is [Pageant](http://the.earth.li/\~sgtatham/putty/0.66/htmldoc/Chapter9.html#pageant). | string | `ssh` | `false` |
 | `agent_identity` | Specifies the preferred identity from the SSH agent to use for authentication. | string | `ssh` | none |
 | `host_key` | Specifies the public key from the remote host or the signing CA to verify the connection. | string | `ssh` | none |
@@ -707,7 +707,7 @@ resource {
 ```
 
 
-When you run the specified Terraform command, Terraform performs run the command specified in the [`command`](#command) argument. Refer to [Destroy-time provisioners](terraform/language/resources/provisioners#destroy-time-provisioners) for instructions on using the `when` argument.
+When you run the specified Terraform command, Terraform runs the command specified in the [`command`](#command) argument. Refer to [Destroy-time provisioners](/terraform/language/resources/provisioners#destroy-time-provisioners) for instructions on using the `when` argument.
 
 #### Summary
 
@@ -954,9 +954,9 @@ resource "aws_iam_role_policy" "example" {
 }
 
 resource "aws_instance" "example" {
-  ami           = "data.aws_ami.example.id"
+  ami           = data.aws_ami.example.id
   instance_type = "t2.micro"
-  iam_instance_profile = aws_iam_instance_profile.example
+  iam_instance_profile = aws_iam_instance_profile.example.name
   depends_on = [
     aws_iam_role_policy.example
   ]

--- a/content/terraform/v1.16.x/docs/language/resources/configure.mdx
+++ b/content/terraform/v1.16.x/docs/language/resources/configure.mdx
@@ -22,7 +22,7 @@ Complete the following steps to configure a resource:
 
 - Declare a `resource` block and specify its type and a name.
 - Configure provider arguments. Most arguments in your resource configuration are specific to your provider.
-- Configure Terraform meta-arguments arguments. Meta-arguments are arguments built into Terraform configuration language to control how Terraform creates and manages resources.
+- Configure Terraform meta-arguments. Meta-arguments are arguments built into Terraform configuration language to control how Terraform creates and manages resources.
 
 ## Prerequisites
 

--- a/content/terraform/v1.16.x/docs/language/resources/index.mdx
+++ b/content/terraform/v1.16.x/docs/language/resources/index.mdx
@@ -42,8 +42,8 @@ Use the Terraform CLI to [apply the configuration](/terraform/cli/commands/apply
 As your infrastructure needs change, you may want to add or remove resources from your configuration, refactor collections of resources into reusable modules, or remove or retire resources from your cloud provider or state file. Refer to the following topics for more information about managing resources:
 
 - [Creating modules](/terraform/language/modules/develop) provides instructions on how to collect resources into reusable modules.
-- [Refactoring modules](/terraform/language/modules/develop/refactoring) provides instructions on moving and renaming sources. 
+- [Refactoring modules](/terraform/language/modules/develop/refactoring) provides instructions on moving and renaming resources. 
 - [Remove a resource from state](/terraform/language/state/remove) describes how to remove a resource from state without destroying the actual infrastructure object.
 - [Destroy a resource](/terraform/language/resources/destroy) describes how to remove a resource from state and destroy the actual infrastructure.
 
-Many providers also allow you to read data from the provider so that you can use data from exisitng infrastructure without provisioning actual infrastructure objects. Refer to [Query data sources](/terraform/language/data-sources) for more information.
+Many providers also allow you to read data from the provider so that you can use data from existing infrastructure without provisioning actual infrastructure objects. Refer to [Query data sources](/terraform/language/data-sources) for more information.


### PR DESCRIPTION
Re-creating PR https://github.com/hashicorp/web-unified-docs/pull/2147 because of automation issues caused by it being an external person's branch, and us not having looked at it promptly. Quicker and easier to just re-create.

Changes are at
- https://unified-docs-frontend-preview-mc5191vyf-hashicorp.vercel.app/terraform/language/block/resource
- https://unified-docs-frontend-preview-mc5191vyf-hashicorp.vercel.app/terraform/language/resources
- https://unified-docs-frontend-preview-mc5191vyf-hashicorp.vercel.app/terraform/language/resources/configure

Most of the changes occur several times across versions.

Original PR was reviewed by Adam.  My commit applies the fixes to v1.15.x.

Original write-up from @neronsoda follows

----------

What

Fixed multiple typos and errors in the resource block reference and resources pages across versions v1.12.x, v1.13.x, v1.14.x, and v1.15.x (beta).

v1.15.x (beta)

    content/terraform/v1.15.x (beta)/docs/language/block/resource.mdx
    content/terraform/v1.15.x (beta)/docs/language/resources/configure.mdx
    content/terraform/v1.15.x (beta)/docs/language/resources/index.mdx

v1.14.x

    content/terraform/v1.14.x/docs/language/block/resource.mdx
    content/terraform/v1.14.x/docs/language/resources/configure.mdx
    content/terraform/v1.14.x/docs/language/resources/index.mdx

v1.13.x

    content/terraform/v1.13.x/docs/language/block/resource.mdx
    content/terraform/v1.13.x/docs/language/resources/configure.mdx
    content/terraform/v1.13.x/docs/language/resources/index.mdx

v1.12.x

    content/terraform/v1.12.x/docs/language/block/resource.mdx
    content/terraform/v1.12.x/docs/language/resources/configure.mdx
    content/terraform/v1.12.x/docs/language/resources/index.mdx

Why

block/resource.mdx (all versions)

    Learn configure `resource`... → Learn how to configure `resource`... (missing word in page description)
    You must also configure a  `private_key` arugment → a `private_key` argument (typo + extra space)
    in the the [`command`] → in the [`command`] (duplicate word)
    Terraform performs run the command → Terraform runs the command (grammar error)
    [Destroy-time provisioners](terraform/language/...) → [Destroy-time provisioners](/terraform/language/...) (missing leading slash in URL)

block/resource.mdx (v1.14.x and v1.15.x beta only)

    <EXPRESSSION> → <EXPRESSION> (triple S typo in code example)

block/resource.mdx (v1.14.x only)

    (#replace-triggered_by) → (#replace_triggered_by) (hyphen should be underscore in anchor link)

block/resource.mdx (v1.12.x, v1.14.x, v1.15.x beta)

    ami = "data.aws_ami.example.id" → ami = data.aws_ami.example.id (string literal should be a reference expression)
    iam_instance_profile = aws_iam_instance_profile.example → .example.name (missing .name attribute — resource object passed where string is expected)

resources/configure.mdx (all versions)

    Configure Terraform meta-arguments arguments → Configure Terraform meta-arguments (duplicate word)

resources/index.mdx (all versions)

    moving and renaming sources → moving and renaming resources (wrong word)

resources/index.mdx (v1.12.x and v1.15.x beta only)

    exisitng → existing (typo)

resources/index.mdx (v1.12.x only)

    or a general overview → For a general overview (missing capital F)

Screenshots
Merge Checklist

If items do not apply to your changes, add (N/A) and mark them as complete.
Pull Request

    (N/A) Description links to related pull requests or issues, if any.

Content

    (N/A) You added redirects to content/terraform-docs-common/redirects.jsonc for moved, renamed, or deleted pages across all affected versions. Refer to [Redirects](https://github.com/hashicorp/web-unified-docs/blob/main/docs/content-guide/redirects.md#example-redirects) for examples and guidance.
    (N/A) Links to related content where appropriate (e.g., CLI, language, API endpoints, permissions, etc.).
    (N/A) Pages with related content are updated and link to this content when appropriate.
    (N/A) Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
    (N/A) New pages have metadata (page name and description) at the top.
    (N/A) New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
    (N/A) New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
    (N/A) UI elements (button names, page names, etc.) are bolded.
    The Vercel website preview successfully deployed.

Reviews

    I or someone else reviewed the content for technical accuracy.
    I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
