### PR TITLE
IPE-1759: Remove leftover beta disclaimer from policy sets index page

### DIFF
--- a/content/terraform-docs-common/docs/cloud-docs/workspaces/policy-enforcement/manage-policy-sets/index.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/workspaces/policy-enforcement/manage-policy-sets/index.mdx
@@ -20,12 +20,6 @@ Policies are rules that HCP Terraform enforces on Terraform runs. You can define
 
 Policy sets are collections of policies you can apply globally, to specific [projects](/terraform/cloud-docs/projects/manage) and workspaces, or to workspaces with specific tags in your organization. For each run in the applicable workspaces, HCP Terraform checks the Terraform plan against the policy set. Depending on the [enforcement level](#policy-enforcement-levels), failed policies can stop a run in a workspace. If you do not want to enforce a policy set on a specific project, workspace, or tag, you can exclude it from that set.
 
-<Note>
-
-Using tags to set the scope of your policy sets is in beta. Do not use beta functionality in production environments.
-
-</Note>
-
 ## Policy checks versus policy evaluations
 
 Policy checks and evaluations can access different types of data and enable slightly different workflows.


### PR DESCRIPTION
## Summary

Follow-up to #(previous merged PR removing beta disclaimers and documenting tag match logic for policy sets).

That PR updated `configure.mdx` but missed a separate beta `<Note>` callout on `manage-policy-sets/index.mdx` — the page actually rendered at https://developer.hashicorp.com/terraform/cloud-docs/workspaces/policy-enforcement/manage-policy-sets. This PR removes that leftover disclaimer since tag-based policy set scoping is now generally available.

## Changes

- Removed the beta `<Note>` callout from `content/terraform-docs-common/docs/cloud-docs/workspaces/policy-enforcement/manage-policy-sets/index.mdx`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>