### PR TITLE
Consul Docs: update FIPS documentation for the 140-3 migration

### DIFF
--- a/content/consul/v1.21.x/content/docs/deploy/index.mdx
+++ b/content/consul/v1.21.x/content/docs/deploy/index.mdx
@@ -5,7 +5,7 @@ description: >-
   Learn about the editions of Consul you can deploy as Consul server agents, client agents, and dataplanes. You can find additional guidance for the deployment process in our tutorials.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-11-04T10:42:51-06:00
-last_modified: 2025-11-04T10:42:51-06:00
+last_modified: 2026-09-08T05:22:32.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -23,7 +23,7 @@ You can configure agents to run a specific edition of Consul.
 | :------------------- | :---------------------------------------------------- |
 | Community edition    | Enabled by default.                                   |
 | Enterprise           | Configure `license` block in the agent configuration. |
-| [FIPS 140-2 compliant](/consul/docs/deploy/server/fips) | Specify an alternate source binary or image.          |
+| [FIPS 140-3 compliant](/consul/docs/deploy/server/fips) | Specify an alternate source binary or image.          |
 
 To find the package for a specific release, refer to [releases.hashicorp.com](https://releases.hashicorp.com). To learn more about the differences in Consul editions and their available features, refer to [Consul edition fundamentals](/consul/docs/fundamentals/editions).
 

--- a/content/consul/v1.21.x/content/docs/deploy/server/fips.mdx
+++ b/content/consul/v1.21.x/content/docs/deploy/server/fips.mdx
@@ -1,17 +1,17 @@
 ---
 layout: docs
-page_title: Deploy FIPS 140-2 compliant Consul servers
+page_title: Deploy FIPS 140-3 compliant Consul servers
 description: >-
-  A version of Consul compliant with FIPS 140-2 is available to Enterprise users. Learn about where to find FIPS-compliant versions of Consul, as well as usage restrictions and technical details.
+  A version of Consul compliant with FIPS 140-3 is available to Enterprise users. Learn about where to find FIPS-compliant versions of Consul, as well as usage restrictions and technical details.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-11-04T10:42:51-06:00
-last_modified: 2025-11-04T10:42:51-06:00
+last_modified: 2026-09-08T05:22:32.000Z
 # END AUTO GENERATED METADATA
 ---
 
-# Deploy FIPS 140-2 compliant Consul servers
+# Deploy FIPS 140-3 compliant Consul servers
 
-Builds of Consul Enterprise marked with a `fips1402` feature name include built-in support for FIPS 140-2 compliance.
+Builds of Consul Enterprise marked with a `fips1403` feature name include built-in support for FIPS 140-3 compliance.
 
 To use this feature, you must have an [active or trial license for Consul
 Enterprise](/consul/docs/enterprise/license). To start a trial, contact
@@ -19,54 +19,85 @@ HashiCorp sales.
 
 <EnterpriseAlert product="consul" />
 
-## Using FIPS 140-2 Consul Enterprise
+<Note title="FIPS 140-3 validation in progress">
 
-FIPS 140-2 builds of Consul Enterprise behave in the same way as non-FIPS builds. There are no restrictions on Consul algorithms, and ensuring that Consul remains in a FIPS-compliant mode of operation is your responsibility. To maintain FIPS-compliant operation, you must [ensure that TLS is enabled](/consul/docs/secure/encryption/tls/enable/new/builtin) so that communication is encrypted. Consul products surface some helpful warnings where settings are insecure.
+FIPS 140-3 builds of Consul Enterprise link a cryptographic module that holds a FIPS 140-3 certificate, but independent validation of how Consul integrates that module is still in progress. Contact HashiCorp sales if your compliance program requires a completed validation report.
 
-Encryption is disabled in Consul Enterprise by default. As a result, Consul may transmit sensitive control plane information. You must ensure that gossip encryption and mTLS is enabled for all agents when running Consul with FIPS-compliant settings. In addition, be aware that TLSv1.3 does not work with FIPS 140-2, as HKDF is not a certified primitive.
+</Note>
+
+## Using FIPS 140-3 Consul Enterprise
+
+FIPS 140-3 builds of Consul Enterprise behave in the same way as non-FIPS builds. There are no restrictions on Consul algorithms, and ensuring that Consul remains in a FIPS-compliant mode of operation is your responsibility. To maintain FIPS-compliant operation, you must [ensure that TLS is enabled](/consul/docs/secure/encryption/tls/enable/new/builtin) so that communication is encrypted. Consul products surface some helpful warnings where settings are insecure.
+
+Encryption is disabled in Consul Enterprise by default. As a result, Consul may transmit sensitive control plane information. You must ensure that gossip encryption and mTLS is enabled for all agents when running Consul with FIPS-compliant settings.
 
 HashiCorp is not a NIST-certified testing laboratory and can only provide general guidance about using Consul Enterprise in a FIPS-compliant manner. We recommend consulting an approved auditor for further information.
 
-The FIPS 140-2 variant of Consul uses separate binaries that are available from the following sources:
+The FIPS 140-3 variant of Consul uses separate binaries that are available from the following sources:
 
-- The [HashiCorp Releases page](https://releases.hashicorp.com/consul), releases ending with the `+ent.fips1402` suffix.
+- The [HashiCorp Releases page](https://releases.hashicorp.com/consul), releases ending with the `+ent.fips1403` suffix.
 - The [Docker Hub `hashicorp/consul-enterprise-fips`](https://hub.docker.com/r/hashicorp/consul-enterprise-fips) container repository.
 - The [AWS ECR `hashicorp/consul-enterprise-fips`](https://gallery.ecr.aws/hashicorp/consul-enterprise-fips) container repository.
 - The [Red Hat Access `hashicorp/consul-enterprise-fips`](https://catalog.redhat.com/software/containers/hashicorp/consul-enterprise-fips/628d50e37ff70c66a88517ea) container repository.
 
-The aforementioned naming conventions, which append `.fips1402` to binary names and tags, and `-fips` to registry names, also apply to `consul-k8s`, `consul-k8s-control-plane`, `consul-dataplane`, and `consul-ecs`, which are packaged separately from Consul Enterprise.
+The aforementioned naming conventions, which append `.fips1403` to binary names and tags, and `-fips` to registry names, also apply to `consul-k8s`, `consul-k8s-control-plane`, `consul-dataplane`, and `consul-ecs`, which are packaged separately from Consul Enterprise.
+
+### Artifact names
+
+Releases that support FIPS 140-3 use different artifact names than releases that support FIPS 140-2. Update any automation that pins FIPS artifact names, package names, or version strings before you upgrade.
+
+| Artifact                                                             | FIPS 140-2                      | FIPS 140-3                      |
+| :------------------------------------------------------------------- | :------------------------------ | :------------------------------ |
+| Consul Enterprise version metadata                                    | `+ent.fips1402`                 | `+ent.fips1403`                 |
+| `consul-k8s`, `consul-dataplane`, and `consul-ecs` version metadata   | `+fips1402`                     | `+fips1403`                     |
+| Operating system packages                                             | `consul-F2_1.20.4-1_amd64.deb`  | `consul-F3_1.20.4-1_amd64.deb`  |
+| Envoy container images                                                | `hashicorp/envoy-fips:VERSION-fips1402` | `hashicorp/envoy-fips:VERSION-fips1403` |
 
 ### Usage restrictions
 
-When using Consul Enterprise with FIPS 140-2, be aware of the following operation restrictions.
+When using Consul Enterprise with FIPS 140-3, be aware of the following operation restrictions.
 
 #### Migration restrictions
 
-We do not support in-place migrations from non-FIPS builds of Consul to FIPS builds of Consul, regardless of version. A fresh cluster installation is required to support FIPS 140-2. You cannot upgrade directly to a FIPS-compliant build.
+We do not support in-place migrations from non-FIPS builds of Consul to FIPS builds of Consul, regardless of version. A fresh cluster installation is required to support FIPS 140-3. You cannot upgrade directly to a FIPS-compliant build.
+
+You can upgrade from a FIPS 140-2 build to a FIPS 140-3 build. Refer to [heterogeneous cluster deployments](#heterogeneous-cluster-deployments) for more information.
 
 #### TLS restrictions
 
-Consul Enterprise's FIPS modifications include restrictions to supported TLS cipher suites and key information. Only the following cipher suites are allowed:
+Consul Enterprise's FIPS modifications include restrictions to supported TLS cipher suites and key information. Only the following TLS v1.2 cipher suites are allowed:
 
 - `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`
 - `TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384`
 - `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256`
 - `TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384`
-- `TLS_RSA_WITH_AES_128_GCM_SHA256`
-- `TLS_RSA_WITH_AES_256_GCM_SHA384`
+- `TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256`
+- `TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256`
+
+Only the following TLS v1.3 cipher suites are allowed:
+
+- `TLS_AES_128_GCM_SHA256`
+- `TLS_AES_256_GCM_SHA384`
 
 In addition, only the following key types are allowed in TLS chains of trust:
 
-- RSA 2048, 3072, and 4096-bit
+- RSA 2048-bit and larger
 - ECDSA P-256, P-384, and P-521
+- Ed25519
 
-Finally, only TLSv1.2 is supported in FIPS mode. These settings are in line with recent NIST guidance and FIPS requirements.
+Both TLS v1.2 and TLS v1.3 are supported in FIPS mode. When a connection uses TLS v1.2, both peers must support the extended master secret extension described in [RFC 7627](https://datatracker.ietf.org/doc/html/rfc7627). Handshakes with peers that do not support the extension fail.
+
+<Warning title="Cipher suite change in FIPS 140-3">
+
+FIPS 140-3 builds do not allow the `TLS_RSA_WITH_AES_128_GCM_SHA256` and `TLS_RSA_WITH_AES_256_GCM_SHA384` cipher suites that FIPS 140-2 builds allow, because RSA key transport is not an approved key establishment method. If your TLS configuration pins either cipher suite, update the configuration before you upgrade.
+
+</Warning>
 
 #### Heterogeneous cluster deployments
 
-We do not support mixed deployment scenarios within the same Consul cluster. An example of an unsupported deployment scenario is one that mixes FIPS and non-FIPS Consul binaries. Nodes across the entire cluster must use a single binary or deployment type.
+We do not support deployment scenarios that mix FIPS and non-FIPS Consul binaries within the same cluster. Running a heterogeneous cluster is not permitted by FIPS, as components of the system are not compliant with FIPS. When an agent attempts to join a cluster whose FIPS status does not match its own, the join fails with a `Cannot join FIPS and non-FIPS Consul` error.
 
-Running a heterogeneous cluster is not permitted by FIPS, as components of the system are not compliant with FIPS. Attempts to join non-FIPS and FIPS nodes or servers may fail.
+Agents that support FIPS 140-2 and agents that support FIPS 140-3 can join the same cluster. Both levels use approved cryptographic primitives, so you can perform a rolling upgrade from `+ent.fips1402` to `+ent.fips1403` without restarting the entire cluster at once.
 
 ### Envoy
 
@@ -74,7 +105,7 @@ To enable users to deploy a FIPS compliant service mesh with Consul, HashiCorp p
 
 ## Deployment prerequisites
 
-Depending on your Consul runtime, there are additional requirements for using FIPS 140-2.
+Depending on your Consul runtime, there are additional requirements for using FIPS 140-3.
 
 ### VMs
 
@@ -86,55 +117,46 @@ When deploying the FIPS builds of Consul on Kubernetes using `consul-k8s` or Hel
 
 ## Technical details
 
-Consul's FIPS 140-2 Linux products use the BoringCrypto integration in the official Go 1.20+ toolchain, which include a FIPS-validated crypto module.
+Consul's FIPS 140-3 products use the Go Cryptographic Module, a cryptographic module included in the official Go toolchain. HashiCorp builds these products with `GOFIPS140=v1.0.0` so that the binary links the module version that holds [CMVP certificate #5247](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/5247). Linux and Windows builds use the same module.
 
-Consul's FIPS 140-2 products on Windows use the CNGCrypto integration in Microsoft's Go toolchain, which include a FIPS-validated crypto module.
+Because the module is written in Go, FIPS 140-3 binaries do not depend on cgo. Unlike FIPS 140-2 Linux binaries, they do not require a GNU C Library (glibc) Linux distribution.
 
-To ensure your build of Consul Enterprise includes FIPS support, confirm that a line with `FIPS: Enabled` appears when you run a `version` command. For example, the following message appears for Linux users:
-
-<CodeBlockConfig hideClipboard>
-
-```log
-FIPS: FIPS 140-2 Enabled, crypto module boringcrypto
-```
-
-</CodeBlockConfig>
-
-The following message appears for Windows users:
+To ensure your build of Consul Enterprise includes FIPS support, confirm that a line beginning with `FIPS:` appears when you run a `version` command. For example, the following message appears when the agent operates in FIPS mode:
 
 <CodeBlockConfig hideClipboard>
 
 ```log
-FIPS: FIPS 140-2 Enabled, crypto module cngcrypto
+FIPS: FIPS 140-3 Enabled, crypto module v1.0.0
 ```
 
 </CodeBlockConfig>
 
-FIPS 140-2 Linux binaries depend on cgo, which require that a GNU C Library (glibc) Linux distribution be used to run Consul. Refer to [instructions for Windows FIPS mode](https://github.com/microsoft/go/blob/microsoft/main/eng/doc/fips/README.md#windows-fips-mode-cng) for more information on running CNGCrypto-enabled Go binaries in FIPS mode.
+### FIPS mode at runtime
 
-The NIST Cryptographic Module Validation Program certifications and accompanying security policies for BoringCrypto and CNG are available through the following external links:
+FIPS builds of Consul set `fips140=on` as the default value of the `GODEBUG` environment variable, so the binary operates in FIPS mode without additional configuration.
 
-- [BoringCrypto](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4407)
-- [CNG](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4515)
+This default is not an enforcement. If you set `GODEBUG=fips140=off` in the agent's environment, the binary starts without FIPS mode enabled. The agent then reports that FIPS is not enabled, stops advertising FIPS status to other agents, and cannot join a FIPS cluster. Do not override the `fips140` setting in `GODEBUG` on agents that must operate in FIPS mode.
 
 ### Validating FIPS crypto modules
 
-To validate that a FIPS 140-2 Linux binary correctly includes BoringCrypto, run `go tool nm` on the binary to get a symbol dump.  On FIPS-enabled builds, many results appear, as in the following example.
+To validate that a binary links the certified cryptographic module, run `go version -m` on the binary and inspect its build settings.
 
 ```shell-session
-$ go tool nm consul | grep -i goboringcrypto
-4014d0 T _cgo_6880f0fbb71e_Cfunc__goboringcrypto_AES_cbc_encrypt
-4014f0 T _cgo_6880f0fbb71e_Cfunc__goboringcrypto_AES_ctr128_encrypt
-401520 T _cgo_6880f0fbb71e_Cfunc__goboringcrypto_AES_decrypt
-401540 T _cgo_6880f0fbb71e_Cfunc__goboringcrypto_AES_encrypt
-401560 T _cgo_6880f0fbb71e_Cfunc__goboringcrypto_AES_set_decrypt_key
+$ go version -m consul | grep -e GOFIPS140 -e DefaultGODEBUG -e tags
+	build	-tags=consulent,fips,fips140v1.0
+	build	DefaultGODEBUG=fips140=on
+	build	GOFIPS140=v1.0.0
 ```
 
-Similarly, on a FIPS Windows binary, run `go tool nm` on the binary to get a symbol dump, and then search for `go-crypto-winnative`.
-
-On both Linux and Windows non-FIPS builds, the search output yields no results.
+Non-FIPS builds do not report the `GOFIPS140` or `DefaultGODEBUG=fips140=on` build settings.
 
 ## Leidos validation
+
+<Note>
+
+This validation covers FIPS 140-2 builds of Consul. It does not apply to FIPS 140-3 builds.
+
+</Note>
 
 In 2024, Leidos certified the integration of FIPS 140-2 cryptographic module [BoringCrypto Cert. #4407](https://csrc.nist.gov/Projects/Cryptographic-Module-Validation-Program/Certificate/4407) for the following Consul releases:
 

--- a/content/consul/v1.21.x/content/docs/enterprise/index.mdx
+++ b/content/consul/v1.21.x/content/docs/enterprise/index.mdx
@@ -5,7 +5,7 @@ description: >-
   Consul Enterprise is a paid offering that extends Consul Community Edition to support large and complex deployments. Learn about scaling infrastructure, simplifying operations, and making networks more resilient with Enterprise. Evaluate Enterprise features with the feature availability and compatibility matrix.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-11-04T10:42:51-06:00
-last_modified: 2026-04-16T19:56:29.000Z
+last_modified: 2026-09-08T05:22:33.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -57,11 +57,11 @@ The following features are [available in several forms of Consul Enterprise](#co
 
 ### Regulatory compliance
 
-- [FIPS 140-2 Compliance](/consul/docs/deploy/server/fips): Leverage FIPS builds of Consul Enterprise to ensure your Consul deployments are secured with BoringCrypto and CNGCrypto, and compliant with FIPS 140-2.
+- [FIPS 140-3 Compliance](/consul/docs/deploy/server/fips): Leverage FIPS builds of Consul Enterprise to ensure your Consul deployments are secured with the Go Cryptographic Module, and compliant with FIPS 140-3.
 
   <Note>
 
-  FIPS 140-2 builds of Consul Enterprise support all runtimes (VMs, Kubernetes) except for Lambda and ECS. In addition, HCP does not currently support FIPS builds of Consul Enterprise.
+  FIPS 140-3 builds of Consul Enterprise support all runtimes (VMs, Kubernetes) except for Lambda and ECS. In addition, HCP does not currently support FIPS builds of Consul Enterprise.
 
   </Note>
 
@@ -83,7 +83,7 @@ The following features are [available in several forms of Consul Enterprise](#co
 | Multiple runtime support            | &#10060;                               | &#9989;             | &#9989;            |
 | Multi-tenancy support               | &#10060;                               | &#9989;             | &#9989;            |
 | Additional resiliency & scalability | &#10060;                               | &#9989;             | &#9989;            |
-| FIPS 140-2 Compliance               | &#10060;                               | &#9989;             | &#9989;            |
+| FIPS 140-3 Compliance               | &#10060;                               | &#9989;             | &#9989;            |
 | Consul-Terraform-Sync (CTS) support | &#9989;                                | &#9989;             | &#9989;            |
 
 Some Consul features are not supported with a Standard Enterprise license because the feature is used only when the service mesh is deployed.
@@ -110,7 +110,7 @@ Enterprise licenses include support for the following features.
 | [Consul-Terraform-Sync Enterprise](/consul/docs/enterprise/cts)                                 | &#9989;                     | &#9989;                    |
 | [Enhanced Read Scalability](/consul/docs/manage/scale/read-replica)                             | &#9989;                     | &#9989;                    |
 | [Fault injection](/consul/docs/troubleshoot/fault-injection)                                    | &#10060;                    | &#9989;                    |
-| [FIPS 140-2 Compliance](/consul/docs/deploy/server/fips)                                        | &#9989;                     | &#9989;                    |
+| [FIPS 140-3 Compliance](/consul/docs/deploy/server/fips)                                        | &#9989;                     | &#9989;                    |
 | [JWT verification for API gateways](/consul/docs/north-south/api-gateway/secure-traffic/jwt/vm) | &#10060;                    | &#9989;                    |
 | [Locality-aware routing](/consul/docs/manage-traffic/route-local)                               | &#10060;                    | &#9989;                    |
 | [Long Term Support (LTS)](/consul/docs/upgrade/lts)                                             | &#9989;                     | &#9989;                    |
@@ -139,7 +139,7 @@ Consul Enterprise feature availability can change depending on your server and c
 | [Automated Server Upgrades](/consul/docs/upgrade/automated)                                                 |  &#9989;  |  &#9989;   |  &#9989;   |
 | [Enhanced Read Scalability](/consul/docs/manage/scale/read-replica)                                               |  &#9989;  |  &#9989;   |  &#9989;   |
 | [Fault injection](/consul/docs/troubleshoot/fault-injection)                                        |  &#9989;  |  &#9989;   |  &#9989;   |
-| [FIPS 140-2 Compliance](/consul/docs/deploy/server/fips)                                                         |  &#9989;  |  &#9989;   |  &#9989;   |
+| [FIPS 140-3 Compliance](/consul/docs/deploy/server/fips)                                                         |  &#9989;  |  &#9989;   |  &#9989;   |
 | [JWT verification for API gateways](/consul/docs/north-south/api-gateway/secure-traffic/jwt/vm) |  &#9989;  |  &#9989;   |  &#10060;  |
 | [Locality-aware routing](/consul/docs/manage-traffic/route-local)                        |  &#9989;  |  &#9989;   |  &#9989;   |
 | [Long Term Support (LTS)](/consul/docs/upgrade/lts)                                          |  &#9989;  |  &#9989;   |  &#10060;  |
@@ -164,7 +164,7 @@ Consul Enterprise feature availability can change depending on your server and c
 | [Automated Server Upgrades](/consul/docs/upgrade/automated)                                                 |  &#10060; |  &#10060;  |  &#10060;  |
 | [Enhanced Read Scalability](/consul/docs/manage/scale/read-replica)                                               |  &#10060; |  &#10060;  |  &#10060;  |
 | [Fault injection](/consul/docs/troubleshoot/fault-injection)                                        |  &#9989;  |  &#9989;   |  &#9989;   |
-| [FIPS 140-2 Compliance](/consul/docs/deploy/server/fips)                                                         |  &#9989;  |  &#9989;   |  &#9989;   |
+| [FIPS 140-3 Compliance](/consul/docs/deploy/server/fips)                                                         |  &#9989;  |  &#9989;   |  &#9989;   |
 | [JWT verification for API gateways](/consul/docs/north-south/api-gateway/secure-traffic/jwt/k8s) |  &#9989;  |  &#9989;   |  &#10060;  |
 | [Locality-aware routing](/consul/docs/manage-traffic/route-local)                        |  &#9989;  |  &#9989;   |  &#9989;   |
 | [Long Term Support (LTS)](/consul/docs/upgrade/lts)                                          |  &#9989;  |  &#9989;   |  &#10060;  |
@@ -188,7 +188,7 @@ Consul Enterprise feature availability can change depending on your server and c
 | [Automated Server Upgrades](/consul/docs/upgrade/automated)                                                 |  &#9989;  |  &#9989;   |  &#9989;   |
 | [Enhanced Read Scalability](/consul/docs/manage/scale/read-replica)                                               |  &#10060; |  &#10060;  |  &#10060;  |
 | [Fault injection](/consul/docs/troubleshoot/fault-injection)                                        |  &#9989;  |  &#9989;   |  &#9989;   |
-| [FIPS 140-2 Compliance](/consul/docs/deploy/server/fips)                                                         |  &#10060; |  &#10060;  |  &#10060;  |
+| [FIPS 140-3 Compliance](/consul/docs/deploy/server/fips)                                                         |  &#10060; |  &#10060;  |  &#10060;  |
 | [JWT verification for API gateways](/consul/docs/north-south/api-gateway/secure-traffic/jwt/vm) |  &#9989;  |  &#9989;   |  &#10060;  |
 | [Locality-aware routing](/consul/docs/manage-traffic/route-local)                        |  &#9989;  |  &#9989;   |  &#9989;   |
 | [Long Term Support (LTS)](/consul/docs/upgrade/lts)                                          |  N/A      |  N/A       |  N/A       |

--- a/content/consul/v1.21.x/content/docs/fundamentals/editions.mdx
+++ b/content/consul/v1.21.x/content/docs/fundamentals/editions.mdx
@@ -5,7 +5,7 @@ description: >-
   Learn about the various Consul releases and their differences.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-11-04T10:42:51-06:00
-last_modified: 2026-04-16T19:56:31.000Z
+last_modified: 2026-09-08T05:22:35.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -40,7 +40,7 @@ To run Consul Enterprise, you must configure Consul agents with an Enterprise li
 | Multiple runtime support            | &#10060;                               | &#9989;             | &#9989;            |
 | Multi-tenancy support               | &#10060;                               | &#9989;             | &#9989;            |
 | Additional resiliency & scalability | &#10060;                               | &#9989;             | &#9989;            |
-| FIPS 140-2 Compliance               | &#10060;                               | &#9989;             | &#9989;            |
+| FIPS 140-3 Compliance               | &#10060;                               | &#9989;             | &#9989;            |
 | Consul-Terraform-Sync (CTS) support | &#9989;                                | &#9989;             | &#9989;            |
 
 To learn more about Consul Enterprise and its features, refer to [Consul Enterprise](/consul/docs/enterprise).

--- a/content/consul/v1.21.x/content/docs/fundamentals/install/index.mdx
+++ b/content/consul/v1.21.x/content/docs/fundamentals/install/index.mdx
@@ -5,7 +5,7 @@ description: >-
   Install Consul to get started with service discovery and service mesh. Follow the installation instructions to download the precompiled binary, or use Go to compile from source.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-11-04T10:42:51-06:00
-last_modified: 2025-11-04T10:42:51-06:00
+last_modified: 2026-09-08T05:22:35.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -27,7 +27,7 @@ We recommend using a precompiled binary. We also distribute a PGP signature with
 
 ## Precompiled binaries
 
-To install the precompiled binary, [download the appropriate package for your system](/consul/install). To find other versions, including Enterprise versions with support for FIPS 1420 compliance, refer to [the complete list of Consul releases on releases.hashicorp.com](https://releases.hashicorp.com/consul/). Consul is currently packaged as a `.zip` file.
+To install the precompiled binary, [download the appropriate package for your system](/consul/install). To find other versions, including Enterprise versions with support for FIPS 140-3 compliance, refer to [the complete list of Consul releases on releases.hashicorp.com](https://releases.hashicorp.com/consul/). Consul is currently packaged as a `.zip` file.
 
 After your download completes, unzip it into any directory. The `consul` binary or `.exe` file inside is the only file required to run Consul.
 

--- a/content/consul/v1.21.x/data/docs-nav-data.json
+++ b/content/consul/v1.21.x/data/docs-nav-data.json
@@ -224,7 +224,7 @@
             "href": "reference/architecture/ports"
           },
           {
-            "title": "FIPS 140-2 compliance",
+            "title": "FIPS 140-3 compliance",
             "path": "deploy/server/fips"
           },
           {

--- a/content/consul/v1.22.x/content/docs/deploy/index.mdx
+++ b/content/consul/v1.22.x/content/docs/deploy/index.mdx
@@ -5,7 +5,7 @@ description: >-
   Learn about the editions of Consul you can deploy as Consul server agents, client agents, and dataplanes. You can find additional guidance for the deployment process in our tutorials.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-11-05T11:02:51-05:00
-last_modified: 2025-11-05T11:02:51-05:00
+last_modified: 2026-09-08T05:22:36.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -23,7 +23,7 @@ You can configure agents to run a specific edition of Consul.
 | :------------------- | :---------------------------------------------------- |
 | Community edition    | Enabled by default.                                   |
 | Enterprise           | Configure `license` block in the agent configuration. |
-| [FIPS 140-2 compliant](/consul/docs/deploy/server/fips) | Specify an alternate source binary or image.          |
+| [FIPS 140-3 compliant](/consul/docs/deploy/server/fips) | Specify an alternate source binary or image.          |
 
 To find the package for a specific release, refer to [releases.hashicorp.com](https://releases.hashicorp.com). To learn more about the differences in Consul editions and their available features, refer to [Consul edition fundamentals](/consul/docs/fundamentals/editions).
 

--- a/content/consul/v1.22.x/content/docs/deploy/server/fips.mdx
+++ b/content/consul/v1.22.x/content/docs/deploy/server/fips.mdx
@@ -1,17 +1,17 @@
 ---
 layout: docs
-page_title: Deploy FIPS 140-2 compliant Consul servers
+page_title: Deploy FIPS 140-3 compliant Consul servers
 description: >-
-  A version of Consul compliant with FIPS 140-2 is available to Enterprise users. Learn about where to find FIPS-compliant versions of Consul, as well as usage restrictions and technical details.
+  A version of Consul compliant with FIPS 140-3 is available to Enterprise users. Learn about where to find FIPS-compliant versions of Consul, as well as usage restrictions and technical details.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-11-05T11:02:51-05:00
-last_modified: 2025-11-05T11:02:51-05:00
+last_modified: 2026-09-08T05:22:36.000Z
 # END AUTO GENERATED METADATA
 ---
 
-# Deploy FIPS 140-2 compliant Consul servers
+# Deploy FIPS 140-3 compliant Consul servers
 
-Builds of Consul Enterprise marked with a `fips1402` feature name include built-in support for FIPS 140-2 compliance.
+Builds of Consul Enterprise marked with a `fips1403` feature name include built-in support for FIPS 140-3 compliance.
 
 To use this feature, you must have an [active or trial license for Consul
 Enterprise](/consul/docs/enterprise/license). To start a trial, contact
@@ -19,54 +19,85 @@ HashiCorp sales.
 
 <EnterpriseAlert product="consul" />
 
-## Using FIPS 140-2 Consul Enterprise
+<Note title="FIPS 140-3 validation in progress">
 
-FIPS 140-2 builds of Consul Enterprise behave in the same way as non-FIPS builds. There are no restrictions on Consul algorithms, and ensuring that Consul remains in a FIPS-compliant mode of operation is your responsibility. To maintain FIPS-compliant operation, you must [ensure that TLS is enabled](/consul/docs/secure/encryption/tls/enable/new/builtin) so that communication is encrypted. Consul products surface some helpful warnings where settings are insecure.
+FIPS 140-3 builds of Consul Enterprise link a cryptographic module that holds a FIPS 140-3 certificate, but independent validation of how Consul integrates that module is still in progress. Contact HashiCorp sales if your compliance program requires a completed validation report.
 
-Encryption is disabled in Consul Enterprise by default. As a result, Consul may transmit sensitive control plane information. You must ensure that gossip encryption and mTLS is enabled for all agents when running Consul with FIPS-compliant settings. In addition, be aware that TLSv1.3 does not work with FIPS 140-2, as HKDF is not a certified primitive.
+</Note>
+
+## Using FIPS 140-3 Consul Enterprise
+
+FIPS 140-3 builds of Consul Enterprise behave in the same way as non-FIPS builds. There are no restrictions on Consul algorithms, and ensuring that Consul remains in a FIPS-compliant mode of operation is your responsibility. To maintain FIPS-compliant operation, you must [ensure that TLS is enabled](/consul/docs/secure/encryption/tls/enable/new/builtin) so that communication is encrypted. Consul products surface some helpful warnings where settings are insecure.
+
+Encryption is disabled in Consul Enterprise by default. As a result, Consul may transmit sensitive control plane information. You must ensure that gossip encryption and mTLS is enabled for all agents when running Consul with FIPS-compliant settings.
 
 HashiCorp is not a NIST-certified testing laboratory and can only provide general guidance about using Consul Enterprise in a FIPS-compliant manner. We recommend consulting an approved auditor for further information.
 
-The FIPS 140-2 variant of Consul uses separate binaries that are available from the following sources:
+The FIPS 140-3 variant of Consul uses separate binaries that are available from the following sources:
 
-- The [HashiCorp Releases page](https://releases.hashicorp.com/consul), releases ending with the `+ent.fips1402` suffix.
+- The [HashiCorp Releases page](https://releases.hashicorp.com/consul), releases ending with the `+ent.fips1403` suffix.
 - The [Docker Hub `hashicorp/consul-enterprise-fips`](https://hub.docker.com/r/hashicorp/consul-enterprise-fips) container repository.
 - The [AWS ECR `hashicorp/consul-enterprise-fips`](https://gallery.ecr.aws/hashicorp/consul-enterprise-fips) container repository.
 - The [Red Hat Access `hashicorp/consul-enterprise-fips`](https://catalog.redhat.com/software/containers/hashicorp/consul-enterprise-fips/628d50e37ff70c66a88517ea) container repository.
 
-The aforementioned naming conventions, which append `.fips1402` to binary names and tags, and `-fips` to registry names, also apply to `consul-k8s`, `consul-k8s-control-plane`, `consul-dataplane`, and `consul-ecs`, which are packaged separately from Consul Enterprise.
+The aforementioned naming conventions, which append `.fips1403` to binary names and tags, and `-fips` to registry names, also apply to `consul-k8s`, `consul-k8s-control-plane`, `consul-dataplane`, and `consul-ecs`, which are packaged separately from Consul Enterprise.
+
+### Artifact names
+
+Releases that support FIPS 140-3 use different artifact names than releases that support FIPS 140-2. Update any automation that pins FIPS artifact names, package names, or version strings before you upgrade.
+
+| Artifact                                                             | FIPS 140-2                      | FIPS 140-3                      |
+| :------------------------------------------------------------------- | :------------------------------ | :------------------------------ |
+| Consul Enterprise version metadata                                    | `+ent.fips1402`                 | `+ent.fips1403`                 |
+| `consul-k8s`, `consul-dataplane`, and `consul-ecs` version metadata   | `+fips1402`                     | `+fips1403`                     |
+| Operating system packages                                             | `consul-F2_1.20.4-1_amd64.deb`  | `consul-F3_1.20.4-1_amd64.deb`  |
+| Envoy container images                                                | `hashicorp/envoy-fips:VERSION-fips1402` | `hashicorp/envoy-fips:VERSION-fips1403` |
 
 ### Usage restrictions
 
-When using Consul Enterprise with FIPS 140-2, be aware of the following operation restrictions.
+When using Consul Enterprise with FIPS 140-3, be aware of the following operation restrictions.
 
 #### Migration restrictions
 
-We do not support in-place migrations from non-FIPS builds of Consul to FIPS builds of Consul, regardless of version. A fresh cluster installation is required to support FIPS 140-2. You cannot upgrade directly to a FIPS-compliant build.
+We do not support in-place migrations from non-FIPS builds of Consul to FIPS builds of Consul, regardless of version. A fresh cluster installation is required to support FIPS 140-3. You cannot upgrade directly to a FIPS-compliant build.
+
+You can upgrade from a FIPS 140-2 build to a FIPS 140-3 build. Refer to [heterogeneous cluster deployments](#heterogeneous-cluster-deployments) for more information.
 
 #### TLS restrictions
 
-Consul Enterprise's FIPS modifications include restrictions to supported TLS cipher suites and key information. Only the following cipher suites are allowed:
+Consul Enterprise's FIPS modifications include restrictions to supported TLS cipher suites and key information. Only the following TLS v1.2 cipher suites are allowed:
 
 - `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`
 - `TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384`
 - `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256`
 - `TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384`
-- `TLS_RSA_WITH_AES_128_GCM_SHA256`
-- `TLS_RSA_WITH_AES_256_GCM_SHA384`
+- `TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256`
+- `TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256`
+
+Only the following TLS v1.3 cipher suites are allowed:
+
+- `TLS_AES_128_GCM_SHA256`
+- `TLS_AES_256_GCM_SHA384`
 
 In addition, only the following key types are allowed in TLS chains of trust:
 
-- RSA 2048, 3072, and 4096-bit
+- RSA 2048-bit and larger
 - ECDSA P-256, P-384, and P-521
+- Ed25519
 
-Finally, only TLSv1.2 is supported in FIPS mode. These settings are in line with recent NIST guidance and FIPS requirements.
+Both TLS v1.2 and TLS v1.3 are supported in FIPS mode. When a connection uses TLS v1.2, both peers must support the extended master secret extension described in [RFC 7627](https://datatracker.ietf.org/doc/html/rfc7627). Handshakes with peers that do not support the extension fail.
+
+<Warning title="Cipher suite change in FIPS 140-3">
+
+FIPS 140-3 builds do not allow the `TLS_RSA_WITH_AES_128_GCM_SHA256` and `TLS_RSA_WITH_AES_256_GCM_SHA384` cipher suites that FIPS 140-2 builds allow, because RSA key transport is not an approved key establishment method. If your TLS configuration pins either cipher suite, update the configuration before you upgrade.
+
+</Warning>
 
 #### Heterogeneous cluster deployments
 
-We do not support mixed deployment scenarios within the same Consul cluster. An example of an unsupported deployment scenario is one that mixes FIPS and non-FIPS Consul binaries. Nodes across the entire cluster must use a single binary or deployment type.
+We do not support deployment scenarios that mix FIPS and non-FIPS Consul binaries within the same cluster. Running a heterogeneous cluster is not permitted by FIPS, as components of the system are not compliant with FIPS. When an agent attempts to join a cluster whose FIPS status does not match its own, the join fails with a `Cannot join FIPS and non-FIPS Consul` error.
 
-Running a heterogeneous cluster is not permitted by FIPS, as components of the system are not compliant with FIPS. Attempts to join non-FIPS and FIPS nodes or servers may fail.
+Agents that support FIPS 140-2 and agents that support FIPS 140-3 can join the same cluster. Both levels use approved cryptographic primitives, so you can perform a rolling upgrade from `+ent.fips1402` to `+ent.fips1403` without restarting the entire cluster at once.
 
 ### Envoy
 
@@ -74,7 +105,7 @@ To enable users to deploy a FIPS compliant service mesh with Consul, HashiCorp p
 
 ## Deployment prerequisites
 
-Depending on your Consul runtime, there are additional requirements for using FIPS 140-2.
+Depending on your Consul runtime, there are additional requirements for using FIPS 140-3.
 
 ### VMs
 
@@ -86,55 +117,46 @@ When deploying the FIPS builds of Consul on Kubernetes using `consul-k8s` or Hel
 
 ## Technical details
 
-Consul's FIPS 140-2 Linux products use the BoringCrypto integration in the official Go 1.20+ toolchain, which include a FIPS-validated crypto module.
+Consul's FIPS 140-3 products use the Go Cryptographic Module, a cryptographic module included in the official Go toolchain. HashiCorp builds these products with `GOFIPS140=v1.0.0` so that the binary links the module version that holds [CMVP certificate #5247](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/5247). Linux and Windows builds use the same module.
 
-Consul's FIPS 140-2 products on Windows use the CNGCrypto integration in Microsoft's Go toolchain, which include a FIPS-validated crypto module.
+Because the module is written in Go, FIPS 140-3 binaries do not depend on cgo. Unlike FIPS 140-2 Linux binaries, they do not require a GNU C Library (glibc) Linux distribution.
 
-To ensure your build of Consul Enterprise includes FIPS support, confirm that a line with `FIPS: Enabled` appears when you run a `version` command. For example, the following message appears for Linux users:
-
-<CodeBlockConfig hideClipboard>
-
-```log
-FIPS: FIPS 140-2 Enabled, crypto module boringcrypto
-```
-
-</CodeBlockConfig>
-
-The following message appears for Windows users:
+To ensure your build of Consul Enterprise includes FIPS support, confirm that a line beginning with `FIPS:` appears when you run a `version` command. For example, the following message appears when the agent operates in FIPS mode:
 
 <CodeBlockConfig hideClipboard>
 
 ```log
-FIPS: FIPS 140-2 Enabled, crypto module cngcrypto
+FIPS: FIPS 140-3 Enabled, crypto module v1.0.0
 ```
 
 </CodeBlockConfig>
 
-FIPS 140-2 Linux binaries depend on cgo, which require that a GNU C Library (glibc) Linux distribution be used to run Consul. Refer to [instructions for Windows FIPS mode](https://github.com/microsoft/go/blob/microsoft/main/eng/doc/fips/README.md#windows-fips-mode-cng) for more information on running CNGCrypto-enabled Go binaries in FIPS mode.
+### FIPS mode at runtime
 
-The NIST Cryptographic Module Validation Program certifications and accompanying security policies for BoringCrypto and CNG are available through the following external links:
+FIPS builds of Consul set `fips140=on` as the default value of the `GODEBUG` environment variable, so the binary operates in FIPS mode without additional configuration.
 
-- [BoringCrypto](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4407)
-- [CNG](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4515)
+This default is not an enforcement. If you set `GODEBUG=fips140=off` in the agent's environment, the binary starts without FIPS mode enabled. The agent then reports that FIPS is not enabled, stops advertising FIPS status to other agents, and cannot join a FIPS cluster. Do not override the `fips140` setting in `GODEBUG` on agents that must operate in FIPS mode.
 
 ### Validating FIPS crypto modules
 
-To validate that a FIPS 140-2 Linux binary correctly includes BoringCrypto, run `go tool nm` on the binary to get a symbol dump.  On FIPS-enabled builds, many results appear, as in the following example.
+To validate that a binary links the certified cryptographic module, run `go version -m` on the binary and inspect its build settings.
 
 ```shell-session
-$ go tool nm consul | grep -i goboringcrypto
-4014d0 T _cgo_6880f0fbb71e_Cfunc__goboringcrypto_AES_cbc_encrypt
-4014f0 T _cgo_6880f0fbb71e_Cfunc__goboringcrypto_AES_ctr128_encrypt
-401520 T _cgo_6880f0fbb71e_Cfunc__goboringcrypto_AES_decrypt
-401540 T _cgo_6880f0fbb71e_Cfunc__goboringcrypto_AES_encrypt
-401560 T _cgo_6880f0fbb71e_Cfunc__goboringcrypto_AES_set_decrypt_key
+$ go version -m consul | grep -e GOFIPS140 -e DefaultGODEBUG -e tags
+	build	-tags=consulent,fips,fips140v1.0
+	build	DefaultGODEBUG=fips140=on
+	build	GOFIPS140=v1.0.0
 ```
 
-Similarly, on a FIPS Windows binary, run `go tool nm` on the binary to get a symbol dump, and then search for `go-crypto-winnative`.
-
-On both Linux and Windows non-FIPS builds, the search output yields no results.
+Non-FIPS builds do not report the `GOFIPS140` or `DefaultGODEBUG=fips140=on` build settings.
 
 ## Leidos validation
+
+<Note>
+
+This validation covers FIPS 140-2 builds of Consul. It does not apply to FIPS 140-3 builds.
+
+</Note>
 
 In 2024, Leidos certified the integration of FIPS 140-2 cryptographic module [BoringCrypto Cert. #4407](https://csrc.nist.gov/Projects/Cryptographic-Module-Validation-Program/Certificate/4407) for the following Consul releases:
 

--- a/content/consul/v1.22.x/content/docs/enterprise/index.mdx
+++ b/content/consul/v1.22.x/content/docs/enterprise/index.mdx
@@ -5,7 +5,7 @@ description: >-
   Consul Enterprise is a paid offering that extends Consul Community Edition to support large and complex deployments. Learn about scaling infrastructure, simplifying operations, and making networks more resilient with Enterprise. Evaluate Enterprise features with the feature availability and compatibility matrix.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-11-05T11:02:51-05:00
-last_modified: 2026-04-16T19:56:35.000Z
+last_modified: 2026-09-08T05:22:36.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -57,11 +57,11 @@ The following features are available with an Enterprise license.
 
 ### Regulatory compliance
 
-- [FIPS 140-2 Compliance](/consul/docs/deploy/server/fips): Leverage FIPS builds of Consul Enterprise to ensure your Consul deployments are secured with BoringCrypto and CNGCrypto, and compliant with FIPS 140-2.
+- [FIPS 140-3 Compliance](/consul/docs/deploy/server/fips): Leverage FIPS builds of Consul Enterprise to ensure your Consul deployments are secured with the Go Cryptographic Module, and compliant with FIPS 140-3.
 
   <Note>
 
-  FIPS 140-2 builds of Consul Enterprise support all runtimes (VMs, Kubernetes) except for Lambda and ECS. In addition, HCP does not currently support FIPS builds of Consul Enterprise.
+  FIPS 140-3 builds of Consul Enterprise support all runtimes (VMs, Kubernetes) except for Lambda and ECS. In addition, HCP does not currently support FIPS builds of Consul Enterprise.
 
   </Note>
 
@@ -85,7 +85,7 @@ IBM offers the following packages of licensed support:
 | Multiple runtime support            | &#10060;                               | &#9989;             | &#9989;            |
 | Multi-tenancy support               | &#10060;                               | &#9989;             | &#9989;            |
 | Additional resiliency & scalability | &#10060;                               | &#9989;             | &#9989;            |
-| FIPS 140-2 Compliance               | &#10060;                               | &#9989;             | &#9989;            |
+| FIPS 140-3 Compliance               | &#10060;                               | &#9989;             | &#9989;            |
 | Consul-Terraform-Sync (CTS) support | &#9989;                                | &#9989;             | &#9989;            |
 
 Some Consul features are not supported with a Standard Enterprise license because the feature is used only when the service mesh is deployed.
@@ -107,7 +107,7 @@ Enterprise licenses include support for the following features.
 | [Consul-Terraform-Sync Enterprise](/consul/docs/enterprise/cts)                                 | &#9989;                     | &#9989;                    |
 | [Enhanced Read Scalability](/consul/docs/manage/scale/read-replica)                             | &#9989;                     | &#9989;                    |
 | [Fault injection](/consul/docs/troubleshoot/fault-injection)                                    | &#10060;                    | &#9989;                    |
-| [FIPS 140-2 Compliance](/consul/docs/deploy/server/fips)                                        | &#9989;                     | &#9989;                    |
+| [FIPS 140-3 Compliance](/consul/docs/deploy/server/fips)                                        | &#9989;                     | &#9989;                    |
 | [JWT verification for API gateways](/consul/docs/north-south/api-gateway/secure-traffic/jwt/vm) | &#10060;                    | &#9989;                    |
 | [Locality-aware routing](/consul/docs/manage-traffic/route-local)                               | &#10060;                    | &#9989;                    |
 | [Long Term Support (LTS)](/consul/docs/upgrade/lts)                                             | &#9989;                     | &#9989;                    |
@@ -136,7 +136,7 @@ Consul Enterprise feature availability can change depending on your server and c
 | [Automated Server Upgrades](/consul/docs/upgrade/automated)                                                 |  &#9989;  |  &#9989;   |  &#9989;   |
 | [Enhanced Read Scalability](/consul/docs/manage/scale/read-replica)                                               |  &#9989;  |  &#9989;   |  &#9989;   |
 | [Fault injection](/consul/docs/troubleshoot/fault-injection)                                        |  &#9989;  |  &#9989;   |  &#9989;   |
-| [FIPS 140-2 Compliance](/consul/docs/deploy/server/fips)                                                         |  &#9989;  |  &#9989;   |  &#9989;   |
+| [FIPS 140-3 Compliance](/consul/docs/deploy/server/fips)                                                         |  &#9989;  |  &#9989;   |  &#9989;   |
 | [JWT verification for API gateways](/consul/docs/north-south/api-gateway/secure-traffic/jwt/vm) |  &#9989;  |  &#9989;   |  &#10060;  |
 | [Locality-aware routing](/consul/docs/manage-traffic/route-local)                        |  &#9989;  |  &#9989;   |  &#9989;   |
 | [Long Term Support (LTS)](/consul/docs/upgrade/lts)                                          |  &#9989;  |  &#9989;   |  &#10060;  |
@@ -161,7 +161,7 @@ Consul Enterprise feature availability can change depending on your server and c
 | [Automated Server Upgrades](/consul/docs/upgrade/automated)                                                 |  &#10060; |  &#10060;  |  &#10060;  |
 | [Enhanced Read Scalability](/consul/docs/manage/scale/read-replica)                                               |  &#10060; |  &#10060;  |  &#10060;  |
 | [Fault injection](/consul/docs/troubleshoot/fault-injection)                                        |  &#9989;  |  &#9989;   |  &#9989;   |
-| [FIPS 140-2 Compliance](/consul/docs/deploy/server/fips)                                                         |  &#9989;  |  &#9989;   |  &#9989;   |
+| [FIPS 140-3 Compliance](/consul/docs/deploy/server/fips)                                                         |  &#9989;  |  &#9989;   |  &#9989;   |
 | [JWT verification for API gateways](/consul/docs/north-south/api-gateway/secure-traffic/jwt/k8s) |  &#9989;  |  &#9989;   |  &#10060;  |
 | [Locality-aware routing](/consul/docs/manage-traffic/route-local)                        |  &#9989;  |  &#9989;   |  &#9989;   |
 | [Long Term Support (LTS)](/consul/docs/upgrade/lts)                                          |  &#9989;  |  &#9989;   |  &#10060;  |

--- a/content/consul/v1.22.x/content/docs/fundamentals/editions.mdx
+++ b/content/consul/v1.22.x/content/docs/fundamentals/editions.mdx
@@ -5,7 +5,7 @@ description: >-
   Learn about the various Consul releases and their differences.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-11-05T11:02:51-05:00
-last_modified: 2026-04-16T19:56:35.000Z
+last_modified: 2026-09-08T05:22:37.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -40,7 +40,7 @@ To run Consul Enterprise, you must configure Consul agents with an Enterprise li
 | Multiple runtime support            | &#10060;                               | &#9989;             | &#9989;            |
 | Multi-tenancy support               | &#10060;                               | &#9989;             | &#9989;            |
 | Additional resiliency & scalability | &#10060;                               | &#9989;             | &#9989;            |
-| FIPS 140-2 Compliance               | &#10060;                               | &#9989;             | &#9989;            |
+| FIPS 140-3 Compliance               | &#10060;                               | &#9989;             | &#9989;            |
 | Consul-Terraform-Sync (CTS) support | &#9989;                                | &#9989;             | &#9989;            |
 
 To learn more about Consul Enterprise and its features, refer to [Consul Enterprise](/consul/docs/enterprise).

--- a/content/consul/v1.22.x/content/docs/fundamentals/install/index.mdx
+++ b/content/consul/v1.22.x/content/docs/fundamentals/install/index.mdx
@@ -5,7 +5,7 @@ description: >-
   Install Consul to get started with service discovery and service mesh. Follow the installation instructions to download the precompiled binary, or use Go to compile from source.
 # START AUTO GENERATED METADATA, DO NOT EDIT
 created_at: 2025-11-05T11:02:51-05:00
-last_modified: 2025-11-05T11:02:51-05:00
+last_modified: 2026-09-08T05:22:37.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -27,7 +27,7 @@ We recommend using a precompiled binary. We also distribute a PGP signature with
 
 ## Precompiled binaries
 
-To install the precompiled binary, [download the appropriate package for your system](/consul/install). To find other versions, including Enterprise versions with support for FIPS 1420 compliance, refer to [the complete list of Consul releases on releases.hashicorp.com](https://releases.hashicorp.com/consul/). Consul is currently packaged as a `.zip` file.
+To install the precompiled binary, [download the appropriate package for your system](/consul/install). To find other versions, including Enterprise versions with support for FIPS 140-3 compliance, refer to [the complete list of Consul releases on releases.hashicorp.com](https://releases.hashicorp.com/consul/). Consul is currently packaged as a `.zip` file.
 
 After your download completes, unzip it into any directory. The `consul` binary or `.exe` file inside is the only file required to run Consul.
 

--- a/content/consul/v1.22.x/data/docs-nav-data.json
+++ b/content/consul/v1.22.x/data/docs-nav-data.json
@@ -224,7 +224,7 @@
             "href": "reference/architecture/ports"
           },
           {
-            "title": "FIPS 140-2 compliance",
+            "title": "FIPS 140-3 compliance",
             "path": "deploy/server/fips"
           },
           {

--- a/content/consul/v2.0.x/content/docs/deploy/index.mdx
+++ b/content/consul/v2.0.x/content/docs/deploy/index.mdx
@@ -4,8 +4,8 @@ page_title: Deploy Consul
 description: >-
   Learn about the editions of Consul you can deploy as Consul server agents, client agents, and dataplanes. You can find additional guidance for the deployment process in our tutorials.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2026-03-31T20:44:40.000Z
-last_modified: 2026-03-31T20:44:40.000Z
+created_at: 2026-03-31T13:43:36-07:00
+last_modified: 2026-09-08T05:22:37.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -23,7 +23,7 @@ You can configure agents to run a specific edition of Consul.
 | :------------------- | :---------------------------------------------------- |
 | Community edition    | Enabled by default.                                   |
 | Enterprise           | Configure `license` block in the agent configuration. |
-| [FIPS 140-2 compliant](/consul/docs/deploy/server/fips) | Specify an alternate source binary or image.          |
+| [FIPS 140-3 compliant](/consul/docs/deploy/server/fips) | Specify an alternate source binary or image.          |
 
 To find the package for a specific release, refer to [releases.hashicorp.com](https://releases.hashicorp.com). To learn more about the differences in Consul editions and their available features, refer to [Consul edition fundamentals](/consul/docs/fundamentals/editions).
 

--- a/content/consul/v2.0.x/content/docs/deploy/server/fips.mdx
+++ b/content/consul/v2.0.x/content/docs/deploy/server/fips.mdx
@@ -1,17 +1,17 @@
 ---
 layout: docs
-page_title: Deploy FIPS 140-2 compliant Consul servers
+page_title: Deploy FIPS 140-3 compliant Consul servers
 description: >-
-  A version of Consul compliant with FIPS 140-2 is available to Enterprise users. Learn about where to find FIPS-compliant versions of Consul, as well as usage restrictions and technical details.
+  A version of Consul compliant with FIPS 140-3 is available to Enterprise users. Learn about where to find FIPS-compliant versions of Consul, as well as usage restrictions and technical details.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2026-03-31T20:44:40.000Z
-last_modified: 2026-03-31T20:44:40.000Z
+created_at: 2026-03-31T13:43:36-07:00
+last_modified: 2026-09-08T05:22:38.000Z
 # END AUTO GENERATED METADATA
 ---
 
-# Deploy FIPS 140-2 compliant Consul servers
+# Deploy FIPS 140-3 compliant Consul servers
 
-Builds of Consul Enterprise marked with a `fips1402` feature name include built-in support for FIPS 140-2 compliance.
+Builds of Consul Enterprise marked with a `fips1403` feature name include built-in support for FIPS 140-3 compliance.
 
 To use this feature, you must have an [active or trial license for Consul
 Enterprise](/consul/docs/enterprise/license). To start a trial, contact
@@ -19,54 +19,85 @@ HashiCorp sales.
 
 <EnterpriseAlert product="consul" />
 
-## Using FIPS 140-2 Consul Enterprise
+<Note title="FIPS 140-3 validation in progress">
 
-FIPS 140-2 builds of Consul Enterprise behave in the same way as non-FIPS builds. There are no restrictions on Consul algorithms, and ensuring that Consul remains in a FIPS-compliant mode of operation is your responsibility. To maintain FIPS-compliant operation, you must [ensure that TLS is enabled](/consul/docs/secure/encryption/tls/enable/new/builtin) so that communication is encrypted. Consul products surface some helpful warnings where settings are insecure.
+FIPS 140-3 builds of Consul Enterprise link a cryptographic module that holds a FIPS 140-3 certificate, but independent validation of how Consul integrates that module is still in progress. Contact HashiCorp sales if your compliance program requires a completed validation report.
 
-Encryption is disabled in Consul Enterprise by default. As a result, Consul may transmit sensitive control plane information. You must ensure that gossip encryption and mTLS is enabled for all agents when running Consul with FIPS-compliant settings. In addition, be aware that TLSv1.3 does not work with FIPS 140-2, as HKDF is not a certified primitive.
+</Note>
+
+## Using FIPS 140-3 Consul Enterprise
+
+FIPS 140-3 builds of Consul Enterprise behave in the same way as non-FIPS builds. There are no restrictions on Consul algorithms, and ensuring that Consul remains in a FIPS-compliant mode of operation is your responsibility. To maintain FIPS-compliant operation, you must [ensure that TLS is enabled](/consul/docs/secure/encryption/tls/enable/new/builtin) so that communication is encrypted. Consul products surface some helpful warnings where settings are insecure.
+
+Encryption is disabled in Consul Enterprise by default. As a result, Consul may transmit sensitive control plane information. You must ensure that gossip encryption and mTLS is enabled for all agents when running Consul with FIPS-compliant settings.
 
 HashiCorp is not a NIST-certified testing laboratory and can only provide general guidance about using Consul Enterprise in a FIPS-compliant manner. We recommend consulting an approved auditor for further information.
 
-The FIPS 140-2 variant of Consul uses separate binaries that are available from the following sources:
+The FIPS 140-3 variant of Consul uses separate binaries that are available from the following sources:
 
-- The [HashiCorp Releases page](https://releases.hashicorp.com/consul), releases ending with the `+ent.fips1402` suffix.
+- The [HashiCorp Releases page](https://releases.hashicorp.com/consul), releases ending with the `+ent.fips1403` suffix.
 - The [Docker Hub `hashicorp/consul-enterprise-fips`](https://hub.docker.com/r/hashicorp/consul-enterprise-fips) container repository.
 - The [AWS ECR `hashicorp/consul-enterprise-fips`](https://gallery.ecr.aws/hashicorp/consul-enterprise-fips) container repository.
 - The [Red Hat Access `hashicorp/consul-enterprise-fips`](https://catalog.redhat.com/software/containers/hashicorp/consul-enterprise-fips/628d50e37ff70c66a88517ea) container repository.
 
-The aforementioned naming conventions, which append `.fips1402` to binary names and tags, and `-fips` to registry names, also apply to `consul-k8s`, `consul-k8s-control-plane`, `consul-dataplane`, and `consul-ecs`, which are packaged separately from Consul Enterprise.
+The aforementioned naming conventions, which append `.fips1403` to binary names and tags, and `-fips` to registry names, also apply to `consul-k8s`, `consul-k8s-control-plane`, `consul-dataplane`, and `consul-ecs`, which are packaged separately from Consul Enterprise.
+
+### Artifact names
+
+Releases that support FIPS 140-3 use different artifact names than releases that support FIPS 140-2. Update any automation that pins FIPS artifact names, package names, or version strings before you upgrade.
+
+| Artifact                                                             | FIPS 140-2                      | FIPS 140-3                      |
+| :------------------------------------------------------------------- | :------------------------------ | :------------------------------ |
+| Consul Enterprise version metadata                                    | `+ent.fips1402`                 | `+ent.fips1403`                 |
+| `consul-k8s`, `consul-dataplane`, and `consul-ecs` version metadata   | `+fips1402`                     | `+fips1403`                     |
+| Operating system packages                                             | `consul-F2_1.20.4-1_amd64.deb`  | `consul-F3_1.20.4-1_amd64.deb`  |
+| Envoy container images                                                | `hashicorp/envoy-fips:VERSION-fips1402` | `hashicorp/envoy-fips:VERSION-fips1403` |
 
 ### Usage restrictions
 
-When using Consul Enterprise with FIPS 140-2, be aware of the following operation restrictions.
+When using Consul Enterprise with FIPS 140-3, be aware of the following operation restrictions.
 
 #### Migration restrictions
 
-We do not support in-place migrations from non-FIPS builds of Consul to FIPS builds of Consul, regardless of version. A fresh cluster installation is required to support FIPS 140-2. You cannot upgrade directly to a FIPS-compliant build.
+We do not support in-place migrations from non-FIPS builds of Consul to FIPS builds of Consul, regardless of version. A fresh cluster installation is required to support FIPS 140-3. You cannot upgrade directly to a FIPS-compliant build.
+
+You can upgrade from a FIPS 140-2 build to a FIPS 140-3 build. Refer to [heterogeneous cluster deployments](#heterogeneous-cluster-deployments) for more information.
 
 #### TLS restrictions
 
-Consul Enterprise's FIPS modifications include restrictions to supported TLS cipher suites and key information. Only the following cipher suites are allowed:
+Consul Enterprise's FIPS modifications include restrictions to supported TLS cipher suites and key information. Only the following TLS v1.2 cipher suites are allowed:
 
 - `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`
 - `TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384`
 - `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256`
 - `TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384`
-- `TLS_RSA_WITH_AES_128_GCM_SHA256`
-- `TLS_RSA_WITH_AES_256_GCM_SHA384`
+- `TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256`
+- `TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256`
+
+Only the following TLS v1.3 cipher suites are allowed:
+
+- `TLS_AES_128_GCM_SHA256`
+- `TLS_AES_256_GCM_SHA384`
 
 In addition, only the following key types are allowed in TLS chains of trust:
 
-- RSA 2048, 3072, and 4096-bit
+- RSA 2048-bit and larger
 - ECDSA P-256, P-384, and P-521
+- Ed25519
 
-Finally, only TLSv1.2 is supported in FIPS mode. These settings are in line with recent NIST guidance and FIPS requirements.
+Both TLS v1.2 and TLS v1.3 are supported in FIPS mode. When a connection uses TLS v1.2, both peers must support the extended master secret extension described in [RFC 7627](https://datatracker.ietf.org/doc/html/rfc7627). Handshakes with peers that do not support the extension fail.
+
+<Warning title="Cipher suite change in FIPS 140-3">
+
+FIPS 140-3 builds do not allow the `TLS_RSA_WITH_AES_128_GCM_SHA256` and `TLS_RSA_WITH_AES_256_GCM_SHA384` cipher suites that FIPS 140-2 builds allow, because RSA key transport is not an approved key establishment method. If your TLS configuration pins either cipher suite, update the configuration before you upgrade.
+
+</Warning>
 
 #### Heterogeneous cluster deployments
 
-We do not support mixed deployment scenarios within the same Consul cluster. An example of an unsupported deployment scenario is one that mixes FIPS and non-FIPS Consul binaries. Nodes across the entire cluster must use a single binary or deployment type.
+We do not support deployment scenarios that mix FIPS and non-FIPS Consul binaries within the same cluster. Running a heterogeneous cluster is not permitted by FIPS, as components of the system are not compliant with FIPS. When an agent attempts to join a cluster whose FIPS status does not match its own, the join fails with a `Cannot join FIPS and non-FIPS Consul` error.
 
-Running a heterogeneous cluster is not permitted by FIPS, as components of the system are not compliant with FIPS. Attempts to join non-FIPS and FIPS nodes or servers may fail.
+Agents that support FIPS 140-2 and agents that support FIPS 140-3 can join the same cluster. Both levels use approved cryptographic primitives, so you can perform a rolling upgrade from `+ent.fips1402` to `+ent.fips1403` without restarting the entire cluster at once.
 
 ### Envoy
 
@@ -74,7 +105,7 @@ To enable users to deploy a FIPS compliant service mesh with Consul, HashiCorp p
 
 ## Deployment prerequisites
 
-Depending on your Consul runtime, there are additional requirements for using FIPS 140-2.
+Depending on your Consul runtime, there are additional requirements for using FIPS 140-3.
 
 ### VMs
 
@@ -86,55 +117,46 @@ When deploying the FIPS builds of Consul on Kubernetes using `consul-k8s` or Hel
 
 ## Technical details
 
-Consul's FIPS 140-2 Linux products use the BoringCrypto integration in the official Go 1.20+ toolchain, which include a FIPS-validated crypto module.
+Consul's FIPS 140-3 products use the Go Cryptographic Module, a cryptographic module included in the official Go toolchain. HashiCorp builds these products with `GOFIPS140=v1.0.0` so that the binary links the module version that holds [CMVP certificate #5247](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/5247). Linux and Windows builds use the same module.
 
-Consul's FIPS 140-2 products on Windows use the CNGCrypto integration in Microsoft's Go toolchain, which include a FIPS-validated crypto module.
+Because the module is written in Go, FIPS 140-3 binaries do not depend on cgo. Unlike FIPS 140-2 Linux binaries, they do not require a GNU C Library (glibc) Linux distribution.
 
-To ensure your build of Consul Enterprise includes FIPS support, confirm that a line with `FIPS: Enabled` appears when you run a `version` command. For example, the following message appears for Linux users:
-
-<CodeBlockConfig hideClipboard>
-
-```log
-FIPS: FIPS 140-2 Enabled, crypto module boringcrypto
-```
-
-</CodeBlockConfig>
-
-The following message appears for Windows users:
+To ensure your build of Consul Enterprise includes FIPS support, confirm that a line beginning with `FIPS:` appears when you run a `version` command. For example, the following message appears when the agent operates in FIPS mode:
 
 <CodeBlockConfig hideClipboard>
 
 ```log
-FIPS: FIPS 140-2 Enabled, crypto module cngcrypto
+FIPS: FIPS 140-3 Enabled, crypto module v1.0.0
 ```
 
 </CodeBlockConfig>
 
-FIPS 140-2 Linux binaries depend on cgo, which require that a GNU C Library (glibc) Linux distribution be used to run Consul. Refer to [instructions for Windows FIPS mode](https://github.com/microsoft/go/blob/microsoft/main/eng/doc/fips/README.md#windows-fips-mode-cng) for more information on running CNGCrypto-enabled Go binaries in FIPS mode.
+### FIPS mode at runtime
 
-The NIST Cryptographic Module Validation Program certifications and accompanying security policies for BoringCrypto and CNG are available through the following external links:
+FIPS builds of Consul set `fips140=on` as the default value of the `GODEBUG` environment variable, so the binary operates in FIPS mode without additional configuration.
 
-- [BoringCrypto](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4407)
-- [CNG](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4515)
+This default is not an enforcement. If you set `GODEBUG=fips140=off` in the agent's environment, the binary starts without FIPS mode enabled. The agent then reports that FIPS is not enabled, stops advertising FIPS status to other agents, and cannot join a FIPS cluster. Do not override the `fips140` setting in `GODEBUG` on agents that must operate in FIPS mode.
 
 ### Validating FIPS crypto modules
 
-To validate that a FIPS 140-2 Linux binary correctly includes BoringCrypto, run `go tool nm` on the binary to get a symbol dump.  On FIPS-enabled builds, many results appear, as in the following example.
+To validate that a binary links the certified cryptographic module, run `go version -m` on the binary and inspect its build settings.
 
 ```shell-session
-$ go tool nm consul | grep -i goboringcrypto
-4014d0 T _cgo_6880f0fbb71e_Cfunc__goboringcrypto_AES_cbc_encrypt
-4014f0 T _cgo_6880f0fbb71e_Cfunc__goboringcrypto_AES_ctr128_encrypt
-401520 T _cgo_6880f0fbb71e_Cfunc__goboringcrypto_AES_decrypt
-401540 T _cgo_6880f0fbb71e_Cfunc__goboringcrypto_AES_encrypt
-401560 T _cgo_6880f0fbb71e_Cfunc__goboringcrypto_AES_set_decrypt_key
+$ go version -m consul | grep -e GOFIPS140 -e DefaultGODEBUG -e tags
+	build	-tags=consulent,fips,fips140v1.0
+	build	DefaultGODEBUG=fips140=on
+	build	GOFIPS140=v1.0.0
 ```
 
-Similarly, on a FIPS Windows binary, run `go tool nm` on the binary to get a symbol dump, and then search for `go-crypto-winnative`.
-
-On both Linux and Windows non-FIPS builds, the search output yields no results.
+Non-FIPS builds do not report the `GOFIPS140` or `DefaultGODEBUG=fips140=on` build settings.
 
 ## Leidos validation
+
+<Note>
+
+This validation covers FIPS 140-2 builds of Consul. It does not apply to FIPS 140-3 builds.
+
+</Note>
 
 In 2024, Leidos certified the integration of FIPS 140-2 cryptographic module [BoringCrypto Cert. #4407](https://csrc.nist.gov/Projects/Cryptographic-Module-Validation-Program/Certificate/4407) for the following Consul releases:
 

--- a/content/consul/v2.0.x/content/docs/enterprise/index.mdx
+++ b/content/consul/v2.0.x/content/docs/enterprise/index.mdx
@@ -4,8 +4,8 @@ page_title: Consul Enterprise
 description: >-
   Consul Enterprise is a paid offering that extends Consul Community Edition to support large and complex deployments. Learn about scaling infrastructure, simplifying operations, and making networks more resilient with Enterprise. Evaluate Enterprise features with the feature availability and compatibility matrix.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-11-05T11:02:51-05:00
-last_modified: 2026-04-16T19:56:35.000Z
+created_at: 2026-03-31T13:43:36-07:00
+last_modified: 2026-09-08T05:22:39.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -57,11 +57,11 @@ The following features are available with an Enterprise license.
 
 ### Regulatory compliance
 
-- [FIPS 140-2 Compliance](/consul/docs/deploy/server/fips): Leverage FIPS builds of Consul Enterprise to ensure your Consul deployments are secured with BoringCrypto and CNGCrypto, and compliant with FIPS 140-2.
+- [FIPS 140-3 Compliance](/consul/docs/deploy/server/fips): Leverage FIPS builds of Consul Enterprise to ensure your Consul deployments are secured with the Go Cryptographic Module, and compliant with FIPS 140-3.
 
   <Note>
 
-  FIPS 140-2 builds of Consul Enterprise support all runtimes (VMs, Kubernetes) except for Lambda and ECS. In addition, HCP does not currently support FIPS builds of Consul Enterprise.
+  FIPS 140-3 builds of Consul Enterprise support all runtimes (VMs, Kubernetes) except for Lambda and ECS. In addition, HCP does not currently support FIPS builds of Consul Enterprise.
 
   </Note>
 
@@ -85,7 +85,7 @@ The following table summarizes the major differences between Consul CE and the C
 | Multiple runtime support            | &#10060;                               | &#9989;             | &#9989;            |
 | Multi-tenancy support               | &#10060;                               | &#9989;             | &#9989;            |
 | Additional resiliency & scalability | &#10060;                               | &#9989;             | &#9989;            |
-| FIPS 140-2 Compliance               | &#10060;                               | &#9989;             | &#9989;            |
+| FIPS 140-3 Compliance               | &#10060;                               | &#9989;             | &#9989;            |
 | Consul-Terraform-Sync (CTS) support | &#9989;                                | &#9989;             | &#9989;            |
 
 Some Consul features are not supported with a Standard Enterprise license because the feature is used only when the service mesh is deployed.
@@ -107,7 +107,7 @@ Enterprise licenses include support for the following features.
 | [Consul-Terraform-Sync Enterprise](/consul/docs/enterprise/cts)                                 | &#9989;                     | &#9989;                    |
 | [Enhanced Read Scalability](/consul/docs/manage/scale/read-replica)                             | &#9989;                     | &#9989;                    |
 | [Fault injection](/consul/docs/troubleshoot/fault-injection)                                    | &#10060;                    | &#9989;                    |
-| [FIPS 140-2 Compliance](/consul/docs/deploy/server/fips)                                        | &#9989;                     | &#9989;                    |
+| [FIPS 140-3 Compliance](/consul/docs/deploy/server/fips)                                        | &#9989;                     | &#9989;                    |
 | [JWT verification for API gateways](/consul/docs/north-south/api-gateway/secure-traffic/jwt/vm) | &#10060;                    | &#9989;                    |
 | [Locality-aware routing](/consul/docs/manage-traffic/route-local)                               | &#10060;                    | &#9989;                    |
 | [Long Term Support (LTS)](/consul/docs/upgrade/lts)                                             | &#9989;                     | &#9989;                    |
@@ -136,7 +136,7 @@ Consul Enterprise feature availability can change depending on your server and c
 | [Automated Server Upgrades](/consul/docs/upgrade/automated)                                                 |  &#9989;  |  &#9989;   |  &#9989;   |
 | [Enhanced Read Scalability](/consul/docs/manage/scale/read-replica)                                               |  &#9989;  |  &#9989;   |  &#9989;   |
 | [Fault injection](/consul/docs/troubleshoot/fault-injection)                                        |  &#9989;  |  &#9989;   |  &#9989;   |
-| [FIPS 140-2 Compliance](/consul/docs/deploy/server/fips)                                                         |  &#9989;  |  &#9989;   |  &#9989;   |
+| [FIPS 140-3 Compliance](/consul/docs/deploy/server/fips)                                                         |  &#9989;  |  &#9989;   |  &#9989;   |
 | [JWT verification for API gateways](/consul/docs/north-south/api-gateway/secure-traffic/jwt/vm) |  &#9989;  |  &#9989;   |  &#10060;  |
 | [Locality-aware routing](/consul/docs/manage-traffic/route-local)                        |  &#9989;  |  &#9989;   |  &#9989;   |
 | [Long Term Support (LTS)](/consul/docs/upgrade/lts)                                          |  &#9989;  |  &#9989;   |  &#10060;  |
@@ -161,7 +161,7 @@ Consul Enterprise feature availability can change depending on your server and c
 | [Automated Server Upgrades](/consul/docs/upgrade/automated)                                                 |  &#10060; |  &#10060;  |  &#10060;  |
 | [Enhanced Read Scalability](/consul/docs/manage/scale/read-replica)                                               |  &#10060; |  &#10060;  |  &#10060;  |
 | [Fault injection](/consul/docs/troubleshoot/fault-injection)                                        |  &#9989;  |  &#9989;   |  &#9989;   |
-| [FIPS 140-2 Compliance](/consul/docs/deploy/server/fips)                                                         |  &#9989;  |  &#9989;   |  &#9989;   |
+| [FIPS 140-3 Compliance](/consul/docs/deploy/server/fips)                                                         |  &#9989;  |  &#9989;   |  &#9989;   |
 | [JWT verification for API gateways](/consul/docs/north-south/api-gateway/secure-traffic/jwt/k8s) |  &#9989;  |  &#9989;   |  &#10060;  |
 | [Locality-aware routing](/consul/docs/manage-traffic/route-local)                        |  &#9989;  |  &#9989;   |  &#9989;   |
 | [Long Term Support (LTS)](/consul/docs/upgrade/lts)                                          |  &#9989;  |  &#9989;   |  &#10060;  |

--- a/content/consul/v2.0.x/content/docs/fundamentals/editions.mdx
+++ b/content/consul/v2.0.x/content/docs/fundamentals/editions.mdx
@@ -4,8 +4,8 @@ page_title: Consul editions and tool binaries
 description: >-
   Learn about the various Consul releases and their differences.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2025-11-05T11:02:51-05:00
-last_modified: 2026-04-16T19:56:35.000Z
+created_at: 2026-03-31T13:43:36-07:00
+last_modified: 2026-09-08T05:22:41.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -40,7 +40,7 @@ To run Consul Enterprise, you must configure Consul agents with an Enterprise li
 | Multiple runtime support            | &#10060;                               | &#9989;             | &#9989;            |
 | Multi-tenancy support               | &#10060;                               | &#9989;             | &#9989;            |
 | Additional resiliency & scalability | &#10060;                               | &#9989;             | &#9989;            |
-| FIPS 140-2 Compliance               | &#10060;                               | &#9989;             | &#9989;            |
+| FIPS 140-3 Compliance               | &#10060;                               | &#9989;             | &#9989;            |
 | Consul-Terraform-Sync (CTS) support | &#9989;                                | &#9989;             | &#9989;            |
 
 To learn more about Consul Enterprise and its features, refer to [Consul Enterprise](/consul/docs/enterprise).

--- a/content/consul/v2.0.x/content/docs/fundamentals/install/index.mdx
+++ b/content/consul/v2.0.x/content/docs/fundamentals/install/index.mdx
@@ -4,8 +4,8 @@ page_title: How to install Consul
 description: >-
   Install Consul to get started with service discovery and service mesh. Follow the installation instructions to download the precompiled binary, or use Go to compile from source.
 # START AUTO GENERATED METADATA, DO NOT EDIT
-created_at: 2026-03-31T20:45:06.000Z
-last_modified: 2026-03-31T20:45:06.000Z
+created_at: 2026-03-31T13:43:36-07:00
+last_modified: 2026-09-08T05:22:42.000Z
 # END AUTO GENERATED METADATA
 ---
 
@@ -27,7 +27,7 @@ We recommend using a precompiled binary. We also distribute a PGP signature with
 
 ## Precompiled binaries
 
-To install the precompiled binary, [download the appropriate package for your system](/consul/install). To find other versions, including Enterprise versions with support for FIPS 1420 compliance, refer to [the complete list of Consul releases on releases.hashicorp.com](https://releases.hashicorp.com/consul/). Consul is currently packaged as a `.zip` file.
+To install the precompiled binary, [download the appropriate package for your system](/consul/install). To find other versions, including Enterprise versions with support for FIPS 140-3 compliance, refer to [the complete list of Consul releases on releases.hashicorp.com](https://releases.hashicorp.com/consul/). Consul is currently packaged as a `.zip` file.
 
 After your download completes, unzip it into any directory. The `consul` binary or `.exe` file inside is the only file required to run Consul.
 

--- a/content/consul/v2.0.x/data/docs-nav-data.json
+++ b/content/consul/v2.0.x/data/docs-nav-data.json
@@ -224,7 +224,7 @@
             "href": "reference/architecture/ports"
           },
           {
-            "title": "FIPS 140-2 compliance",
+            "title": "FIPS 140-3 compliance",
             "path": "deploy/server/fips"
           },
           {


### PR DESCRIPTION
## Description

Consul Enterprise, `consul-k8s`, `consul-dataplane`, and `consul-ecs` migrated FIPS builds from FIPS 140-2 (BoringCrypto and CNG cgo toolchains) to FIPS 140-3 using the Go Cryptographic Module (`GOFIPS140=v1.0.0`). This PR updates the Consul documentation to match the shipped behavior.

Target versions are **v1.21.x, v1.22.x, and v2.0.x**, matching the `backport/ent/*` labels on hashicorp/consul-enterprise#12992. Versions v1.16.x through v1.20.x intentionally remain on FIPS 140-2.

### FIPS page

- Adds a callout stating that independent validation of Consul's integration of the module is still in progress, and directing readers with a compliance requirement to HashiCorp sales.
- **Corrects the TLS restrictions.** TLS 1.3 is now supported, so the previous statement that "TLSv1.3 does not work with FIPS 140-2, as HKDF is not a certified primitive" is removed. The allowed cipher suite lists are replaced, allowed key types become RSA 2048-bit and larger, ECDSA P-256/P-384/P-521, and Ed25519, and TLS 1.2 connections now require Extended Master Secret.
- Adds an artifact naming table covering `+ent.fips1403`, `+fips1403`, the `F2` to `F3` package suffix, and the Envoy image tag.
- Rewrites the heterogeneous cluster guidance: FIPS and non-FIPS agents cannot join the same cluster, while 140-2 and 140-3 agents can, which supports rolling upgrades.
- Adds a section explaining that `fips140=on` is a baked-in default rather than an enforcement, and that overriding `GODEBUG` removes the agent from a FIPS cluster.
- Replaces the BoringCrypto and CNG technical details, removes the cgo and glibc requirement because builds are now pure Go, and replaces the `go tool nm` symbol dump with `go version -m`.
- Scopes the Leidos validation section to FIPS 140-2 builds.

### Supporting pages

Updates `deploy/index.mdx`, `enterprise/index.mdx`, `fundamentals/editions.mdx`, `fundamentals/install/index.mdx`, and the navigation titles. Also corrects an existing `FIPS 1420` typo on the install page.

## Breaking change for readers

FIPS 140-3 builds no longer permit `TLS_RSA_WITH_AES_128_GCM_SHA256` or `TLS_RSA_WITH_AES_256_GCM_SHA384`, because RSA key transport is not an approved key establishment method. Operators who pin either suite must update their configuration before upgrading. This is called out in a `<Warning>` on the page.

## How the technical details were verified

Rather than relying on the code PR descriptions, the specifics were checked against primary sources:

- **TLS cipher suites, versions, and key types** come from `src/crypto/tls/defaults_fips140.go` in Go `go1.26.7`, which is the toolchain `consul-enterprise` builds with per its `.go-version` and `go.mod`. Because the code PRs removed `crypto/tls/fipsonly`, these restrictions are enforced by Go's runtime FIPS mode rather than by Consul code. Enforcement was traced to `common.go` (cipher suite, version, and certificate chain filtering), `handshake_client.go` (TLS 1.3 suite selection), and `handshake_server.go` (the Extended Master Secret requirement).
- **The `go version -m` output** in the validation section was produced by compiling a binary locally with `CGO_ENABLED=0 GOFIPS140=v1.0.0`, not transcribed from documentation.
- **CMVP certificate #5247** was confirmed as Active on the NIST registry, which also lists the TLS v1.3 KDF as an approved algorithm.

Note for future maintenance: these lists are tied to the Go toolchain version, not the Consul version, so they should be re-checked when Consul bumps Go.

## Links

Related code changes:

- hashicorp/consul-enterprise#12992
- hashicorp/consul-k8s#5492
- hashicorp/consul-dataplane#1196
- hashicorp/consul-ecs#368
- hashicorp/envoy-release#94

## Contributor checklists

Review urgency:

- [ ] ASAP: Bug fixes, broken content, imminent releases
- [ ] 3 days: Small changes, easy reviews
- [x] 1 week: Default expectation
- [ ] Best effort: No urgency

Pull request:

- [x] Verify that the PR is set to merge into the correct base branch
- [ ] Verify that all status checks passed
- [ ] Verify that the preview environment deployed successfully
- [ ] Add additional reviewers if they are not part of assigned groups

Content:

- [x] I added redirects for any moved or removed pages
- [x] I followed the [Education style guide](https://github.com/hashicorp/web-unified-docs/tree/main/docs/style-guide)
- [x] I looked at the local or Vercel build to make sure the content rendered correctly

## Reviewer checklist

- [x] This PR is set to merge into the correct base branch.
- [x] The content does not contain technical inaccuracies.
- [x] The content follows the Education content and style guides.
- [ ] I have verified and tested changes to instructions for end users.
