### PR TITLE
docs(tfe): replace support.hashicorp.com link in agents-on-tfe.mdx

### DIFF
--- a/content/terraform-enterprise/1.0.x/docs/enterprise/application-administration/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/1.0.x/docs/enterprise/application-administration/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ The following list describes the differences between connecting agents to Terraf
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the Terraform Enterprise application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in Terraform Enterprise.
 
 * **Network Access Requirements**: HCP Terraform agents on Terraform Enterprise must be able to

--- a/content/terraform-enterprise/1.1.x/docs/enterprise/application-administration/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/1.1.x/docs/enterprise/application-administration/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ The following list describes the differences between connecting agents to Terraf
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the Terraform Enterprise application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in Terraform Enterprise.
 
 * **Network Access Requirements**: HCP Terraform agents on Terraform Enterprise must be able to

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/application-administration/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/application-administration/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ The following list describes the differences between connecting agents to Terraf
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the Terraform Enterprise application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in Terraform Enterprise.
 
 * **Network Access Requirements**: HCP Terraform agents on Terraform Enterprise must be able to

--- a/content/terraform-enterprise/2.0.x/docs/enterprise/application-administration/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/2.0.x/docs/enterprise/application-administration/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ The following list describes the differences between connecting agents to Terraf
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the Terraform Enterprise application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in Terraform Enterprise.
 
 * **Network Access Requirements**: HCP Terraform agents on Terraform Enterprise must be able to

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/admin/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/admin/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ and later.
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the TFE application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in TFE.
 
 * **Network Access Requirements**: Terraform Cloud Agents on TFE must be able to

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/admin/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/admin/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ and later.
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the TFE application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in TFE.
 
 * **Network Access Requirements**: Terraform Cloud Agents on TFE must be able to

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/admin/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/admin/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ and later.
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the TFE application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in TFE.
 
 * **Network Access Requirements**: Terraform Cloud Agents on TFE must be able to

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/admin/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/admin/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ and later.
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the TFE application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in TFE.
 
 * **Network Access Requirements**: Terraform Cloud Agents on TFE must be able to

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/admin/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/admin/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ and later.
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the TFE application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in TFE.
 
 * **Network Access Requirements**: Terraform Cloud Agents on TFE must be able to

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/admin/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/admin/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ and later.
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the TFE application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in TFE.
 
 * **Network Access Requirements**: Terraform Cloud Agents on TFE must be able to

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/admin/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/admin/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ and later.
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the TFE application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in TFE.
 
 * **Network Access Requirements**: Terraform Cloud Agents on TFE must be able to

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/admin/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/admin/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ and later.
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the TFE application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in TFE.
 
 * **Network Access Requirements**: Terraform Cloud Agents on TFE must be able to

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/admin/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/admin/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ and later.
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the TFE application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in TFE.
 
 * **Network Access Requirements**: Terraform Cloud Agents on TFE must be able to

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/admin/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/admin/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ and later.
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the TFE application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in TFE.
 
 * **Network Access Requirements**: Terraform Cloud Agents on TFE must be able to

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/admin/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/admin/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ and later.
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the TFE application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in TFE.
 
 * **Network Access Requirements**: Terraform Cloud Agents on TFE must be able to

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/admin/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/admin/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ and later.
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the TFE application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in TFE.
 
 * **Network Access Requirements**: Terraform Cloud Agents on TFE must be able to

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/admin/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/admin/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ and later.
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the TFE application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in TFE.
 
 * **Network Access Requirements**: Terraform Cloud Agents on TFE must be able to

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/admin/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/admin/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ and later.
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the TFE application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in TFE.
 
 * **Network Access Requirements**: Terraform Cloud Agents on TFE must be able to

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/admin/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/admin/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ and later.
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the TFE application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in TFE.
 
 * **Network Access Requirements**: Terraform Cloud Agents on TFE must be able to

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/admin/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/admin/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ and later.
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the TFE application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in TFE.
 
 * **Network Access Requirements**: Terraform Cloud Agents on TFE must be able to

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/admin/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/admin/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ and later.
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the TFE application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in TFE.
 
 * **Network Access Requirements**: Terraform Cloud Agents on TFE must be able to

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/admin/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/admin/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ and later.
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the TFE application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in TFE.
 
 * **Network Access Requirements**: Terraform Cloud Agents on TFE must be able to

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/admin/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/admin/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ and later.
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the TFE application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in TFE.
 
 * **Network Access Requirements**: Terraform Cloud Agents on TFE must be able to

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/admin/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/admin/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ and later.
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the TFE application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in TFE.
 
 * **Network Access Requirements**: Terraform Cloud Agents on TFE must be able to

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/admin/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/admin/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ and later.
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the TFE application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in TFE.
 
 * **Network Access Requirements**: Terraform Cloud Agents on TFE must be able to

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/admin/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/admin/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ and later.
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the TFE application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in TFE.
 
 * **Network Access Requirements**: Terraform Cloud Agents on TFE must be able to

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/application-administration/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/application-administration/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ and later.
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the TFE application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in TFE.
 
 * **Network Access Requirements**: Terraform Cloud Agents on TFE must be able to

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/application-administration/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/application-administration/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ and later.
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the TFE application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in TFE.
 
 * **Network Access Requirements**: Terraform Cloud Agents on TFE must be able to

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/application-administration/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/application-administration/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ and later.
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the TFE application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in TFE.
 
 * **Network Access Requirements**: Terraform Cloud Agents on TFE must be able to

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/application-administration/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/application-administration/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ and later.
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the TFE application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in TFE.
 
 * **Network Access Requirements**: Terraform Cloud Agents on TFE must be able to

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/application-administration/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/application-administration/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ and later.
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the TFE application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in TFE.
 
 * **Network Access Requirements**: Terraform Cloud Agents on TFE must be able to

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/application-administration/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/application-administration/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ and later.
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the TFE application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in TFE.
 
 * **Network Access Requirements**: Terraform Cloud Agents on TFE must be able to

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/application-administration/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/application-administration/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ and later.
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the TFE application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in TFE.
 
 * **Network Access Requirements**: Terraform Cloud Agents on TFE must be able to

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/application-administration/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/application-administration/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ and later.
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the Terraform Enterprise application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in Terraform Enterprise.
 
 * **Network Access Requirements**: Terraform Cloud agents on Terraform Enterprise must be able to

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/application-administration/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/application-administration/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ and later.
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the Terraform Enterprise application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in Terraform Enterprise.
 
 * **Network Access Requirements**: Terraform Cloud agents on Terraform Enterprise must be able to

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/application-administration/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/application-administration/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ and later.
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the Terraform Enterprise application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in Terraform Enterprise.
 
 * **Network Access Requirements**: HCP Terraform agents on Terraform Enterprise must be able to

--- a/content/terraform-enterprise/v202405-1/docs/enterprise/application-administration/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202405-1/docs/enterprise/application-administration/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ and later.
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the Terraform Enterprise application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in Terraform Enterprise.
 
 * **Network Access Requirements**: HCP Terraform agents on Terraform Enterprise must be able to

--- a/content/terraform-enterprise/v202406-1/docs/enterprise/application-administration/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202406-1/docs/enterprise/application-administration/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ and later.
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the Terraform Enterprise application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in Terraform Enterprise.
 
 * **Network Access Requirements**: HCP Terraform agents on Terraform Enterprise must be able to

--- a/content/terraform-enterprise/v202407-1/docs/enterprise/application-administration/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202407-1/docs/enterprise/application-administration/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ and later.
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the Terraform Enterprise application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in Terraform Enterprise.
 
 * **Network Access Requirements**: HCP Terraform agents on Terraform Enterprise must be able to

--- a/content/terraform-enterprise/v202408-1/docs/enterprise/application-administration/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202408-1/docs/enterprise/application-administration/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ and later.
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the Terraform Enterprise application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in Terraform Enterprise.
 
 * **Network Access Requirements**: HCP Terraform agents on Terraform Enterprise must be able to

--- a/content/terraform-enterprise/v202409-1/docs/enterprise/application-administration/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202409-1/docs/enterprise/application-administration/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ and later.
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the Terraform Enterprise application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in Terraform Enterprise.
 
 * **Network Access Requirements**: HCP Terraform agents on Terraform Enterprise must be able to

--- a/content/terraform-enterprise/v202409-2/docs/enterprise/application-administration/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202409-2/docs/enterprise/application-administration/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ and later.
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the Terraform Enterprise application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in Terraform Enterprise.
 
 * **Network Access Requirements**: HCP Terraform agents on Terraform Enterprise must be able to

--- a/content/terraform-enterprise/v202409-3/docs/enterprise/application-administration/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202409-3/docs/enterprise/application-administration/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ and later.
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the Terraform Enterprise application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in Terraform Enterprise.
 
 * **Network Access Requirements**: HCP Terraform agents on Terraform Enterprise must be able to

--- a/content/terraform-enterprise/v202410-1/docs/enterprise/application-administration/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202410-1/docs/enterprise/application-administration/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ and later.
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the Terraform Enterprise application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in Terraform Enterprise.
 
 * **Network Access Requirements**: HCP Terraform agents on Terraform Enterprise must be able to

--- a/content/terraform-enterprise/v202411-1/docs/enterprise/application-administration/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202411-1/docs/enterprise/application-administration/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ The following list describes the differences between connecting agents to Terraf
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the Terraform Enterprise application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in Terraform Enterprise.
 
 * **Network Access Requirements**: HCP Terraform agents on Terraform Enterprise must be able to

--- a/content/terraform-enterprise/v202411-2/docs/enterprise/application-administration/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202411-2/docs/enterprise/application-administration/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ The following list describes the differences between connecting agents to Terraf
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the Terraform Enterprise application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in Terraform Enterprise.
 
 * **Network Access Requirements**: HCP Terraform agents on Terraform Enterprise must be able to

--- a/content/terraform-enterprise/v202501-1/docs/enterprise/application-administration/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202501-1/docs/enterprise/application-administration/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ The following list describes the differences between connecting agents to Terraf
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the Terraform Enterprise application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in Terraform Enterprise.
 
 * **Network Access Requirements**: HCP Terraform agents on Terraform Enterprise must be able to

--- a/content/terraform-enterprise/v202502-1/docs/enterprise/application-administration/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202502-1/docs/enterprise/application-administration/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ The following list describes the differences between connecting agents to Terraf
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the Terraform Enterprise application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in Terraform Enterprise.
 
 * **Network Access Requirements**: HCP Terraform agents on Terraform Enterprise must be able to

--- a/content/terraform-enterprise/v202502-2/docs/enterprise/application-administration/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202502-2/docs/enterprise/application-administration/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ The following list describes the differences between connecting agents to Terraf
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the Terraform Enterprise application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in Terraform Enterprise.
 
 * **Network Access Requirements**: HCP Terraform agents on Terraform Enterprise must be able to

--- a/content/terraform-enterprise/v202503-1/docs/enterprise/application-administration/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202503-1/docs/enterprise/application-administration/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ The following list describes the differences between connecting agents to Terraf
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the Terraform Enterprise application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in Terraform Enterprise.
 
 * **Network Access Requirements**: HCP Terraform agents on Terraform Enterprise must be able to

--- a/content/terraform-enterprise/v202504-1/docs/enterprise/application-administration/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202504-1/docs/enterprise/application-administration/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ The following list describes the differences between connecting agents to Terraf
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the Terraform Enterprise application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in Terraform Enterprise.
 
 * **Network Access Requirements**: HCP Terraform agents on Terraform Enterprise must be able to

--- a/content/terraform-enterprise/v202505-1/docs/enterprise/application-administration/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202505-1/docs/enterprise/application-administration/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ The following list describes the differences between connecting agents to Terraf
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the Terraform Enterprise application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in Terraform Enterprise.
 
 * **Network Access Requirements**: HCP Terraform agents on Terraform Enterprise must be able to

--- a/content/terraform-enterprise/v202506-1/docs/enterprise/application-administration/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202506-1/docs/enterprise/application-administration/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ The following list describes the differences between connecting agents to Terraf
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the Terraform Enterprise application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in Terraform Enterprise.
 
 * **Network Access Requirements**: HCP Terraform agents on Terraform Enterprise must be able to

--- a/content/terraform-enterprise/v202507-1/docs/enterprise/application-administration/agents-on-tfe.mdx
+++ b/content/terraform-enterprise/v202507-1/docs/enterprise/application-administration/agents-on-tfe.mdx
@@ -43,7 +43,7 @@ The following list describes the differences between connecting agents to Terraf
   [custom Terraform bundles](https://github.com/hashicorp/terraform/tree/main/tools/terraform-bundle).
   Custom bundles are created and defined within the Terraform Enterprise application; Agents will
   download the custom bundle based on the Terraform version information. See
-  [using a custom Terraform bundle](https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise)
+  [using a custom Terraform bundle](https://www.ibm.com/support/pages/node/7265413)
   for more detail on custom bundles in Terraform Enterprise.
 
 * **Network Access Requirements**: HCP Terraform agents on Terraform Enterprise must be able to


### PR DESCRIPTION
## Summary

Replaces legacy HashiCorp support URL with IBM equivalent across all affected version directories.

| | |
|---|---|
| **Product** | Terraform Enterprise |
| **Document path** | `docs/enterprise/admin/agents-on-tfe.mdx` |
| **Old URL** | `https://support.hashicorp.com/hc/en-us/articles/360016992613-Using-custom-and-community-providers-in-Terraform-Cloud-and-Enterprise` |
| **New URL** | `https://www.ibm.com/support/pages/node/7265413` |
| **Versions updated** | 54 |

Part of the IBM DevDoc KB Remapping effort.