### PR TITLE
docs(tfe): replace support.hashicorp.com link in automated-license-utilization-reporting.mdx

### DIFF
--- a/content/terraform-enterprise/v202206-1/docs/enterprise/admin/infrastructure/logging.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/admin/infrastructure/logging.mdx
@@ -117,7 +117,7 @@ Doing this creates a loop that continuously emits logs!
 
 Once log forwarding is enabled and configured, you need to restart Terraform
 Enterprise for the changes to take effect. Please refer to the
-[HashiCorp Help Center](https://support.hashicorp.com/hc/en-us/articles/360047602093-Restarting-Terraform-Enterprise)
+[HashiCorp Help Center](https://www.ibm.com/support/pages/node/7265064)
 for details on how to restart Terraform Enterprise.
 
 ## Supported External Destinations

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/admin/infrastructure/logging.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/admin/infrastructure/logging.mdx
@@ -117,7 +117,7 @@ Doing this creates a loop that continuously emits logs!
 
 Once log forwarding is enabled and configured, you need to restart Terraform
 Enterprise for the changes to take effect. Please refer to the
-[HashiCorp Help Center](https://support.hashicorp.com/hc/en-us/articles/360047602093-Restarting-Terraform-Enterprise)
+[HashiCorp Help Center](https://www.ibm.com/support/pages/node/7265064)
 for details on how to restart Terraform Enterprise.
 
 ## Supported External Destinations

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/admin/infrastructure/logging.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/admin/infrastructure/logging.mdx
@@ -117,7 +117,7 @@ Doing this creates a loop that continuously emits logs!
 
 Once log forwarding is enabled and configured, you need to restart Terraform
 Enterprise for the changes to take effect. Please refer to the
-[HashiCorp Help Center](https://support.hashicorp.com/hc/en-us/articles/360047602093-Restarting-Terraform-Enterprise)
+[HashiCorp Help Center](https://www.ibm.com/support/pages/node/7265064)
 for details on how to restart Terraform Enterprise.
 
 ## Supported External Destinations

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/admin/infrastructure/logging.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/admin/infrastructure/logging.mdx
@@ -117,7 +117,7 @@ Doing this creates a loop that continuously emits logs!
 
 Once log forwarding is enabled and configured, you need to restart Terraform
 Enterprise for the changes to take effect. Please refer to the
-[HashiCorp Help Center](https://support.hashicorp.com/hc/en-us/articles/360047602093-Restarting-Terraform-Enterprise)
+[HashiCorp Help Center](https://www.ibm.com/support/pages/node/7265064)
 for details on how to restart Terraform Enterprise.
 
 ## Supported External Destinations

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/admin/infrastructure/logging.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/admin/infrastructure/logging.mdx
@@ -117,7 +117,7 @@ Doing this creates a loop that continuously emits logs!
 
 Once log forwarding is enabled and configured, you need to restart Terraform
 Enterprise for the changes to take effect. Please refer to the
-[HashiCorp Help Center](https://support.hashicorp.com/hc/en-us/articles/360047602093-Restarting-Terraform-Enterprise)
+[HashiCorp Help Center](https://www.ibm.com/support/pages/node/7265064)
 for details on how to restart Terraform Enterprise.
 
 ## Supported External Destinations

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/admin/infrastructure/logging.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/admin/infrastructure/logging.mdx
@@ -117,7 +117,7 @@ Doing this creates a loop that continuously emits logs!
 
 Once log forwarding is enabled and configured, you need to restart Terraform
 Enterprise for the changes to take effect. Please refer to the
-[HashiCorp Help Center](https://support.hashicorp.com/hc/en-us/articles/360047602093-Restarting-Terraform-Enterprise)
+[HashiCorp Help Center](https://www.ibm.com/support/pages/node/7265064)
 for details on how to restart Terraform Enterprise.
 
 ## Supported External Destinations

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/admin/infrastructure/logging.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/admin/infrastructure/logging.mdx
@@ -117,7 +117,7 @@ Doing this creates a loop that continuously emits logs!
 
 Once log forwarding is enabled and configured, you need to restart Terraform
 Enterprise for the changes to take effect. Please refer to the
-[HashiCorp Help Center](https://support.hashicorp.com/hc/en-us/articles/360047602093-Restarting-Terraform-Enterprise)
+[HashiCorp Help Center](https://www.ibm.com/support/pages/node/7265064)
 for details on how to restart Terraform Enterprise.
 
 ## Supported External Destinations

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/admin/infrastructure/logging.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/admin/infrastructure/logging.mdx
@@ -117,7 +117,7 @@ Doing this creates a loop that continuously emits logs!
 
 Once log forwarding is enabled and configured, you need to restart Terraform
 Enterprise for the changes to take effect. Please refer to the
-[HashiCorp Help Center](https://support.hashicorp.com/hc/en-us/articles/360047602093-Restarting-Terraform-Enterprise)
+[HashiCorp Help Center](https://www.ibm.com/support/pages/node/7265064)
 for details on how to restart Terraform Enterprise.
 
 ## Supported External Destinations

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/admin/infrastructure/logging.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/admin/infrastructure/logging.mdx
@@ -117,7 +117,7 @@ Doing this creates a loop that continuously emits logs!
 
 Once log forwarding is enabled and configured, you need to restart Terraform
 Enterprise for the changes to take effect. Please refer to the
-[HashiCorp Help Center](https://support.hashicorp.com/hc/en-us/articles/360047602093-Restarting-Terraform-Enterprise)
+[HashiCorp Help Center](https://www.ibm.com/support/pages/node/7265064)
 for details on how to restart Terraform Enterprise.
 
 ## Supported External Destinations

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/admin/infrastructure/logging.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/admin/infrastructure/logging.mdx
@@ -117,7 +117,7 @@ Doing this creates a loop that continuously emits logs!
 
 Once log forwarding is enabled and configured, you need to restart Terraform
 Enterprise for the changes to take effect. Please refer to the
-[HashiCorp Help Center](https://support.hashicorp.com/hc/en-us/articles/360047602093-Restarting-Terraform-Enterprise)
+[HashiCorp Help Center](https://www.ibm.com/support/pages/node/7265064)
 for details on how to restart Terraform Enterprise.
 
 ## Supported External Destinations

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/admin/infrastructure/logging.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/admin/infrastructure/logging.mdx
@@ -117,7 +117,7 @@ Doing this creates a loop that continuously emits logs!
 
 Once log forwarding is enabled and configured, you need to restart Terraform
 Enterprise for the changes to take effect. Please refer to the
-[HashiCorp Help Center](https://support.hashicorp.com/hc/en-us/articles/360047602093-Restarting-Terraform-Enterprise)
+[HashiCorp Help Center](https://www.ibm.com/support/pages/node/7265064)
 for details on how to restart Terraform Enterprise.
 
 ## Supported External Destinations

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/admin/infrastructure/logging.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/admin/infrastructure/logging.mdx
@@ -117,7 +117,7 @@ Doing this creates a loop that continuously emits logs!
 
 Once log forwarding is enabled and configured, you need to restart Terraform
 Enterprise for the changes to take effect. Please refer to the
-[HashiCorp Help Center](https://support.hashicorp.com/hc/en-us/articles/360047602093-Restarting-Terraform-Enterprise)
+[HashiCorp Help Center](https://www.ibm.com/support/pages/node/7265064)
 for details on how to restart Terraform Enterprise.
 
 ## Supported External Destinations

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/admin/infrastructure/logging.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/admin/infrastructure/logging.mdx
@@ -117,7 +117,7 @@ Doing this creates a loop that continuously emits logs!
 
 Once log forwarding is enabled and configured, you need to restart Terraform
 Enterprise for the changes to take effect. Please refer to the
-[HashiCorp Help Center](https://support.hashicorp.com/hc/en-us/articles/360047602093-Restarting-Terraform-Enterprise)
+[HashiCorp Help Center](https://www.ibm.com/support/pages/node/7265064)
 for details on how to restart Terraform Enterprise.
 
 ## Supported External Destinations

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/admin/infrastructure/logging.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/admin/infrastructure/logging.mdx
@@ -117,7 +117,7 @@ Doing this creates a loop that continuously emits logs!
 
 Once log forwarding is enabled and configured, you need to restart Terraform
 Enterprise for the changes to take effect. Please refer to the
-[HashiCorp Help Center](https://support.hashicorp.com/hc/en-us/articles/360047602093-Restarting-Terraform-Enterprise)
+[HashiCorp Help Center](https://www.ibm.com/support/pages/node/7265064)
 for details on how to restart Terraform Enterprise.
 
 ## Supported External Destinations

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/admin/infrastructure/logging.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/admin/infrastructure/logging.mdx
@@ -117,7 +117,7 @@ Doing this creates a loop that continuously emits logs!
 
 Once log forwarding is enabled and configured, you need to restart Terraform
 Enterprise for the changes to take effect. Please refer to the
-[HashiCorp Help Center](https://support.hashicorp.com/hc/en-us/articles/360047602093-Restarting-Terraform-Enterprise)
+[HashiCorp Help Center](https://www.ibm.com/support/pages/node/7265064)
 for details on how to restart Terraform Enterprise.
 
 ## Supported External Destinations

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/admin/infrastructure/logging.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/admin/infrastructure/logging.mdx
@@ -119,7 +119,7 @@ Doing this creates a loop that continuously emits logs!
 
 Once log forwarding is enabled and configured, you need to restart Terraform
 Enterprise for the changes to take effect. Please refer to the
-[HashiCorp Help Center](https://support.hashicorp.com/hc/en-us/articles/360047602093-Restarting-Terraform-Enterprise)
+[HashiCorp Help Center](https://www.ibm.com/support/pages/node/7265064)
 for details on how to restart Terraform Enterprise.
 
 ## Supported External Destinations

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/admin/infrastructure/logging.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/admin/infrastructure/logging.mdx
@@ -119,7 +119,7 @@ Doing this creates a loop that continuously emits logs!
 
 Once log forwarding is enabled and configured, you need to restart Terraform
 Enterprise for the changes to take effect. Please refer to the
-[HashiCorp Help Center](https://support.hashicorp.com/hc/en-us/articles/360047602093-Restarting-Terraform-Enterprise)
+[HashiCorp Help Center](https://www.ibm.com/support/pages/node/7265064)
 for details on how to restart Terraform Enterprise.
 
 ## Supported External Destinations

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/admin/application/automated-license-utilization-reporting.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/admin/application/automated-license-utilization-reporting.mdx
@@ -77,7 +77,7 @@ Add the following JSON to the Replicated Application Settings Config (`settings.
 
 If you are on a standalone installation, you can also configure this setting in the [Replicated Admin Console UI](/terraform/enterprise/admin/application/admin-access). 
 
-Now restart your system by following [these Help Center instructions](https://support.hashicorp.com/hc/en-us/articles/360047602093-Restarting-Terraform-Enterprise).
+Now restart your system by following [these Help Center instructions](https://www.ibm.com/support/pages/node/7265064).
 
 Check your product logs 24 hours after opting out to make sure that the system isn’t trying to send reports.
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/admin/infrastructure/logging.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/admin/infrastructure/logging.mdx
@@ -121,7 +121,7 @@ Doing this creates a loop that continuously emits logs!
 
 Once log forwarding is enabled and configured, you need to restart Terraform
 Enterprise for the changes to take effect. Please refer to the
-[HashiCorp Help Center](https://support.hashicorp.com/hc/en-us/articles/360047602093-Restarting-Terraform-Enterprise)
+[HashiCorp Help Center](https://www.ibm.com/support/pages/node/7265064)
 for details on how to restart Terraform Enterprise.
 
 ## Supported External Destinations

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/admin/application/automated-license-utilization-reporting.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/admin/application/automated-license-utilization-reporting.mdx
@@ -77,7 +77,7 @@ Add the following JSON to the Replicated Application Settings Config (`settings.
 
 If you are on a standalone installation, you can also configure this setting in the [Replicated Admin Console UI](/terraform/enterprise/admin/application/admin-access). 
 
-Now restart your system by following [these Help Center instructions](https://support.hashicorp.com/hc/en-us/articles/360047602093-Restarting-Terraform-Enterprise).
+Now restart your system by following [these Help Center instructions](https://www.ibm.com/support/pages/node/7265064).
 
 Check your product logs 24 hours after opting out to make sure that the system isn’t trying to send reports.
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/admin/infrastructure/logging.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/admin/infrastructure/logging.mdx
@@ -121,7 +121,7 @@ Doing this creates a loop that continuously emits logs!
 
 Once log forwarding is enabled and configured, you need to restart Terraform
 Enterprise for the changes to take effect. Please refer to the
-[HashiCorp Help Center](https://support.hashicorp.com/hc/en-us/articles/360047602093-Restarting-Terraform-Enterprise)
+[HashiCorp Help Center](https://www.ibm.com/support/pages/node/7265064)
 for details on how to restart Terraform Enterprise.
 
 ## Supported External Destinations

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/admin/application/automated-license-utilization-reporting.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/admin/application/automated-license-utilization-reporting.mdx
@@ -77,7 +77,7 @@ Add the following JSON to the Replicated Application Settings Config (`settings.
 
 If you are on a standalone installation, you can also configure this setting in the [Replicated Admin Console UI](/terraform/enterprise/admin/application/admin-access). 
 
-Now restart your system by following [these Help Center instructions](https://support.hashicorp.com/hc/en-us/articles/360047602093-Restarting-Terraform-Enterprise).
+Now restart your system by following [these Help Center instructions](https://www.ibm.com/support/pages/node/7265064).
 
 Check your product logs 24 hours after opting out to make sure that the system isn’t trying to send reports.
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/admin/infrastructure/logging.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/admin/infrastructure/logging.mdx
@@ -121,7 +121,7 @@ Doing this creates a loop that continuously emits logs!
 
 Once log forwarding is enabled and configured, you need to restart Terraform
 Enterprise for the changes to take effect. Please refer to the
-[HashiCorp Help Center](https://support.hashicorp.com/hc/en-us/articles/360047602093-Restarting-Terraform-Enterprise)
+[HashiCorp Help Center](https://www.ibm.com/support/pages/node/7265064)
 for details on how to restart Terraform Enterprise.
 
 ## Supported External Destinations

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/admin/application/automated-license-utilization-reporting.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/admin/application/automated-license-utilization-reporting.mdx
@@ -77,7 +77,7 @@ Add the following JSON to the Replicated Application Settings Config (`settings.
 
 If you are on a standalone installation, you can also configure this setting in the [Replicated Admin Console UI](/terraform/enterprise/admin/application/admin-access). 
 
-Now restart your system by following [these Help Center instructions](https://support.hashicorp.com/hc/en-us/articles/360047602093-Restarting-Terraform-Enterprise).
+Now restart your system by following [these Help Center instructions](https://www.ibm.com/support/pages/node/7265064).
 
 Check your product logs 24 hours after opting out to make sure that the system isn’t trying to send reports.
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/admin/infrastructure/logging.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/admin/infrastructure/logging.mdx
@@ -121,7 +121,7 @@ Doing this creates a loop that continuously emits logs!
 
 Once log forwarding is enabled and configured, you need to restart Terraform
 Enterprise for the changes to take effect. Please refer to the
-[HashiCorp Help Center](https://support.hashicorp.com/hc/en-us/articles/360047602093-Restarting-Terraform-Enterprise)
+[HashiCorp Help Center](https://www.ibm.com/support/pages/node/7265064)
 for details on how to restart Terraform Enterprise.
 
 ## Supported External Destinations

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/admin/application/automated-license-utilization-reporting.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/admin/application/automated-license-utilization-reporting.mdx
@@ -77,7 +77,7 @@ Add the following JSON to the Replicated Application Settings Config (`settings.
 
 If you are on a standalone installation, you can also configure this setting in the [Replicated Admin Console UI](/terraform/enterprise/admin/application/admin-access). 
 
-Now restart your system by following [these Help Center instructions](https://support.hashicorp.com/hc/en-us/articles/360047602093-Restarting-Terraform-Enterprise).
+Now restart your system by following [these Help Center instructions](https://www.ibm.com/support/pages/node/7265064).
 
 Check your product logs roughly 24 hours after opting out to make sure that the system isn’t trying to send reports.
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/admin/infrastructure/logging.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/admin/infrastructure/logging.mdx
@@ -121,7 +121,7 @@ Doing this creates a loop that continuously emits logs!
 
 Once log forwarding is enabled and configured, you need to restart Terraform
 Enterprise for the changes to take effect. Please refer to the
-[HashiCorp Help Center](https://support.hashicorp.com/hc/en-us/articles/360047602093-Restarting-Terraform-Enterprise)
+[HashiCorp Help Center](https://www.ibm.com/support/pages/node/7265064)
 for details on how to restart Terraform Enterprise.
 
 ## Supported External Destinations


### PR DESCRIPTION
## Summary

Replaces legacy HashiCorp support URL with IBM equivalent across all affected version directories.

| | |
|---|---|
| **Product** | Terraform Enterprise |
| **Document path** | `docs/enterprise/admin/application/automated-license-utilization-reporting.mdx` |
| **Old URL** | `https://support.hashicorp.com/hc/en-us/articles/360047602093-Restarting-Terraform-Enterprise` |
| **New URL** | `https://www.ibm.com/support/pages/node/7265064` |
| **Versions updated** | 27 |

Part of the IBM DevDoc KB Remapping effort.