### PR TITLE
Is-within added to Terraform API Docs

### DIFF
--- a/content/terraform-docs-common/docs/cloud-docs/api-docs/explorer.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/api-docs/explorer.mdx
@@ -242,7 +242,8 @@ filter%5B0%5D%5Bname%5D%5Bcontains%5D%5B0%5D=aws&filter%5B0%5D%5Bversion%5D%5Bis
 | `gteq`             | `number`                      | Filters data to rows where the field value is greater than or equal to the filter value. |
 | `lteq`             | `number`                      | Filters data to rows where the field value is less than or equal to the filter value. |
 | `is_before`        | `datetime`                    | Filters data to rows where the field value is earlier than the filter value. ISO 8601 formatted timestamps are required for filter values. If no time zone offset is provided, the filter value is interpreted as UTC. |
-| `is_after`         | `datetime`                    | Filters data to rows where the field value is earlier than the filter value. ISO 8601 formatted timestamps are required for filter values. If no time zone offset is provided, the filter value is interpreted as UTC. |
+| `is_after`         | `datetime`                    | Filters data to rows where the field value is later than the filter value. ISO 8601 formatted timestamps are required for filter values. If no time zone offset is provided, the filter value is interpreted as UTC. |
+| `is_within`        | `datetime`                    | Filters data to rows where the field value is between the two filter values. ISO 8601 formatted timestamps are required for filter values. If no time zone offset is provided, the filter value is interpreted as UTC. |
 
 ### Pagination
 


### PR DESCRIPTION
### What
Added is_within to the page on explorer api. is_after had a typo that was fixed to reflect its functionality. 

### Links

- [Atlas PR](https://github.com/hashicorp/atlas/pull/30966/changes#diff-f24074e562c98565f9854b4f6b6222583c9b1d183440219521076994f471905c)
- [Jira ticket](https://hashicorp.atlassian.net/browse/TF-10840?atlOrigin=eyJpIjoiMzU5NTQ0NmFlMGQ3NDc1MWEzM2RhZjBkNTgzYjBkOGUiLCJwIjoiaiJ9)


### Why
The docs now correctly reflect the options for explorer. 

### Screenshots

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] (N/A) You added redirects to `content/terraform-docs-common/redirects.jsonc` for moved, renamed, or deleted pages **across all affected versions**. Refer to [Redirects](https://github.com/hashicorp/web-unified-docs/blob/main/docs/content-guide/redirects.md#example-redirects) for examples and guidance. 
- [x] (N/A) Links to related content where appropriate (e.g., CLI, language, API endpoints, permissions, etc.).
- [x] (N/A) Pages with related content are updated and link to this content when appropriate.
- [x] (N/A) Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] (N/A) New pages have metadata (page name and description) at the top.
- [x] (N/A) New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] (N/A) New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] (N/A) UI elements (button names, page names, etc.) are bolded.
- [x] (N/A) The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
