### PR TITLE
Terraform Docs: fix curl .netrc documentation links

### DIFF
--- a/content/terraform/v1.1.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.1.x/docs/language/modules/sources.mdx
@@ -340,7 +340,7 @@ using one of the forms documented elsewhere on this page.
 
 If an HTTP/HTTPS URL requires authentication credentials, use a `.netrc`
 file in your home directory to configure these. For information on this format,
-see [the documentation for using it in `curl`](https://everything.curl.dev/usingcurl/netrc).
+see [the documentation for using it in `curl`](https://everything.curl.dev/usingcurl/netrc.html).
 
 ### Fetching archives over HTTP
 

--- a/content/terraform/v1.10.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.10.x/docs/language/modules/sources.mdx
@@ -367,7 +367,7 @@ using one of the forms documented elsewhere on this page.
 If an HTTP/HTTPS URL requires authentication credentials, use a `.netrc`
 file to configure the credentials. By default, Terraform searches for the `.netrc` file 
 in your HOME directory. However, you can override the default filesystem location by setting the `NETRC` environment variable. For information on the `.netrc` format,
-refer to [the documentation for using it in `curl`](https://everything.curl.dev/usingcurl/netrc).
+refer to [the documentation for using it in `curl`](https://everything.curl.dev/usingcurl/netrc.html).
 
 ### Fetching archives over HTTP
 

--- a/content/terraform/v1.11.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.11.x/docs/language/modules/sources.mdx
@@ -367,7 +367,7 @@ using one of the forms documented elsewhere on this page.
 If an HTTP/HTTPS URL requires authentication credentials, use a `.netrc`
 file to configure the credentials. By default, Terraform searches for the `.netrc` file 
 in your HOME directory. However, you can override the default filesystem location by setting the `NETRC` environment variable. For information on the `.netrc` format,
-refer to [the documentation for using it in `curl`](https://everything.curl.dev/usingcurl/netrc).
+refer to [the documentation for using it in `curl`](https://everything.curl.dev/usingcurl/netrc.html).
 
 ### Fetching archives over HTTP
 

--- a/content/terraform/v1.11.x/docs/language/providers/index.mdx
+++ b/content/terraform/v1.11.x/docs/language/providers/index.mdx
@@ -116,7 +116,7 @@ file to provide those credentials.
 By default, Terraform searches for the `.netrc` file in your `HOME` directory.
 However, you can override the default filesystem location by setting the `NETRC`
 environment variable. For information on the format of`.netrc`, refer to the
-[`curl` documentation](https://everything.curl.dev/usingcurl/netrc).
+[`curl` documentation](https://everything.curl.dev/usingcurl/netrc.html).
 
 ## How to Find Providers
 

--- a/content/terraform/v1.12.x/docs/language/block/module.mdx
+++ b/content/terraform/v1.12.x/docs/language/block/module.mdx
@@ -300,7 +300,7 @@ When Terraform receives a response with a successful `200` code, it checks the f
 Terraform interprets the result as the source address so that it can install the module.
 
 By default, Terraform searches your `HOME` directory for a `.netrc` file when the listening service requests credentials for authentication. You can set the `NETRC` environment variable to override the default filesystem location. For information on the `.netrc` format,
-refer to [the documentation for using it in `curl`](https://everything.curl.dev/usingcurl/netrc).
+refer to [the documentation for using it in `curl`](https://everything.curl.dev/usingcurl/netrc.html).
 
 If an HTTPS URL has a common file extension associated with an archive file format, Terraform bypasses the `terraform-get=1` redirection and uses the contents of the referenced archive as the module source code.
 

--- a/content/terraform/v1.12.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.12.x/docs/language/modules/sources.mdx
@@ -367,7 +367,7 @@ using one of the forms documented elsewhere on this page.
 If an HTTP/HTTPS URL requires authentication credentials, use a `.netrc`
 file to configure the credentials. By default, Terraform searches for the `.netrc` file 
 in your HOME directory. However, you can override the default filesystem location by setting the `NETRC` environment variable. For information on the `.netrc` format,
-refer to [the documentation for using it in `curl`](https://everything.curl.dev/usingcurl/netrc).
+refer to [the documentation for using it in `curl`](https://everything.curl.dev/usingcurl/netrc.html).
 
 ### Fetching archives over HTTP
 

--- a/content/terraform/v1.12.x/docs/language/providers/index.mdx
+++ b/content/terraform/v1.12.x/docs/language/providers/index.mdx
@@ -116,7 +116,7 @@ file to provide those credentials.
 By default, Terraform searches for the `.netrc` file in your `HOME` directory.
 However, you can override the default filesystem location by setting the `NETRC`
 environment variable. For information on the format of`.netrc`, refer to the
-[`curl` documentation](https://everything.curl.dev/usingcurl/netrc).
+[`curl` documentation](https://everything.curl.dev/usingcurl/netrc.html).
 
 ## How to Find Providers
 

--- a/content/terraform/v1.13.x/docs/language/block/module.mdx
+++ b/content/terraform/v1.13.x/docs/language/block/module.mdx
@@ -300,7 +300,7 @@ When Terraform receives a response with a successful `200` code, it checks the f
 Terraform interprets the result as the source address so that it can install the module.
 
 By default, Terraform searches your `HOME` directory for a `.netrc` file when the listening service requests credentials for authentication. You can set the `NETRC` environment variable to override the default filesystem location. For information on the `.netrc` format,
-refer to [the documentation for using it in `curl`](https://everything.curl.dev/usingcurl/netrc).
+refer to [the documentation for using it in `curl`](https://everything.curl.dev/usingcurl/netrc.html).
 
 If an HTTPS URL has a common file extension associated with an archive file format, Terraform bypasses the `terraform-get=1` redirection and uses the contents of the referenced archive as the module source code.
 

--- a/content/terraform/v1.13.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.13.x/docs/language/modules/sources.mdx
@@ -367,7 +367,7 @@ using one of the forms documented elsewhere on this page.
 If an HTTP/HTTPS URL requires authentication credentials, use a `.netrc`
 file to configure the credentials. By default, Terraform searches for the `.netrc` file 
 in your HOME directory. However, you can override the default filesystem location by setting the `NETRC` environment variable. For information on the `.netrc` format,
-refer to [the documentation for using it in `curl`](https://everything.curl.dev/usingcurl/netrc).
+refer to [the documentation for using it in `curl`](https://everything.curl.dev/usingcurl/netrc.html).
 
 ### Fetching archives over HTTP
 

--- a/content/terraform/v1.13.x/docs/language/providers/index.mdx
+++ b/content/terraform/v1.13.x/docs/language/providers/index.mdx
@@ -116,7 +116,7 @@ file to provide those credentials.
 By default, Terraform searches for the `.netrc` file in your `HOME` directory.
 However, you can override the default filesystem location by setting the `NETRC`
 environment variable. For information on the format of`.netrc`, refer to the
-[`curl` documentation](https://everything.curl.dev/usingcurl/netrc).
+[`curl` documentation](https://everything.curl.dev/usingcurl/netrc.html).
 
 ## How to Find Providers
 

--- a/content/terraform/v1.14.x/docs/language/block/module.mdx
+++ b/content/terraform/v1.14.x/docs/language/block/module.mdx
@@ -296,7 +296,7 @@ When Terraform receives a response with a successful `200` code, it checks the f
 Terraform interprets the result as the source address so that it can install the module.
 
 By default, Terraform searches your `HOME` directory for a `.netrc` file when the listening service requests credentials for authentication. You can set the `NETRC` environment variable to override the default filesystem location. For information on the `.netrc` format,
-refer to [the documentation for using it in `curl`](https://everything.curl.dev/usingcurl/netrc).
+refer to [the documentation for using it in `curl`](https://everything.curl.dev/usingcurl/netrc.html).
 
 If an HTTPS URL has a common file extension associated with an archive file format, Terraform bypasses the `terraform-get=1` redirection and uses the contents of the referenced archive as the module source code.
 

--- a/content/terraform/v1.14.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.14.x/docs/language/modules/sources.mdx
@@ -367,7 +367,7 @@ using one of the forms documented elsewhere on this page.
 If an HTTP/HTTPS URL requires authentication credentials, use a `.netrc`
 file to configure the credentials. By default, Terraform searches for the `.netrc` file 
 in your HOME directory. However, you can override the default filesystem location by setting the `NETRC` environment variable. For information on the `.netrc` format,
-refer to [the documentation for using it in `curl`](https://everything.curl.dev/usingcurl/netrc).
+refer to [the documentation for using it in `curl`](https://everything.curl.dev/usingcurl/netrc.html).
 
 ### Fetching archives over HTTP
 

--- a/content/terraform/v1.14.x/docs/language/providers/index.mdx
+++ b/content/terraform/v1.14.x/docs/language/providers/index.mdx
@@ -116,7 +116,7 @@ file to provide those credentials.
 By default, Terraform searches for the `.netrc` file in your `HOME` directory.
 However, you can override the default filesystem location by setting the `NETRC`
 environment variable. For information on the format of`.netrc`, refer to the
-[`curl` documentation](https://everything.curl.dev/usingcurl/netrc).
+[`curl` documentation](https://everything.curl.dev/usingcurl/netrc.html).
 
 ## How to Find Providers
 

--- a/content/terraform/v1.15.x/docs/language/block/module.mdx
+++ b/content/terraform/v1.15.x/docs/language/block/module.mdx
@@ -304,7 +304,7 @@ When Terraform receives a response with a successful `200` code, it checks the f
 Terraform interprets the result as the source address so that it can install the module.
 
 By default, Terraform searches your `HOME` directory for a `.netrc` file when the listening service requests credentials for authentication. You can set the `NETRC` environment variable to override the default filesystem location. For information on the `.netrc` format,
-refer to [the documentation for using it in `curl`](https://everything.curl.dev/usingcurl/netrc).
+refer to [the documentation for using it in `curl`](https://everything.curl.dev/usingcurl/netrc.html).
 
 If an HTTPS URL has a common file extension associated with an archive file format, Terraform bypasses the `terraform-get=1` redirection and uses the contents of the referenced archive as the module source code.
 

--- a/content/terraform/v1.15.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.15.x/docs/language/modules/sources.mdx
@@ -367,7 +367,7 @@ using one of the forms documented elsewhere on this page.
 If an HTTP/HTTPS URL requires authentication credentials, use a `.netrc`
 file to configure the credentials. By default, Terraform searches for the `.netrc` file 
 in your HOME directory. However, you can override the default filesystem location by setting the `NETRC` environment variable. For information on the `.netrc` format,
-refer to [the documentation for using it in `curl`](https://everything.curl.dev/usingcurl/netrc).
+refer to [the documentation for using it in `curl`](https://everything.curl.dev/usingcurl/netrc.html).
 
 ### Fetching archives over HTTP
 

--- a/content/terraform/v1.15.x/docs/language/providers/index.mdx
+++ b/content/terraform/v1.15.x/docs/language/providers/index.mdx
@@ -116,7 +116,7 @@ file to provide those credentials.
 By default, Terraform searches for the `.netrc` file in your `HOME` directory.
 However, you can override the default filesystem location by setting the `NETRC`
 environment variable. For information on the format of`.netrc`, refer to the
-[`curl` documentation](https://everything.curl.dev/usingcurl/netrc).
+[`curl` documentation](https://everything.curl.dev/usingcurl/netrc.html).
 
 ## How to Find Providers
 

--- a/content/terraform/v1.16.x/docs/language/block/module.mdx
+++ b/content/terraform/v1.16.x/docs/language/block/module.mdx
@@ -304,7 +304,7 @@ When Terraform receives a response with a successful `200` code, it checks the f
 Terraform interprets the result as the source address so that it can install the module.
 
 By default, Terraform searches your `HOME` directory for a `.netrc` file when the listening service requests credentials for authentication. You can set the `NETRC` environment variable to override the default filesystem location. For information on the `.netrc` format,
-refer to [the documentation for using it in `curl`](https://everything.curl.dev/usingcurl/netrc).
+refer to [the documentation for using it in `curl`](https://everything.curl.dev/usingcurl/netrc.html).
 
 If an HTTPS URL has a common file extension associated with an archive file format, Terraform bypasses the `terraform-get=1` redirection and uses the contents of the referenced archive as the module source code.
 

--- a/content/terraform/v1.16.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.16.x/docs/language/modules/sources.mdx
@@ -367,7 +367,7 @@ using one of the forms documented elsewhere on this page.
 If an HTTP/HTTPS URL requires authentication credentials, use a `.netrc`
 file to configure the credentials. By default, Terraform searches for the `.netrc` file 
 in your HOME directory. However, you can override the default filesystem location by setting the `NETRC` environment variable. For information on the `.netrc` format,
-refer to [the documentation for using it in `curl`](https://everything.curl.dev/usingcurl/netrc).
+refer to [the documentation for using it in `curl`](https://everything.curl.dev/usingcurl/netrc.html).
 
 ### Fetching archives over HTTP
 

--- a/content/terraform/v1.16.x/docs/language/providers/index.mdx
+++ b/content/terraform/v1.16.x/docs/language/providers/index.mdx
@@ -116,7 +116,7 @@ file to provide those credentials.
 By default, Terraform searches for the `.netrc` file in your `HOME` directory.
 However, you can override the default filesystem location by setting the `NETRC`
 environment variable. For information on the format of`.netrc`, refer to the
-[`curl` documentation](https://everything.curl.dev/usingcurl/netrc).
+[`curl` documentation](https://everything.curl.dev/usingcurl/netrc.html).
 
 ## How to Find Providers
 

--- a/content/terraform/v1.2.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.2.x/docs/language/modules/sources.mdx
@@ -361,7 +361,7 @@ using one of the forms documented elsewhere on this page.
 
 If an HTTP/HTTPS URL requires authentication credentials, use a `.netrc`
 file in your home directory to configure these. For information on this format,
-see [the documentation for using it in `curl`](https://everything.curl.dev/usingcurl/netrc).
+see [the documentation for using it in `curl`](https://everything.curl.dev/usingcurl/netrc.html).
 
 ### Fetching archives over HTTP
 

--- a/content/terraform/v1.3.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.3.x/docs/language/modules/sources.mdx
@@ -361,7 +361,7 @@ using one of the forms documented elsewhere on this page.
 
 If an HTTP/HTTPS URL requires authentication credentials, use a `.netrc`
 file in your home directory to configure these. For information on this format,
-see [the documentation for using it in `curl`](https://everything.curl.dev/usingcurl/netrc).
+see [the documentation for using it in `curl`](https://everything.curl.dev/usingcurl/netrc.html).
 
 ### Fetching archives over HTTP
 

--- a/content/terraform/v1.4.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.4.x/docs/language/modules/sources.mdx
@@ -362,7 +362,7 @@ using one of the forms documented elsewhere on this page.
 If an HTTP/HTTPS URL requires authentication credentials, use a `.netrc`
 file to configure the credentials. By default, Terraform searches for the `.netrc` file 
 in your HOME directory. However, you can override the default filesystem location by setting the `NETRC` environment variable. For information on the `.netrc` format,
-refer to [the documentation for using it in `curl`](https://everything.curl.dev/usingcurl/netrc).
+refer to [the documentation for using it in `curl`](https://everything.curl.dev/usingcurl/netrc.html).
 
 ### Fetching archives over HTTP
 

--- a/content/terraform/v1.5.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.5.x/docs/language/modules/sources.mdx
@@ -362,7 +362,7 @@ using one of the forms documented elsewhere on this page.
 If an HTTP/HTTPS URL requires authentication credentials, use a `.netrc`
 file to configure the credentials. By default, Terraform searches for the `.netrc` file 
 in your HOME directory. However, you can override the default filesystem location by setting the `NETRC` environment variable. For information on the `.netrc` format,
-refer to [the documentation for using it in `curl`](https://everything.curl.dev/usingcurl/netrc).
+refer to [the documentation for using it in `curl`](https://everything.curl.dev/usingcurl/netrc.html).
 
 ### Fetching archives over HTTP
 

--- a/content/terraform/v1.6.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.6.x/docs/language/modules/sources.mdx
@@ -364,7 +364,7 @@ using one of the forms documented elsewhere on this page.
 If an HTTP/HTTPS URL requires authentication credentials, use a `.netrc`
 file to configure the credentials. By default, Terraform searches for the `.netrc` file 
 in your HOME directory. However, you can override the default filesystem location by setting the `NETRC` environment variable. For information on the `.netrc` format,
-refer to [the documentation for using it in `curl`](https://everything.curl.dev/usingcurl/netrc).
+refer to [the documentation for using it in `curl`](https://everything.curl.dev/usingcurl/netrc.html).
 
 ### Fetching archives over HTTP
 

--- a/content/terraform/v1.7.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.7.x/docs/language/modules/sources.mdx
@@ -366,7 +366,7 @@ using one of the forms documented elsewhere on this page.
 If an HTTP/HTTPS URL requires authentication credentials, use a `.netrc`
 file to configure the credentials. By default, Terraform searches for the `.netrc` file 
 in your HOME directory. However, you can override the default filesystem location by setting the `NETRC` environment variable. For information on the `.netrc` format,
-refer to [the documentation for using it in `curl`](https://everything.curl.dev/usingcurl/netrc).
+refer to [the documentation for using it in `curl`](https://everything.curl.dev/usingcurl/netrc.html).
 
 ### Fetching archives over HTTP
 

--- a/content/terraform/v1.8.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.8.x/docs/language/modules/sources.mdx
@@ -366,7 +366,7 @@ using one of the forms documented elsewhere on this page.
 If an HTTP/HTTPS URL requires authentication credentials, use a `.netrc`
 file to configure the credentials. By default, Terraform searches for the `.netrc` file 
 in your HOME directory. However, you can override the default filesystem location by setting the `NETRC` environment variable. For information on the `.netrc` format,
-refer to [the documentation for using it in `curl`](https://everything.curl.dev/usingcurl/netrc).
+refer to [the documentation for using it in `curl`](https://everything.curl.dev/usingcurl/netrc.html).
 
 ### Fetching archives over HTTP
 

--- a/content/terraform/v1.9.x/docs/language/modules/sources.mdx
+++ b/content/terraform/v1.9.x/docs/language/modules/sources.mdx
@@ -367,7 +367,7 @@ using one of the forms documented elsewhere on this page.
 If an HTTP/HTTPS URL requires authentication credentials, use a `.netrc`
 file to configure the credentials. By default, Terraform searches for the `.netrc` file 
 in your HOME directory. However, you can override the default filesystem location by setting the `NETRC` environment variable. For information on the `.netrc` format,
-refer to [the documentation for using it in `curl`](https://everything.curl.dev/usingcurl/netrc).
+refer to [the documentation for using it in `curl`](https://everything.curl.dev/usingcurl/netrc.html).
 
 ### Fetching archives over HTTP
 


### PR DESCRIPTION
## What

Updates Terraform documentation links to curl's .netrc documentation from:

https://everything.curl.dev/usingcurl/netrc

to:

https://everything.curl.dev/usingcurl/netrc.html

## Why

The previous curl documentation URL no longer resolves to the intended page. The updated URL points directly to the current .netrc documentation page.

## Details

This updates the affected Terraform versioned documentation pages, including provider and module source references, so the same broken external link is fixed consistently across published Terraform docs versions.

## Validation

- Confirmed the old URL no longer appears in tracked MDX content.
- Confirmed the replacement URL resolves successfully.
- Ran Prettier checks on the touched MDX files.