### PR TITLE
docs(tfe): replace support.hashicorp.com link in settings.mdx

### DIFF
--- a/content/terraform-enterprise/1.0.x/docs/enterprise/api-docs/admin/settings.mdx
+++ b/content/terraform-enterprise/1.0.x/docs/enterprise/api-docs/admin/settings.mdx
@@ -769,7 +769,7 @@ curl \
 
 ### Sample Response
 
-Note that the `support-email-address` attribute in the following example returns `support@hashicorp.com`, which is a not a functional email address. If you need assistance, visit the [HashiCorp support page](https://support.hashicorp.com/hc/en-us) and open a ticket. 
+Note that the `support-email-address` attribute in the following example returns `support@hashicorp.com`, which is a not a functional email address. If you need assistance, visit the [HashiCorp support page](https://www.ibm.com/mysupport) and open a ticket. 
 
 ```json
 {
@@ -803,7 +803,7 @@ This PATCH endpoint requires a JSON object with the following properties as a re
 
 | Key path                                | Type   | Default                   | Description                                                                                   |
 | --------------------------------------- | ------ | ------------------------- | --------------------------------------------------------------------------------------------- |
-| `data.attributes.support-email-address` | string | `"support@hashicorp.com"` <p>Note that this is a non-functional address. If you need assistance, visit the [HashiCorp support page](https://support.hashicorp.com/hc/en-us) and open a ticket.</p> | The deprecated support address for outgoing emails.                                                      |
+| `data.attributes.support-email-address` | string | `"support@hashicorp.com"` <p>Note that this is a non-functional address. If you need assistance, visit the [HashiCorp support page](https://www.ibm.com/mysupport) and open a ticket.</p> | The deprecated support address for outgoing emails.                                                      |
 | `data.attributes.login-help`            | string | `""`                      | The login help text presented to users on the login page.                                     |
 | `data.attributes.footer`                | string | `""`                      | Custom footer content that is added to the application.                                       |
 | `data.attributes.error`                 | string | `""`                      | Error instruction content that is presented to users upon unexpected errors.                  |
@@ -811,7 +811,7 @@ This PATCH endpoint requires a JSON object with the following properties as a re
 
 ### Sample Payload
 
-In the following example, the `support-email-address` attribute specifies `support@hashicorp.com`, which is not a functional email address. If you need assistance, visit the [HashiCorp support page](https://support.hashicorp.com/hc/en-us) and open a ticket. 
+In the following example, the `support-email-address` attribute specifies `support@hashicorp.com`, which is not a functional email address. If you need assistance, visit the [HashiCorp support page](https://www.ibm.com/mysupport) and open a ticket. 
 
 ```json
 {
@@ -840,7 +840,7 @@ curl \
 
 ### Sample Response
 
-In the following example, the `support-email-address` attribute specifies `support@hashicorp.com`, which is a not a functional address. If you need assistance, visit the [HashiCorp support page](https://support.hashicorp.com/hc/en-us) and open a ticket. 
+In the following example, the `support-email-address` attribute specifies `support@hashicorp.com`, which is a not a functional address. If you need assistance, visit the [HashiCorp support page](https://www.ibm.com/mysupport) and open a ticket. 
 
 ```json
 {

--- a/content/terraform-enterprise/1.1.x/docs/enterprise/api-docs/admin/settings.mdx
+++ b/content/terraform-enterprise/1.1.x/docs/enterprise/api-docs/admin/settings.mdx
@@ -769,7 +769,7 @@ curl \
 
 ### Sample Response
 
-Note that the `support-email-address` attribute in the following example returns `support@hashicorp.com`, which is a not a functional email address. If you need assistance, visit the [HashiCorp support page](https://support.hashicorp.com/hc/en-us) and open a ticket. 
+Note that the `support-email-address` attribute in the following example returns `support@hashicorp.com`, which is a not a functional email address. If you need assistance, visit the [HashiCorp support page](https://www.ibm.com/mysupport) and open a ticket. 
 
 ```json
 {
@@ -803,7 +803,7 @@ This PATCH endpoint requires a JSON object with the following properties as a re
 
 | Key path                                | Type   | Default                   | Description                                                                                   |
 | --------------------------------------- | ------ | ------------------------- | --------------------------------------------------------------------------------------------- |
-| `data.attributes.support-email-address` | string | `"support@hashicorp.com"` <p>Note that this is a non-functional address. If you need assistance, visit the [HashiCorp support page](https://support.hashicorp.com/hc/en-us) and open a ticket.</p> | The deprecated support address for outgoing emails.                                                      |
+| `data.attributes.support-email-address` | string | `"support@hashicorp.com"` <p>Note that this is a non-functional address. If you need assistance, visit the [HashiCorp support page](https://www.ibm.com/mysupport) and open a ticket.</p> | The deprecated support address for outgoing emails.                                                      |
 | `data.attributes.login-help`            | string | `""`                      | The login help text presented to users on the login page.                                     |
 | `data.attributes.footer`                | string | `""`                      | Custom footer content that is added to the application.                                       |
 | `data.attributes.error`                 | string | `""`                      | Error instruction content that is presented to users upon unexpected errors.                  |
@@ -811,7 +811,7 @@ This PATCH endpoint requires a JSON object with the following properties as a re
 
 ### Sample Payload
 
-In the following example, the `support-email-address` attribute specifies `support@hashicorp.com`, which is not a functional email address. If you need assistance, visit the [HashiCorp support page](https://support.hashicorp.com/hc/en-us) and open a ticket. 
+In the following example, the `support-email-address` attribute specifies `support@hashicorp.com`, which is not a functional email address. If you need assistance, visit the [HashiCorp support page](https://www.ibm.com/mysupport) and open a ticket. 
 
 ```json
 {
@@ -840,7 +840,7 @@ curl \
 
 ### Sample Response
 
-In the following example, the `support-email-address` attribute specifies `support@hashicorp.com`, which is a not a functional address. If you need assistance, visit the [HashiCorp support page](https://support.hashicorp.com/hc/en-us) and open a ticket. 
+In the following example, the `support-email-address` attribute specifies `support@hashicorp.com`, which is a not a functional address. If you need assistance, visit the [HashiCorp support page](https://www.ibm.com/mysupport) and open a ticket. 
 
 ```json
 {

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/admin/settings.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/admin/settings.mdx
@@ -769,7 +769,7 @@ curl \
 
 ### Sample Response
 
-Note that the `support-email-address` attribute in the following example returns `support@hashicorp.com`, which is a not a functional email address. If you need assistance, visit the [HashiCorp support page](https://support.hashicorp.com/hc/en-us) and open a ticket. 
+Note that the `support-email-address` attribute in the following example returns `support@hashicorp.com`, which is a not a functional email address. If you need assistance, visit the [HashiCorp support page](https://www.ibm.com/mysupport) and open a ticket. 
 
 ```json
 {
@@ -803,7 +803,7 @@ This PATCH endpoint requires a JSON object with the following properties as a re
 
 | Key path                                | Type   | Default                   | Description                                                                                   |
 | --------------------------------------- | ------ | ------------------------- | --------------------------------------------------------------------------------------------- |
-| `data.attributes.support-email-address` | string | `"support@hashicorp.com"` <p>Note that this is a non-functional address. If you need assistance, visit the [HashiCorp support page](https://support.hashicorp.com/hc/en-us) and open a ticket.</p> | The deprecated support address for outgoing emails.                                                      |
+| `data.attributes.support-email-address` | string | `"support@hashicorp.com"` <p>Note that this is a non-functional address. If you need assistance, visit the [HashiCorp support page](https://www.ibm.com/mysupport) and open a ticket.</p> | The deprecated support address for outgoing emails.                                                      |
 | `data.attributes.login-help`            | string | `""`                      | The login help text presented to users on the login page.                                     |
 | `data.attributes.footer`                | string | `""`                      | Custom footer content that is added to the application.                                       |
 | `data.attributes.error`                 | string | `""`                      | Error instruction content that is presented to users upon unexpected errors.                  |
@@ -811,7 +811,7 @@ This PATCH endpoint requires a JSON object with the following properties as a re
 
 ### Sample Payload
 
-In the following example, the `support-email-address` attribute specifies `support@hashicorp.com`, which is not a functional email address. If you need assistance, visit the [HashiCorp support page](https://support.hashicorp.com/hc/en-us) and open a ticket. 
+In the following example, the `support-email-address` attribute specifies `support@hashicorp.com`, which is not a functional email address. If you need assistance, visit the [HashiCorp support page](https://www.ibm.com/mysupport) and open a ticket. 
 
 ```json
 {
@@ -840,7 +840,7 @@ curl \
 
 ### Sample Response
 
-In the following example, the `support-email-address` attribute specifies `support@hashicorp.com`, which is a not a functional address. If you need assistance, visit the [HashiCorp support page](https://support.hashicorp.com/hc/en-us) and open a ticket. 
+In the following example, the `support-email-address` attribute specifies `support@hashicorp.com`, which is a not a functional address. If you need assistance, visit the [HashiCorp support page](https://www.ibm.com/mysupport) and open a ticket. 
 
 ```json
 {

--- a/content/terraform-enterprise/2.0.x/docs/enterprise/api-docs/admin/settings.mdx
+++ b/content/terraform-enterprise/2.0.x/docs/enterprise/api-docs/admin/settings.mdx
@@ -774,7 +774,7 @@ curl \
 
 ### Sample Response
 
-Note that the `support-email-address` attribute in the following example returns `support@hashicorp.com`, which is a not a functional email address. If you need assistance, visit the [HashiCorp support page](https://support.hashicorp.com/hc/en-us) and open a ticket. 
+Note that the `support-email-address` attribute in the following example returns `support@hashicorp.com`, which is a not a functional email address. If you need assistance, visit the [HashiCorp support page](https://www.ibm.com/mysupport) and open a ticket. 
 
 ```json
 {
@@ -808,7 +808,7 @@ This PATCH endpoint requires a JSON object with the following properties as a re
 
 | Key path                                | Type   | Default                   | Description                                                                                   |
 | --------------------------------------- | ------ | ------------------------- | --------------------------------------------------------------------------------------------- |
-| `data.attributes.support-email-address` | string | `"support@hashicorp.com"` <p>Note that this is a non-functional address. If you need assistance, visit the [HashiCorp support page](https://support.hashicorp.com/hc/en-us) and open a ticket.</p> | The deprecated support address for outgoing emails.                                                      |
+| `data.attributes.support-email-address` | string | `"support@hashicorp.com"` <p>Note that this is a non-functional address. If you need assistance, visit the [HashiCorp support page](https://www.ibm.com/mysupport) and open a ticket.</p> | The deprecated support address for outgoing emails.                                                      |
 | `data.attributes.login-help`            | string | `""`                      | The login help text presented to users on the login page.                                     |
 | `data.attributes.footer`                | string | `""`                      | Custom footer content that is added to the application.                                       |
 | `data.attributes.error`                 | string | `""`                      | Error instruction content that is presented to users upon unexpected errors.                  |
@@ -816,7 +816,7 @@ This PATCH endpoint requires a JSON object with the following properties as a re
 
 ### Sample Payload
 
-In the following example, the `support-email-address` attribute specifies `support@hashicorp.com`, which is not a functional email address. If you need assistance, visit the [HashiCorp support page](https://support.hashicorp.com/hc/en-us) and open a ticket. 
+In the following example, the `support-email-address` attribute specifies `support@hashicorp.com`, which is not a functional email address. If you need assistance, visit the [HashiCorp support page](https://www.ibm.com/mysupport) and open a ticket. 
 
 ```json
 {
@@ -845,7 +845,7 @@ curl \
 
 ### Sample Response
 
-In the following example, the `support-email-address` attribute specifies `support@hashicorp.com`, which is a not a functional address. If you need assistance, visit the [HashiCorp support page](https://support.hashicorp.com/hc/en-us) and open a ticket. 
+In the following example, the `support-email-address` attribute specifies `support@hashicorp.com`, which is a not a functional address. If you need assistance, visit the [HashiCorp support page](https://www.ibm.com/mysupport) and open a ticket. 
 
 ```json
 {

--- a/content/terraform-enterprise/v202501-1/docs/enterprise/api-docs/admin/settings.mdx
+++ b/content/terraform-enterprise/v202501-1/docs/enterprise/api-docs/admin/settings.mdx
@@ -769,7 +769,7 @@ curl \
 
 ### Sample Response
 
-Note that the `support-email-address` attribute in the following example returns `support@hashicorp.com`, which is a not a functional email address. If you need assistance, visit the [HashiCorp support page](https://support.hashicorp.com/hc/en-us) and open a ticket. 
+Note that the `support-email-address` attribute in the following example returns `support@hashicorp.com`, which is a not a functional email address. If you need assistance, visit the [HashiCorp support page](https://www.ibm.com/mysupport) and open a ticket. 
 
 ```json
 {
@@ -803,7 +803,7 @@ This PATCH endpoint requires a JSON object with the following properties as a re
 
 | Key path                                | Type   | Default                   | Description                                                                                   |
 | --------------------------------------- | ------ | ------------------------- | --------------------------------------------------------------------------------------------- |
-| `data.attributes.support-email-address` | string | `"support@hashicorp.com"` <p>Note that this is a non-functional address. If you need assistance, visit the [HashiCorp support page](https://support.hashicorp.com/hc/en-us) and open a ticket.</p> | The deprecated support address for outgoing emails.                                                      |
+| `data.attributes.support-email-address` | string | `"support@hashicorp.com"` <p>Note that this is a non-functional address. If you need assistance, visit the [HashiCorp support page](https://www.ibm.com/mysupport) and open a ticket.</p> | The deprecated support address for outgoing emails.                                                      |
 | `data.attributes.login-help`            | string | `""`                      | The login help text presented to users on the login page.                                     |
 | `data.attributes.footer`                | string | `""`                      | Custom footer content that is added to the application.                                       |
 | `data.attributes.error`                 | string | `""`                      | Error instruction content that is presented to users upon unexpected errors.                  |
@@ -811,7 +811,7 @@ This PATCH endpoint requires a JSON object with the following properties as a re
 
 ### Sample Payload
 
-In the following example, the `support-email-address` attribute specifies `support@hashicorp.com`, which is not a functional email address. If you need assistance, visit the [HashiCorp support page](https://support.hashicorp.com/hc/en-us) and open a ticket. 
+In the following example, the `support-email-address` attribute specifies `support@hashicorp.com`, which is not a functional email address. If you need assistance, visit the [HashiCorp support page](https://www.ibm.com/mysupport) and open a ticket. 
 
 ```json
 {
@@ -840,7 +840,7 @@ curl \
 
 ### Sample Response
 
-In the following example, the `support-email-address` attribute specifies `support@hashicorp.com`, which is a not a functional address. If you need assistance, visit the [HashiCorp support page](https://support.hashicorp.com/hc/en-us) and open a ticket. 
+In the following example, the `support-email-address` attribute specifies `support@hashicorp.com`, which is a not a functional address. If you need assistance, visit the [HashiCorp support page](https://www.ibm.com/mysupport) and open a ticket. 
 
 ```json
 {

--- a/content/terraform-enterprise/v202502-2/docs/enterprise/api-docs/admin/settings.mdx
+++ b/content/terraform-enterprise/v202502-2/docs/enterprise/api-docs/admin/settings.mdx
@@ -769,7 +769,7 @@ curl \
 
 ### Sample Response
 
-Note that the `support-email-address` attribute in the following example returns `support@hashicorp.com`, which is a not a functional email address. If you need assistance, visit the [HashiCorp support page](https://support.hashicorp.com/hc/en-us) and open a ticket. 
+Note that the `support-email-address` attribute in the following example returns `support@hashicorp.com`, which is a not a functional email address. If you need assistance, visit the [HashiCorp support page](https://www.ibm.com/mysupport) and open a ticket. 
 
 ```json
 {
@@ -803,7 +803,7 @@ This PATCH endpoint requires a JSON object with the following properties as a re
 
 | Key path                                | Type   | Default                   | Description                                                                                   |
 | --------------------------------------- | ------ | ------------------------- | --------------------------------------------------------------------------------------------- |
-| `data.attributes.support-email-address` | string | `"support@hashicorp.com"` <p>Note that this is a non-functional address. If you need assistance, visit the [HashiCorp support page](https://support.hashicorp.com/hc/en-us) and open a ticket.</p> | The deprecated support address for outgoing emails.                                                      |
+| `data.attributes.support-email-address` | string | `"support@hashicorp.com"` <p>Note that this is a non-functional address. If you need assistance, visit the [HashiCorp support page](https://www.ibm.com/mysupport) and open a ticket.</p> | The deprecated support address for outgoing emails.                                                      |
 | `data.attributes.login-help`            | string | `""`                      | The login help text presented to users on the login page.                                     |
 | `data.attributes.footer`                | string | `""`                      | Custom footer content that is added to the application.                                       |
 | `data.attributes.error`                 | string | `""`                      | Error instruction content that is presented to users upon unexpected errors.                  |
@@ -811,7 +811,7 @@ This PATCH endpoint requires a JSON object with the following properties as a re
 
 ### Sample Payload
 
-In the following example, the `support-email-address` attribute specifies `support@hashicorp.com`, which is not a functional email address. If you need assistance, visit the [HashiCorp support page](https://support.hashicorp.com/hc/en-us) and open a ticket. 
+In the following example, the `support-email-address` attribute specifies `support@hashicorp.com`, which is not a functional email address. If you need assistance, visit the [HashiCorp support page](https://www.ibm.com/mysupport) and open a ticket. 
 
 ```json
 {
@@ -840,7 +840,7 @@ curl \
 
 ### Sample Response
 
-In the following example, the `support-email-address` attribute specifies `support@hashicorp.com`, which is a not a functional address. If you need assistance, visit the [HashiCorp support page](https://support.hashicorp.com/hc/en-us) and open a ticket. 
+In the following example, the `support-email-address` attribute specifies `support@hashicorp.com`, which is a not a functional address. If you need assistance, visit the [HashiCorp support page](https://www.ibm.com/mysupport) and open a ticket. 
 
 ```json
 {

--- a/content/terraform-enterprise/v202503-1/docs/enterprise/api-docs/admin/settings.mdx
+++ b/content/terraform-enterprise/v202503-1/docs/enterprise/api-docs/admin/settings.mdx
@@ -769,7 +769,7 @@ curl \
 
 ### Sample Response
 
-Note that the `support-email-address` attribute in the following example returns `support@hashicorp.com`, which is a not a functional email address. If you need assistance, visit the [HashiCorp support page](https://support.hashicorp.com/hc/en-us) and open a ticket. 
+Note that the `support-email-address` attribute in the following example returns `support@hashicorp.com`, which is a not a functional email address. If you need assistance, visit the [HashiCorp support page](https://www.ibm.com/mysupport) and open a ticket. 
 
 ```json
 {
@@ -803,7 +803,7 @@ This PATCH endpoint requires a JSON object with the following properties as a re
 
 | Key path                                | Type   | Default                   | Description                                                                                   |
 | --------------------------------------- | ------ | ------------------------- | --------------------------------------------------------------------------------------------- |
-| `data.attributes.support-email-address` | string | `"support@hashicorp.com"` <p>Note that this is a non-functional address. If you need assistance, visit the [HashiCorp support page](https://support.hashicorp.com/hc/en-us) and open a ticket.</p> | The deprecated support address for outgoing emails.                                                      |
+| `data.attributes.support-email-address` | string | `"support@hashicorp.com"` <p>Note that this is a non-functional address. If you need assistance, visit the [HashiCorp support page](https://www.ibm.com/mysupport) and open a ticket.</p> | The deprecated support address for outgoing emails.                                                      |
 | `data.attributes.login-help`            | string | `""`                      | The login help text presented to users on the login page.                                     |
 | `data.attributes.footer`                | string | `""`                      | Custom footer content that is added to the application.                                       |
 | `data.attributes.error`                 | string | `""`                      | Error instruction content that is presented to users upon unexpected errors.                  |
@@ -811,7 +811,7 @@ This PATCH endpoint requires a JSON object with the following properties as a re
 
 ### Sample Payload
 
-In the following example, the `support-email-address` attribute specifies `support@hashicorp.com`, which is not a functional email address. If you need assistance, visit the [HashiCorp support page](https://support.hashicorp.com/hc/en-us) and open a ticket. 
+In the following example, the `support-email-address` attribute specifies `support@hashicorp.com`, which is not a functional email address. If you need assistance, visit the [HashiCorp support page](https://www.ibm.com/mysupport) and open a ticket. 
 
 ```json
 {
@@ -840,7 +840,7 @@ curl \
 
 ### Sample Response
 
-In the following example, the `support-email-address` attribute specifies `support@hashicorp.com`, which is a not a functional address. If you need assistance, visit the [HashiCorp support page](https://support.hashicorp.com/hc/en-us) and open a ticket. 
+In the following example, the `support-email-address` attribute specifies `support@hashicorp.com`, which is a not a functional address. If you need assistance, visit the [HashiCorp support page](https://www.ibm.com/mysupport) and open a ticket. 
 
 ```json
 {

--- a/content/terraform-enterprise/v202504-1/docs/enterprise/api-docs/admin/settings.mdx
+++ b/content/terraform-enterprise/v202504-1/docs/enterprise/api-docs/admin/settings.mdx
@@ -769,7 +769,7 @@ curl \
 
 ### Sample Response
 
-Note that the `support-email-address` attribute in the following example returns `support@hashicorp.com`, which is a not a functional email address. If you need assistance, visit the [HashiCorp support page](https://support.hashicorp.com/hc/en-us) and open a ticket. 
+Note that the `support-email-address` attribute in the following example returns `support@hashicorp.com`, which is a not a functional email address. If you need assistance, visit the [HashiCorp support page](https://www.ibm.com/mysupport) and open a ticket. 
 
 ```json
 {
@@ -803,7 +803,7 @@ This PATCH endpoint requires a JSON object with the following properties as a re
 
 | Key path                                | Type   | Default                   | Description                                                                                   |
 | --------------------------------------- | ------ | ------------------------- | --------------------------------------------------------------------------------------------- |
-| `data.attributes.support-email-address` | string | `"support@hashicorp.com"` <p>Note that this is a non-functional address. If you need assistance, visit the [HashiCorp support page](https://support.hashicorp.com/hc/en-us) and open a ticket.</p> | The deprecated support address for outgoing emails.                                                      |
+| `data.attributes.support-email-address` | string | `"support@hashicorp.com"` <p>Note that this is a non-functional address. If you need assistance, visit the [HashiCorp support page](https://www.ibm.com/mysupport) and open a ticket.</p> | The deprecated support address for outgoing emails.                                                      |
 | `data.attributes.login-help`            | string | `""`                      | The login help text presented to users on the login page.                                     |
 | `data.attributes.footer`                | string | `""`                      | Custom footer content that is added to the application.                                       |
 | `data.attributes.error`                 | string | `""`                      | Error instruction content that is presented to users upon unexpected errors.                  |
@@ -811,7 +811,7 @@ This PATCH endpoint requires a JSON object with the following properties as a re
 
 ### Sample Payload
 
-In the following example, the `support-email-address` attribute specifies `support@hashicorp.com`, which is not a functional email address. If you need assistance, visit the [HashiCorp support page](https://support.hashicorp.com/hc/en-us) and open a ticket. 
+In the following example, the `support-email-address` attribute specifies `support@hashicorp.com`, which is not a functional email address. If you need assistance, visit the [HashiCorp support page](https://www.ibm.com/mysupport) and open a ticket. 
 
 ```json
 {
@@ -840,7 +840,7 @@ curl \
 
 ### Sample Response
 
-In the following example, the `support-email-address` attribute specifies `support@hashicorp.com`, which is a not a functional address. If you need assistance, visit the [HashiCorp support page](https://support.hashicorp.com/hc/en-us) and open a ticket. 
+In the following example, the `support-email-address` attribute specifies `support@hashicorp.com`, which is a not a functional address. If you need assistance, visit the [HashiCorp support page](https://www.ibm.com/mysupport) and open a ticket. 
 
 ```json
 {

--- a/content/terraform-enterprise/v202505-1/docs/enterprise/api-docs/admin/settings.mdx
+++ b/content/terraform-enterprise/v202505-1/docs/enterprise/api-docs/admin/settings.mdx
@@ -769,7 +769,7 @@ curl \
 
 ### Sample Response
 
-Note that the `support-email-address` attribute in the following example returns `support@hashicorp.com`, which is a not a functional email address. If you need assistance, visit the [HashiCorp support page](https://support.hashicorp.com/hc/en-us) and open a ticket. 
+Note that the `support-email-address` attribute in the following example returns `support@hashicorp.com`, which is a not a functional email address. If you need assistance, visit the [HashiCorp support page](https://www.ibm.com/mysupport) and open a ticket. 
 
 ```json
 {
@@ -803,7 +803,7 @@ This PATCH endpoint requires a JSON object with the following properties as a re
 
 | Key path                                | Type   | Default                   | Description                                                                                   |
 | --------------------------------------- | ------ | ------------------------- | --------------------------------------------------------------------------------------------- |
-| `data.attributes.support-email-address` | string | `"support@hashicorp.com"` <p>Note that this is a non-functional address. If you need assistance, visit the [HashiCorp support page](https://support.hashicorp.com/hc/en-us) and open a ticket.</p> | The deprecated support address for outgoing emails.                                                      |
+| `data.attributes.support-email-address` | string | `"support@hashicorp.com"` <p>Note that this is a non-functional address. If you need assistance, visit the [HashiCorp support page](https://www.ibm.com/mysupport) and open a ticket.</p> | The deprecated support address for outgoing emails.                                                      |
 | `data.attributes.login-help`            | string | `""`                      | The login help text presented to users on the login page.                                     |
 | `data.attributes.footer`                | string | `""`                      | Custom footer content that is added to the application.                                       |
 | `data.attributes.error`                 | string | `""`                      | Error instruction content that is presented to users upon unexpected errors.                  |
@@ -811,7 +811,7 @@ This PATCH endpoint requires a JSON object with the following properties as a re
 
 ### Sample Payload
 
-In the following example, the `support-email-address` attribute specifies `support@hashicorp.com`, which is not a functional email address. If you need assistance, visit the [HashiCorp support page](https://support.hashicorp.com/hc/en-us) and open a ticket. 
+In the following example, the `support-email-address` attribute specifies `support@hashicorp.com`, which is not a functional email address. If you need assistance, visit the [HashiCorp support page](https://www.ibm.com/mysupport) and open a ticket. 
 
 ```json
 {
@@ -840,7 +840,7 @@ curl \
 
 ### Sample Response
 
-In the following example, the `support-email-address` attribute specifies `support@hashicorp.com`, which is a not a functional address. If you need assistance, visit the [HashiCorp support page](https://support.hashicorp.com/hc/en-us) and open a ticket. 
+In the following example, the `support-email-address` attribute specifies `support@hashicorp.com`, which is a not a functional address. If you need assistance, visit the [HashiCorp support page](https://www.ibm.com/mysupport) and open a ticket. 
 
 ```json
 {

--- a/content/terraform-enterprise/v202506-1/docs/enterprise/api-docs/admin/settings.mdx
+++ b/content/terraform-enterprise/v202506-1/docs/enterprise/api-docs/admin/settings.mdx
@@ -769,7 +769,7 @@ curl \
 
 ### Sample Response
 
-Note that the `support-email-address` attribute in the following example returns `support@hashicorp.com`, which is a not a functional email address. If you need assistance, visit the [HashiCorp support page](https://support.hashicorp.com/hc/en-us) and open a ticket. 
+Note that the `support-email-address` attribute in the following example returns `support@hashicorp.com`, which is a not a functional email address. If you need assistance, visit the [HashiCorp support page](https://www.ibm.com/mysupport) and open a ticket. 
 
 ```json
 {
@@ -803,7 +803,7 @@ This PATCH endpoint requires a JSON object with the following properties as a re
 
 | Key path                                | Type   | Default                   | Description                                                                                   |
 | --------------------------------------- | ------ | ------------------------- | --------------------------------------------------------------------------------------------- |
-| `data.attributes.support-email-address` | string | `"support@hashicorp.com"` <p>Note that this is a non-functional address. If you need assistance, visit the [HashiCorp support page](https://support.hashicorp.com/hc/en-us) and open a ticket.</p> | The deprecated support address for outgoing emails.                                                      |
+| `data.attributes.support-email-address` | string | `"support@hashicorp.com"` <p>Note that this is a non-functional address. If you need assistance, visit the [HashiCorp support page](https://www.ibm.com/mysupport) and open a ticket.</p> | The deprecated support address for outgoing emails.                                                      |
 | `data.attributes.login-help`            | string | `""`                      | The login help text presented to users on the login page.                                     |
 | `data.attributes.footer`                | string | `""`                      | Custom footer content that is added to the application.                                       |
 | `data.attributes.error`                 | string | `""`                      | Error instruction content that is presented to users upon unexpected errors.                  |
@@ -811,7 +811,7 @@ This PATCH endpoint requires a JSON object with the following properties as a re
 
 ### Sample Payload
 
-In the following example, the `support-email-address` attribute specifies `support@hashicorp.com`, which is not a functional email address. If you need assistance, visit the [HashiCorp support page](https://support.hashicorp.com/hc/en-us) and open a ticket. 
+In the following example, the `support-email-address` attribute specifies `support@hashicorp.com`, which is not a functional email address. If you need assistance, visit the [HashiCorp support page](https://www.ibm.com/mysupport) and open a ticket. 
 
 ```json
 {
@@ -840,7 +840,7 @@ curl \
 
 ### Sample Response
 
-In the following example, the `support-email-address` attribute specifies `support@hashicorp.com`, which is a not a functional address. If you need assistance, visit the [HashiCorp support page](https://support.hashicorp.com/hc/en-us) and open a ticket. 
+In the following example, the `support-email-address` attribute specifies `support@hashicorp.com`, which is a not a functional address. If you need assistance, visit the [HashiCorp support page](https://www.ibm.com/mysupport) and open a ticket. 
 
 ```json
 {

--- a/content/terraform-enterprise/v202507-1/docs/enterprise/api-docs/admin/settings.mdx
+++ b/content/terraform-enterprise/v202507-1/docs/enterprise/api-docs/admin/settings.mdx
@@ -769,7 +769,7 @@ curl \
 
 ### Sample Response
 
-Note that the `support-email-address` attribute in the following example returns `support@hashicorp.com`, which is a not a functional email address. If you need assistance, visit the [HashiCorp support page](https://support.hashicorp.com/hc/en-us) and open a ticket. 
+Note that the `support-email-address` attribute in the following example returns `support@hashicorp.com`, which is a not a functional email address. If you need assistance, visit the [HashiCorp support page](https://www.ibm.com/mysupport) and open a ticket. 
 
 ```json
 {
@@ -803,7 +803,7 @@ This PATCH endpoint requires a JSON object with the following properties as a re
 
 | Key path                                | Type   | Default                   | Description                                                                                   |
 | --------------------------------------- | ------ | ------------------------- | --------------------------------------------------------------------------------------------- |
-| `data.attributes.support-email-address` | string | `"support@hashicorp.com"` <p>Note that this is a non-functional address. If you need assistance, visit the [HashiCorp support page](https://support.hashicorp.com/hc/en-us) and open a ticket.</p> | The deprecated support address for outgoing emails.                                                      |
+| `data.attributes.support-email-address` | string | `"support@hashicorp.com"` <p>Note that this is a non-functional address. If you need assistance, visit the [HashiCorp support page](https://www.ibm.com/mysupport) and open a ticket.</p> | The deprecated support address for outgoing emails.                                                      |
 | `data.attributes.login-help`            | string | `""`                      | The login help text presented to users on the login page.                                     |
 | `data.attributes.footer`                | string | `""`                      | Custom footer content that is added to the application.                                       |
 | `data.attributes.error`                 | string | `""`                      | Error instruction content that is presented to users upon unexpected errors.                  |
@@ -811,7 +811,7 @@ This PATCH endpoint requires a JSON object with the following properties as a re
 
 ### Sample Payload
 
-In the following example, the `support-email-address` attribute specifies `support@hashicorp.com`, which is not a functional email address. If you need assistance, visit the [HashiCorp support page](https://support.hashicorp.com/hc/en-us) and open a ticket. 
+In the following example, the `support-email-address` attribute specifies `support@hashicorp.com`, which is not a functional email address. If you need assistance, visit the [HashiCorp support page](https://www.ibm.com/mysupport) and open a ticket. 
 
 ```json
 {
@@ -840,7 +840,7 @@ curl \
 
 ### Sample Response
 
-In the following example, the `support-email-address` attribute specifies `support@hashicorp.com`, which is a not a functional address. If you need assistance, visit the [HashiCorp support page](https://support.hashicorp.com/hc/en-us) and open a ticket. 
+In the following example, the `support-email-address` attribute specifies `support@hashicorp.com`, which is a not a functional address. If you need assistance, visit the [HashiCorp support page](https://www.ibm.com/mysupport) and open a ticket. 
 
 ```json
 {


### PR DESCRIPTION
## Summary

Replaces legacy HashiCorp support URL with IBM equivalent across all affected version directories.

| | |
|---|---|
| **Product** | Terraform Enterprise |
| **Document path** | `docs/enterprise/api-docs/admin/settings.mdx` |
| **Old URL** | `https://support.hashicorp.com/hc/en-us` |
| **New URL** | `https://www.ibm.com/mysupport` |
| **Versions updated** | 11 |

Part of the IBM DevDoc KB Remapping effort.