### PR TITLE
docs(tfe): replace support.hashicorp.com links with ibm.com/mysupport across TFE docs

### DIFF
--- a/content/terraform-enterprise/1.0.x/docs/enterprise/api-docs/index.mdx
+++ b/content/terraform-enterprise/1.0.x/docs/enterprise/api-docs/index.mdx
@@ -46,13 +46,13 @@ last_modified: 2025-11-19T09:33:54-08:00
 
 <!-- BEGIN: TFC:only -->
 
-HCP Terraform provides an API for a subset of its features. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://support.hashicorp.com/hc/en-us) and open a ticket.
+HCP Terraform provides an API for a subset of its features. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://www.ibm.com/mysupport) and open a ticket.
 
 <!-- END: TFC:only -->
 
 <!-- BEGIN: TFEnterprise:only name:api-overview -->
 
-Terraform Enterprise provides an API for a subset of its features. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://support.hashicorp.com/hc/en-us) and open a ticket.
+Terraform Enterprise provides an API for a subset of its features. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://www.ibm.com/mysupport) and open a ticket.
 
 <!-- END: TFEnterprise:only name:api-overview  -->
 

--- a/content/terraform-enterprise/1.0.x/docs/enterprise/application-administration/customization.mdx
+++ b/content/terraform-enterprise/1.0.x/docs/enterprise/application-administration/customization.mdx
@@ -26,7 +26,7 @@ You can update the support content displayed in the UI.
 
 Terraform Enterprise uses the support email address for system emails, error pages, and all other situations where users are prompted to contact support. You can specify a local email address if you want users to contact a specific person or team when they have issues.
 
-Note that this field defaults to `support@hashicorp.com`, which is not a functional email address for HashiCorp support. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://support.hashicorp.com/hc/en-us) and open a ticket.
+Note that this field defaults to `support@hashicorp.com`, which is not a functional email address for HashiCorp support. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://www.ibm.com/mysupport) and open a ticket.
 
 ### Error Instructions
 

--- a/content/terraform-enterprise/1.0.x/docs/enterprise/deploy/replicated/architecture/reference-architecture/vmware.mdx
+++ b/content/terraform-enterprise/1.0.x/docs/enterprise/deploy/replicated/architecture/reference-architecture/vmware.mdx
@@ -270,7 +270,7 @@ application data stored in this location. This allows for further [server-side
 encryption](https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html)
 by S3 if required by your security policy.
 
-Recommended object storage solutions are AWS S3, Google Cloud storage, Azure blob storage. Other options for S3-compatible storage are [MinIO](https://www.minio.io/), and [Ceph](https://ceph.com/), and [ECS](https://www.dell.com/en-us/shop/cty/sf/objectscale?hve=explore+objectscale). Please feel free to reach out to [support](https://support.hashicorp.com/hc/en-us) with questions.
+Recommended object storage solutions are AWS S3, Google Cloud storage, Azure blob storage. Other options for S3-compatible storage are [MinIO](https://www.minio.io/), and [Ceph](https://ceph.com/), and [ECS](https://www.dell.com/en-us/shop/cty/sf/objectscale?hve=explore+objectscale). Please feel free to reach out to [support](https://www.ibm.com/mysupport) with questions.
 
 ### External Services - PostgreSQL Database
 

--- a/content/terraform-enterprise/1.0.x/docs/enterprise/deploy/replicated/install/uninstall.mdx
+++ b/content/terraform-enterprise/1.0.x/docs/enterprise/deploy/replicated/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/1.0.x/docs/enterprise/deploy/replicated/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/1.0.x/docs/enterprise/deploy/replicated/requirements/data-storage/operational-mode-requirements.mdx
@@ -33,4 +33,4 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 - `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 - `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.

--- a/content/terraform-enterprise/1.0.x/docs/enterprise/deploy/troubleshoot/contact-support.mdx
+++ b/content/terraform-enterprise/1.0.x/docs/enterprise/deploy/troubleshoot/contact-support.mdx
@@ -14,7 +14,7 @@ expected, reach out to support for help.
 
 ## Open a ticket
 
-If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://support.hashicorp.com/hc/en-us) and open a ticket.
+If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://www.ibm.com/mysupport) and open a ticket.
 
 ## Diagnostics
 
@@ -52,7 +52,7 @@ Once you have downloaded your support bundle, please use a secure method to uplo
 
 Attach the bundle to your support ticket. 
 
-If possible, use the SendSafely integration available in the [HashiCorp support portal](https://support.hashicorp.com/hc/en-us). SendSafely lets you upload large file.
+If possible, use the SendSafely integration available in the [HashiCorp support portal](https://www.ibm.com/mysupport). SendSafely lets you upload large file.
 
 If you are unable to use the integration in the portal, upload the bundle directly to `https://hashicorp.sendsafely.com/u/ptfe-support-bundles`.
 

--- a/content/terraform-enterprise/1.0.x/docs/enterprise/vcs/bitbucket-data-center.mdx
+++ b/content/terraform-enterprise/1.0.x/docs/enterprise/vcs/bitbucket-data-center.mdx
@@ -16,7 +16,7 @@ This topic describes how to connect Bitbucket Data Center to HCP Terraform. For 
 
 **Bitbucket Server is deprecated**.  Atlassian ended support for Bitbucket Server on February 15, 2024, and recommends using either Bitbucket Data Center (v8.0 or newer) or Bitbucket Cloud instead. Refer to the [Atlassian documentation](https://bitbucket.org/blog/cloud-migration-benefits) for additional information. 
 
-HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://support.hashicorp.com/hc/en-us) if you have any questions regarding this change.
+HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://www.ibm.com/mysupport) if you have any questions regarding this change.
 
 ## Overview
 

--- a/content/terraform-enterprise/1.1.x/docs/enterprise/api-docs/index.mdx
+++ b/content/terraform-enterprise/1.1.x/docs/enterprise/api-docs/index.mdx
@@ -46,13 +46,13 @@ last_modified: 2025-11-19T09:33:54-08:00
 
 <!-- BEGIN: TFC:only -->
 
-HCP Terraform provides an API for a subset of its features. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://support.hashicorp.com/hc/en-us) and open a ticket.
+HCP Terraform provides an API for a subset of its features. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://www.ibm.com/mysupport) and open a ticket.
 
 <!-- END: TFC:only -->
 
 <!-- BEGIN: TFEnterprise:only name:api-overview -->
 
-Terraform Enterprise provides an API for a subset of its features. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://support.hashicorp.com/hc/en-us) and open a ticket.
+Terraform Enterprise provides an API for a subset of its features. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://www.ibm.com/mysupport) and open a ticket.
 
 <!-- END: TFEnterprise:only name:api-overview  -->
 

--- a/content/terraform-enterprise/1.1.x/docs/enterprise/application-administration/customization.mdx
+++ b/content/terraform-enterprise/1.1.x/docs/enterprise/application-administration/customization.mdx
@@ -26,7 +26,7 @@ You can update the support content displayed in the UI.
 
 Terraform Enterprise uses the support email address for system emails, error pages, and all other situations where users are prompted to contact support. You can specify a local email address if you want users to contact a specific person or team when they have issues.
 
-Note that this field defaults to `support@hashicorp.com`, which is not a functional email address for HashiCorp support. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://support.hashicorp.com/hc/en-us) and open a ticket.
+Note that this field defaults to `support@hashicorp.com`, which is not a functional email address for HashiCorp support. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://www.ibm.com/mysupport) and open a ticket.
 
 ### Error Instructions
 

--- a/content/terraform-enterprise/1.1.x/docs/enterprise/deploy/manage/upgrade.mdx
+++ b/content/terraform-enterprise/1.1.x/docs/enterprise/deploy/manage/upgrade.mdx
@@ -282,6 +282,6 @@ If any validation step fails or the application does not stabilize:
    1. Restore object storage from the pre-upgrade snapshot.
    1. Deploy the previous Terraform Enterprise image version.
    1. Verify the application starts successfully.
-1. Contact [HashiCorp Support](https://support.hashicorp.com/hc/en-us) with collected logs, the upgrade path attempted, and error messages for assistance.
+1. Contact [HashiCorp Support](https://www.ibm.com/mysupport) with collected logs, the upgrade path attempted, and error messages for assistance.
 
-If you encounter issues at any point, contact [HashiCorp Support](https://support.hashicorp.com/hc/en-us) with your upgrade plan, release sequence, and the relevant logs.
+If you encounter issues at any point, contact [HashiCorp Support](https://www.ibm.com/mysupport) with your upgrade plan, release sequence, and the relevant logs.

--- a/content/terraform-enterprise/1.1.x/docs/enterprise/deploy/replicated/architecture/reference-architecture/vmware.mdx
+++ b/content/terraform-enterprise/1.1.x/docs/enterprise/deploy/replicated/architecture/reference-architecture/vmware.mdx
@@ -270,7 +270,7 @@ application data stored in this location. This allows for further [server-side
 encryption](https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html)
 by S3 if required by your security policy.
 
-Recommended object storage solutions are AWS S3, Google Cloud storage, Azure blob storage. Other options for S3-compatible storage are [MinIO](https://www.minio.io/), and [Ceph](https://ceph.com/), and [ECS](https://www.dell.com/en-us/shop/cty/sf/objectscale?hve=explore+objectscale). Please feel free to reach out to [support](https://support.hashicorp.com/hc/en-us) with questions.
+Recommended object storage solutions are AWS S3, Google Cloud storage, Azure blob storage. Other options for S3-compatible storage are [MinIO](https://www.minio.io/), and [Ceph](https://ceph.com/), and [ECS](https://www.dell.com/en-us/shop/cty/sf/objectscale?hve=explore+objectscale). Please feel free to reach out to [support](https://www.ibm.com/mysupport) with questions.
 
 ### External Services - PostgreSQL Database
 

--- a/content/terraform-enterprise/1.1.x/docs/enterprise/deploy/replicated/install/uninstall.mdx
+++ b/content/terraform-enterprise/1.1.x/docs/enterprise/deploy/replicated/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/1.1.x/docs/enterprise/deploy/replicated/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/1.1.x/docs/enterprise/deploy/replicated/requirements/data-storage/operational-mode-requirements.mdx
@@ -33,4 +33,4 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 - `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 - `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.

--- a/content/terraform-enterprise/1.1.x/docs/enterprise/deploy/troubleshoot/contact-support.mdx
+++ b/content/terraform-enterprise/1.1.x/docs/enterprise/deploy/troubleshoot/contact-support.mdx
@@ -14,7 +14,7 @@ expected, reach out to support for help.
 
 ## Open a ticket
 
-If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://support.hashicorp.com/hc/en-us) and open a ticket.
+If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://www.ibm.com/mysupport) and open a ticket.
 
 ## Diagnostics
 
@@ -52,7 +52,7 @@ Once you have downloaded your support bundle, please use a secure method to uplo
 
 Attach the bundle to your support ticket. 
 
-If possible, use the SendSafely integration available in the [HashiCorp support portal](https://support.hashicorp.com/hc/en-us). SendSafely lets you upload large file.
+If possible, use the SendSafely integration available in the [HashiCorp support portal](https://www.ibm.com/mysupport). SendSafely lets you upload large file.
 
 If you are unable to use the integration in the portal, upload the bundle directly to `https://hashicorp.sendsafely.com/u/ptfe-support-bundles`.
 

--- a/content/terraform-enterprise/1.1.x/docs/enterprise/vcs/bitbucket-data-center.mdx
+++ b/content/terraform-enterprise/1.1.x/docs/enterprise/vcs/bitbucket-data-center.mdx
@@ -16,7 +16,7 @@ This topic describes how to connect Bitbucket Data Center to HCP Terraform. For 
 
 **Bitbucket Server is deprecated**.  Atlassian ended support for Bitbucket Server on February 15, 2024, and recommends using either Bitbucket Data Center (v8.0 or newer) or Bitbucket Cloud instead. Refer to the [Atlassian documentation](https://bitbucket.org/blog/cloud-migration-benefits) for additional information.
 
-HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://support.hashicorp.com/hc/en-us) if you have any questions regarding this change.
+HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://www.ibm.com/mysupport) if you have any questions regarding this change.
 
 ## Overview
 

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/api-docs/index.mdx
@@ -46,13 +46,13 @@ last_modified: 2026-02-06T08:59:42-08:00
 
 <!-- BEGIN: TFC:only -->
 
-HCP Terraform provides an API for a subset of its features. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://support.hashicorp.com/hc/en-us) and open a ticket.
+HCP Terraform provides an API for a subset of its features. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://www.ibm.com/mysupport) and open a ticket.
 
 <!-- END: TFC:only -->
 
 <!-- BEGIN: TFEnterprise:only name:api-overview -->
 
-Terraform Enterprise provides an API for a subset of its features. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://support.hashicorp.com/hc/en-us) and open a ticket.
+Terraform Enterprise provides an API for a subset of its features. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://www.ibm.com/mysupport) and open a ticket.
 
 <!-- END: TFEnterprise:only name:api-overview  -->
 

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/application-administration/customization.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/application-administration/customization.mdx
@@ -26,7 +26,7 @@ You can update the support content displayed in the UI.
 
 Terraform Enterprise uses the support email address for system emails, error pages, and all other situations where users are prompted to contact support. You can specify a local email address if you want users to contact a specific person or team when they have issues.
 
-Note that this field defaults to `support@hashicorp.com`, which is not a functional email address for HashiCorp support. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://support.hashicorp.com/hc/en-us) and open a ticket.
+Note that this field defaults to `support@hashicorp.com`, which is not a functional email address for HashiCorp support. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://www.ibm.com/mysupport) and open a ticket.
 
 ### Error Instructions
 

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/manage/upgrade.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/manage/upgrade.mdx
@@ -282,6 +282,6 @@ If any validation step fails or the application does not stabilize:
    1. Restore object storage from the pre-upgrade snapshot.
    1. Deploy the previous Terraform Enterprise image version.
    1. Verify the application starts successfully.
-1. Contact [HashiCorp Support](https://support.hashicorp.com/hc/en-us) with collected logs, the upgrade path attempted, and error messages for assistance.
+1. Contact [HashiCorp Support](https://www.ibm.com/mysupport) with collected logs, the upgrade path attempted, and error messages for assistance.
 
-If you encounter issues at any point, contact [HashiCorp Support](https://support.hashicorp.com/hc/en-us) with your upgrade plan, release sequence, and the relevant logs.
+If you encounter issues at any point, contact [HashiCorp Support](https://www.ibm.com/mysupport) with your upgrade plan, release sequence, and the relevant logs.

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/architecture/reference-architecture/vmware.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/architecture/reference-architecture/vmware.mdx
@@ -270,7 +270,7 @@ application data stored in this location. This allows for further [server-side
 encryption](https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html)
 by S3 if required by your security policy.
 
-Recommended object storage solutions are AWS S3, Google Cloud storage, Azure blob storage. Other options for S3-compatible storage are [MinIO](https://www.minio.io/), and [Ceph](https://ceph.com/), and [ECS](https://www.dell.com/en-us/shop/cty/sf/objectscale?hve=explore+objectscale). Please feel free to reach out to [support](https://support.hashicorp.com/hc/en-us) with questions.
+Recommended object storage solutions are AWS S3, Google Cloud storage, Azure blob storage. Other options for S3-compatible storage are [MinIO](https://www.minio.io/), and [Ceph](https://ceph.com/), and [ECS](https://www.dell.com/en-us/shop/cty/sf/objectscale?hve=explore+objectscale). Please feel free to reach out to [support](https://www.ibm.com/mysupport) with questions.
 
 ### External Services - PostgreSQL Database
 

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/install/uninstall.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/requirements/data-storage/operational-mode-requirements.mdx
@@ -33,4 +33,4 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 - `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 - `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/troubleshoot/contact-support.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/troubleshoot/contact-support.mdx
@@ -14,7 +14,7 @@ expected, reach out to support for help.
 
 ## Open a ticket
 
-If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://support.hashicorp.com/hc/en-us) and open a ticket.
+If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://www.ibm.com/mysupport) and open a ticket.
 
 ## Diagnostics
 
@@ -52,7 +52,7 @@ Once you have downloaded your support bundle, please use a secure method to uplo
 
 Attach the bundle to your support ticket. 
 
-If possible, use the SendSafely integration available in the [HashiCorp support portal](https://support.hashicorp.com/hc/en-us). SendSafely lets you upload large file.
+If possible, use the SendSafely integration available in the [HashiCorp support portal](https://www.ibm.com/mysupport). SendSafely lets you upload large file.
 
 If you are unable to use the integration in the portal, upload the bundle directly to `https://hashicorp.sendsafely.com/u/ptfe-support-bundles`.
 

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/vcs/bitbucket-data-center.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/vcs/bitbucket-data-center.mdx
@@ -16,7 +16,7 @@ This topic describes how to connect Bitbucket Data Center to HCP Terraform. For 
 
 **Bitbucket Server is deprecated**.  Atlassian ended support for Bitbucket Server on February 15, 2024, and recommends using either Bitbucket Data Center (v8.0 or newer) or Bitbucket Cloud instead. Refer to the [Atlassian documentation](https://bitbucket.org/blog/cloud-migration-benefits) for additional information.
 
-HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://support.hashicorp.com/hc/en-us) if you have any questions regarding this change.
+HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://www.ibm.com/mysupport) if you have any questions regarding this change.
 
 ## Overview
 

--- a/content/terraform-enterprise/2.0.x/docs/enterprise/api-docs/index.mdx
+++ b/content/terraform-enterprise/2.0.x/docs/enterprise/api-docs/index.mdx
@@ -46,13 +46,13 @@ last_modified: 2026-04-08T18:54:16.000Z
 
 <!-- BEGIN: TFC:only -->
 
-HCP Terraform provides an API for a subset of its features. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://support.hashicorp.com/hc/en-us) and open a ticket.
+HCP Terraform provides an API for a subset of its features. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://www.ibm.com/mysupport) and open a ticket.
 
 <!-- END: TFC:only -->
 
 <!-- BEGIN: TFEnterprise:only name:api-overview -->
 
-Terraform Enterprise provides an API for a subset of its features. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://support.hashicorp.com/hc/en-us) and open a ticket.
+Terraform Enterprise provides an API for a subset of its features. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://www.ibm.com/mysupport) and open a ticket.
 
 <!-- END: TFEnterprise:only name:api-overview  -->
 

--- a/content/terraform-enterprise/2.0.x/docs/enterprise/application-administration/customization.mdx
+++ b/content/terraform-enterprise/2.0.x/docs/enterprise/application-administration/customization.mdx
@@ -26,7 +26,7 @@ You can update the support content displayed in the UI.
 
 Terraform Enterprise uses the support email address for system emails, error pages, and all other situations where users are prompted to contact support. You can specify a local email address if you want users to contact a specific person or team when they have issues.
 
-Note that this field defaults to `support@hashicorp.com`, which is not a functional email address for HashiCorp support. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://support.hashicorp.com/hc/en-us) and open a ticket.
+Note that this field defaults to `support@hashicorp.com`, which is not a functional email address for HashiCorp support. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://www.ibm.com/mysupport) and open a ticket.
 
 ### Error Instructions
 

--- a/content/terraform-enterprise/2.0.x/docs/enterprise/deploy/manage/upgrade/index.mdx
+++ b/content/terraform-enterprise/2.0.x/docs/enterprise/deploy/manage/upgrade/index.mdx
@@ -285,6 +285,6 @@ If any validation step fails or the application does not stabilize:
    1. Restore object storage from the pre-upgrade snapshot.
    1. Deploy the previous Terraform Enterprise image version.
    1. Verify the application starts successfully.
-1. Contact [HashiCorp Support](https://support.hashicorp.com/hc/en-us) with collected logs, the upgrade path attempted, and error messages for assistance.
+1. Contact [HashiCorp Support](https://www.ibm.com/mysupport) with collected logs, the upgrade path attempted, and error messages for assistance.
 
-If you encounter issues at any point, contact [HashiCorp Support](https://support.hashicorp.com/hc/en-us) with your upgrade plan, release sequence, and the relevant logs.
+If you encounter issues at any point, contact [HashiCorp Support](https://www.ibm.com/mysupport) with your upgrade plan, release sequence, and the relevant logs.

--- a/content/terraform-enterprise/2.0.x/docs/enterprise/deploy/replicated/architecture/reference-architecture/vmware.mdx
+++ b/content/terraform-enterprise/2.0.x/docs/enterprise/deploy/replicated/architecture/reference-architecture/vmware.mdx
@@ -270,7 +270,7 @@ application data stored in this location. This allows for further [server-side
 encryption](https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html)
 by S3 if required by your security policy.
 
-Recommended object storage solutions are AWS S3, Google Cloud storage, Azure blob storage. Other options for S3-compatible storage are [MinIO](https://www.minio.io/), and [Ceph](https://ceph.com/), and [ECS](https://www.dell.com/en-us/shop/cty/sf/objectscale?hve=explore+objectscale). Please feel free to reach out to [support](https://support.hashicorp.com/hc/en-us) with questions.
+Recommended object storage solutions are AWS S3, Google Cloud storage, Azure blob storage. Other options for S3-compatible storage are [MinIO](https://www.minio.io/), and [Ceph](https://ceph.com/), and [ECS](https://www.dell.com/en-us/shop/cty/sf/objectscale?hve=explore+objectscale). Please feel free to reach out to [support](https://www.ibm.com/mysupport) with questions.
 
 ### External Services - PostgreSQL Database
 

--- a/content/terraform-enterprise/2.0.x/docs/enterprise/deploy/replicated/install/uninstall.mdx
+++ b/content/terraform-enterprise/2.0.x/docs/enterprise/deploy/replicated/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/2.0.x/docs/enterprise/deploy/replicated/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/2.0.x/docs/enterprise/deploy/replicated/requirements/data-storage/operational-mode-requirements.mdx
@@ -33,4 +33,4 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 - `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 - `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.

--- a/content/terraform-enterprise/2.0.x/docs/enterprise/deploy/troubleshoot/contact-support.mdx
+++ b/content/terraform-enterprise/2.0.x/docs/enterprise/deploy/troubleshoot/contact-support.mdx
@@ -14,7 +14,7 @@ expected, reach out to support for help.
 
 ## Open a ticket
 
-If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://support.hashicorp.com/hc/en-us) and open a ticket.
+If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://www.ibm.com/mysupport) and open a ticket.
 
 ## Diagnostics
 
@@ -52,7 +52,7 @@ Once you have downloaded your support bundle, please use a secure method to uplo
 
 Attach the bundle to your support ticket. 
 
-If possible, use the SendSafely integration available in the [HashiCorp support portal](https://support.hashicorp.com/hc/en-us). SendSafely lets you upload large file.
+If possible, use the SendSafely integration available in the [HashiCorp support portal](https://www.ibm.com/mysupport). SendSafely lets you upload large file.
 
 If you are unable to use the integration in the portal, upload the bundle directly to `https://hashicorp.sendsafely.com/u/ptfe-support-bundles`.
 

--- a/content/terraform-enterprise/2.0.x/docs/enterprise/vcs/bitbucket-data-center.mdx
+++ b/content/terraform-enterprise/2.0.x/docs/enterprise/vcs/bitbucket-data-center.mdx
@@ -16,7 +16,7 @@ This topic describes how to connect Bitbucket Data Center to HCP Terraform. For 
 
 **Bitbucket Server is deprecated**.  Atlassian ended support for Bitbucket Server on February 15, 2024, and recommends using either Bitbucket Data Center (v8.0 or newer) or Bitbucket Cloud instead. Refer to the [Atlassian documentation](https://bitbucket.org/blog/cloud-migration-benefits) for additional information.
 
-HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://support.hashicorp.com/hc/en-us) if you have any questions regarding this change.
+HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://www.ibm.com/mysupport) if you have any questions regarding this change.
 
 ## Overview
 

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
@@ -81,4 +81,4 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 * `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 * `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/support/index.mdx
@@ -14,7 +14,7 @@ expected, please reach out to support for help.
 
 ## Email
 
-You can engage HashiCorp support via the web portal at <https://support.hashicorp.com> or
+You can engage HashiCorp support via the web portal at <https://www.ibm.com/mysupport> or
 by email at <support@hashicorp.com>. Please make sure
 to use your organization email (not your personal email) when contacting us so
 we can associate the support request with your organization and expedite our

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
@@ -81,4 +81,4 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 * `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 * `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/support/index.mdx
@@ -14,7 +14,7 @@ expected, please reach out to support for help.
 
 ## Email
 
-You can engage HashiCorp support via the web portal at <https://support.hashicorp.com> or
+You can engage HashiCorp support via the web portal at <https://www.ibm.com/mysupport> or
 by email at <support@hashicorp.com>. Please make sure
 to use your organization email (not your personal email) when contacting us so
 we can associate the support request with your organization and expedite our

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
@@ -81,4 +81,4 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 * `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 * `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/support/index.mdx
@@ -14,7 +14,7 @@ expected, please reach out to support for help.
 
 ## Email
 
-You can engage HashiCorp support via the web portal at <https://support.hashicorp.com> or
+You can engage HashiCorp support via the web portal at <https://www.ibm.com/mysupport> or
 by email at <support@hashicorp.com>. Please make sure
 to use your organization email (not your personal email) when contacting us so
 we can associate the support request with your organization and expedite our

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
@@ -81,4 +81,4 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 * `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 * `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/support/index.mdx
@@ -14,7 +14,7 @@ expected, please reach out to support for help.
 
 ## Email
 
-You can engage HashiCorp support via the web portal at <https://support.hashicorp.com> or
+You can engage HashiCorp support via the web portal at <https://www.ibm.com/mysupport> or
 by email at <support@hashicorp.com>. Please make sure
 to use your organization email (not your personal email) when contacting us so
 we can associate the support request with your organization and expedite our

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
@@ -81,4 +81,4 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 * `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 * `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/support/index.mdx
@@ -14,7 +14,7 @@ expected, please reach out to support for help.
 
 ## Email
 
-You can engage HashiCorp support via the web portal at <https://support.hashicorp.com> or
+You can engage HashiCorp support via the web portal at <https://www.ibm.com/mysupport> or
 by email at <support@hashicorp.com>. Please make sure
 to use your organization email (not your personal email) when contacting us so
 we can associate the support request with your organization and expedite our

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
@@ -81,4 +81,4 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 * `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 * `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/support/index.mdx
@@ -14,7 +14,7 @@ expected, please reach out to support for help.
 
 ## Email
 
-You can engage HashiCorp support via the web portal at <https://support.hashicorp.com> or
+You can engage HashiCorp support via the web portal at <https://www.ibm.com/mysupport> or
 by email at <support@hashicorp.com>. Please make sure
 to use your organization email (not your personal email) when contacting us so
 we can associate the support request with your organization and expedite our

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
@@ -81,4 +81,4 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 * `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 * `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/support/index.mdx
@@ -14,7 +14,7 @@ expected, please reach out to support for help.
 
 ## Email
 
-You can engage HashiCorp support via the web portal at <https://support.hashicorp.com> or
+You can engage HashiCorp support via the web portal at <https://www.ibm.com/mysupport> or
 by email at <support@hashicorp.com>. Please make sure
 to use your organization email (not your personal email) when contacting us so
 we can associate the support request with your organization and expedite our

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
@@ -81,4 +81,4 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 * `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 * `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/support/index.mdx
@@ -14,7 +14,7 @@ expected, please reach out to support for help.
 
 ## Email
 
-You can engage HashiCorp support via the web portal at <https://support.hashicorp.com> or
+You can engage HashiCorp support via the web portal at <https://www.ibm.com/mysupport> or
 by email at <support@hashicorp.com>. Please make sure
 to use your organization email (not your personal email) when contacting us so
 we can associate the support request with your organization and expedite our

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
@@ -81,5 +81,5 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 * `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 * `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.
 

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/support/index.mdx
@@ -14,7 +14,7 @@ expected, please reach out to support for help.
 
 ## Email
 
-You can engage HashiCorp support via the web portal at <https://support.hashicorp.com> or
+You can engage HashiCorp support via the web portal at <https://www.ibm.com/mysupport> or
 by email at <support@hashicorp.com>. Please make sure
 to use your organization email (not your personal email) when contacting us so
 we can associate the support request with your organization and expedite our

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
@@ -81,5 +81,5 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 * `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 * `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.
 

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/support/index.mdx
@@ -14,7 +14,7 @@ expected, please reach out to support for help.
 
 ## Email
 
-You can engage HashiCorp support via the web portal at <https://support.hashicorp.com> or
+You can engage HashiCorp support via the web portal at <https://www.ibm.com/mysupport> or
 by email at <support@hashicorp.com>. Please make sure
 to use your organization email (not your personal email) when contacting us so
 we can associate the support request with your organization and expedite our

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
@@ -81,5 +81,5 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 * `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 * `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.
 

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/support/index.mdx
@@ -14,7 +14,7 @@ expected, please reach out to support for help.
 
 ## Email
 
-You can engage HashiCorp support via the web portal at <https://support.hashicorp.com> or
+You can engage HashiCorp support via the web portal at <https://www.ibm.com/mysupport> or
 by email at <support@hashicorp.com>. Please make sure
 to use your organization email (not your personal email) when contacting us so
 we can associate the support request with your organization and expedite our

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
@@ -81,5 +81,5 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 * `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 * `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.
 

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/support/index.mdx
@@ -14,7 +14,7 @@ expected, please reach out to support for help.
 
 ## Email
 
-You can engage HashiCorp support via the web portal at <https://support.hashicorp.com> or
+You can engage HashiCorp support via the web portal at <https://www.ibm.com/mysupport> or
 by email at <support@hashicorp.com>. Please make sure
 to use your organization email (not your personal email) when contacting us so
 we can associate the support request with your organization and expedite our

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
@@ -81,5 +81,5 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 * `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 * `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.
 

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/support/index.mdx
@@ -14,7 +14,7 @@ expected, please reach out to support for help.
 
 ## Email
 
-You can engage HashiCorp support via the web portal at <https://support.hashicorp.com> or
+You can engage HashiCorp support via the web portal at <https://www.ibm.com/mysupport> or
 by email at <support@hashicorp.com>. Please make sure
 to use your organization email (not your personal email) when contacting us so
 we can associate the support request with your organization and expedite our

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
@@ -81,5 +81,5 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 * `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 * `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.
 

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/support/index.mdx
@@ -14,7 +14,7 @@ expected, please reach out to support for help.
 
 ## Email
 
-You can engage HashiCorp support via the web portal at <https://support.hashicorp.com> or
+You can engage HashiCorp support via the web portal at <https://www.ibm.com/mysupport> or
 by email at <support@hashicorp.com>. Please make sure
 to use your organization email (not your personal email) when contacting us so
 we can associate the support request with your organization and expedite our

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
@@ -81,5 +81,5 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 * `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 * `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/support/index.mdx
@@ -14,7 +14,7 @@ expected, please reach out to support for help.
 
 ## Email
 
-You can engage HashiCorp support via the web portal at <https://support.hashicorp.com> or
+You can engage HashiCorp support via the web portal at <https://www.ibm.com/mysupport> or
 by email at <support@hashicorp.com>. Please make sure
 to use your organization email (not your personal email) when contacting us so
 we can associate the support request with your organization and expedite our

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
@@ -80,5 +80,5 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 * `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 * `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/support/index.mdx
@@ -14,7 +14,7 @@ expected, please reach out to support for help.
 
 ## Email
 
-You can engage HashiCorp support via the web portal at <https://support.hashicorp.com> or
+You can engage HashiCorp support via the web portal at <https://www.ibm.com/mysupport> or
 by email at <support@hashicorp.com>. Please make sure
 to use your organization email (not your personal email) when contacting us so
 we can associate the support request with your organization and expedite our

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
@@ -80,5 +80,5 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 * `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 * `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/support/index.mdx
@@ -14,7 +14,7 @@ expected, please reach out to support for help.
 
 ## Email
 
-You can engage HashiCorp support via the web portal at <https://support.hashicorp.com> or
+You can engage HashiCorp support via the web portal at <https://www.ibm.com/mysupport> or
 by email at <support@hashicorp.com>. Please make sure
 to use your organization email (not your personal email) when contacting us so
 we can associate the support request with your organization and expedite our

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
@@ -80,5 +80,5 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 * `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 * `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/support/index.mdx
@@ -14,7 +14,7 @@ expected, please reach out to support for help.
 
 ## Email
 
-You can engage HashiCorp support via the web portal at <https://support.hashicorp.com> or
+You can engage HashiCorp support via the web portal at <https://www.ibm.com/mysupport> or
 by email at <support@hashicorp.com>. Please make sure
 to use your organization email (not your personal email) when contacting us so
 we can associate the support request with your organization and expedite our

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
@@ -80,5 +80,5 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 * `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 * `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/support/index.mdx
@@ -14,7 +14,7 @@ expected, please reach out to support for help.
 
 ## Email
 
-You can engage HashiCorp support via the web portal at <https://support.hashicorp.com> or
+You can engage HashiCorp support via the web portal at <https://www.ibm.com/mysupport> or
 by email at <support@hashicorp.com>. Please make sure
 to use your organization email (not your personal email) when contacting us so
 we can associate the support request with your organization and expedite our

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/admin/admin-cli/admin-cli.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/admin/admin-cli/admin-cli.mdx
@@ -13,7 +13,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Terraform Enterprise admin CLI commands

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/admin/admin-cli/backup-restore.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/admin/admin-cli/backup-restore.mdx
@@ -13,7 +13,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Terraform Enterprise backups and restores

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/admin/index.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/admin/index.mdx
@@ -13,7 +13,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Terraform Enterprise Flexible Deployment Options administration

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/admin/support.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/admin/support.mdx
@@ -13,7 +13,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Support
@@ -30,7 +30,7 @@ HashiCorp support does not adhere to standard SLAs for issues that occur during 
 HashiCorp support will provide support for issues related to install or operation of Terraform Enterprise during the Flexible Deployment Options beta program.
 While every effort will be made to respond quickly to Beta issues, please note that response times on beta releases are not held to standard SLAs.
 
-Please open a Low or Normal priority ticket on [support.hashicorp.com](https://support.hashicorp.com/), specifying your deployment option, and that you’re using the beta release. You can do this in the ‘Terraform Enterprise Version’ field, by selecting “Docker/Kubernetes” → “Beta 1.0”.
+Please open a Low or Normal priority ticket on [support.hashicorp.com](https://www.ibm.com/mysupport/), specifying your deployment option, and that you’re using the beta release. You can do this in the ‘Terraform Enterprise Version’ field, by selecting “Docker/Kubernetes” → “Beta 1.0”.
 
 Included in your ticket should be the following:
 * Information about your deployment:

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/index.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/index.mdx
@@ -12,7 +12,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Terraform Enterprise Flexible Deployment Options
@@ -45,4 +45,4 @@ session to raise the issue! You can open a [support ticket](/terraform/enterpris
 
 ## Support for beta issues
 
-[HashiCorp Support](https://support.hashicorp.com) is providing support for issues related to the operation of Terraform Enterprise during the Flexible Deployment Options beta. While we will make every effort to respond quickly to beta issues, please note that response times on beta releases are not held to SLAs. [Learn more about beta support](/terraform/enterprise/flexible-deployments-beta/admin/support).
+[HashiCorp Support](https://www.ibm.com/mysupport) is providing support for issues related to the operation of Terraform Enterprise during the Flexible Deployment Options beta. While we will make every effort to respond quickly to beta issues, please note that response times on beta releases are not held to SLAs. [Learn more about beta support](/terraform/enterprise/flexible-deployments-beta/admin/support).

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/install/configuration.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/install/configuration.mdx
@@ -12,7 +12,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Terraform Enterprise Flexible Deployment Options configuration reference

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/install/docker.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/install/docker.mdx
@@ -13,7 +13,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Docker installation

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/install/initial-admin-user.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/install/initial-admin-user.mdx
@@ -12,7 +12,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Creating the initial admin user

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/install/kubernetes.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/install/kubernetes.mdx
@@ -13,7 +13,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Prerequisites for installing on Kubernetes

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/install/migration.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/install/migration.mdx
@@ -14,7 +14,7 @@ last_modified: 2023-01-01T00:00:00.000Z
 		
   If you would like to participate in the beta program, please contact your HashiCorp account team. 
 
-  All support requests should go to [https://support.hashicorp.com](https://support.hashicorp.com). Please review the [Beta Support documentation page](/terraform/enterprise/flexible-deployments-beta/admin/support) for more information.
+  All support requests should go to [https://www.ibm.com/mysupport](https://www.ibm.com/mysupport). Please review the [Beta Support documentation page](/terraform/enterprise/flexible-deployments-beta/admin/support) for more information.
 
 </Note>
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/install/requirements/docker.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/install/requirements/docker.mdx
@@ -13,7 +13,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/install/requirements/kubernetes.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/install/requirements/kubernetes.mdx
@@ -13,7 +13,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Kubernetes requirements

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/install/requirements/license.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/install/requirements/license.mdx
@@ -12,7 +12,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # HashiCorp-issued Terraform Enterprise license

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/install/scaling.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/install/scaling.mdx
@@ -13,7 +13,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Scaling guide for Kubernetes runtime

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/monitoring/observability/logs.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/monitoring/observability/logs.mdx
@@ -13,7 +13,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Logs

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/monitoring/observability/metrics.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/monitoring/observability/metrics.mdx
@@ -12,7 +12,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Metrics

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/monitoring/startup-checks.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/monitoring/startup-checks.mdx
@@ -13,7 +13,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Startup checks

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/replicated-migration.mdx
@@ -12,7 +12,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Migrating from Replicated

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/requirements/network.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/requirements/network.mdx
@@ -13,7 +13,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Network Requirements for Terraform Enterprise

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/flexible-deployments-beta/troubleshooting.mdx
@@ -12,7 +12,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Troubleshooting

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
@@ -80,5 +80,5 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 * `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 * `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/support/index.mdx
@@ -14,7 +14,7 @@ expected, please reach out to support for help.
 
 ## Email
 
-You can engage HashiCorp support via the web portal at <https://support.hashicorp.com> or
+You can engage HashiCorp support via the web portal at <https://www.ibm.com/mysupport> or
 by email at <support@hashicorp.com>. Please make sure
 to use your organization email (not your personal email) when contacting us so
 we can associate the support request with your organization and expedite our

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/admin/admin-cli/admin-cli.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/admin/admin-cli/admin-cli.mdx
@@ -13,7 +13,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Terraform Enterprise admin CLI commands

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/admin/admin-cli/backup-restore.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/admin/admin-cli/backup-restore.mdx
@@ -13,7 +13,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Terraform Enterprise backups and restores

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/admin/index.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/admin/index.mdx
@@ -13,7 +13,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Terraform Enterprise Flexible Deployment Options administration

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/admin/support.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/admin/support.mdx
@@ -13,7 +13,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Support
@@ -30,7 +30,7 @@ HashiCorp support does not adhere to standard SLAs for issues that occur during 
 HashiCorp support will provide support for issues related to install or operation of Terraform Enterprise during the Flexible Deployment Options beta program.
 While every effort will be made to respond quickly to Beta issues, please note that response times on beta releases are not held to standard SLAs.
 
-Please open a Low or Normal priority ticket on [support.hashicorp.com](https://support.hashicorp.com/), specifying your deployment option, and that you’re using the beta release. You can do this in the ‘Terraform Enterprise Version’ field, by selecting “Docker/Kubernetes” → “Beta 1.0”.
+Please open a Low or Normal priority ticket on [support.hashicorp.com](https://www.ibm.com/mysupport/), specifying your deployment option, and that you’re using the beta release. You can do this in the ‘Terraform Enterprise Version’ field, by selecting “Docker/Kubernetes” → “Beta 1.0”.
 
 Included in your ticket should be the following:
 * Information about your deployment:

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/index.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/index.mdx
@@ -12,7 +12,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Terraform Enterprise Flexible Deployment Options
@@ -45,4 +45,4 @@ session to raise the issue! You can open a [support ticket](/terraform/enterpris
 
 ## Support for beta issues
 
-[HashiCorp Support](https://support.hashicorp.com) is providing support for issues related to the operation of Terraform Enterprise during the Flexible Deployment Options beta. While we will make every effort to respond quickly to beta issues, please note that response times on beta releases are not held to SLAs. [Learn more about beta support](/terraform/enterprise/flexible-deployments-beta/admin/support).
+[HashiCorp Support](https://www.ibm.com/mysupport) is providing support for issues related to the operation of Terraform Enterprise during the Flexible Deployment Options beta. While we will make every effort to respond quickly to beta issues, please note that response times on beta releases are not held to SLAs. [Learn more about beta support](/terraform/enterprise/flexible-deployments-beta/admin/support).

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/install/configuration.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/install/configuration.mdx
@@ -12,7 +12,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Terraform Enterprise Flexible Deployment Options configuration reference

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/install/docker.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/install/docker.mdx
@@ -13,7 +13,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Docker installation

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/install/initial-admin-user.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/install/initial-admin-user.mdx
@@ -12,7 +12,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Creating the initial admin user

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/install/kubernetes.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/install/kubernetes.mdx
@@ -13,7 +13,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Prerequisites for installing on Kubernetes

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/install/migration.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/install/migration.mdx
@@ -14,7 +14,7 @@ last_modified: 2023-01-01T00:00:00.000Z
 		
   If you would like to participate in the beta program, please contact your HashiCorp account team. 
 
-  All support requests should go to [https://support.hashicorp.com](https://support.hashicorp.com). Please review the [Beta Support documentation page](/terraform/enterprise/flexible-deployments-beta/admin/support) for more information.
+  All support requests should go to [https://www.ibm.com/mysupport](https://www.ibm.com/mysupport). Please review the [Beta Support documentation page](/terraform/enterprise/flexible-deployments-beta/admin/support) for more information.
 
 </Note>
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/install/requirements/docker.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/install/requirements/docker.mdx
@@ -13,7 +13,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/install/requirements/kubernetes.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/install/requirements/kubernetes.mdx
@@ -13,7 +13,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Kubernetes requirements

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/install/requirements/license.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/install/requirements/license.mdx
@@ -12,7 +12,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # HashiCorp-issued Terraform Enterprise license

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/install/scaling.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/install/scaling.mdx
@@ -13,7 +13,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Scaling guide for Kubernetes runtime

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/monitoring/observability/logs.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/monitoring/observability/logs.mdx
@@ -13,7 +13,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Logs

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/monitoring/observability/metrics.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/monitoring/observability/metrics.mdx
@@ -12,7 +12,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Metrics

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/monitoring/startup-checks.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/monitoring/startup-checks.mdx
@@ -13,7 +13,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Startup checks

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/replicated-migration.mdx
@@ -12,7 +12,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Migrating from Replicated

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/requirements/network.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/requirements/network.mdx
@@ -13,7 +13,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Network Requirements for Terraform Enterprise

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/flexible-deployments-beta/troubleshooting.mdx
@@ -12,7 +12,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Troubleshooting

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
@@ -80,5 +80,5 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 * `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 * `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/support/index.mdx
@@ -14,7 +14,7 @@ expected, please reach out to support for help.
 
 ## Email
 
-You can engage HashiCorp support via the web portal at <https://support.hashicorp.com> or
+You can engage HashiCorp support via the web portal at <https://www.ibm.com/mysupport> or
 by email at <support@hashicorp.com>. Please make sure
 to use your organization email (not your personal email) when contacting us so
 we can associate the support request with your organization and expedite our

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/admin/admin-cli/admin-cli.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/admin/admin-cli/admin-cli.mdx
@@ -13,7 +13,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Terraform Enterprise admin CLI commands

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/admin/admin-cli/backup-restore.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/admin/admin-cli/backup-restore.mdx
@@ -13,7 +13,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Terraform Enterprise backups and restores

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/admin/index.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/admin/index.mdx
@@ -13,7 +13,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Terraform Enterprise Flexible Deployment Options administration

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/admin/support.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/admin/support.mdx
@@ -13,7 +13,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Support
@@ -30,7 +30,7 @@ HashiCorp support does not adhere to standard SLAs for issues that occur during 
 HashiCorp support will provide support for issues related to install or operation of Terraform Enterprise during the Flexible Deployment Options beta program.
 While every effort will be made to respond quickly to Beta issues, please note that response times on beta releases are not held to standard SLAs.
 
-Please open a Low or Normal priority ticket on [support.hashicorp.com](https://support.hashicorp.com/), specifying your deployment option, and that you’re using the beta release. You can do this in the ‘Terraform Enterprise Version’ field, by selecting “Docker/Kubernetes” → “Beta 1.0”.
+Please open a Low or Normal priority ticket on [support.hashicorp.com](https://www.ibm.com/mysupport/), specifying your deployment option, and that you’re using the beta release. You can do this in the ‘Terraform Enterprise Version’ field, by selecting “Docker/Kubernetes” → “Beta 1.0”.
 
 Included in your ticket should be the following:
 * Information about your deployment:

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/index.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/index.mdx
@@ -12,7 +12,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Terraform Enterprise Flexible Deployment Options
@@ -45,4 +45,4 @@ session to raise the issue! You can open a [support ticket](/terraform/enterpris
 
 ## Support for beta issues
 
-[HashiCorp Support](https://support.hashicorp.com) is providing support for issues related to the operation of Terraform Enterprise during the Flexible Deployment Options beta. While we will make every effort to respond quickly to beta issues, please note that response times on beta releases are not held to SLAs. [Learn more about beta support](/terraform/enterprise/flexible-deployments-beta/admin/support).
+[HashiCorp Support](https://www.ibm.com/mysupport) is providing support for issues related to the operation of Terraform Enterprise during the Flexible Deployment Options beta. While we will make every effort to respond quickly to beta issues, please note that response times on beta releases are not held to SLAs. [Learn more about beta support](/terraform/enterprise/flexible-deployments-beta/admin/support).

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/install/configuration.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/install/configuration.mdx
@@ -12,7 +12,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Terraform Enterprise Flexible Deployment Options configuration reference

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/install/docker.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/install/docker.mdx
@@ -13,7 +13,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Docker installation

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/install/initial-admin-user.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/install/initial-admin-user.mdx
@@ -12,7 +12,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Creating the initial admin user

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/install/kubernetes.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/install/kubernetes.mdx
@@ -13,7 +13,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Prerequisites for installing on Kubernetes

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/install/requirements/docker.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/install/requirements/docker.mdx
@@ -13,7 +13,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/install/requirements/kubernetes.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/install/requirements/kubernetes.mdx
@@ -13,7 +13,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Kubernetes requirements

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/install/requirements/license.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/install/requirements/license.mdx
@@ -12,7 +12,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # HashiCorp-issued Terraform Enterprise license

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/install/scaling.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/install/scaling.mdx
@@ -13,7 +13,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Scaling guide for Kubernetes runtime

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/monitoring/observability/logs.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/monitoring/observability/logs.mdx
@@ -13,7 +13,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Logs

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/monitoring/observability/metrics.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/monitoring/observability/metrics.mdx
@@ -12,7 +12,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Metrics

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/monitoring/startup-checks.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/monitoring/startup-checks.mdx
@@ -13,7 +13,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Startup checks

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/replicated-migration.mdx
@@ -12,7 +12,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Migrating from Replicated

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/requirements/network.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/requirements/network.mdx
@@ -13,7 +13,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Network Requirements for Terraform Enterprise

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/troubleshooting.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/flexible-deployments-beta/troubleshooting.mdx
@@ -12,7 +12,7 @@ last_modified: 2023-01-01T00:00:00.000Z
   This documentation supports the Beta release of Terraform Enterprise Flexible Deployment Options. The information here does not apply to other generally available releases of Terraform Enterprise. 
 <br/>
 
-  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://support.hashicorp.com).
+  If you want to participate in the beta program, get in touch with your HashiCorp account team. For beta support, visit our [Support page](/terraform/enterprise/flexible-deployments-beta/admin/support) or [submit a request directly](https://www.ibm.com/mysupport).
 </Note>
 
 # Troubleshooting

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx
@@ -80,5 +80,5 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 * `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 * `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/support/index.mdx
@@ -14,7 +14,7 @@ expected, please reach out to support for help.
 
 ## Email
 
-You can engage HashiCorp support via the web portal at <https://support.hashicorp.com> or
+You can engage HashiCorp support via the web portal at <https://www.ibm.com/mysupport> or
 by email at <support@hashicorp.com>. Please make sure
 to use your organization email (not your personal email) when contacting us so
 we can associate the support request with your organization and expedite our

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
@@ -33,4 +33,4 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 - `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 - `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/support/index.mdx
@@ -14,7 +14,7 @@ expected, please reach out to support for help.
 
 ## Email
 
-You can engage HashiCorp support via the web portal at <https://support.hashicorp.com> or
+You can engage HashiCorp support via the web portal at <https://www.ibm.com/mysupport> or
 by emailing <support@hashicorp.com>. Please make sure
 to use your organization email (not your personal email) when contacting us so
 we can associate the support request with your organization and expedite our

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
@@ -33,4 +33,4 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 - `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 - `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/support/index.mdx
@@ -14,7 +14,7 @@ expected, please reach out to support for help.
 
 ## Email
 
-You can engage HashiCorp support via the web portal at <https://support.hashicorp.com> or
+You can engage HashiCorp support via the web portal at <https://www.ibm.com/mysupport> or
 by emailing <support@hashicorp.com>. Please make sure
 to use your organization email (not your personal email) when contacting us so
 we can associate the support request with your organization and expedite our

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
@@ -33,4 +33,4 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 - `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 - `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/support/index.mdx
@@ -14,7 +14,7 @@ expected, please reach out to support for help.
 
 ## Email
 
-You can engage HashiCorp support via the web portal at <https://support.hashicorp.com> or
+You can engage HashiCorp support via the web portal at <https://www.ibm.com/mysupport> or
 by emailing <support@hashicorp.com>. Please make sure
 to use your organization email (not your personal email) when contacting us so
 we can associate the support request with your organization and expedite our

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
@@ -33,4 +33,4 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 - `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 - `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/support/index.mdx
@@ -14,7 +14,7 @@ expected, please reach out to support for help.
 
 ## Email
 
-You can engage HashiCorp support via the web portal at <https://support.hashicorp.com> or
+You can engage HashiCorp support via the web portal at <https://www.ibm.com/mysupport> or
 by emailing <support@hashicorp.com>. Please make sure
 to use your organization email (not your personal email) when contacting us so
 we can associate the support request with your organization and expedite our

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
@@ -33,4 +33,4 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 - `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 - `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/support/index.mdx
@@ -14,7 +14,7 @@ expected, please reach out to support for help.
 
 ## Email
 
-You can engage HashiCorp support via the web portal at <https://support.hashicorp.com> or
+You can engage HashiCorp support via the web portal at <https://www.ibm.com/mysupport> or
 by emailing <support@hashicorp.com>. Please make sure
 to use your organization email (not your personal email) when contacting us so
 we can associate the support request with your organization and expedite our

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
@@ -33,4 +33,4 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 - `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 - `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/support/index.mdx
@@ -14,7 +14,7 @@ expected, please reach out to support for help.
 
 ## Email
 
-You can engage HashiCorp support via the web portal at <https://support.hashicorp.com> or
+You can engage HashiCorp support via the web portal at <https://www.ibm.com/mysupport> or
 by emailing <support@hashicorp.com>. Please make sure
 to use your organization email (not your personal email) when contacting us so
 we can associate the support request with your organization and expedite our

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
@@ -33,4 +33,4 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 - `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 - `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/support/index.mdx
@@ -14,7 +14,7 @@ expected, please reach out to support for help.
 
 ## Email
 
-You can engage HashiCorp support via the web portal at <https://support.hashicorp.com> or
+You can engage HashiCorp support via the web portal at <https://www.ibm.com/mysupport> or
 by emailing <support@hashicorp.com>. Please make sure
 to use your organization email (not your personal email) when contacting us so
 we can associate the support request with your organization and expedite our

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
@@ -33,4 +33,4 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 - `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 - `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/support/index.mdx
@@ -14,7 +14,7 @@ expected, please reach out to support for help.
 
 ## Email
 
-You can engage HashiCorp support via the web portal at <https://support.hashicorp.com> or
+You can engage HashiCorp support via the web portal at <https://www.ibm.com/mysupport> or
 by emailing <support@hashicorp.com>. Please make sure
 to use your organization email (not your personal email) when contacting us so
 we can associate the support request with your organization and expedite our

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
@@ -33,4 +33,4 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 - `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 - `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/support/index.mdx
@@ -14,7 +14,7 @@ expected, please reach out to support for help.
 
 ## Email
 
-You can engage HashiCorp support via the web portal at <https://support.hashicorp.com> or
+You can engage HashiCorp support via the web portal at <https://www.ibm.com/mysupport> or
 by emailing <support@hashicorp.com>. Please make sure
 to use your organization email (not your personal email) when contacting us so
 we can associate the support request with your organization and expedite our

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/vcs/bitbucket-data-center.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/vcs/bitbucket-data-center.mdx
@@ -14,7 +14,7 @@ This topic describes how to connect Bitbucket Data Center to HCP Terraform. For 
 
 **Bitbucket Server is deprecated**.  Atlassian ended support for Bitbucket Server on February 15, 2024, and recommends using either Bitbucket Data Center or Bitbucket Cloud instead. Refer to the [Atlassian documentation](https://bitbucket.org/blog/cloud-migration-benefits) for additional information.
 
-HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://support.hashicorp.com/hc/en-us) if you have any questions regarding this change.
+HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://www.ibm.com/mysupport) if you have any questions regarding this change.
 
 ## Overview
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
@@ -33,4 +33,4 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 - `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 - `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/support/index.mdx
@@ -14,7 +14,7 @@ expected, please reach out to support for help.
 
 ## Email
 
-You can engage HashiCorp support via the web portal at <https://support.hashicorp.com> or
+You can engage HashiCorp support via the web portal at <https://www.ibm.com/mysupport> or
 by emailing <support@hashicorp.com>. Please make sure
 to use your organization email (not your personal email) when contacting us so
 we can associate the support request with your organization and expedite our

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/vcs/bitbucket-data-center.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/vcs/bitbucket-data-center.mdx
@@ -14,7 +14,7 @@ This topic describes how to connect Bitbucket Data Center to HCP Terraform. For 
 
 **Bitbucket Server is deprecated**.  Atlassian ended support for Bitbucket Server on February 15, 2024, and recommends using either Bitbucket Data Center (v8.0 or newer) or Bitbucket Cloud instead. Refer to the [Atlassian documentation](https://bitbucket.org/blog/cloud-migration-benefits) for additional information. 
 
-HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://support.hashicorp.com/hc/en-us) if you have any questions regarding this change.
+HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://www.ibm.com/mysupport) if you have any questions regarding this change.
 
 ## Overview
 

--- a/content/terraform-enterprise/v202405-1/docs/enterprise/replicated/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202405-1/docs/enterprise/replicated/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202405-1/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202405-1/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
@@ -33,4 +33,4 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 - `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 - `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.

--- a/content/terraform-enterprise/v202405-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202405-1/docs/enterprise/support/index.mdx
@@ -14,7 +14,7 @@ expected, please reach out to support for help.
 
 ## Email
 
-You can engage HashiCorp support via the web portal at <https://support.hashicorp.com> or
+You can engage HashiCorp support via the web portal at <https://www.ibm.com/mysupport> or
 by emailing <support@hashicorp.com>. Please make sure
 to use your organization email (not your personal email) when contacting us so
 we can associate the support request with your organization and expedite our

--- a/content/terraform-enterprise/v202405-1/docs/enterprise/vcs/bitbucket-data-center.mdx
+++ b/content/terraform-enterprise/v202405-1/docs/enterprise/vcs/bitbucket-data-center.mdx
@@ -14,7 +14,7 @@ This topic describes how to connect Bitbucket Data Center to HCP Terraform. For 
 
 **Bitbucket Server is deprecated**.  Atlassian ended support for Bitbucket Server on February 15, 2024, and recommends using either Bitbucket Data Center or Bitbucket Cloud instead. Refer to the [Atlassian documentation](https://bitbucket.org/blog/cloud-migration-benefits) for additional information.
 
-HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://support.hashicorp.com/hc/en-us) if you have any questions regarding this change.
+HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://www.ibm.com/mysupport) if you have any questions regarding this change.
 
 ## Overview
 

--- a/content/terraform-enterprise/v202406-1/docs/enterprise/replicated/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202406-1/docs/enterprise/replicated/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202406-1/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202406-1/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
@@ -33,4 +33,4 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 - `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 - `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.

--- a/content/terraform-enterprise/v202406-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202406-1/docs/enterprise/support/index.mdx
@@ -14,7 +14,7 @@ expected, please reach out to support for help.
 
 ## Email
 
-You can engage HashiCorp support via the web portal at <https://support.hashicorp.com> or
+You can engage HashiCorp support via the web portal at <https://www.ibm.com/mysupport> or
 by emailing <support@hashicorp.com>. Please make sure
 to use your organization email (not your personal email) when contacting us so
 we can associate the support request with your organization and expedite our

--- a/content/terraform-enterprise/v202406-1/docs/enterprise/vcs/bitbucket-data-center.mdx
+++ b/content/terraform-enterprise/v202406-1/docs/enterprise/vcs/bitbucket-data-center.mdx
@@ -14,7 +14,7 @@ This topic describes how to connect Bitbucket Data Center to HCP Terraform. For 
 
 **Bitbucket Server is deprecated**.  Atlassian ended support for Bitbucket Server on February 15, 2024, and recommends using either Bitbucket Data Center (v8.0 or newer) or Bitbucket Cloud instead. Refer to the [Atlassian documentation](https://bitbucket.org/blog/cloud-migration-benefits) for additional information. 
 
-HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://support.hashicorp.com/hc/en-us) if you have any questions regarding this change.
+HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://www.ibm.com/mysupport) if you have any questions regarding this change.
 
 ## Overview
 

--- a/content/terraform-enterprise/v202407-1/docs/enterprise/replicated/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202407-1/docs/enterprise/replicated/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202407-1/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202407-1/docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx
@@ -33,4 +33,4 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 - `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 - `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.

--- a/content/terraform-enterprise/v202407-1/docs/enterprise/support/index.mdx
+++ b/content/terraform-enterprise/v202407-1/docs/enterprise/support/index.mdx
@@ -14,7 +14,7 @@ expected, please reach out to support for help.
 
 ## Email
 
-You can engage HashiCorp support via the web portal at <https://support.hashicorp.com> or
+You can engage HashiCorp support via the web portal at <https://www.ibm.com/mysupport> or
 by emailing <support@hashicorp.com>. Please make sure
 to use your organization email (not your personal email) when contacting us so
 we can associate the support request with your organization and expedite our

--- a/content/terraform-enterprise/v202407-1/docs/enterprise/vcs/bitbucket-data-center.mdx
+++ b/content/terraform-enterprise/v202407-1/docs/enterprise/vcs/bitbucket-data-center.mdx
@@ -14,7 +14,7 @@ This topic describes how to connect Bitbucket Data Center to HCP Terraform. For 
 
 **Bitbucket Server is deprecated**.  Atlassian ended support for Bitbucket Server on February 15, 2024, and recommends using either Bitbucket Data Center (v8.0 or newer) or Bitbucket Cloud instead. Refer to the [Atlassian documentation](https://bitbucket.org/blog/cloud-migration-benefits) for additional information. 
 
-HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://support.hashicorp.com/hc/en-us) if you have any questions regarding this change.
+HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://www.ibm.com/mysupport) if you have any questions regarding this change.
 
 ## Overview
 

--- a/content/terraform-enterprise/v202408-1/docs/enterprise/deploy/replicated/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202408-1/docs/enterprise/deploy/replicated/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202408-1/docs/enterprise/deploy/replicated/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202408-1/docs/enterprise/deploy/replicated/requirements/data-storage/operational-mode-requirements.mdx
@@ -33,4 +33,4 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 - `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 - `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.

--- a/content/terraform-enterprise/v202408-1/docs/enterprise/vcs/bitbucket-data-center.mdx
+++ b/content/terraform-enterprise/v202408-1/docs/enterprise/vcs/bitbucket-data-center.mdx
@@ -14,7 +14,7 @@ This topic describes how to connect Bitbucket Data Center to HCP Terraform. For 
 
 **Bitbucket Server is deprecated**.  Atlassian ended support for Bitbucket Server on February 15, 2024, and recommends using either Bitbucket Data Center (v8.0 or newer) or Bitbucket Cloud instead. Refer to the [Atlassian documentation](https://bitbucket.org/blog/cloud-migration-benefits) for additional information. 
 
-HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://support.hashicorp.com/hc/en-us) if you have any questions regarding this change.
+HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://www.ibm.com/mysupport) if you have any questions regarding this change.
 
 ## Overview
 

--- a/content/terraform-enterprise/v202409-1/docs/enterprise/deploy/replicated/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202409-1/docs/enterprise/deploy/replicated/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202409-1/docs/enterprise/deploy/replicated/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202409-1/docs/enterprise/deploy/replicated/requirements/data-storage/operational-mode-requirements.mdx
@@ -33,4 +33,4 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 - `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 - `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.

--- a/content/terraform-enterprise/v202409-1/docs/enterprise/vcs/bitbucket-data-center.mdx
+++ b/content/terraform-enterprise/v202409-1/docs/enterprise/vcs/bitbucket-data-center.mdx
@@ -14,7 +14,7 @@ This topic describes how to connect Bitbucket Data Center to HCP Terraform. For 
 
 **Bitbucket Server is deprecated**.  Atlassian ended support for Bitbucket Server on February 15, 2024, and recommends using either Bitbucket Data Center (v8.0 or newer) or Bitbucket Cloud instead. Refer to the [Atlassian documentation](https://bitbucket.org/blog/cloud-migration-benefits) for additional information. 
 
-HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://support.hashicorp.com/hc/en-us) if you have any questions regarding this change.
+HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://www.ibm.com/mysupport) if you have any questions regarding this change.
 
 ## Overview
 

--- a/content/terraform-enterprise/v202409-2/docs/enterprise/deploy/replicated/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202409-2/docs/enterprise/deploy/replicated/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202409-2/docs/enterprise/deploy/replicated/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202409-2/docs/enterprise/deploy/replicated/requirements/data-storage/operational-mode-requirements.mdx
@@ -33,4 +33,4 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 - `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 - `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.

--- a/content/terraform-enterprise/v202409-2/docs/enterprise/vcs/bitbucket-data-center.mdx
+++ b/content/terraform-enterprise/v202409-2/docs/enterprise/vcs/bitbucket-data-center.mdx
@@ -14,7 +14,7 @@ This topic describes how to connect Bitbucket Data Center to HCP Terraform. For 
 
 **Bitbucket Server is deprecated**.  Atlassian ended support for Bitbucket Server on February 15, 2024, and recommends using either Bitbucket Data Center (v8.0 or newer) or Bitbucket Cloud instead. Refer to the [Atlassian documentation](https://bitbucket.org/blog/cloud-migration-benefits) for additional information. 
 
-HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://support.hashicorp.com/hc/en-us) if you have any questions regarding this change.
+HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://www.ibm.com/mysupport) if you have any questions regarding this change.
 
 ## Overview
 

--- a/content/terraform-enterprise/v202409-3/docs/enterprise/deploy/replicated/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202409-3/docs/enterprise/deploy/replicated/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202409-3/docs/enterprise/deploy/replicated/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202409-3/docs/enterprise/deploy/replicated/requirements/data-storage/operational-mode-requirements.mdx
@@ -33,4 +33,4 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 - `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 - `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.

--- a/content/terraform-enterprise/v202409-3/docs/enterprise/vcs/bitbucket-data-center.mdx
+++ b/content/terraform-enterprise/v202409-3/docs/enterprise/vcs/bitbucket-data-center.mdx
@@ -14,7 +14,7 @@ This topic describes how to connect Bitbucket Data Center to HCP Terraform. For 
 
 **Bitbucket Server is deprecated**.  Atlassian ended support for Bitbucket Server on February 15, 2024, and recommends using either Bitbucket Data Center (v8.0 or newer) or Bitbucket Cloud instead. Refer to the [Atlassian documentation](https://bitbucket.org/blog/cloud-migration-benefits) for additional information. 
 
-HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://support.hashicorp.com/hc/en-us) if you have any questions regarding this change.
+HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://www.ibm.com/mysupport) if you have any questions regarding this change.
 
 ## Overview
 

--- a/content/terraform-enterprise/v202410-1/docs/enterprise/deploy/replicated/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202410-1/docs/enterprise/deploy/replicated/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202410-1/docs/enterprise/deploy/replicated/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202410-1/docs/enterprise/deploy/replicated/requirements/data-storage/operational-mode-requirements.mdx
@@ -33,4 +33,4 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 - `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 - `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.

--- a/content/terraform-enterprise/v202410-1/docs/enterprise/vcs/bitbucket-data-center.mdx
+++ b/content/terraform-enterprise/v202410-1/docs/enterprise/vcs/bitbucket-data-center.mdx
@@ -14,7 +14,7 @@ This topic describes how to connect Bitbucket Data Center to HCP Terraform. For 
 
 **Bitbucket Server is deprecated**.  Atlassian ended support for Bitbucket Server on February 15, 2024, and recommends using either Bitbucket Data Center (v8.0 or newer) or Bitbucket Cloud instead. Refer to the [Atlassian documentation](https://bitbucket.org/blog/cloud-migration-benefits) for additional information. 
 
-HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://support.hashicorp.com/hc/en-us) if you have any questions regarding this change.
+HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://www.ibm.com/mysupport) if you have any questions regarding this change.
 
 ## Overview
 

--- a/content/terraform-enterprise/v202411-1/docs/enterprise/deploy/replicated/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202411-1/docs/enterprise/deploy/replicated/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202411-1/docs/enterprise/deploy/replicated/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202411-1/docs/enterprise/deploy/replicated/requirements/data-storage/operational-mode-requirements.mdx
@@ -33,4 +33,4 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 - `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 - `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.

--- a/content/terraform-enterprise/v202411-1/docs/enterprise/vcs/bitbucket-data-center.mdx
+++ b/content/terraform-enterprise/v202411-1/docs/enterprise/vcs/bitbucket-data-center.mdx
@@ -14,7 +14,7 @@ This topic describes how to connect Bitbucket Data Center to HCP Terraform. For 
 
 **Bitbucket Server is deprecated**.  Atlassian ended support for Bitbucket Server on February 15, 2024, and recommends using either Bitbucket Data Center (v8.0 or newer) or Bitbucket Cloud instead. Refer to the [Atlassian documentation](https://bitbucket.org/blog/cloud-migration-benefits) for additional information. 
 
-HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://support.hashicorp.com/hc/en-us) if you have any questions regarding this change.
+HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://www.ibm.com/mysupport) if you have any questions regarding this change.
 
 ## Overview
 

--- a/content/terraform-enterprise/v202411-2/docs/enterprise/deploy/replicated/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202411-2/docs/enterprise/deploy/replicated/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202411-2/docs/enterprise/deploy/replicated/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202411-2/docs/enterprise/deploy/replicated/requirements/data-storage/operational-mode-requirements.mdx
@@ -33,4 +33,4 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 - `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 - `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.

--- a/content/terraform-enterprise/v202411-2/docs/enterprise/vcs/bitbucket-data-center.mdx
+++ b/content/terraform-enterprise/v202411-2/docs/enterprise/vcs/bitbucket-data-center.mdx
@@ -14,7 +14,7 @@ This topic describes how to connect Bitbucket Data Center to HCP Terraform. For 
 
 **Bitbucket Server is deprecated**.  Atlassian ended support for Bitbucket Server on February 15, 2024, and recommends using either Bitbucket Data Center (v8.0 or newer) or Bitbucket Cloud instead. Refer to the [Atlassian documentation](https://bitbucket.org/blog/cloud-migration-benefits) for additional information. 
 
-HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://support.hashicorp.com/hc/en-us) if you have any questions regarding this change.
+HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://www.ibm.com/mysupport) if you have any questions regarding this change.
 
 ## Overview
 

--- a/content/terraform-enterprise/v202501-1/docs/enterprise/api-docs/index.mdx
+++ b/content/terraform-enterprise/v202501-1/docs/enterprise/api-docs/index.mdx
@@ -44,7 +44,7 @@ last_modified: 2023-01-01T00:00:00.000Z
 
 # HCP Terraform API documentation
 
-HCP Terraform provides an API for a subset of its features. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://support.hashicorp.com/hc/en-us) and open a ticket.
+HCP Terraform provides an API for a subset of its features. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://www.ibm.com/mysupport) and open a ticket.
 
 -> **Note:** Before planning an API integration, consider whether [the `tfe` Terraform provider](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs) meets your needs. It can't create or approve runs in response to arbitrary events, but it's a useful tool for managing your organizations, teams, and workspaces as code.
 

--- a/content/terraform-enterprise/v202501-1/docs/enterprise/application-administration/customization.mdx
+++ b/content/terraform-enterprise/v202501-1/docs/enterprise/application-administration/customization.mdx
@@ -26,7 +26,7 @@ You can update the support content displayed in the UI.
 
 Terraform Enterprise uses the support email address for system emails, error pages, and all other situations where users are prompted to contact support. You can specify a local email address if you want users to contact a specific person or team when they have issues.
 
-Note that this field defaults to `support@hashicorp.com`, which is not a functional email address for HashiCorp support. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://support.hashicorp.com/hc/en-us) and open a ticket.
+Note that this field defaults to `support@hashicorp.com`, which is not a functional email address for HashiCorp support. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://www.ibm.com/mysupport) and open a ticket.
 
 ### Error Instructions
 

--- a/content/terraform-enterprise/v202501-1/docs/enterprise/deploy/replicated/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202501-1/docs/enterprise/deploy/replicated/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202501-1/docs/enterprise/deploy/replicated/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202501-1/docs/enterprise/deploy/replicated/requirements/data-storage/operational-mode-requirements.mdx
@@ -33,4 +33,4 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 - `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 - `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.

--- a/content/terraform-enterprise/v202501-1/docs/enterprise/deploy/troubleshoot/contact-support.mdx
+++ b/content/terraform-enterprise/v202501-1/docs/enterprise/deploy/troubleshoot/contact-support.mdx
@@ -14,7 +14,7 @@ expected, reach out to support for help.
 
 ## Open a ticket
 
-If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://support.hashicorp.com/hc/en-us) and open a ticket.
+If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://www.ibm.com/mysupport) and open a ticket.
 
 ## Diagnostics
 
@@ -52,7 +52,7 @@ Once you have downloaded your support bundle, please use a secure method to uplo
 
 Attach the bundle to your support ticket.
 
-If possible, use the SendSafely integration available in the [HashiCorp support portal](https://support.hashicorp.com/hc/en-us). SendSafely lets you upload large file.
+If possible, use the SendSafely integration available in the [HashiCorp support portal](https://www.ibm.com/mysupport). SendSafely lets you upload large file.
 
 If you are unable to use the integration in the portal, upload the bundle directly to `https://hashicorp.sendsafely.com/u/ptfe-support-bundles`.
 

--- a/content/terraform-enterprise/v202501-1/docs/enterprise/vcs/bitbucket-data-center.mdx
+++ b/content/terraform-enterprise/v202501-1/docs/enterprise/vcs/bitbucket-data-center.mdx
@@ -16,7 +16,7 @@ This topic describes how to connect Bitbucket Data Center to HCP Terraform. For 
 
 **Bitbucket Server is deprecated**.  Atlassian ended support for Bitbucket Server on February 15, 2024, and recommends using either Bitbucket Data Center (v8.0 or newer) or Bitbucket Cloud instead. Refer to the [Atlassian documentation](https://bitbucket.org/blog/cloud-migration-benefits) for additional information. 
 
-HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://support.hashicorp.com/hc/en-us) if you have any questions regarding this change.
+HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://www.ibm.com/mysupport) if you have any questions regarding this change.
 
 ## Overview
 

--- a/content/terraform-enterprise/v202502-1/docs/enterprise/deploy/replicated/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202502-1/docs/enterprise/deploy/replicated/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202502-1/docs/enterprise/deploy/replicated/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202502-1/docs/enterprise/deploy/replicated/requirements/data-storage/operational-mode-requirements.mdx
@@ -33,4 +33,4 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 - `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 - `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.

--- a/content/terraform-enterprise/v202502-1/docs/enterprise/vcs/bitbucket-data-center.mdx
+++ b/content/terraform-enterprise/v202502-1/docs/enterprise/vcs/bitbucket-data-center.mdx
@@ -16,7 +16,7 @@ This topic describes how to connect Bitbucket Data Center to HCP Terraform. For 
 
 **Bitbucket Server is deprecated**.  Atlassian ended support for Bitbucket Server on February 15, 2024, and recommends using either Bitbucket Data Center (v8.0 or newer) or Bitbucket Cloud instead. Refer to the [Atlassian documentation](https://bitbucket.org/blog/cloud-migration-benefits) for additional information. 
 
-HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://support.hashicorp.com/hc/en-us) if you have any questions regarding this change.
+HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://www.ibm.com/mysupport) if you have any questions regarding this change.
 
 ## Overview
 

--- a/content/terraform-enterprise/v202502-2/docs/enterprise/api-docs/index.mdx
+++ b/content/terraform-enterprise/v202502-2/docs/enterprise/api-docs/index.mdx
@@ -44,7 +44,7 @@ last_modified: 2023-01-01T00:00:00.000Z
 
 # HCP Terraform API documentation
 
-HCP Terraform provides an API for a subset of its features. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://support.hashicorp.com/hc/en-us) and open a ticket.
+HCP Terraform provides an API for a subset of its features. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://www.ibm.com/mysupport) and open a ticket.
 
 -> **Note:** Before planning an API integration, consider whether [the `tfe` Terraform provider](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs) meets your needs. It can't create or approve runs in response to arbitrary events, but it's a useful tool for managing your organizations, teams, and workspaces as code.
 

--- a/content/terraform-enterprise/v202502-2/docs/enterprise/application-administration/customization.mdx
+++ b/content/terraform-enterprise/v202502-2/docs/enterprise/application-administration/customization.mdx
@@ -26,7 +26,7 @@ You can update the support content displayed in the UI.
 
 Terraform Enterprise uses the support email address for system emails, error pages, and all other situations where users are prompted to contact support. You can specify a local email address if you want users to contact a specific person or team when they have issues.
 
-Note that this field defaults to `support@hashicorp.com`, which is not a functional email address for HashiCorp support. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://support.hashicorp.com/hc/en-us) and open a ticket.
+Note that this field defaults to `support@hashicorp.com`, which is not a functional email address for HashiCorp support. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://www.ibm.com/mysupport) and open a ticket.
 
 ### Error Instructions
 

--- a/content/terraform-enterprise/v202502-2/docs/enterprise/deploy/replicated/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202502-2/docs/enterprise/deploy/replicated/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202502-2/docs/enterprise/deploy/replicated/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202502-2/docs/enterprise/deploy/replicated/requirements/data-storage/operational-mode-requirements.mdx
@@ -33,4 +33,4 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 - `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 - `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.

--- a/content/terraform-enterprise/v202502-2/docs/enterprise/deploy/troubleshoot/contact-support.mdx
+++ b/content/terraform-enterprise/v202502-2/docs/enterprise/deploy/troubleshoot/contact-support.mdx
@@ -14,7 +14,7 @@ expected, reach out to support for help.
 
 ## Open a ticket
 
-If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://support.hashicorp.com/hc/en-us) and open a ticket.
+If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://www.ibm.com/mysupport) and open a ticket.
 
 ## Diagnostics
 
@@ -52,7 +52,7 @@ Once you have downloaded your support bundle, please use a secure method to uplo
 
 Attach the bundle to your support ticket.
 
-If possible, use the SendSafely integration available in the [HashiCorp support portal](https://support.hashicorp.com/hc/en-us). SendSafely lets you upload large file.
+If possible, use the SendSafely integration available in the [HashiCorp support portal](https://www.ibm.com/mysupport). SendSafely lets you upload large file.
 
 If you are unable to use the integration in the portal, upload the bundle directly to `https://hashicorp.sendsafely.com/u/ptfe-support-bundles`.
 

--- a/content/terraform-enterprise/v202502-2/docs/enterprise/vcs/bitbucket-data-center.mdx
+++ b/content/terraform-enterprise/v202502-2/docs/enterprise/vcs/bitbucket-data-center.mdx
@@ -16,7 +16,7 @@ This topic describes how to connect Bitbucket Data Center to HCP Terraform. For 
 
 **Bitbucket Server is deprecated**.  Atlassian ended support for Bitbucket Server on February 15, 2024, and recommends using either Bitbucket Data Center (v8.0 or newer) or Bitbucket Cloud instead. Refer to the [Atlassian documentation](https://bitbucket.org/blog/cloud-migration-benefits) for additional information. 
 
-HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://support.hashicorp.com/hc/en-us) if you have any questions regarding this change.
+HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://www.ibm.com/mysupport) if you have any questions regarding this change.
 
 ## Overview
 

--- a/content/terraform-enterprise/v202503-1/docs/enterprise/api-docs/index.mdx
+++ b/content/terraform-enterprise/v202503-1/docs/enterprise/api-docs/index.mdx
@@ -44,7 +44,7 @@ last_modified: 2023-01-01T00:00:00.000Z
 
 # HCP Terraform API documentation
 
-HCP Terraform provides an API for a subset of its features. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://support.hashicorp.com/hc/en-us) and open a ticket.
+HCP Terraform provides an API for a subset of its features. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://www.ibm.com/mysupport) and open a ticket.
 
 -> **Note:** Before planning an API integration, consider whether [the `tfe` Terraform provider](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs) meets your needs. It can't create or approve runs in response to arbitrary events, but it's a useful tool for managing your organizations, teams, and workspaces as code.
 

--- a/content/terraform-enterprise/v202503-1/docs/enterprise/application-administration/customization.mdx
+++ b/content/terraform-enterprise/v202503-1/docs/enterprise/application-administration/customization.mdx
@@ -26,7 +26,7 @@ You can update the support content displayed in the UI.
 
 Terraform Enterprise uses the support email address for system emails, error pages, and all other situations where users are prompted to contact support. You can specify a local email address if you want users to contact a specific person or team when they have issues.
 
-Note that this field defaults to `support@hashicorp.com`, which is not a functional email address for HashiCorp support. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://support.hashicorp.com/hc/en-us) and open a ticket.
+Note that this field defaults to `support@hashicorp.com`, which is not a functional email address for HashiCorp support. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://www.ibm.com/mysupport) and open a ticket.
 
 ### Error Instructions
 

--- a/content/terraform-enterprise/v202503-1/docs/enterprise/deploy/replicated/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202503-1/docs/enterprise/deploy/replicated/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202503-1/docs/enterprise/deploy/replicated/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202503-1/docs/enterprise/deploy/replicated/requirements/data-storage/operational-mode-requirements.mdx
@@ -33,4 +33,4 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 - `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 - `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.

--- a/content/terraform-enterprise/v202503-1/docs/enterprise/deploy/troubleshoot/contact-support.mdx
+++ b/content/terraform-enterprise/v202503-1/docs/enterprise/deploy/troubleshoot/contact-support.mdx
@@ -14,7 +14,7 @@ expected, reach out to support for help.
 
 ## Open a ticket
 
-If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://support.hashicorp.com/hc/en-us) and open a ticket.
+If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://www.ibm.com/mysupport) and open a ticket.
 
 ## Diagnostics
 
@@ -52,7 +52,7 @@ Once you have downloaded your support bundle, please use a secure method to uplo
 
 Attach the bundle to your support ticket.
 
-If possible, use the SendSafely integration available in the [HashiCorp support portal](https://support.hashicorp.com/hc/en-us). SendSafely lets you upload large file.
+If possible, use the SendSafely integration available in the [HashiCorp support portal](https://www.ibm.com/mysupport). SendSafely lets you upload large file.
 
 If you are unable to use the integration in the portal, upload the bundle directly to `https://hashicorp.sendsafely.com/u/ptfe-support-bundles`.
 

--- a/content/terraform-enterprise/v202503-1/docs/enterprise/vcs/bitbucket-data-center.mdx
+++ b/content/terraform-enterprise/v202503-1/docs/enterprise/vcs/bitbucket-data-center.mdx
@@ -16,7 +16,7 @@ This topic describes how to connect Bitbucket Data Center to HCP Terraform. For 
 
 **Bitbucket Server is deprecated**.  Atlassian ended support for Bitbucket Server on February 15, 2024, and recommends using either Bitbucket Data Center (v8.0 or newer) or Bitbucket Cloud instead. Refer to the [Atlassian documentation](https://bitbucket.org/blog/cloud-migration-benefits) for additional information. 
 
-HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://support.hashicorp.com/hc/en-us) if you have any questions regarding this change.
+HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://www.ibm.com/mysupport) if you have any questions regarding this change.
 
 ## Overview
 

--- a/content/terraform-enterprise/v202504-1/docs/enterprise/api-docs/index.mdx
+++ b/content/terraform-enterprise/v202504-1/docs/enterprise/api-docs/index.mdx
@@ -44,7 +44,7 @@ last_modified: 2023-01-01T00:00:00.000Z
 
 # HCP Terraform API documentation
 
-HCP Terraform provides an API for a subset of its features. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://support.hashicorp.com/hc/en-us) and open a ticket.
+HCP Terraform provides an API for a subset of its features. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://www.ibm.com/mysupport) and open a ticket.
 
 -> **Note:** Before planning an API integration, consider whether [the `tfe` Terraform provider](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs) meets your needs. It can't create or approve runs in response to arbitrary events, but it's a useful tool for managing your organizations, teams, and workspaces as code.
 

--- a/content/terraform-enterprise/v202504-1/docs/enterprise/application-administration/customization.mdx
+++ b/content/terraform-enterprise/v202504-1/docs/enterprise/application-administration/customization.mdx
@@ -26,7 +26,7 @@ You can update the support content displayed in the UI.
 
 Terraform Enterprise uses the support email address for system emails, error pages, and all other situations where users are prompted to contact support. You can specify a local email address if you want users to contact a specific person or team when they have issues.
 
-Note that this field defaults to `support@hashicorp.com`, which is not a functional email address for HashiCorp support. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://support.hashicorp.com/hc/en-us) and open a ticket.
+Note that this field defaults to `support@hashicorp.com`, which is not a functional email address for HashiCorp support. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://www.ibm.com/mysupport) and open a ticket.
 
 ### Error Instructions
 

--- a/content/terraform-enterprise/v202504-1/docs/enterprise/deploy/replicated/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202504-1/docs/enterprise/deploy/replicated/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202504-1/docs/enterprise/deploy/replicated/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202504-1/docs/enterprise/deploy/replicated/requirements/data-storage/operational-mode-requirements.mdx
@@ -33,4 +33,4 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 - `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 - `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.

--- a/content/terraform-enterprise/v202504-1/docs/enterprise/deploy/troubleshoot/contact-support.mdx
+++ b/content/terraform-enterprise/v202504-1/docs/enterprise/deploy/troubleshoot/contact-support.mdx
@@ -14,7 +14,7 @@ expected, reach out to support for help.
 
 ## Open a ticket
 
-If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://support.hashicorp.com/hc/en-us) and open a ticket.
+If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://www.ibm.com/mysupport) and open a ticket.
 
 ## Diagnostics
 
@@ -52,7 +52,7 @@ Once you have downloaded your support bundle, please use a secure method to uplo
 
 Attach the bundle to your support ticket.
 
-If possible, use the SendSafely integration available in the [HashiCorp support portal](https://support.hashicorp.com/hc/en-us). SendSafely lets you upload large file.
+If possible, use the SendSafely integration available in the [HashiCorp support portal](https://www.ibm.com/mysupport). SendSafely lets you upload large file.
 
 If you are unable to use the integration in the portal, upload the bundle directly to `https://hashicorp.sendsafely.com/u/ptfe-support-bundles`.
 

--- a/content/terraform-enterprise/v202504-1/docs/enterprise/vcs/bitbucket-data-center.mdx
+++ b/content/terraform-enterprise/v202504-1/docs/enterprise/vcs/bitbucket-data-center.mdx
@@ -16,7 +16,7 @@ This topic describes how to connect Bitbucket Data Center to HCP Terraform. For 
 
 **Bitbucket Server is deprecated**.  Atlassian ended support for Bitbucket Server on February 15, 2024, and recommends using either Bitbucket Data Center (v8.0 or newer) or Bitbucket Cloud instead. Refer to the [Atlassian documentation](https://bitbucket.org/blog/cloud-migration-benefits) for additional information. 
 
-HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://support.hashicorp.com/hc/en-us) if you have any questions regarding this change.
+HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://www.ibm.com/mysupport) if you have any questions regarding this change.
 
 ## Overview
 

--- a/content/terraform-enterprise/v202505-1/docs/enterprise/api-docs/index.mdx
+++ b/content/terraform-enterprise/v202505-1/docs/enterprise/api-docs/index.mdx
@@ -46,7 +46,7 @@ last_modified: 2023-01-01T00:00:00.000Z
 
 ## HCP Terraform API
 
-HCP Terraform provides an API for a subset of its features. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://support.hashicorp.com/hc/en-us) and open a ticket.
+HCP Terraform provides an API for a subset of its features. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://www.ibm.com/mysupport) and open a ticket.
 
 -> **Note:** Before planning an API integration, consider whether [the `tfe` Terraform provider](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs) meets your needs. It can't create or approve runs in response to arbitrary events, but it's a useful tool for managing your organizations, teams, and workspaces as code.
 

--- a/content/terraform-enterprise/v202505-1/docs/enterprise/application-administration/customization.mdx
+++ b/content/terraform-enterprise/v202505-1/docs/enterprise/application-administration/customization.mdx
@@ -26,7 +26,7 @@ You can update the support content displayed in the UI.
 
 Terraform Enterprise uses the support email address for system emails, error pages, and all other situations where users are prompted to contact support. You can specify a local email address if you want users to contact a specific person or team when they have issues.
 
-Note that this field defaults to `support@hashicorp.com`, which is not a functional email address for HashiCorp support. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://support.hashicorp.com/hc/en-us) and open a ticket.
+Note that this field defaults to `support@hashicorp.com`, which is not a functional email address for HashiCorp support. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://www.ibm.com/mysupport) and open a ticket.
 
 ### Error Instructions
 

--- a/content/terraform-enterprise/v202505-1/docs/enterprise/deploy/replicated/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202505-1/docs/enterprise/deploy/replicated/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202505-1/docs/enterprise/deploy/replicated/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202505-1/docs/enterprise/deploy/replicated/requirements/data-storage/operational-mode-requirements.mdx
@@ -33,4 +33,4 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 - `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 - `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.

--- a/content/terraform-enterprise/v202505-1/docs/enterprise/deploy/troubleshoot/contact-support.mdx
+++ b/content/terraform-enterprise/v202505-1/docs/enterprise/deploy/troubleshoot/contact-support.mdx
@@ -14,7 +14,7 @@ expected, reach out to support for help.
 
 ## Open a ticket
 
-If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://support.hashicorp.com/hc/en-us) and open a ticket.
+If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://www.ibm.com/mysupport) and open a ticket.
 
 ## Diagnostics
 
@@ -52,7 +52,7 @@ Once you have downloaded your support bundle, please use a secure method to uplo
 
 Attach the bundle to your support ticket.
 
-If possible, use the SendSafely integration available in the [HashiCorp support portal](https://support.hashicorp.com/hc/en-us). SendSafely lets you upload large file.
+If possible, use the SendSafely integration available in the [HashiCorp support portal](https://www.ibm.com/mysupport). SendSafely lets you upload large file.
 
 If you are unable to use the integration in the portal, upload the bundle directly to `https://hashicorp.sendsafely.com/u/ptfe-support-bundles`.
 

--- a/content/terraform-enterprise/v202505-1/docs/enterprise/vcs/bitbucket-data-center.mdx
+++ b/content/terraform-enterprise/v202505-1/docs/enterprise/vcs/bitbucket-data-center.mdx
@@ -16,7 +16,7 @@ This topic describes how to connect Bitbucket Data Center to HCP Terraform. For 
 
 **Bitbucket Server is deprecated**.  Atlassian ended support for Bitbucket Server on February 15, 2024, and recommends using either Bitbucket Data Center (v8.0 or newer) or Bitbucket Cloud instead. Refer to the [Atlassian documentation](https://bitbucket.org/blog/cloud-migration-benefits) for additional information. 
 
-HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://support.hashicorp.com/hc/en-us) if you have any questions regarding this change.
+HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://www.ibm.com/mysupport) if you have any questions regarding this change.
 
 ## Overview
 

--- a/content/terraform-enterprise/v202506-1/docs/enterprise/api-docs/index.mdx
+++ b/content/terraform-enterprise/v202506-1/docs/enterprise/api-docs/index.mdx
@@ -44,7 +44,7 @@ last_modified: 2023-01-01T00:00:00.000Z
 
 # API documentation overview
 
-Terraform Enterprise provides an API for a subset of its features. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://support.hashicorp.com/hc/en-us) and open a ticket.
+Terraform Enterprise provides an API for a subset of its features. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://www.ibm.com/mysupport) and open a ticket.
 
 Before planning an API integration, consider whether the [HCP Terraform and Terraform Enterprise provider](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs) meets your needs. It can't create or approve runs in response to arbitrary events, but it's a useful tool for managing your organizations, teams, and workspaces as code.
 

--- a/content/terraform-enterprise/v202506-1/docs/enterprise/application-administration/customization.mdx
+++ b/content/terraform-enterprise/v202506-1/docs/enterprise/application-administration/customization.mdx
@@ -26,7 +26,7 @@ You can update the support content displayed in the UI.
 
 Terraform Enterprise uses the support email address for system emails, error pages, and all other situations where users are prompted to contact support. You can specify a local email address if you want users to contact a specific person or team when they have issues.
 
-Note that this field defaults to `support@hashicorp.com`, which is not a functional email address for HashiCorp support. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://support.hashicorp.com/hc/en-us) and open a ticket.
+Note that this field defaults to `support@hashicorp.com`, which is not a functional email address for HashiCorp support. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://www.ibm.com/mysupport) and open a ticket.
 
 ### Error Instructions
 

--- a/content/terraform-enterprise/v202506-1/docs/enterprise/deploy/replicated/architecture/reference-architecture/vmware.mdx
+++ b/content/terraform-enterprise/v202506-1/docs/enterprise/deploy/replicated/architecture/reference-architecture/vmware.mdx
@@ -270,7 +270,7 @@ application data stored in this location. This allows for further [server-side
 encryption](https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html)
 by S3 if required by your security policy.
 
-Recommended object storage solutions are AWS S3, Google Cloud storage, Azure blob storage. Other options for S3-compatible storage are [MinIO](https://www.minio.io/), and [Ceph](https://ceph.com/), and [ECS](https://www.dell.com/en-us/shop/cty/sf/objectscale?hve=explore+objectscale). Please feel free to reach out to [support](https://support.hashicorp.com/hc/en-us) with questions.
+Recommended object storage solutions are AWS S3, Google Cloud storage, Azure blob storage. Other options for S3-compatible storage are [MinIO](https://www.minio.io/), and [Ceph](https://ceph.com/), and [ECS](https://www.dell.com/en-us/shop/cty/sf/objectscale?hve=explore+objectscale). Please feel free to reach out to [support](https://www.ibm.com/mysupport) with questions.
 
 ### External Services - PostgreSQL Database
 

--- a/content/terraform-enterprise/v202506-1/docs/enterprise/deploy/replicated/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202506-1/docs/enterprise/deploy/replicated/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202506-1/docs/enterprise/deploy/replicated/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202506-1/docs/enterprise/deploy/replicated/requirements/data-storage/operational-mode-requirements.mdx
@@ -33,4 +33,4 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 - `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 - `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.

--- a/content/terraform-enterprise/v202506-1/docs/enterprise/deploy/troubleshoot/contact-support.mdx
+++ b/content/terraform-enterprise/v202506-1/docs/enterprise/deploy/troubleshoot/contact-support.mdx
@@ -14,7 +14,7 @@ expected, reach out to support for help.
 
 ## Open a ticket
 
-If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://support.hashicorp.com/hc/en-us) and open a ticket.
+If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://www.ibm.com/mysupport) and open a ticket.
 
 ## Diagnostics
 
@@ -52,7 +52,7 @@ Once you have downloaded your support bundle, please use a secure method to uplo
 
 Attach the bundle to your support ticket. 
 
-If possible, use the SendSafely integration available in the [HashiCorp support portal](https://support.hashicorp.com/hc/en-us). SendSafely lets you upload large file.
+If possible, use the SendSafely integration available in the [HashiCorp support portal](https://www.ibm.com/mysupport). SendSafely lets you upload large file.
 
 If you are unable to use the integration in the portal, upload the bundle directly to `https://hashicorp.sendsafely.com/u/ptfe-support-bundles`.
 

--- a/content/terraform-enterprise/v202506-1/docs/enterprise/vcs/bitbucket-data-center.mdx
+++ b/content/terraform-enterprise/v202506-1/docs/enterprise/vcs/bitbucket-data-center.mdx
@@ -16,7 +16,7 @@ This topic describes how to connect Bitbucket Data Center to HCP Terraform. For 
 
 **Bitbucket Server is deprecated**.  Atlassian ended support for Bitbucket Server on February 15, 2024, and recommends using either Bitbucket Data Center (v8.0 or newer) or Bitbucket Cloud instead. Refer to the [Atlassian documentation](https://bitbucket.org/blog/cloud-migration-benefits) for additional information. 
 
-HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://support.hashicorp.com/hc/en-us) if you have any questions regarding this change.
+HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://www.ibm.com/mysupport) if you have any questions regarding this change.
 
 ## Overview
 

--- a/content/terraform-enterprise/v202507-1/docs/enterprise/api-docs/index.mdx
+++ b/content/terraform-enterprise/v202507-1/docs/enterprise/api-docs/index.mdx
@@ -46,13 +46,13 @@ last_modified: 2025-11-19T09:33:54-08:00
 
 <!-- BEGIN: TFC:only -->
 
-HCP Terraform provides an API for a subset of its features. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://support.hashicorp.com/hc/en-us) and open a ticket.
+HCP Terraform provides an API for a subset of its features. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://www.ibm.com/mysupport) and open a ticket.
 
 <!-- END: TFC:only -->
 
 <!-- BEGIN: TFEnterprise:only name:api-overview -->
 
-Terraform Enterprise provides an API for a subset of its features. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://support.hashicorp.com/hc/en-us) and open a ticket.
+Terraform Enterprise provides an API for a subset of its features. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://www.ibm.com/mysupport) and open a ticket.
 
 <!-- END: TFEnterprise:only name:api-overview  -->
 

--- a/content/terraform-enterprise/v202507-1/docs/enterprise/application-administration/customization.mdx
+++ b/content/terraform-enterprise/v202507-1/docs/enterprise/application-administration/customization.mdx
@@ -26,7 +26,7 @@ You can update the support content displayed in the UI.
 
 Terraform Enterprise uses the support email address for system emails, error pages, and all other situations where users are prompted to contact support. You can specify a local email address if you want users to contact a specific person or team when they have issues.
 
-Note that this field defaults to `support@hashicorp.com`, which is not a functional email address for HashiCorp support. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://support.hashicorp.com/hc/en-us) and open a ticket.
+Note that this field defaults to `support@hashicorp.com`, which is not a functional email address for HashiCorp support. If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://www.ibm.com/mysupport) and open a ticket.
 
 ### Error Instructions
 

--- a/content/terraform-enterprise/v202507-1/docs/enterprise/deploy/replicated/architecture/reference-architecture/vmware.mdx
+++ b/content/terraform-enterprise/v202507-1/docs/enterprise/deploy/replicated/architecture/reference-architecture/vmware.mdx
@@ -270,7 +270,7 @@ application data stored in this location. This allows for further [server-side
 encryption](https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html)
 by S3 if required by your security policy.
 
-Recommended object storage solutions are AWS S3, Google Cloud storage, Azure blob storage. Other options for S3-compatible storage are [MinIO](https://www.minio.io/), and [Ceph](https://ceph.com/), and [ECS](https://www.dell.com/en-us/shop/cty/sf/objectscale?hve=explore+objectscale). Please feel free to reach out to [support](https://support.hashicorp.com/hc/en-us) with questions.
+Recommended object storage solutions are AWS S3, Google Cloud storage, Azure blob storage. Other options for S3-compatible storage are [MinIO](https://www.minio.io/), and [Ceph](https://ceph.com/), and [ECS](https://www.dell.com/en-us/shop/cty/sf/objectscale?hve=explore+objectscale). Please feel free to reach out to [support](https://www.ibm.com/mysupport) with questions.
 
 ### External Services - PostgreSQL Database
 

--- a/content/terraform-enterprise/v202507-1/docs/enterprise/deploy/replicated/install/uninstall.mdx
+++ b/content/terraform-enterprise/v202507-1/docs/enterprise/deploy/replicated/install/uninstall.mdx
@@ -249,4 +249,4 @@ If the system cannot reach [install.terraform.io][install]:
 
 [uninstall link]: https://install.terraform.io/tfe/uninstall
 
-[support]: https://support.hashicorp.com
+[support]: https://www.ibm.com/mysupport

--- a/content/terraform-enterprise/v202507-1/docs/enterprise/deploy/replicated/requirements/data-storage/operational-mode-requirements.mdx
+++ b/content/terraform-enterprise/v202507-1/docs/enterprise/deploy/replicated/requirements/data-storage/operational-mode-requirements.mdx
@@ -33,4 +33,4 @@ There are three CLI commands available as of v202005-2 to facilitate management 
 - `replicated admin db-restore`: This will run a `pg_restore` using `/backup/ptfe.db` as it's data source.
 - `replicated admin db-reindex`: This will run a `REINDEX` against the application database. Note: A reindex can take anywhere from minutes to hours to complete, depending on the size of your database. Running this command locks the database and prevents any other action against it.
 
-These commands will only display output if there is an error. Please contact [support](https://support.hashicorp.com) if you have any questions or issues with these commands.
+These commands will only display output if there is an error. Please contact [support](https://www.ibm.com/mysupport) if you have any questions or issues with these commands.

--- a/content/terraform-enterprise/v202507-1/docs/enterprise/deploy/troubleshoot/contact-support.mdx
+++ b/content/terraform-enterprise/v202507-1/docs/enterprise/deploy/troubleshoot/contact-support.mdx
@@ -14,7 +14,7 @@ expected, reach out to support for help.
 
 ## Open a ticket
 
-If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://support.hashicorp.com/hc/en-us) and open a ticket.
+If you need assistance or want to submit a feature request, visit the [HashiCorp support center](https://www.ibm.com/mysupport) and open a ticket.
 
 ## Diagnostics
 
@@ -52,7 +52,7 @@ Once you have downloaded your support bundle, please use a secure method to uplo
 
 Attach the bundle to your support ticket. 
 
-If possible, use the SendSafely integration available in the [HashiCorp support portal](https://support.hashicorp.com/hc/en-us). SendSafely lets you upload large file.
+If possible, use the SendSafely integration available in the [HashiCorp support portal](https://www.ibm.com/mysupport). SendSafely lets you upload large file.
 
 If you are unable to use the integration in the portal, upload the bundle directly to `https://hashicorp.sendsafely.com/u/ptfe-support-bundles`.
 

--- a/content/terraform-enterprise/v202507-1/docs/enterprise/vcs/bitbucket-data-center.mdx
+++ b/content/terraform-enterprise/v202507-1/docs/enterprise/vcs/bitbucket-data-center.mdx
@@ -16,7 +16,7 @@ This topic describes how to connect Bitbucket Data Center to HCP Terraform. For 
 
 **Bitbucket Server is deprecated**.  Atlassian ended support for Bitbucket Server on February 15, 2024, and recommends using either Bitbucket Data Center (v8.0 or newer) or Bitbucket Cloud instead. Refer to the [Atlassian documentation](https://bitbucket.org/blog/cloud-migration-benefits) for additional information. 
 
-HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://support.hashicorp.com/hc/en-us) if you have any questions regarding this change.
+HCP Terraform will end support Bitbucket Server on August 15, 2024. Terraform Enterprise will also end support for Bitbucket Server in Terraform Enterprise v202410. [Contact HashiCorp support](https://www.ibm.com/mysupport) if you have any questions regarding this change.
 
 ## Overview
 


### PR DESCRIPTION
## Summary

Replaces legacy HashiCorp support URLs with the IBM support equivalent (`https://www.ibm.com/mysupport`) across all affected TFE document paths and version directories.

| | |
|---|---|
| **Product** | Terraform Enterprise |
| **Old URLs** | `https://support.hashicorp.com/hc/en-us` and `https://support.hashicorp.com` |
| **New URL** | `https://www.ibm.com/mysupport` |
| **Files updated** | 268 |

### Document paths included

| Document path | Versions |
|---|---|
| `docs/enterprise/api-docs/index.mdx` | 11 |
| `docs/enterprise/application-administration/customization.mdx` | 11 |
| `docs/enterprise/deploy/manage/upgrade.mdx` | 2 |
| `docs/enterprise/deploy/manage/upgrade/index.mdx` | 1 |
| `docs/enterprise/deploy/replicated/architecture/reference-architecture/vmware.mdx` | 6 |
| `docs/enterprise/deploy/replicated/install/uninstall.mdx` | 19 |
| `docs/enterprise/deploy/replicated/requirements/data-storage/operational-mode-requirements.mdx` | 19 |
| `docs/enterprise/deploy/troubleshoot/contact-support.mdx` | 19 |
| `docs/enterprise/flexible-deployments-beta/**` | 59 |
| `docs/enterprise/install/uninstall.mdx` | 22 |
| `docs/enterprise/replicated/install/uninstall.mdx` | 13 |
| `docs/enterprise/replicated/requirements/data-storage/operational-mode-requirements.mdx` | 13 |
| `docs/enterprise/requirements/data-storage/operational-mode-requirements.mdx` | 22 |
| `docs/enterprise/support/index.mdx` | 35 |
| `docs/enterprise/vcs/bitbucket-data-center.mdx` | 24 |

### Notes on residual text
Some files contain `support@hashicorp.com` (an email address) or `support.hashicorp.com` as link display text — these are intentionally not modified as they are not `https://` URLs.

Part of the IBM DevDoc KB Remapping effort.