### PR TITLE
Replace support.hashicorp.com links with IBM support URLs

### DIFF
--- a/content/vault/v1.16.x/content/docs/troubleshoot/lease-issues.mdx
+++ b/content/vault/v1.16.x/content/docs/troubleshoot/lease-issues.mdx
@@ -117,7 +117,7 @@ environment.
    Revoking or forcefully revoking leases is potentially a dangerous operation.
    Do not proceed without a valid snapshot. If you have a valid Vault
    Enterprise license, consider contacting the
-   [HashiCorp Customer Support team](https://support.hashicorp.com/) for help.
+   [HashiCorp Customer Support team](https://www.ibm.com/mysupport) for help.
 
 </Warning>
 

--- a/content/vault/v1.17.x/content/docs/troubleshoot/lease-issues.mdx
+++ b/content/vault/v1.17.x/content/docs/troubleshoot/lease-issues.mdx
@@ -117,7 +117,7 @@ environment.
    Revoking or forcefully revoking leases is potentially a dangerous operation.
    Do not proceed without a valid snapshot. If you have a valid Vault
    Enterprise license, consider contacting the
-   [HashiCorp Customer Support team](https://support.hashicorp.com/) for help.
+   [HashiCorp Customer Support team](https://www.ibm.com/mysupport) for help.
 
 </Warning>
 

--- a/content/vault/v1.18.x/content/docs/troubleshoot/lease-issues.mdx
+++ b/content/vault/v1.18.x/content/docs/troubleshoot/lease-issues.mdx
@@ -117,7 +117,7 @@ environment.
    Revoking or forcefully revoking leases is potentially a dangerous operation.
    Do not proceed without a valid snapshot. If you have a valid Vault
    Enterprise license, consider contacting the
-   [HashiCorp Customer Support team](https://support.hashicorp.com/) for help.
+   [HashiCorp Customer Support team](https://www.ibm.com/mysupport) for help.
 
 </Warning>
 

--- a/content/vault/v1.19.x/content/docs/deploy/aws/run.mdx
+++ b/content/vault/v1.19.x/content/docs/deploy/aws/run.mdx
@@ -45,4 +45,4 @@ For the Community Vault AMI, support can be obtained through the [community chan
 
 ## Enterprise
 
-For customers that purchase the Enterprise Vault AMI through the AWS Marketplace, Enterprise Support is also available from HashiCorp. To learn more, [see our support website](https://support.hashicorp.com/hc/en-us)
+For customers that purchase the Enterprise Vault AMI through the AWS Marketplace, Enterprise Support is also available from HashiCorp. To learn more, [see our support website](https://www.ibm.com/mysupport)

--- a/content/vault/v1.19.x/content/docs/troubleshoot/lease-issues.mdx
+++ b/content/vault/v1.19.x/content/docs/troubleshoot/lease-issues.mdx
@@ -117,7 +117,7 @@ environment.
    Revoking or forcefully revoking leases is potentially a dangerous operation.
    Do not proceed without a valid snapshot. If you have a valid Vault
    Enterprise license, consider contacting the
-   [HashiCorp Customer Support team](https://support.hashicorp.com/) for help.
+   [HashiCorp Customer Support team](https://www.ibm.com/mysupport) for help.
 
 </Warning>
 

--- a/content/vault/v1.19.x/content/docs/updates/deprecation.mdx
+++ b/content/vault/v1.19.x/content/docs/updates/deprecation.mdx
@@ -34,7 +34,7 @@ or raise a ticket with your support team.
   The Vault Support Team can provide <b>limited</b> help with a deprecated feature.
   Limited support includes troubleshooting solutions and workarounds but does not
   include software patches or bug fixes. Refer to
-  the <a href="https://support.hashicorp.com/hc/en-us/articles/360021185113-Support-Period-and-End-of-Life-EOL-Policy">HashiCorp Support Policy</a> for
+  the <a href="https://www.ibm.com/support/pages/lifecycle/">IBM Support Product lifecycle</a> for
   more information on the product support timeline.
 </EnterpriseAlert>
 

--- a/content/vault/v1.20.x/content/docs/deploy/aws/run.mdx
+++ b/content/vault/v1.20.x/content/docs/deploy/aws/run.mdx
@@ -45,4 +45,4 @@ For the Community Vault AMI, support can be obtained through the [community chan
 
 ## Enterprise
 
-For customers that purchase the Enterprise Vault AMI through the AWS Marketplace, Enterprise Support is also available from HashiCorp. To learn more, [see our support website](https://support.hashicorp.com/hc/en-us)
+For customers that purchase the Enterprise Vault AMI through the AWS Marketplace, Enterprise Support is also available from HashiCorp. To learn more, [see our support website](https://www.ibm.com/mysupport)

--- a/content/vault/v1.20.x/content/docs/troubleshoot/lease-issues.mdx
+++ b/content/vault/v1.20.x/content/docs/troubleshoot/lease-issues.mdx
@@ -117,7 +117,7 @@ environment.
    Revoking or forcefully revoking leases is potentially a dangerous operation.
    Do not proceed without a valid snapshot. If you have a valid Vault
    Enterprise license, consider contacting the
-   [HashiCorp Customer Support team](https://support.hashicorp.com/) for help.
+   [HashiCorp Customer Support team](https://www.ibm.com/mysupport) for help.
 
 </Warning>
 

--- a/content/vault/v1.20.x/content/docs/updates/deprecation.mdx
+++ b/content/vault/v1.20.x/content/docs/updates/deprecation.mdx
@@ -34,7 +34,7 @@ or raise a ticket with your support team.
   The Vault Support Team can provide <b>limited</b> help with a deprecated feature.
   Limited support includes troubleshooting solutions and workarounds but does not
   include software patches or bug fixes. Refer to
-  the <a href="https://support.hashicorp.com/hc/en-us/articles/360021185113-Support-Period-and-End-of-Life-EOL-Policy">HashiCorp Support Policy</a> for
+  the <a href="https://www.ibm.com/support/pages/lifecycle/">IBM Support Product lifecycle</a> for
   more information on the product support timeline.
 </EnterpriseAlert>
 

--- a/content/vault/v1.21.x/content/docs/deploy/aws/run.mdx
+++ b/content/vault/v1.21.x/content/docs/deploy/aws/run.mdx
@@ -45,4 +45,4 @@ For the Community Vault AMI, support can be obtained through the [community chan
 
 ## Enterprise
 
-For customers that purchase the Enterprise Vault AMI through the AWS Marketplace, Enterprise Support is also available from HashiCorp. To learn more, [see our support website](https://support.hashicorp.com/hc/en-us)
+For customers that purchase the Enterprise Vault AMI through the AWS Marketplace, Enterprise Support is also available from HashiCorp. To learn more, [see our support website](https://www.ibm.com/mysupport)

--- a/content/vault/v1.21.x/content/docs/troubleshoot/lease-issues.mdx
+++ b/content/vault/v1.21.x/content/docs/troubleshoot/lease-issues.mdx
@@ -117,7 +117,7 @@ environment.
    Revoking or forcefully revoking leases is potentially a dangerous operation.
    Do not proceed without a valid snapshot. If you have a valid Vault
    Enterprise license, consider contacting the
-   [HashiCorp Customer Support team](https://support.hashicorp.com/) for help.
+   [HashiCorp Customer Support team](https://www.ibm.com/mysupport) for help.
 
 </Warning>
 

--- a/content/vault/v1.21.x/content/docs/updates/deprecation.mdx
+++ b/content/vault/v1.21.x/content/docs/updates/deprecation.mdx
@@ -31,7 +31,7 @@ or raise a ticket with your support team.
   The Vault Support Team can provide <b>limited</b> help with a deprecated feature.
   Limited support includes troubleshooting solutions and workarounds but does not
   include software patches or bug fixes. Refer to
-  the <a href="https://support.hashicorp.com/hc/en-us/articles/360021185113-Support-Period-and-End-of-Life-EOL-Policy">HashiCorp Support Policy</a> for
+  the <a href="https://www.ibm.com/support/pages/lifecycle/">IBM Support Product lifecycle</a> for
   more information on the product support timeline.
 </EnterpriseAlert>
 

--- a/content/vault/v2.x/content/docs/deploy/aws/run.mdx
+++ b/content/vault/v2.x/content/docs/deploy/aws/run.mdx
@@ -45,4 +45,4 @@ For the Community Vault AMI, support can be obtained through the [community chan
 
 ## Enterprise
 
-For customers that purchase the Enterprise Vault AMI through the AWS Marketplace, Enterprise Support is also available from HashiCorp. To learn more, [see our support website](https://support.hashicorp.com/hc/en-us)
+For customers that purchase the Enterprise Vault AMI through the AWS Marketplace, Enterprise Support is also available from HashiCorp. To learn more, [see our support website](https://www.ibm.com/mysupport)

--- a/content/vault/v2.x/content/docs/troubleshoot/lease-issues.mdx
+++ b/content/vault/v2.x/content/docs/troubleshoot/lease-issues.mdx
@@ -117,7 +117,7 @@ environment.
    Revoking or forcefully revoking leases is potentially a dangerous operation.
    Do not proceed without a valid snapshot. If you have a valid Vault
    Enterprise license, consider contacting the
-   [HashiCorp Customer Support team](https://support.hashicorp.com/) for help.
+   [HashiCorp Customer Support team](https://www.ibm.com/mysupport) for help.
 
 </Warning>
 

--- a/content/vault/v2.x/content/docs/updates/deprecation.mdx
+++ b/content/vault/v2.x/content/docs/updates/deprecation.mdx
@@ -31,7 +31,7 @@ or raise a ticket with your support team.
   The Vault Support Team can provide <b>limited</b> help with a deprecated feature.
   Limited support includes troubleshooting solutions and workarounds but does not
   include software patches or bug fixes. Refer to
-  the <a href="https://support.hashicorp.com/hc/en-us/articles/360021185113-Support-Period-and-End-of-Life-EOL-Policy">HashiCorp Support Policy</a> for
+  the <a href="https://www.ibm.com/support/pages/lifecycle/">IBM Support Product lifecycle</a> for
   more information on the product support timeline.
 </EnterpriseAlert>
 


### PR DESCRIPTION
First wave of updates to remove deprecated Support portal links and update with current Support links

| Document | Versions updated | Old URL | New URL | Link text changed? |
|---|---|---|---|---|
| `content/docs/deploy/aws/run.mdx` | v1.19.x, v1.20.x, v1.21.x, v2.x (4) | `https://support.hashicorp.com/hc/en-us` | `https://www.ibm.com/mysupport` | No |
| `content/docs/troubleshoot/lease-issues.mdx` | v1.16.x, v1.17.x, v1.18.x, v1.19.x, v1.20.x, v1.21.x, v2.x (7) | `https://support.hashicorp.com/` | `https://www.ibm.com/mysupport` | No |
| `content/docs/updates/deprecation.mdx` | v1.19.x, v1.20.x, v1.21.x, v2.x (4) | `https://support.hashicorp.com/hc/en-us/articles/360021185113-Support-Period-and-End-of-Life-EOL-Policy` | `https://www.ibm.com/support/pages/lifecycle/` | Yes — "HashiCorp Support Policy" → "IBM Support Product lifecycle" |
