### PR TITLE
docs(tfe): replace support.hashicorp.com links in v202103-1.mdx

### DIFF
--- a/content/terraform-enterprise/1.0.x/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/1.0.x/docs/enterprise/releases/2021/v202103-1.mdx
@@ -95,5 +95,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/1.1.x/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/1.1.x/docs/enterprise/releases/2021/v202103-1.mdx
@@ -95,5 +95,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2021/v202103-1.mdx
@@ -95,5 +95,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/2.0.x/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/2.0.x/docs/enterprise/releases/2021/v202103-1.mdx
@@ -95,5 +95,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -93,5 +93,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -93,5 +93,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/releases/2021/v202103-1.mdx
@@ -93,5 +93,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -93,5 +93,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/releases/2021/v202103-1.mdx
@@ -93,5 +93,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/releases/2021/v202103-1.mdx
@@ -93,5 +93,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -93,5 +93,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/releases/2021/v202103-1.mdx
@@ -93,5 +93,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -93,5 +93,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -93,5 +93,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -93,5 +93,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/releases/2021/v202103-1.mdx
@@ -93,5 +93,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -93,5 +93,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/releases/2021/v202103-1.mdx
@@ -93,5 +93,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -93,5 +93,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -95,5 +95,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -95,5 +95,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -95,5 +95,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2021/v202103-1.mdx
@@ -95,5 +95,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -95,5 +95,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -95,5 +95,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -95,5 +95,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -95,5 +95,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -95,5 +95,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -95,5 +95,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -95,5 +95,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -95,5 +95,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2021/v202103-1.mdx
@@ -95,5 +95,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -95,5 +95,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2021/v202103-1.mdx
@@ -95,5 +95,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -95,5 +95,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2021/v202103-1.mdx
@@ -95,5 +95,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202405-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202405-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -95,5 +95,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202406-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202406-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -95,5 +95,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202407-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202407-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -95,5 +95,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202408-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202408-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -95,5 +95,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202409-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202409-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -95,5 +95,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202409-2/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202409-2/docs/enterprise/releases/2021/v202103-1.mdx
@@ -95,5 +95,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202409-3/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202409-3/docs/enterprise/releases/2021/v202103-1.mdx
@@ -95,5 +95,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202410-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202410-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -95,5 +95,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202411-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202411-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -95,5 +95,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202411-2/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202411-2/docs/enterprise/releases/2021/v202103-1.mdx
@@ -95,5 +95,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202501-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202501-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -95,5 +95,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202502-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202502-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -95,5 +95,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202502-2/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202502-2/docs/enterprise/releases/2021/v202103-1.mdx
@@ -95,5 +95,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202503-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202503-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -95,5 +95,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202504-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202504-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -95,5 +95,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202505-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202505-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -95,5 +95,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202506-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202506-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -95,5 +95,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)

--- a/content/terraform-enterprise/v202507-1/docs/enterprise/releases/2021/v202103-1.mdx
+++ b/content/terraform-enterprise/v202507-1/docs/enterprise/releases/2021/v202103-1.mdx
@@ -95,5 +95,5 @@ The first time a Terraform Enterprise installation is upgraded to v202103-1, a p
 
 Additionally, operators should familiarize themselves with the following knowledge base articles.
 
-* [How to Manually Backup Internally-Managed PostgreSQL Data](https://support.hashicorp.com/hc/en-us/articles/1500003527861)
-* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://support.hashicorp.com/hc/en-us/articles/1500003501501)
+* [How to Manually Backup Internally-Managed PostgreSQL Data](https://www.ibm.com/support/pages/node/7265437)
+* [PostgreSQL 12 Upgrade Error: Timeout waiting for event PostgreSQL Upgraded](https://www.ibm.com/support/pages/node/7265853)


### PR DESCRIPTION
## Summary

Replaces legacy HashiCorp support URLs with IBM equivalents across all affected version directories.

| | |
|---|---|
| **Product** | Terraform Enterprise |
| **Document path** | `docs/enterprise/releases/2021/v202103-1.mdx` |
| **Old URL 1** | `https://support.hashicorp.com/hc/en-us/articles/1500003501501` |
| **New URL 1** | `https://www.ibm.com/support/pages/node/7265853` |
| **Old URL 2** | `https://support.hashicorp.com/hc/en-us/articles/1500003527861` |
| **New URL 2** | `https://www.ibm.com/support/pages/node/7265437` |
| **Versions updated** | 54 |

Part of the IBM DevDoc KB Remapping effort.