### PR TITLE
Clarify customization of httpGet probe path and port

### DIFF
--- a/content/consul/v2.0.x/content/docs/north-south/api-gateway/k8s/tech-specs.mdx
+++ b/content/consul/v2.0.x/content/docs/north-south/api-gateway/k8s/tech-specs.mdx
@@ -193,17 +193,17 @@ spec:
 
 <Warning>
 
-Do not change the `httpGet` probe path or port.
+**Note: Custom Probe Paths and Ports**
+Customizing the `httpGet` probe path and port is supported.
 
-The gateway pod runs a single container — `consul-dataplane` — which internally runs Envoy. 
-Envoy binds its health check listener exclusively to port `21000` and exposes only one valid HTTP endpoint: `/ready`. No other port or path is available for HTTP probes.
+By default, the `consul-dataplane` container (which internally runs Envoy) binds its health check listener to port `21000` with the `/ready` HTTP endpoint. However, you can configure a custom port and custom path as long as your Gateway listeners and Envoy configuration are set up to properly route and serve traffic on that endpoint.
 
-Only the following timing fields are safe to customize: `initialDelaySeconds`, `periodSeconds`, `failureThreshold`, `timeoutSeconds`, and `successThreshold`.
+You can customize the `path` and `port`, along with the timing fields: `initialDelaySeconds`, `periodSeconds`, `failureThreshold`, `timeoutSeconds`, and `successThreshold`.
 
-Overriding the path or port causes the probe to fail:
-- A different port has nothing listening → connection refused.
-- A different path on port `21000` is not recognized by Envoy → HTTP 404.
+When overriding the default path or port, ensure your custom endpoint is valid and listening. If the endpoint is unreachable, Kubernetes will treat it as a probe failure:
+* A different port with nothing listening → connection refused.
+* A path that is not recognized by your configuration → HTTP 404.
 
-Kubernetes treats both as probe failures, which prevents the pod from becoming ready or causes it to restart in a crash loop.
+These failures will prevent the api gateway pod from becoming ready or cause it to restart in a crash loop.
 
 </Warning>


### PR DESCRIPTION
Updated health check probe instructions to clarify customization options and implications.


