### PR TITLE
docs(vault): replace legacy mlock KB link with internal reference acr…

### DIFF
--- a/content/vault/v1.17.x/content/docs/install/install-binary.mdx
+++ b/content/vault/v1.17.x/content/docs/install/install-binary.mdx
@@ -51,9 +51,7 @@ Install Vault using a compiled binary.
    $ sudo setcap cap_ipc_lock=+ep $(readlink -f $(which vault))
    ```
 
-  See the support article
-  [Vault and mlock()](https://support.hashicorp.com/hc/en-us/articles/115012787688-Vault-and-mlock)
-  for more information.
+  Refer to the [`disable_mlock` server configuration documentation](/vault/docs/configuration#disable_mlock) for more information on Linux capabilities and systemd memory locking.
 
 1. Create your Vault data directory:
 

--- a/content/vault/v1.18.x/content/docs/install/install-binary.mdx
+++ b/content/vault/v1.18.x/content/docs/install/install-binary.mdx
@@ -51,9 +51,7 @@ Install Vault using a compiled binary.
    $ sudo setcap cap_ipc_lock=+ep $(readlink -f $(which vault))
    ```
 
-  See the support article
-  [Vault and mlock()](https://support.hashicorp.com/hc/en-us/articles/115012787688-Vault-and-mlock)
-  for more information.
+  Refer to the [`disable_mlock` server configuration documentation](/vault/docs/configuration#disable_mlock) for more information on Linux capabilities and systemd memory locking.
 
 1. Create your Vault data directory:
 

--- a/content/vault/v1.19.x/content/docs/get-vault/install-binary.mdx
+++ b/content/vault/v1.19.x/content/docs/get-vault/install-binary.mdx
@@ -51,9 +51,7 @@ Install Vault using a compiled binary.
    $ sudo setcap cap_ipc_lock=+ep $(readlink -f $(which vault))
    ```
 
-  See the support article
-  [Vault and mlock()](https://support.hashicorp.com/hc/en-us/articles/115012787688-Vault-and-mlock)
-  for more information.
+  Refer to the [`disable_mlock` server configuration documentation](/vault/docs/configuration#disable_mlock) for more information on Linux capabilities and systemd memory locking.
 
 1. Create your Vault data directory:
 

--- a/content/vault/v1.20.x/content/docs/get-vault/install-binary.mdx
+++ b/content/vault/v1.20.x/content/docs/get-vault/install-binary.mdx
@@ -51,9 +51,7 @@ Install Vault using a compiled binary.
    $ sudo setcap cap_ipc_lock=+ep $(readlink -f $(which vault))
    ```
 
-  See the support article
-  [Vault and mlock()](https://support.hashicorp.com/hc/en-us/articles/115012787688-Vault-and-mlock)
-  for more information.
+  Refer to the [`disable_mlock` server configuration documentation](/vault/docs/configuration#disable_mlock) for more information on Linux capabilities and systemd memory locking.
 
 1. Create your Vault data directory:
 

--- a/content/vault/v1.21.x/content/docs/get-vault/install-binary.mdx
+++ b/content/vault/v1.21.x/content/docs/get-vault/install-binary.mdx
@@ -51,9 +51,7 @@ Install Vault using a compiled binary.
    $ sudo setcap cap_ipc_lock=+ep $(readlink -f $(which vault))
    ```
 
-  See the support article
-  [Vault and mlock()](https://support.hashicorp.com/hc/en-us/articles/115012787688-Vault-and-mlock)
-  for more information.
+  Refer to the [`disable_mlock` server configuration documentation](/vault/docs/configuration#disable_mlock) for more information on Linux capabilities and systemd memory locking.
 
 1. Create your Vault data directory:
 

--- a/content/vault/v2.x/content/docs/get-vault/install-binary.mdx
+++ b/content/vault/v2.x/content/docs/get-vault/install-binary.mdx
@@ -51,9 +51,7 @@ Install Vault using a compiled binary.
    $ sudo setcap cap_ipc_lock=+ep $(readlink -f $(which vault))
    ```
 
-  See the support article
-  [Vault and mlock()](https://support.hashicorp.com/hc/en-us/articles/115012787688-Vault-and-mlock)
-  for more information.
+  Refer to the [`disable_mlock` server configuration documentation](/vault/docs/configuration#disable_mlock) for more information on Linux capabilities and systemd memory locking.
 
 1. Create your Vault data directory:
 


### PR DESCRIPTION
### Summary of Changes

| Version | File Path | Previous Text / Link | Updated Text / Link |
| :--- | :--- | :--- | :--- |
| **v2.x** | `content/vault/v2.x/content/docs/get-vault/install-binary.mdx` | `[Vault and mlock()](https://support.hashicorp.com/hc/en-us/articles/115012787688-Vault-and-mlock)` | Refer to the [`disable_mlock` server configuration documentation](/vault/docs/configuration#disable_mlock) for more information on Linux capabilities and systemd memory locking. |
| **v1.21.x** | `content/vault/v1.21.x/content/docs/get-vault/install-binary.mdx` | `[Vault and mlock()](https://support.hashicorp.com/hc/en-us/articles/115012787688-Vault-and-mlock)` | Refer to the [`disable_mlock` server configuration documentation](/vault/docs/configuration#disable_mlock) for more information on Linux capabilities and systemd memory locking. |
| **v1.20.x** | `content/vault/v1.20.x/content/docs/get-vault/install-binary.mdx` | `[Vault and mlock()](https://support.hashicorp.com/hc/en-us/articles/115012787688-Vault-and-mlock)` | Refer to the [`disable_mlock` server configuration documentation](/vault/docs/configuration#disable_mlock) for more information on Linux capabilities and systemd memory locking. |
| **v1.19.x** | `content/vault/v1.19.x/content/docs/get-vault/install-binary.mdx` | `[Vault and mlock()](https://support.hashicorp.com/hc/en-us/articles/115012787688-Vault-and-mlock)` | Refer to the [`disable_mlock` server configuration documentation](/vault/docs/configuration#disable_mlock) for more information on Linux capabilities and systemd memory locking. |
| **v1.18.x** | `content/vault/v1.18.x/content/docs/install/install-binary.mdx` | `[Vault and mlock()](https://support.hashicorp.com/hc/en-us/articles/115012787688-Vault-and-mlock)` | Refer to the [`disable_mlock` server configuration documentation](/vault/docs/configuration#disable_mlock) for more information on Linux capabilities and systemd memory locking. |
| **v1.17.x** | `content/vault/v1.17.x/content/docs/install/install-binary.mdx` | `[Vault and mlock()](https://support.hashicorp.com/hc/en-us/articles/115012787688-Vault-and-mlock)` | Refer to the [`disable_mlock` server configuration documentation](/vault/docs/configuration#disable_mlock) for more information on Linux capabilities and systemd memory locking. |
