### PR TITLE
Chore: Updated more workflows to Node 24

### DIFF
--- a/.github/workflows/broken-link-check-full.yml
+++ b/.github/workflows/broken-link-check-full.yml
@@ -37,7 +37,7 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Close Previous Link Checker Report GitHub Issue with label 'link-checker-report'
-        uses: actions/stale@3a9db7e6a41a89f618792c92c0e97cc736e1b13f # v10.0.0
+        uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
         with:
           # Only issues with ALL these labels are checked
           only-issue-labels: link-checker-report

--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -11,7 +11,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
+      - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
         with:
           days-before-pr-stale: 85
           days-before-pr-close: 5

--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Parse issue form
-        uses: stefanbuck/github-issue-parser@0d9ce93802360bd2925bc2cc4be1d807ed1d1233 # v3.2.4
+        uses: stefanbuck/github-issue-parser@cb6e97157cbf851e3a393ff8d57c93a484cc323f # v3.2.5
         id: issue-parser
         with:
           template-path: .github/ISSUE_TEMPLATE/${{ matrix.template }}

--- a/.github/workflows/trigger-repo-sync.yml
+++ b/.github/workflows/trigger-repo-sync.yml
@@ -14,7 +14,7 @@ jobs:
       
     steps:
       - name: Dispatch workflow in target repo
-        uses: peter-evans/repository-dispatch@5fc4efd1a4797ddb68ffd0714a238564e4cc0e6f # v4.0.0
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ secrets.CI_GITHUB_TOKEN }}
           repository: hashicorp/${{ github.repository == 'hashicorp/web-unified-docs-internal' && 'web-unified-docs' || 'web-unified-docs-internal' }}


### PR DESCRIPTION
### Description
This PR updates all actions that use node to the version with Node 24. Some actions are still on Node 20 and could not be updated.
- hashicorp/setup-copywrite
- redhat-plumbers-in-action/advanced-issue-labeler

### Testing
1. Make sure all CI actions on this PR are working as expected with new action versions
2. Ensure the preview deployments function as intended