### PR TITLE
docs(tfe): replace support.hashicorp.com link in network.mdx

### DIFF
--- a/content/terraform-enterprise/1.0.x/docs/enterprise/deploy/replicated/requirements/network.mdx
+++ b/content/terraform-enterprise/1.0.x/docs/enterprise/deploy/replicated/requirements/network.mdx
@@ -139,8 +139,8 @@ When [Cost Estimation](/terraform/enterprise/application-administration/integrat
    }
    ```
 
-   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://support.hashicorp.com/hc/en-us/articles/4405507244691) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
+   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://www.ibm.com/support/pages/node/7265869) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/1.1.x/docs/enterprise/deploy/replicated/requirements/network.mdx
+++ b/content/terraform-enterprise/1.1.x/docs/enterprise/deploy/replicated/requirements/network.mdx
@@ -139,8 +139,8 @@ When [Cost Estimation](/terraform/enterprise/application-administration/integrat
    }
    ```
 
-   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://support.hashicorp.com/hc/en-us/articles/4405507244691) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
+   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://www.ibm.com/support/pages/node/7265869) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/requirements/network.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/requirements/network.mdx
@@ -139,8 +139,8 @@ When [Cost Estimation](/terraform/enterprise/application-administration/integrat
    }
    ```
 
-   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://support.hashicorp.com/hc/en-us/articles/4405507244691) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
+   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://www.ibm.com/support/pages/node/7265869) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/2.0.x/docs/enterprise/deploy/replicated/requirements/network.mdx
+++ b/content/terraform-enterprise/2.0.x/docs/enterprise/deploy/replicated/requirements/network.mdx
@@ -139,8 +139,8 @@ When [Cost Estimation](/terraform/enterprise/application-administration/integrat
    }
    ```
 
-   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://support.hashicorp.com/hc/en-us/articles/4405507244691) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
+   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://www.ibm.com/support/pages/node/7265869) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202206-1/docs/enterprise/requirements/network.mdx
+++ b/content/terraform-enterprise/v202206-1/docs/enterprise/requirements/network.mdx
@@ -128,4 +128,4 @@ When [Cost Estimation](/enterprise/admin/application/integration#cost-estimation
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202207-1/docs/enterprise/requirements/network.mdx
+++ b/content/terraform-enterprise/v202207-1/docs/enterprise/requirements/network.mdx
@@ -128,4 +128,4 @@ When [Cost Estimation](/enterprise/admin/application/integration#cost-estimation
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202207-2/docs/enterprise/requirements/network.mdx
+++ b/content/terraform-enterprise/v202207-2/docs/enterprise/requirements/network.mdx
@@ -128,4 +128,4 @@ When [Cost Estimation](/enterprise/admin/application/integration#cost-estimation
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202208-1/docs/enterprise/requirements/network.mdx
+++ b/content/terraform-enterprise/v202208-1/docs/enterprise/requirements/network.mdx
@@ -128,4 +128,4 @@ When [Cost Estimation](/enterprise/admin/application/integration#cost-estimation
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202208-2/docs/enterprise/requirements/network.mdx
+++ b/content/terraform-enterprise/v202208-2/docs/enterprise/requirements/network.mdx
@@ -128,4 +128,4 @@ When [Cost Estimation](/enterprise/admin/application/integration#cost-estimation
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202208-3/docs/enterprise/requirements/network.mdx
+++ b/content/terraform-enterprise/v202208-3/docs/enterprise/requirements/network.mdx
@@ -128,4 +128,4 @@ When [Cost Estimation](/enterprise/admin/application/integration#cost-estimation
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202209-1/docs/enterprise/requirements/network.mdx
+++ b/content/terraform-enterprise/v202209-1/docs/enterprise/requirements/network.mdx
@@ -128,4 +128,4 @@ When [Cost Estimation](/enterprise/admin/application/integration#cost-estimation
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202209-2/docs/enterprise/requirements/network.mdx
+++ b/content/terraform-enterprise/v202209-2/docs/enterprise/requirements/network.mdx
@@ -128,4 +128,4 @@ When [Cost Estimation](/enterprise/admin/application/integration#cost-estimation
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202210-1/docs/enterprise/requirements/network.mdx
+++ b/content/terraform-enterprise/v202210-1/docs/enterprise/requirements/network.mdx
@@ -128,4 +128,4 @@ When [Cost Estimation](/enterprise/admin/application/integration#cost-estimation
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202211-1/docs/enterprise/requirements/network.mdx
+++ b/content/terraform-enterprise/v202211-1/docs/enterprise/requirements/network.mdx
@@ -128,4 +128,4 @@ When [Cost Estimation](/enterprise/admin/application/integration#cost-estimation
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202212-1/docs/enterprise/requirements/network.mdx
+++ b/content/terraform-enterprise/v202212-1/docs/enterprise/requirements/network.mdx
@@ -128,4 +128,4 @@ When [Cost Estimation](/enterprise/admin/application/integration#cost-estimation
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202212-2/docs/enterprise/requirements/network.mdx
+++ b/content/terraform-enterprise/v202212-2/docs/enterprise/requirements/network.mdx
@@ -128,4 +128,4 @@ When [Cost Estimation](/enterprise/admin/application/integration#cost-estimation
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202301-1/docs/enterprise/requirements/network.mdx
+++ b/content/terraform-enterprise/v202301-1/docs/enterprise/requirements/network.mdx
@@ -137,4 +137,4 @@ When [Cost Estimation](/enterprise/admin/application/integration#cost-estimation
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202301-2/docs/enterprise/requirements/network.mdx
+++ b/content/terraform-enterprise/v202301-2/docs/enterprise/requirements/network.mdx
@@ -137,4 +137,4 @@ When [Cost Estimation](/enterprise/admin/application/integration#cost-estimation
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/requirements/network.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/requirements/network.mdx
@@ -137,4 +137,4 @@ When [Cost Estimation](/enterprise/admin/application/integration#cost-estimation
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/requirements/network.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/requirements/network.mdx
@@ -137,4 +137,4 @@ When [Cost Estimation](/terraform/enterprise/admin/application/integration#cost-
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/requirements/network.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/requirements/network.mdx
@@ -137,4 +137,4 @@ When [Cost Estimation](/terraform/enterprise/admin/application/integration#cost-
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/requirements/network.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/requirements/network.mdx
@@ -142,4 +142,4 @@ When [Cost Estimation](/terraform/enterprise/admin/application/integration#cost-
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/requirements/network.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/requirements/network.mdx
@@ -142,4 +142,4 @@ When [Cost Estimation](/terraform/enterprise/admin/application/integration#cost-
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/requirements/network.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/requirements/network.mdx
@@ -142,4 +142,4 @@ When [Cost Estimation](/terraform/enterprise/admin/application/integration#cost-
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/requirements/network.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/requirements/network.mdx
@@ -140,8 +140,8 @@ When [Cost Estimation](/terraform/enterprise/admin/application/integration#cost-
    }
    ```
    
-   ~> **Note:** The above only affects the default network `bridge` aka `docker0`.  To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://support.hashicorp.com/hc/en-us/articles/4405507244691) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
+   ~> **Note:** The above only affects the default network `bridge` aka `docker0`.  To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://www.ibm.com/support/pages/node/7265869) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/requirements/network.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/requirements/network.mdx
@@ -140,8 +140,8 @@ When [Cost Estimation](/terraform/enterprise/admin/application/integration#cost-
    }
    ```
    
-   ~> **Note:** The above only affects the default network `bridge` aka `docker0`.  To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://support.hashicorp.com/hc/en-us/articles/4405507244691) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
+   ~> **Note:** The above only affects the default network `bridge` aka `docker0`.  To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://www.ibm.com/support/pages/node/7265869) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/requirements/network.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/requirements/network.mdx
@@ -138,8 +138,8 @@ When [Cost Estimation](/terraform/enterprise/application-administration/integrat
    }
    ```
 
-   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://support.hashicorp.com/hc/en-us/articles/4405507244691) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
+   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://www.ibm.com/support/pages/node/7265869) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/requirements/network.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/requirements/network.mdx
@@ -138,8 +138,8 @@ When [Cost Estimation](/terraform/enterprise/application-administration/integrat
    }
    ```
 
-   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://support.hashicorp.com/hc/en-us/articles/4405507244691) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
+   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://www.ibm.com/support/pages/node/7265869) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/requirements/network.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/requirements/network.mdx
@@ -138,8 +138,8 @@ When [Cost Estimation](/terraform/enterprise/application-administration/integrat
    }
    ```
 
-   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://support.hashicorp.com/hc/en-us/articles/4405507244691) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
+   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://www.ibm.com/support/pages/node/7265869) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/requirements/network.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/requirements/network.mdx
@@ -138,8 +138,8 @@ When [Cost Estimation](/terraform/enterprise/application-administration/integrat
    }
    ```
 
-   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://support.hashicorp.com/hc/en-us/articles/4405507244691) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
+   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://www.ibm.com/support/pages/node/7265869) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/requirements/network.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/requirements/network.mdx
@@ -138,8 +138,8 @@ When [Cost Estimation](/terraform/enterprise/application-administration/integrat
    }
    ```
 
-   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://support.hashicorp.com/hc/en-us/articles/4405507244691) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
+   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://www.ibm.com/support/pages/node/7265869) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/requirements/network.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/requirements/network.mdx
@@ -138,8 +138,8 @@ When [Cost Estimation](/terraform/enterprise/application-administration/integrat
    }
    ```
 
-   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://support.hashicorp.com/hc/en-us/articles/4405507244691) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
+   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://www.ibm.com/support/pages/node/7265869) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/requirements/network.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/requirements/network.mdx
@@ -138,8 +138,8 @@ When [Cost Estimation](/terraform/enterprise/application-administration/integrat
    }
    ```
 
-   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://support.hashicorp.com/hc/en-us/articles/4405507244691) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
+   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://www.ibm.com/support/pages/node/7265869) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/requirements/network.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/requirements/network.mdx
@@ -138,8 +138,8 @@ When [Cost Estimation](/terraform/enterprise/application-administration/integrat
    }
    ```
 
-   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://support.hashicorp.com/hc/en-us/articles/4405507244691) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
+   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://www.ibm.com/support/pages/node/7265869) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/requirements/network.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/requirements/network.mdx
@@ -138,8 +138,8 @@ When [Cost Estimation](/terraform/enterprise/application-administration/integrat
    }
    ```
 
-   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://support.hashicorp.com/hc/en-us/articles/4405507244691) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
+   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://www.ibm.com/support/pages/node/7265869) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/requirements/network.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/requirements/network.mdx
@@ -138,8 +138,8 @@ When [Cost Estimation](/terraform/enterprise/application-administration/integrat
    }
    ```
 
-   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://support.hashicorp.com/hc/en-us/articles/4405507244691) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
+   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://www.ibm.com/support/pages/node/7265869) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202405-1/docs/enterprise/replicated/requirements/network.mdx
+++ b/content/terraform-enterprise/v202405-1/docs/enterprise/replicated/requirements/network.mdx
@@ -138,8 +138,8 @@ When [Cost Estimation](/terraform/enterprise/application-administration/integrat
    }
    ```
 
-   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://support.hashicorp.com/hc/en-us/articles/4405507244691) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
+   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://www.ibm.com/support/pages/node/7265869) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202406-1/docs/enterprise/replicated/requirements/network.mdx
+++ b/content/terraform-enterprise/v202406-1/docs/enterprise/replicated/requirements/network.mdx
@@ -139,8 +139,8 @@ When [Cost Estimation](/terraform/enterprise/application-administration/integrat
    }
    ```
 
-   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://support.hashicorp.com/hc/en-us/articles/4405507244691) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
+   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://www.ibm.com/support/pages/node/7265869) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202407-1/docs/enterprise/replicated/requirements/network.mdx
+++ b/content/terraform-enterprise/v202407-1/docs/enterprise/replicated/requirements/network.mdx
@@ -139,8 +139,8 @@ When [Cost Estimation](/terraform/enterprise/application-administration/integrat
    }
    ```
 
-   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://support.hashicorp.com/hc/en-us/articles/4405507244691) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
+   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://www.ibm.com/support/pages/node/7265869) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202408-1/docs/enterprise/deploy/replicated/requirements/network.mdx
+++ b/content/terraform-enterprise/v202408-1/docs/enterprise/deploy/replicated/requirements/network.mdx
@@ -139,8 +139,8 @@ When [Cost Estimation](/terraform/enterprise/application-administration/integrat
    }
    ```
 
-   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://support.hashicorp.com/hc/en-us/articles/4405507244691) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
+   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://www.ibm.com/support/pages/node/7265869) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202409-1/docs/enterprise/deploy/replicated/requirements/network.mdx
+++ b/content/terraform-enterprise/v202409-1/docs/enterprise/deploy/replicated/requirements/network.mdx
@@ -139,8 +139,8 @@ When [Cost Estimation](/terraform/enterprise/application-administration/integrat
    }
    ```
 
-   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://support.hashicorp.com/hc/en-us/articles/4405507244691) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
+   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://www.ibm.com/support/pages/node/7265869) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202409-2/docs/enterprise/deploy/replicated/requirements/network.mdx
+++ b/content/terraform-enterprise/v202409-2/docs/enterprise/deploy/replicated/requirements/network.mdx
@@ -139,8 +139,8 @@ When [Cost Estimation](/terraform/enterprise/application-administration/integrat
    }
    ```
 
-   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://support.hashicorp.com/hc/en-us/articles/4405507244691) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
+   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://www.ibm.com/support/pages/node/7265869) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202409-3/docs/enterprise/deploy/replicated/requirements/network.mdx
+++ b/content/terraform-enterprise/v202409-3/docs/enterprise/deploy/replicated/requirements/network.mdx
@@ -139,8 +139,8 @@ When [Cost Estimation](/terraform/enterprise/application-administration/integrat
    }
    ```
 
-   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://support.hashicorp.com/hc/en-us/articles/4405507244691) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
+   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://www.ibm.com/support/pages/node/7265869) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202410-1/docs/enterprise/deploy/replicated/requirements/network.mdx
+++ b/content/terraform-enterprise/v202410-1/docs/enterprise/deploy/replicated/requirements/network.mdx
@@ -139,8 +139,8 @@ When [Cost Estimation](/terraform/enterprise/application-administration/integrat
    }
    ```
 
-   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://support.hashicorp.com/hc/en-us/articles/4405507244691) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
+   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://www.ibm.com/support/pages/node/7265869) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202411-1/docs/enterprise/deploy/replicated/requirements/network.mdx
+++ b/content/terraform-enterprise/v202411-1/docs/enterprise/deploy/replicated/requirements/network.mdx
@@ -139,8 +139,8 @@ When [Cost Estimation](/terraform/enterprise/application-administration/integrat
    }
    ```
 
-   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://support.hashicorp.com/hc/en-us/articles/4405507244691) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
+   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://www.ibm.com/support/pages/node/7265869) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202411-2/docs/enterprise/deploy/replicated/requirements/network.mdx
+++ b/content/terraform-enterprise/v202411-2/docs/enterprise/deploy/replicated/requirements/network.mdx
@@ -139,8 +139,8 @@ When [Cost Estimation](/terraform/enterprise/application-administration/integrat
    }
    ```
 
-   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://support.hashicorp.com/hc/en-us/articles/4405507244691) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
+   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://www.ibm.com/support/pages/node/7265869) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202501-1/docs/enterprise/deploy/replicated/requirements/network.mdx
+++ b/content/terraform-enterprise/v202501-1/docs/enterprise/deploy/replicated/requirements/network.mdx
@@ -139,8 +139,8 @@ When [Cost Estimation](/terraform/enterprise/application-administration/integrat
    }
    ```
 
-   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://support.hashicorp.com/hc/en-us/articles/4405507244691) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
+   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://www.ibm.com/support/pages/node/7265869) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202502-1/docs/enterprise/deploy/replicated/requirements/network.mdx
+++ b/content/terraform-enterprise/v202502-1/docs/enterprise/deploy/replicated/requirements/network.mdx
@@ -139,8 +139,8 @@ When [Cost Estimation](/terraform/enterprise/application-administration/integrat
    }
    ```
 
-   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://support.hashicorp.com/hc/en-us/articles/4405507244691) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
+   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://www.ibm.com/support/pages/node/7265869) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202502-2/docs/enterprise/deploy/replicated/requirements/network.mdx
+++ b/content/terraform-enterprise/v202502-2/docs/enterprise/deploy/replicated/requirements/network.mdx
@@ -139,8 +139,8 @@ When [Cost Estimation](/terraform/enterprise/application-administration/integrat
    }
    ```
 
-   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://support.hashicorp.com/hc/en-us/articles/4405507244691) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
+   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://www.ibm.com/support/pages/node/7265869) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202503-1/docs/enterprise/deploy/replicated/requirements/network.mdx
+++ b/content/terraform-enterprise/v202503-1/docs/enterprise/deploy/replicated/requirements/network.mdx
@@ -139,8 +139,8 @@ When [Cost Estimation](/terraform/enterprise/application-administration/integrat
    }
    ```
 
-   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://support.hashicorp.com/hc/en-us/articles/4405507244691) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
+   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://www.ibm.com/support/pages/node/7265869) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202504-1/docs/enterprise/deploy/replicated/requirements/network.mdx
+++ b/content/terraform-enterprise/v202504-1/docs/enterprise/deploy/replicated/requirements/network.mdx
@@ -139,8 +139,8 @@ When [Cost Estimation](/terraform/enterprise/application-administration/integrat
    }
    ```
 
-   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://support.hashicorp.com/hc/en-us/articles/4405507244691) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
+   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://www.ibm.com/support/pages/node/7265869) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202505-1/docs/enterprise/deploy/replicated/requirements/network.mdx
+++ b/content/terraform-enterprise/v202505-1/docs/enterprise/deploy/replicated/requirements/network.mdx
@@ -139,8 +139,8 @@ When [Cost Estimation](/terraform/enterprise/application-administration/integrat
    }
    ```
 
-   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://support.hashicorp.com/hc/en-us/articles/4405507244691) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
+   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://www.ibm.com/support/pages/node/7265869) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202506-1/docs/enterprise/deploy/replicated/requirements/network.mdx
+++ b/content/terraform-enterprise/v202506-1/docs/enterprise/deploy/replicated/requirements/network.mdx
@@ -139,8 +139,8 @@ When [Cost Estimation](/terraform/enterprise/application-administration/integrat
    }
    ```
 
-   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://support.hashicorp.com/hc/en-us/articles/4405507244691) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
+   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://www.ibm.com/support/pages/node/7265869) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).

--- a/content/terraform-enterprise/v202507-1/docs/enterprise/deploy/replicated/requirements/network.mdx
+++ b/content/terraform-enterprise/v202507-1/docs/enterprise/deploy/replicated/requirements/network.mdx
@@ -139,8 +139,8 @@ When [Cost Estimation](/terraform/enterprise/application-administration/integrat
    }
    ```
 
-   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://support.hashicorp.com/hc/en-us/articles/4405507244691) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
+   ~> **Note:** The above only affects the default network `bridge` aka `docker0`. To apply this to the networks `tfe_services` and `tfe_terraform_isolation`, it is [required](https://www.ibm.com/support/pages/node/7265869) to delete these two networks and recreate them with the correct MTU for an existing install or to create these two networks prior to installing Terraform Enterprise for a new install.
 
 1. Ensure the Docker bridge network address is not in use elsewhere on the network. If it is, please refer to the [Docker documentation](https://docs.docker.com/network/bridge/) for information on how to change it.
 
-~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://support.hashicorp.com/hc/en-us/articles/4405507244691).
+~> **Note:** Beginning in version `v202004-1`, non-default Docker networks named `tfe_services` and `tfe_terraform_isolation` were added for the Terraform Enterprise component Docker containers as part of a network segmentation update. Custom configuration [may be required for MTU settings](https://www.ibm.com/support/pages/node/7265869).


### PR DESCRIPTION
## Summary

Replaces legacy HashiCorp support URL with IBM equivalent across all affected version directories.

| | |
|---|---|
| **Product** | Terraform Enterprise |
| **Document paths** | `docs/enterprise/requirements/network.mdx`<br>`docs/enterprise/replicated/requirements/network.mdx`<br>`docs/enterprise/deploy/replicated/requirements/network.mdx` |
| **Old URL** | `https://support.hashicorp.com/hc/en-us/articles/4405507244691` |
| **New URL** | `https://www.ibm.com/support/pages/node/7265869` |
| **Versions updated** | 54 |

Part of the IBM DevDoc KB Remapping effort.