### PR TITLE
docs(tfe): replace support.hashicorp.com link in replicated-migration.mdx

### DIFF
--- a/content/terraform-enterprise/1.0.x/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/1.0.x/docs/enterprise/deploy/replicated-migration.mdx
@@ -91,7 +91,7 @@ $ sudo docker exec terraform-enterprise env | sudo tee env.txt > /dev/null
       $ replicated admin health-check
       ```
 
-      If neither command works, refer to [tfe-admin health-check command fails](https://support.hashicorp.com/hc/en-us/articles/6053728286483-tfe-admin-health-check-command-fails-with-sh-root-ptfe-health-check-not-found) for additional troubleshooting guidance.
+      If neither command works, refer to [tfe-admin health-check command fails](https://www.ibm.com/support/pages/node/7265082) for additional troubleshooting guidance.
 
    1. Do a `terraform plan` and a `terraform apply`.
 

--- a/content/terraform-enterprise/1.1.x/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/1.1.x/docs/enterprise/deploy/replicated-migration.mdx
@@ -92,7 +92,7 @@ $ sudo docker exec terraform-enterprise env | sudo tee env.txt > /dev/null
       $ replicated admin health-check
       ```
 
-      If neither command works, refer to [tfe-admin health-check command fails](https://support.hashicorp.com/hc/en-us/articles/6053728286483-tfe-admin-health-check-command-fails-with-sh-root-ptfe-health-check-not-found) for additional troubleshooting guidance.
+      If neither command works, refer to [tfe-admin health-check command fails](https://www.ibm.com/support/pages/node/7265082) for additional troubleshooting guidance.
 
    1. Do a `terraform plan` and a `terraform apply`.
 

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated-migration.mdx
@@ -92,7 +92,7 @@ $ sudo docker exec terraform-enterprise env | sudo tee env.txt > /dev/null
       $ replicated admin health-check
       ```
 
-      If neither command works, refer to [tfe-admin health-check command fails](https://support.hashicorp.com/hc/en-us/articles/6053728286483-tfe-admin-health-check-command-fails-with-sh-root-ptfe-health-check-not-found) for additional troubleshooting guidance.
+      If neither command works, refer to [tfe-admin health-check command fails](https://www.ibm.com/support/pages/node/7265082) for additional troubleshooting guidance.
 
    1. Do a `terraform plan` and a `terraform apply`.
 

--- a/content/terraform-enterprise/2.0.x/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/2.0.x/docs/enterprise/deploy/replicated-migration.mdx
@@ -92,7 +92,7 @@ $ sudo docker exec terraform-enterprise env | sudo tee env.txt > /dev/null
       $ replicated admin health-check
       ```
 
-      If neither command works, refer to [tfe-admin health-check command fails](https://support.hashicorp.com/hc/en-us/articles/6053728286483-tfe-admin-health-check-command-fails-with-sh-root-ptfe-health-check-not-found) for additional troubleshooting guidance.
+      If neither command works, refer to [tfe-admin health-check command fails](https://www.ibm.com/support/pages/node/7265082) for additional troubleshooting guidance.
 
    1. Do a `terraform plan` and a `terraform apply`.
 

--- a/content/terraform-enterprise/v202408-1/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202408-1/docs/enterprise/deploy/replicated-migration.mdx
@@ -91,7 +91,7 @@ $ sudo docker exec terraform-enterprise env | sudo tee env.txt > /dev/null
       $ replicated admin health-check
       ```
 
-      If neither command works, refer to [tfe-admin health-check command fails](https://support.hashicorp.com/hc/en-us/articles/6053728286483-tfe-admin-health-check-command-fails-with-sh-root-ptfe-health-check-not-found) for additional troubleshooting guidance.
+      If neither command works, refer to [tfe-admin health-check command fails](https://www.ibm.com/support/pages/node/7265082) for additional troubleshooting guidance.
 
    1. Do a `terraform plan` and a `terraform apply`.
 

--- a/content/terraform-enterprise/v202409-1/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202409-1/docs/enterprise/deploy/replicated-migration.mdx
@@ -91,7 +91,7 @@ $ sudo docker exec terraform-enterprise env | sudo tee env.txt > /dev/null
       $ replicated admin health-check
       ```
 
-      If neither command works, refer to [tfe-admin health-check command fails](https://support.hashicorp.com/hc/en-us/articles/6053728286483-tfe-admin-health-check-command-fails-with-sh-root-ptfe-health-check-not-found) for additional troubleshooting guidance.
+      If neither command works, refer to [tfe-admin health-check command fails](https://www.ibm.com/support/pages/node/7265082) for additional troubleshooting guidance.
 
    1. Do a `terraform plan` and a `terraform apply`.
 

--- a/content/terraform-enterprise/v202409-2/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202409-2/docs/enterprise/deploy/replicated-migration.mdx
@@ -91,7 +91,7 @@ $ sudo docker exec terraform-enterprise env | sudo tee env.txt > /dev/null
       $ replicated admin health-check
       ```
 
-      If neither command works, refer to [tfe-admin health-check command fails](https://support.hashicorp.com/hc/en-us/articles/6053728286483-tfe-admin-health-check-command-fails-with-sh-root-ptfe-health-check-not-found) for additional troubleshooting guidance.
+      If neither command works, refer to [tfe-admin health-check command fails](https://www.ibm.com/support/pages/node/7265082) for additional troubleshooting guidance.
 
    1. Do a `terraform plan` and a `terraform apply`.
 

--- a/content/terraform-enterprise/v202409-3/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202409-3/docs/enterprise/deploy/replicated-migration.mdx
@@ -91,7 +91,7 @@ $ sudo docker exec terraform-enterprise env | sudo tee env.txt > /dev/null
       $ replicated admin health-check
       ```
 
-      If neither command works, refer to [tfe-admin health-check command fails](https://support.hashicorp.com/hc/en-us/articles/6053728286483-tfe-admin-health-check-command-fails-with-sh-root-ptfe-health-check-not-found) for additional troubleshooting guidance.
+      If neither command works, refer to [tfe-admin health-check command fails](https://www.ibm.com/support/pages/node/7265082) for additional troubleshooting guidance.
 
    1. Do a `terraform plan` and a `terraform apply`.
 

--- a/content/terraform-enterprise/v202410-1/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202410-1/docs/enterprise/deploy/replicated-migration.mdx
@@ -91,7 +91,7 @@ $ sudo docker exec terraform-enterprise env | sudo tee env.txt > /dev/null
       $ replicated admin health-check
       ```
 
-      If neither command works, refer to [tfe-admin health-check command fails](https://support.hashicorp.com/hc/en-us/articles/6053728286483-tfe-admin-health-check-command-fails-with-sh-root-ptfe-health-check-not-found) for additional troubleshooting guidance.
+      If neither command works, refer to [tfe-admin health-check command fails](https://www.ibm.com/support/pages/node/7265082) for additional troubleshooting guidance.
 
    1. Do a `terraform plan` and a `terraform apply`.
 

--- a/content/terraform-enterprise/v202411-1/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202411-1/docs/enterprise/deploy/replicated-migration.mdx
@@ -91,7 +91,7 @@ $ sudo docker exec terraform-enterprise env | sudo tee env.txt > /dev/null
       $ replicated admin health-check
       ```
 
-      If neither command works, refer to [tfe-admin health-check command fails](https://support.hashicorp.com/hc/en-us/articles/6053728286483-tfe-admin-health-check-command-fails-with-sh-root-ptfe-health-check-not-found) for additional troubleshooting guidance.
+      If neither command works, refer to [tfe-admin health-check command fails](https://www.ibm.com/support/pages/node/7265082) for additional troubleshooting guidance.
 
    1. Do a `terraform plan` and a `terraform apply`.
 

--- a/content/terraform-enterprise/v202411-2/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202411-2/docs/enterprise/deploy/replicated-migration.mdx
@@ -91,7 +91,7 @@ $ sudo docker exec terraform-enterprise env | sudo tee env.txt > /dev/null
       $ replicated admin health-check
       ```
 
-      If neither command works, refer to [tfe-admin health-check command fails](https://support.hashicorp.com/hc/en-us/articles/6053728286483-tfe-admin-health-check-command-fails-with-sh-root-ptfe-health-check-not-found) for additional troubleshooting guidance.
+      If neither command works, refer to [tfe-admin health-check command fails](https://www.ibm.com/support/pages/node/7265082) for additional troubleshooting guidance.
 
    1. Do a `terraform plan` and a `terraform apply`.
 

--- a/content/terraform-enterprise/v202501-1/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202501-1/docs/enterprise/deploy/replicated-migration.mdx
@@ -91,7 +91,7 @@ $ sudo docker exec terraform-enterprise env | sudo tee env.txt > /dev/null
       $ replicated admin health-check
       ```
 
-      If neither command works, refer to [tfe-admin health-check command fails](https://support.hashicorp.com/hc/en-us/articles/6053728286483-tfe-admin-health-check-command-fails-with-sh-root-ptfe-health-check-not-found) for additional troubleshooting guidance.
+      If neither command works, refer to [tfe-admin health-check command fails](https://www.ibm.com/support/pages/node/7265082) for additional troubleshooting guidance.
 
    1. Do a `terraform plan` and a `terraform apply`.
 

--- a/content/terraform-enterprise/v202502-1/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202502-1/docs/enterprise/deploy/replicated-migration.mdx
@@ -91,7 +91,7 @@ $ sudo docker exec terraform-enterprise env | sudo tee env.txt > /dev/null
       $ replicated admin health-check
       ```
 
-      If neither command works, refer to [tfe-admin health-check command fails](https://support.hashicorp.com/hc/en-us/articles/6053728286483-tfe-admin-health-check-command-fails-with-sh-root-ptfe-health-check-not-found) for additional troubleshooting guidance.
+      If neither command works, refer to [tfe-admin health-check command fails](https://www.ibm.com/support/pages/node/7265082) for additional troubleshooting guidance.
 
    1. Do a `terraform plan` and a `terraform apply`.
 

--- a/content/terraform-enterprise/v202502-2/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202502-2/docs/enterprise/deploy/replicated-migration.mdx
@@ -91,7 +91,7 @@ $ sudo docker exec terraform-enterprise env | sudo tee env.txt > /dev/null
       $ replicated admin health-check
       ```
 
-      If neither command works, refer to [tfe-admin health-check command fails](https://support.hashicorp.com/hc/en-us/articles/6053728286483-tfe-admin-health-check-command-fails-with-sh-root-ptfe-health-check-not-found) for additional troubleshooting guidance.
+      If neither command works, refer to [tfe-admin health-check command fails](https://www.ibm.com/support/pages/node/7265082) for additional troubleshooting guidance.
 
    1. Do a `terraform plan` and a `terraform apply`.
 

--- a/content/terraform-enterprise/v202503-1/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202503-1/docs/enterprise/deploy/replicated-migration.mdx
@@ -91,7 +91,7 @@ $ sudo docker exec terraform-enterprise env | sudo tee env.txt > /dev/null
       $ replicated admin health-check
       ```
 
-      If neither command works, refer to [tfe-admin health-check command fails](https://support.hashicorp.com/hc/en-us/articles/6053728286483-tfe-admin-health-check-command-fails-with-sh-root-ptfe-health-check-not-found) for additional troubleshooting guidance.
+      If neither command works, refer to [tfe-admin health-check command fails](https://www.ibm.com/support/pages/node/7265082) for additional troubleshooting guidance.
 
    1. Do a `terraform plan` and a `terraform apply`.
 

--- a/content/terraform-enterprise/v202504-1/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202504-1/docs/enterprise/deploy/replicated-migration.mdx
@@ -91,7 +91,7 @@ $ sudo docker exec terraform-enterprise env | sudo tee env.txt > /dev/null
       $ replicated admin health-check
       ```
 
-      If neither command works, refer to [tfe-admin health-check command fails](https://support.hashicorp.com/hc/en-us/articles/6053728286483-tfe-admin-health-check-command-fails-with-sh-root-ptfe-health-check-not-found) for additional troubleshooting guidance.
+      If neither command works, refer to [tfe-admin health-check command fails](https://www.ibm.com/support/pages/node/7265082) for additional troubleshooting guidance.
 
    1. Do a `terraform plan` and a `terraform apply`.
 

--- a/content/terraform-enterprise/v202505-1/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202505-1/docs/enterprise/deploy/replicated-migration.mdx
@@ -91,7 +91,7 @@ $ sudo docker exec terraform-enterprise env | sudo tee env.txt > /dev/null
       $ replicated admin health-check
       ```
 
-      If neither command works, refer to [tfe-admin health-check command fails](https://support.hashicorp.com/hc/en-us/articles/6053728286483-tfe-admin-health-check-command-fails-with-sh-root-ptfe-health-check-not-found) for additional troubleshooting guidance.
+      If neither command works, refer to [tfe-admin health-check command fails](https://www.ibm.com/support/pages/node/7265082) for additional troubleshooting guidance.
 
    1. Do a `terraform plan` and a `terraform apply`.
 

--- a/content/terraform-enterprise/v202506-1/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202506-1/docs/enterprise/deploy/replicated-migration.mdx
@@ -91,7 +91,7 @@ $ sudo docker exec terraform-enterprise env | sudo tee env.txt > /dev/null
       $ replicated admin health-check
       ```
 
-      If neither command works, refer to [tfe-admin health-check command fails](https://support.hashicorp.com/hc/en-us/articles/6053728286483-tfe-admin-health-check-command-fails-with-sh-root-ptfe-health-check-not-found) for additional troubleshooting guidance.
+      If neither command works, refer to [tfe-admin health-check command fails](https://www.ibm.com/support/pages/node/7265082) for additional troubleshooting guidance.
 
    1. Do a `terraform plan` and a `terraform apply`.
 

--- a/content/terraform-enterprise/v202507-1/docs/enterprise/deploy/replicated-migration.mdx
+++ b/content/terraform-enterprise/v202507-1/docs/enterprise/deploy/replicated-migration.mdx
@@ -91,7 +91,7 @@ $ sudo docker exec terraform-enterprise env | sudo tee env.txt > /dev/null
       $ replicated admin health-check
       ```
 
-      If neither command works, refer to [tfe-admin health-check command fails](https://support.hashicorp.com/hc/en-us/articles/6053728286483-tfe-admin-health-check-command-fails-with-sh-root-ptfe-health-check-not-found) for additional troubleshooting guidance.
+      If neither command works, refer to [tfe-admin health-check command fails](https://www.ibm.com/support/pages/node/7265082) for additional troubleshooting guidance.
 
    1. Do a `terraform plan` and a `terraform apply`.
 


### PR DESCRIPTION
## Summary

Replaces legacy HashiCorp support URL with IBM equivalent across all affected version directories.

| | |
|---|---|
| **Product** | Terraform Enterprise |
| **Document path** | `docs/enterprise/deploy/replicated-migration.mdx` |
| **Old URL** | `https://support.hashicorp.com/hc/en-us/articles/6053728286483-tfe-admin-health-check-command-fails-with-sh-root-ptfe-health-check-not-found` |
| **New URL** | `https://www.ibm.com/support/pages/node/7265082` |
| **Versions updated** | 19 |

Part of the IBM DevDoc KB Remapping effort.