### PR TITLE
docs(tfe): replace support.hashicorp.com link in backup-restore.mdx

### DIFF
--- a/content/terraform-enterprise/1.0.x/docs/enterprise/deploy/replicated/administration/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/1.0.x/docs/enterprise/deploy/replicated/administration/infrastructure/backup-restore.mdx
@@ -32,7 +32,7 @@ Note the following when using the backup and restore API:
 - The backup and restore API times out after 5000 seconds (83.3 minutes). If you have a lot of
   data in the object store, use [`skip-object-storage`](#request-body) to
   finish the backup in time. Then after you restore the backup, manually move your object store data. See this
-  [support article](https://support.hashicorp.com/hc/en-us/articles/10536697730323-Migrate-TFE-from-Mounted-Disk-to-External-Services-mode-with-Backup-Restore-API) for details.
+  [support article](https://www.ibm.com/support/pages/node/7265344) for details.
 - Once a restore is completed, the Terraform Enterprise application will need to be restarted before it can use the restored data.
 
 See also:

--- a/content/terraform-enterprise/1.1.x/docs/enterprise/deploy/replicated/administration/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/1.1.x/docs/enterprise/deploy/replicated/administration/infrastructure/backup-restore.mdx
@@ -32,7 +32,7 @@ Note the following when using the backup and restore API:
 - The backup and restore API times out after 5000 seconds (83.3 minutes). If you have a lot of
   data in the object store, use [`skip-object-storage`](#request-body) to
   finish the backup in time. Then after you restore the backup, manually move your object store data. See this
-  [support article](https://support.hashicorp.com/hc/en-us/articles/10536697730323-Migrate-TFE-from-Mounted-Disk-to-External-Services-mode-with-Backup-Restore-API) for details.
+  [support article](https://www.ibm.com/support/pages/node/7265344) for details.
 - Once a restore is completed, the Terraform Enterprise application will need to be restarted before it can use the restored data.
 
 See also:

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/administration/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/deploy/replicated/administration/infrastructure/backup-restore.mdx
@@ -32,7 +32,7 @@ Note the following when using the backup and restore API:
 - The backup and restore API times out after 5000 seconds (83.3 minutes). If you have a lot of
   data in the object store, use [`skip-object-storage`](#request-body) to
   finish the backup in time. Then after you restore the backup, manually move your object store data. See this
-  [support article](https://support.hashicorp.com/hc/en-us/articles/10536697730323-Migrate-TFE-from-Mounted-Disk-to-External-Services-mode-with-Backup-Restore-API) for details.
+  [support article](https://www.ibm.com/support/pages/node/7265344) for details.
 - Once a restore is completed, the Terraform Enterprise application will need to be restarted before it can use the restored data.
 
 See also:

--- a/content/terraform-enterprise/2.0.x/docs/enterprise/deploy/replicated/administration/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/2.0.x/docs/enterprise/deploy/replicated/administration/infrastructure/backup-restore.mdx
@@ -32,7 +32,7 @@ Note the following when using the backup and restore API:
 - The backup and restore API times out after 5000 seconds (83.3 minutes). If you have a lot of
   data in the object store, use [`skip-object-storage`](#request-body) to
   finish the backup in time. Then after you restore the backup, manually move your object store data. See this
-  [support article](https://support.hashicorp.com/hc/en-us/articles/10536697730323-Migrate-TFE-from-Mounted-Disk-to-External-Services-mode-with-Backup-Restore-API) for details.
+  [support article](https://www.ibm.com/support/pages/node/7265344) for details.
 - Once a restore is completed, the Terraform Enterprise application will need to be restarted before it can use the restored data.
 
 See also:

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
@@ -31,7 +31,7 @@ Please note the following when using the backup and restore API:
 - The backup and restore API times out after 5000 seconds (83.3 minutes). If you have a lot of
   data in the object store, use [`skip-object-storage`](#request-body) to
   finish the backup in time. Then after you restore the backup, manually move your object store data. See this
-  [support article](https://support.hashicorp.com/hc/en-us/articles/10536697730323-Migrate-TFE-from-Mounted-Disk-to-External-Services-mode-with-Backup-Restore-API) for details.
+  [support article](https://www.ibm.com/support/pages/node/7265344) for details.
 - Once a restore is completed, the Terraform Enterprise application will need to be restarted before it can use the restored data.
 
 See also:

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
@@ -32,7 +32,7 @@ Please note the following when using the backup and restore API:
 - The backup and restore API times out after 5000 seconds (83.3 minutes). If you have a lot of
   data in the object store, use [`skip-object-storage`](#request-body) to
   finish the backup in time. Then after you restore the backup, manually move your object store data. See this
-  [support article](https://support.hashicorp.com/hc/en-us/articles/10536697730323-Migrate-TFE-from-Mounted-Disk-to-External-Services-mode-with-Backup-Restore-API) for details.
+  [support article](https://www.ibm.com/support/pages/node/7265344) for details.
 - Once a restore is completed, the Terraform Enterprise application will need to be restarted before it can use the restored data.
 
 See also:

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
@@ -32,7 +32,7 @@ Please note the following when using the backup and restore API:
 - The backup and restore API times out after 5000 seconds (83.3 minutes). If you have a lot of
   data in the object store, use [`skip-object-storage`](#request-body) to
   finish the backup in time. Then after you restore the backup, manually move your object store data. See this
-  [support article](https://support.hashicorp.com/hc/en-us/articles/10536697730323-Migrate-TFE-from-Mounted-Disk-to-External-Services-mode-with-Backup-Restore-API) for details.
+  [support article](https://www.ibm.com/support/pages/node/7265344) for details.
 - Once a restore is completed, the Terraform Enterprise application will need to be restarted before it can use the restored data.
 
 See also:

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
@@ -32,7 +32,7 @@ Please note the following when using the backup and restore API:
 - The backup and restore API times out after 5000 seconds (83.3 minutes). If you have a lot of
   data in the object store, use [`skip-object-storage`](#request-body) to
   finish the backup in time. Then after you restore the backup, manually move your object store data. See this
-  [support article](https://support.hashicorp.com/hc/en-us/articles/10536697730323-Migrate-TFE-from-Mounted-Disk-to-External-Services-mode-with-Backup-Restore-API) for details.
+  [support article](https://www.ibm.com/support/pages/node/7265344) for details.
 - Once a restore is completed, the Terraform Enterprise application will need to be restarted before it can use the restored data.
 
 See also:

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
@@ -31,7 +31,7 @@ Please note the following when using the backup and restore API:
 - The backup and restore API times out after 5000 seconds (83.3 minutes). If you have a lot of
   data in the object store, use [`skip-object-storage`](#request-body) to
   finish the backup in time. Then after you restore the backup, manually move your object store data. See this
-  [support article](https://support.hashicorp.com/hc/en-us/articles/10536697730323-Migrate-TFE-from-Mounted-Disk-to-External-Services-mode-with-Backup-Restore-API) for details.
+  [support article](https://www.ibm.com/support/pages/node/7265344) for details.
 - Once a restore is completed, the Terraform Enterprise application will need to be restarted before it can use the restored data.
 
 See also:

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
@@ -32,7 +32,7 @@ Please note the following when using the backup and restore API:
 - The backup and restore API times out after 5000 seconds (83.3 minutes). If you have a lot of
   data in the object store, use [`skip-object-storage`](#request-body) to
   finish the backup in time. Then after you restore the backup, manually move your object store data. See this
-  [support article](https://support.hashicorp.com/hc/en-us/articles/10536697730323-Migrate-TFE-from-Mounted-Disk-to-External-Services-mode-with-Backup-Restore-API) for details.
+  [support article](https://www.ibm.com/support/pages/node/7265344) for details.
 - Once a restore is completed, the Terraform Enterprise application will need to be restarted before it can use the restored data.
 
 See also:

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
@@ -32,7 +32,7 @@ Please note the following when using the backup and restore API:
 - The backup and restore API times out after 5000 seconds (83.3 minutes). If you have a lot of
   data in the object store, use [`skip-object-storage`](#request-body) to
   finish the backup in time. Then after you restore the backup, manually move your object store data. See this
-  [support article](https://support.hashicorp.com/hc/en-us/articles/10536697730323-Migrate-TFE-from-Mounted-Disk-to-External-Services-mode-with-Backup-Restore-API) for details.
+  [support article](https://www.ibm.com/support/pages/node/7265344) for details.
 - Once a restore is completed, the Terraform Enterprise application will need to be restarted before it can use the restored data.
 
 See also:

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
@@ -32,7 +32,7 @@ Please note the following when using the backup and restore API:
 - The backup and restore API times out after 5000 seconds (83.3 minutes). If you have a lot of
   data in the object store, use [`skip-object-storage`](#request-body) to
   finish the backup in time. Then after you restore the backup, manually move your object store data. See this
-  [support article](https://support.hashicorp.com/hc/en-us/articles/10536697730323-Migrate-TFE-from-Mounted-Disk-to-External-Services-mode-with-Backup-Restore-API) for details.
+  [support article](https://www.ibm.com/support/pages/node/7265344) for details.
 - Once a restore is completed, the Terraform Enterprise application will need to be restarted before it can use the restored data.
 
 See also:

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
@@ -32,7 +32,7 @@ Please note the following when using the backup and restore API:
 - The backup and restore API times out after 5000 seconds (83.3 minutes). If you have a lot of
   data in the object store, use [`skip-object-storage`](#request-body) to
   finish the backup in time. Then after you restore the backup, manually move your object store data. See this
-  [support article](https://support.hashicorp.com/hc/en-us/articles/10536697730323-Migrate-TFE-from-Mounted-Disk-to-External-Services-mode-with-Backup-Restore-API) for details.
+  [support article](https://www.ibm.com/support/pages/node/7265344) for details.
 - Once a restore is completed, the Terraform Enterprise application will need to be restarted before it can use the restored data.
 
 See also:

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
@@ -32,7 +32,7 @@ Please note the following when using the backup and restore API:
 - The backup and restore API times out after 5000 seconds (83.3 minutes). If you have a lot of
   data in the object store, use [`skip-object-storage`](#request-body) to
   finish the backup in time. Then after you restore the backup, manually move your object store data. See this
-  [support article](https://support.hashicorp.com/hc/en-us/articles/10536697730323-Migrate-TFE-from-Mounted-Disk-to-External-Services-mode-with-Backup-Restore-API) for details.
+  [support article](https://www.ibm.com/support/pages/node/7265344) for details.
 - Once a restore is completed, the Terraform Enterprise application will need to be restarted before it can use the restored data.
 
 See also:

--- a/content/terraform-enterprise/v202405-1/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202405-1/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
@@ -32,7 +32,7 @@ Please note the following when using the backup and restore API:
 - The backup and restore API times out after 5000 seconds (83.3 minutes). If you have a lot of
   data in the object store, use [`skip-object-storage`](#request-body) to
   finish the backup in time. Then after you restore the backup, manually move your object store data. See this
-  [support article](https://support.hashicorp.com/hc/en-us/articles/10536697730323-Migrate-TFE-from-Mounted-Disk-to-External-Services-mode-with-Backup-Restore-API) for details.
+  [support article](https://www.ibm.com/support/pages/node/7265344) for details.
 - Once a restore is completed, the Terraform Enterprise application will need to be restarted before it can use the restored data.
 
 See also:

--- a/content/terraform-enterprise/v202406-1/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202406-1/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
@@ -32,7 +32,7 @@ Please note the following when using the backup and restore API:
 - The backup and restore API times out after 5000 seconds (83.3 minutes). If you have a lot of
   data in the object store, use [`skip-object-storage`](#request-body) to
   finish the backup in time. Then after you restore the backup, manually move your object store data. See this
-  [support article](https://support.hashicorp.com/hc/en-us/articles/10536697730323-Migrate-TFE-from-Mounted-Disk-to-External-Services-mode-with-Backup-Restore-API) for details.
+  [support article](https://www.ibm.com/support/pages/node/7265344) for details.
 - Once a restore is completed, the Terraform Enterprise application will need to be restarted before it can use the restored data.
 
 See also:

--- a/content/terraform-enterprise/v202407-1/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202407-1/docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx
@@ -32,7 +32,7 @@ Please note the following when using the backup and restore API:
 - The backup and restore API times out after 5000 seconds (83.3 minutes). If you have a lot of
   data in the object store, use [`skip-object-storage`](#request-body) to
   finish the backup in time. Then after you restore the backup, manually move your object store data. See this
-  [support article](https://support.hashicorp.com/hc/en-us/articles/10536697730323-Migrate-TFE-from-Mounted-Disk-to-External-Services-mode-with-Backup-Restore-API) for details.
+  [support article](https://www.ibm.com/support/pages/node/7265344) for details.
 - Once a restore is completed, the Terraform Enterprise application will need to be restarted before it can use the restored data.
 
 See also:

--- a/content/terraform-enterprise/v202408-1/docs/enterprise/deploy/replicated/administration/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202408-1/docs/enterprise/deploy/replicated/administration/infrastructure/backup-restore.mdx
@@ -32,7 +32,7 @@ Note the following when using the backup and restore API:
 - The backup and restore API times out after 5000 seconds (83.3 minutes). If you have a lot of
   data in the object store, use [`skip-object-storage`](#request-body) to
   finish the backup in time. Then after you restore the backup, manually move your object store data. See this
-  [support article](https://support.hashicorp.com/hc/en-us/articles/10536697730323-Migrate-TFE-from-Mounted-Disk-to-External-Services-mode-with-Backup-Restore-API) for details.
+  [support article](https://www.ibm.com/support/pages/node/7265344) for details.
 - Once a restore is completed, the Terraform Enterprise application will need to be restarted before it can use the restored data.
 
 See also:

--- a/content/terraform-enterprise/v202409-1/docs/enterprise/deploy/replicated/administration/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202409-1/docs/enterprise/deploy/replicated/administration/infrastructure/backup-restore.mdx
@@ -32,7 +32,7 @@ Note the following when using the backup and restore API:
 - The backup and restore API times out after 5000 seconds (83.3 minutes). If you have a lot of
   data in the object store, use [`skip-object-storage`](#request-body) to
   finish the backup in time. Then after you restore the backup, manually move your object store data. See this
-  [support article](https://support.hashicorp.com/hc/en-us/articles/10536697730323-Migrate-TFE-from-Mounted-Disk-to-External-Services-mode-with-Backup-Restore-API) for details.
+  [support article](https://www.ibm.com/support/pages/node/7265344) for details.
 - Once a restore is completed, the Terraform Enterprise application will need to be restarted before it can use the restored data.
 
 See also:

--- a/content/terraform-enterprise/v202409-2/docs/enterprise/deploy/replicated/administration/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202409-2/docs/enterprise/deploy/replicated/administration/infrastructure/backup-restore.mdx
@@ -32,7 +32,7 @@ Note the following when using the backup and restore API:
 - The backup and restore API times out after 5000 seconds (83.3 minutes). If you have a lot of
   data in the object store, use [`skip-object-storage`](#request-body) to
   finish the backup in time. Then after you restore the backup, manually move your object store data. See this
-  [support article](https://support.hashicorp.com/hc/en-us/articles/10536697730323-Migrate-TFE-from-Mounted-Disk-to-External-Services-mode-with-Backup-Restore-API) for details.
+  [support article](https://www.ibm.com/support/pages/node/7265344) for details.
 - Once a restore is completed, the Terraform Enterprise application will need to be restarted before it can use the restored data.
 
 See also:

--- a/content/terraform-enterprise/v202409-3/docs/enterprise/deploy/replicated/administration/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202409-3/docs/enterprise/deploy/replicated/administration/infrastructure/backup-restore.mdx
@@ -32,7 +32,7 @@ Note the following when using the backup and restore API:
 - The backup and restore API times out after 5000 seconds (83.3 minutes). If you have a lot of
   data in the object store, use [`skip-object-storage`](#request-body) to
   finish the backup in time. Then after you restore the backup, manually move your object store data. See this
-  [support article](https://support.hashicorp.com/hc/en-us/articles/10536697730323-Migrate-TFE-from-Mounted-Disk-to-External-Services-mode-with-Backup-Restore-API) for details.
+  [support article](https://www.ibm.com/support/pages/node/7265344) for details.
 - Once a restore is completed, the Terraform Enterprise application will need to be restarted before it can use the restored data.
 
 See also:

--- a/content/terraform-enterprise/v202410-1/docs/enterprise/deploy/replicated/administration/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202410-1/docs/enterprise/deploy/replicated/administration/infrastructure/backup-restore.mdx
@@ -32,7 +32,7 @@ Note the following when using the backup and restore API:
 - The backup and restore API times out after 5000 seconds (83.3 minutes). If you have a lot of
   data in the object store, use [`skip-object-storage`](#request-body) to
   finish the backup in time. Then after you restore the backup, manually move your object store data. See this
-  [support article](https://support.hashicorp.com/hc/en-us/articles/10536697730323-Migrate-TFE-from-Mounted-Disk-to-External-Services-mode-with-Backup-Restore-API) for details.
+  [support article](https://www.ibm.com/support/pages/node/7265344) for details.
 - Once a restore is completed, the Terraform Enterprise application will need to be restarted before it can use the restored data.
 
 See also:

--- a/content/terraform-enterprise/v202411-1/docs/enterprise/deploy/replicated/administration/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202411-1/docs/enterprise/deploy/replicated/administration/infrastructure/backup-restore.mdx
@@ -32,7 +32,7 @@ Note the following when using the backup and restore API:
 - The backup and restore API times out after 5000 seconds (83.3 minutes). If you have a lot of
   data in the object store, use [`skip-object-storage`](#request-body) to
   finish the backup in time. Then after you restore the backup, manually move your object store data. See this
-  [support article](https://support.hashicorp.com/hc/en-us/articles/10536697730323-Migrate-TFE-from-Mounted-Disk-to-External-Services-mode-with-Backup-Restore-API) for details.
+  [support article](https://www.ibm.com/support/pages/node/7265344) for details.
 - Once a restore is completed, the Terraform Enterprise application will need to be restarted before it can use the restored data.
 
 See also:

--- a/content/terraform-enterprise/v202411-2/docs/enterprise/deploy/replicated/administration/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202411-2/docs/enterprise/deploy/replicated/administration/infrastructure/backup-restore.mdx
@@ -32,7 +32,7 @@ Note the following when using the backup and restore API:
 - The backup and restore API times out after 5000 seconds (83.3 minutes). If you have a lot of
   data in the object store, use [`skip-object-storage`](#request-body) to
   finish the backup in time. Then after you restore the backup, manually move your object store data. See this
-  [support article](https://support.hashicorp.com/hc/en-us/articles/10536697730323-Migrate-TFE-from-Mounted-Disk-to-External-Services-mode-with-Backup-Restore-API) for details.
+  [support article](https://www.ibm.com/support/pages/node/7265344) for details.
 - Once a restore is completed, the Terraform Enterprise application will need to be restarted before it can use the restored data.
 
 See also:

--- a/content/terraform-enterprise/v202501-1/docs/enterprise/deploy/replicated/administration/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202501-1/docs/enterprise/deploy/replicated/administration/infrastructure/backup-restore.mdx
@@ -32,7 +32,7 @@ Note the following when using the backup and restore API:
 - The backup and restore API times out after 5000 seconds (83.3 minutes). If you have a lot of
   data in the object store, use [`skip-object-storage`](#request-body) to
   finish the backup in time. Then after you restore the backup, manually move your object store data. See this
-  [support article](https://support.hashicorp.com/hc/en-us/articles/10536697730323-Migrate-TFE-from-Mounted-Disk-to-External-Services-mode-with-Backup-Restore-API) for details.
+  [support article](https://www.ibm.com/support/pages/node/7265344) for details.
 - Once a restore is completed, the Terraform Enterprise application will need to be restarted before it can use the restored data.
 
 See also:

--- a/content/terraform-enterprise/v202502-1/docs/enterprise/deploy/replicated/administration/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202502-1/docs/enterprise/deploy/replicated/administration/infrastructure/backup-restore.mdx
@@ -32,7 +32,7 @@ Note the following when using the backup and restore API:
 - The backup and restore API times out after 5000 seconds (83.3 minutes). If you have a lot of
   data in the object store, use [`skip-object-storage`](#request-body) to
   finish the backup in time. Then after you restore the backup, manually move your object store data. See this
-  [support article](https://support.hashicorp.com/hc/en-us/articles/10536697730323-Migrate-TFE-from-Mounted-Disk-to-External-Services-mode-with-Backup-Restore-API) for details.
+  [support article](https://www.ibm.com/support/pages/node/7265344) for details.
 - Once a restore is completed, the Terraform Enterprise application will need to be restarted before it can use the restored data.
 
 See also:

--- a/content/terraform-enterprise/v202502-2/docs/enterprise/deploy/replicated/administration/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202502-2/docs/enterprise/deploy/replicated/administration/infrastructure/backup-restore.mdx
@@ -32,7 +32,7 @@ Note the following when using the backup and restore API:
 - The backup and restore API times out after 5000 seconds (83.3 minutes). If you have a lot of
   data in the object store, use [`skip-object-storage`](#request-body) to
   finish the backup in time. Then after you restore the backup, manually move your object store data. See this
-  [support article](https://support.hashicorp.com/hc/en-us/articles/10536697730323-Migrate-TFE-from-Mounted-Disk-to-External-Services-mode-with-Backup-Restore-API) for details.
+  [support article](https://www.ibm.com/support/pages/node/7265344) for details.
 - Once a restore is completed, the Terraform Enterprise application will need to be restarted before it can use the restored data.
 
 See also:

--- a/content/terraform-enterprise/v202503-1/docs/enterprise/deploy/replicated/administration/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202503-1/docs/enterprise/deploy/replicated/administration/infrastructure/backup-restore.mdx
@@ -32,7 +32,7 @@ Note the following when using the backup and restore API:
 - The backup and restore API times out after 5000 seconds (83.3 minutes). If you have a lot of
   data in the object store, use [`skip-object-storage`](#request-body) to
   finish the backup in time. Then after you restore the backup, manually move your object store data. See this
-  [support article](https://support.hashicorp.com/hc/en-us/articles/10536697730323-Migrate-TFE-from-Mounted-Disk-to-External-Services-mode-with-Backup-Restore-API) for details.
+  [support article](https://www.ibm.com/support/pages/node/7265344) for details.
 - Once a restore is completed, the Terraform Enterprise application will need to be restarted before it can use the restored data.
 
 See also:

--- a/content/terraform-enterprise/v202504-1/docs/enterprise/deploy/replicated/administration/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202504-1/docs/enterprise/deploy/replicated/administration/infrastructure/backup-restore.mdx
@@ -32,7 +32,7 @@ Note the following when using the backup and restore API:
 - The backup and restore API times out after 5000 seconds (83.3 minutes). If you have a lot of
   data in the object store, use [`skip-object-storage`](#request-body) to
   finish the backup in time. Then after you restore the backup, manually move your object store data. See this
-  [support article](https://support.hashicorp.com/hc/en-us/articles/10536697730323-Migrate-TFE-from-Mounted-Disk-to-External-Services-mode-with-Backup-Restore-API) for details.
+  [support article](https://www.ibm.com/support/pages/node/7265344) for details.
 - Once a restore is completed, the Terraform Enterprise application will need to be restarted before it can use the restored data.
 
 See also:

--- a/content/terraform-enterprise/v202505-1/docs/enterprise/deploy/replicated/administration/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202505-1/docs/enterprise/deploy/replicated/administration/infrastructure/backup-restore.mdx
@@ -32,7 +32,7 @@ Note the following when using the backup and restore API:
 - The backup and restore API times out after 5000 seconds (83.3 minutes). If you have a lot of
   data in the object store, use [`skip-object-storage`](#request-body) to
   finish the backup in time. Then after you restore the backup, manually move your object store data. See this
-  [support article](https://support.hashicorp.com/hc/en-us/articles/10536697730323-Migrate-TFE-from-Mounted-Disk-to-External-Services-mode-with-Backup-Restore-API) for details.
+  [support article](https://www.ibm.com/support/pages/node/7265344) for details.
 - Once a restore is completed, the Terraform Enterprise application will need to be restarted before it can use the restored data.
 
 See also:

--- a/content/terraform-enterprise/v202506-1/docs/enterprise/deploy/replicated/administration/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202506-1/docs/enterprise/deploy/replicated/administration/infrastructure/backup-restore.mdx
@@ -32,7 +32,7 @@ Note the following when using the backup and restore API:
 - The backup and restore API times out after 5000 seconds (83.3 minutes). If you have a lot of
   data in the object store, use [`skip-object-storage`](#request-body) to
   finish the backup in time. Then after you restore the backup, manually move your object store data. See this
-  [support article](https://support.hashicorp.com/hc/en-us/articles/10536697730323-Migrate-TFE-from-Mounted-Disk-to-External-Services-mode-with-Backup-Restore-API) for details.
+  [support article](https://www.ibm.com/support/pages/node/7265344) for details.
 - Once a restore is completed, the Terraform Enterprise application will need to be restarted before it can use the restored data.
 
 See also:

--- a/content/terraform-enterprise/v202507-1/docs/enterprise/deploy/replicated/administration/infrastructure/backup-restore.mdx
+++ b/content/terraform-enterprise/v202507-1/docs/enterprise/deploy/replicated/administration/infrastructure/backup-restore.mdx
@@ -32,7 +32,7 @@ Note the following when using the backup and restore API:
 - The backup and restore API times out after 5000 seconds (83.3 minutes). If you have a lot of
   data in the object store, use [`skip-object-storage`](#request-body) to
   finish the backup in time. Then after you restore the backup, manually move your object store data. See this
-  [support article](https://support.hashicorp.com/hc/en-us/articles/10536697730323-Migrate-TFE-from-Mounted-Disk-to-External-Services-mode-with-Backup-Restore-API) for details.
+  [support article](https://www.ibm.com/support/pages/node/7265344) for details.
 - Once a restore is completed, the Terraform Enterprise application will need to be restarted before it can use the restored data.
 
 See also:


### PR DESCRIPTION
## Summary

Replaces legacy HashiCorp support URL with IBM equivalent across all affected version directories.

| | |
|---|---|
| **Product** | Terraform Enterprise |
| **Document paths** | `docs/enterprise/deploy/replicated/administration/infrastructure/backup-restore.mdx`<br>`docs/enterprise/replicated/administration/infrastructure/backup-restore.mdx` |
| **Old URL** | `https://support.hashicorp.com/hc/en-us/articles/10536697730323-Migrate-TFE-from-Mounted-Disk-to-External-Services-mode-with-Backup-Restore-API` |
| **New URL** | `https://www.ibm.com/support/pages/node/7265344` |
| **Versions updated** | 32 |

Part of the IBM DevDoc KB Remapping effort.