### PR TITLE
docs(tfe): replace support.hashicorp.com link in releases/1.0.x/index.mdx

### DIFF
--- a/content/terraform-enterprise/1.0.x/docs/enterprise/releases/1.0.x/index.mdx
+++ b/content/terraform-enterprise/1.0.x/docs/enterprise/releases/1.0.x/index.mdx
@@ -137,7 +137,7 @@ Flexible Deployment Options `terraform-enterprise` container digest: amd64/linux
 
 ## Known Issues
 1. (Updated 12/15/2025) You may experience failures when using some S3-compatible storage solutions. This release includes an AWS library upgrade that introduces authentication issues with some third-party storage providers. To prevent errors when running plans, applies, or accessing Terraform state files, upgrade your storage solution to a version compatible with AWS SDK for Go v2. For additional details, refer to [issue 2960](https://github.com/aws/aws-sdk-go-v2/discussions/2960) on the AWS SDK GitHub issues page.
-1. (Updated 8/27/2025) For Terraform Enterprise installs that make use of Redis with mTLS, you may experience [a failure](https://support.hashicorp.com/hc/en-us/articles/44197346705427-Terraform-Enterprise-not-able-to-connect-to-Redis-with-mTLS) where the archivist service exits early. A fix for this bug will be shipped in the 1.0.1 release.
+1. (Updated 8/27/2025) For Terraform Enterprise installs that make use of Redis with mTLS, you may experience [a failure](https://www.ibm.com/support/pages/node/7265675) where the archivist service exits early. A fix for this bug will be shipped in the 1.0.1 release.
 1. (Updated 11/27/2025) Product usage may generate heavy database queries that can overload the database and impact production workloads. This issue is fixed in 1.0.3 and in 1.1.0
 1. (Updated 05/07/2026) A known issue in the underlying Vault version can prevent workspaces with abnormally large output values from completing Terraform apply. Refer to [IBM Support node 7264524](https://www.ibm.com/support/pages/node/7264524).
 

--- a/content/terraform-enterprise/1.1.x/docs/enterprise/releases/1.0.x/index.mdx
+++ b/content/terraform-enterprise/1.1.x/docs/enterprise/releases/1.0.x/index.mdx
@@ -138,7 +138,7 @@ Flexible Deployment Options `terraform-enterprise` container digest: amd64/linux
 ## Known Issues
 1. (Updated 11/27/2025) Product usage may generate heavy database queries that can overload the database and impact production workloads. This issue is fixed in 1.0.3 and in 1.1.0
 1. (Updated 12/15/2025) You may experience failures when using some S3-compatible storage solutions. This release includes an AWS library upgrade that introduces authentication issues with some third-party storage providers. To prevent errors when running plans, applies, or accessing Terraform state files, upgrade your storage solution to a version compatible with AWS SDK for Go v2. For additional details, refer to [issue 2960](https://github.com/aws/aws-sdk-go-v2/discussions/2960) on the AWS SDK GitHub issues page.
-1. (Updated 8/27/2025) For Terraform Enterprise installs that make use of Redis with mTLS, you may experience [a failure](https://support.hashicorp.com/hc/en-us/articles/44197346705427-Terraform-Enterprise-not-able-to-connect-to-Redis-with-mTLS) where the archivist service exits early. A fix for this bug will be shipped in the 1.0.1 release.  
+1. (Updated 8/27/2025) For Terraform Enterprise installs that make use of Redis with mTLS, you may experience [a failure](https://www.ibm.com/support/pages/node/7265675) where the archivist service exits early. A fix for this bug will be shipped in the 1.0.1 release.  
 1. (Updated 05/07/2026) A known issue in the underlying Vault version can prevent workspaces with abnormally large output values from completing Terraform apply. Refer to [IBM Support node 7264524](https://www.ibm.com/support/pages/node/7264524).
 
 ## Deprecations

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/1.0.x/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/1.0.x/index.mdx
@@ -138,7 +138,7 @@ Flexible Deployment Options `terraform-enterprise` container digest: amd64/linux
 ## Known Issues
 1. (Updated 11/27/2025) Product usage may generate heavy database queries that can overload the database and impact production workloads. This issue is fixed in 1.0.3 and in 1.1.0
 1. (Updated 12/15/2025) You may experience failures when using some S3-compatible storage solutions. This release includes an AWS library upgrade that introduces authentication issues with some third-party storage providers. To prevent errors when running plans, applies, or accessing Terraform state files, upgrade your storage solution to a version compatible with AWS SDK for Go v2. For additional details, refer to [issue 2960](https://github.com/aws/aws-sdk-go-v2/discussions/2960) on the AWS SDK GitHub issues page.
-1. (Updated 8/27/2025) For Terraform Enterprise installs that make use of Redis with mTLS, you may experience [a failure](https://support.hashicorp.com/hc/en-us/articles/44197346705427-Terraform-Enterprise-not-able-to-connect-to-Redis-with-mTLS) where the archivist service exits early. A fix for this bug will be shipped in the 1.0.1 release.  
+1. (Updated 8/27/2025) For Terraform Enterprise installs that make use of Redis with mTLS, you may experience [a failure](https://www.ibm.com/support/pages/node/7265675) where the archivist service exits early. A fix for this bug will be shipped in the 1.0.1 release.  
 1. (Updated 05/07/2026) A known issue in the underlying Vault version can prevent workspaces with abnormally large output values from completing Terraform apply. Refer to [IBM Support node 7264524](https://www.ibm.com/support/pages/node/7264524).
 
 ## Deprecations

--- a/content/terraform-enterprise/2.0.x/docs/enterprise/releases/1.0.x/index.mdx
+++ b/content/terraform-enterprise/2.0.x/docs/enterprise/releases/1.0.x/index.mdx
@@ -138,7 +138,7 @@ Flexible Deployment Options `terraform-enterprise` container digest: amd64/linux
 ## Known Issues
 1. (Updated 11/27/2025) Product usage may generate heavy database queries that can overload the database and impact production workloads. This issue is fixed in 1.0.3 and in 1.1.0
 1. (Updated 12/15/2025) You may experience failures when using some S3-compatible storage solutions. This release includes an AWS library upgrade that introduces authentication issues with some third-party storage providers. To prevent errors when running plans, applies, or accessing Terraform state files, upgrade your storage solution to a version compatible with AWS SDK for Go v2. For additional details, refer to [issue 2960](https://github.com/aws/aws-sdk-go-v2/discussions/2960) on the AWS SDK GitHub issues page.
-1. (Updated 8/27/2025) For Terraform Enterprise installs that make use of Redis with mTLS, you may experience [a failure](https://support.hashicorp.com/hc/en-us/articles/44197346705427-Terraform-Enterprise-not-able-to-connect-to-Redis-with-mTLS) where the archivist service exits early. A fix for this bug will be shipped in the 1.0.1 release.  
+1. (Updated 8/27/2025) For Terraform Enterprise installs that make use of Redis with mTLS, you may experience [a failure](https://www.ibm.com/support/pages/node/7265675) where the archivist service exits early. A fix for this bug will be shipped in the 1.0.1 release.  
 
 ## Deprecations
 1. PostgreSQL v13 will reach end of life on November 13 2025 and will no longer be supported in Terraform Enterprise after that date. Refer to the requirements for [connecting to an external PostgreSQL database](/terraform/enterprise/deploy/configuration/storage/connect-database/postgres#server) for a complete list of supported versions.


### PR DESCRIPTION
## Summary

Replaces legacy HashiCorp support URL with IBM equivalent across all affected version directories.

| | |
|---|---|
| **Product** | Terraform Enterprise |
| **Document path** | `docs/enterprise/releases/1.0.x/index.mdx` |
| **Old URL** | `https://support.hashicorp.com/hc/en-us/articles/44197346705427-Terraform-Enterprise-not-able-to-connect-to-Redis-with-mTLS` |
| **New URL** | `https://www.ibm.com/support/pages/node/7265675` |
| **Versions updated** | 4 |

Part of the IBM DevDoc KB Remapping effort.