### PR TITLE
docs(tfe): replace support.hashicorp.com links in releases/2023/v202302-1.mdx

### DIFF
--- a/content/terraform-enterprise/1.0.x/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/1.0.x/docs/enterprise/releases/2023/v202302-1.mdx
@@ -18,11 +18,11 @@ Last required release: [v202207-2 (642)](/terraform/enterprise/releases/2022/v20
 1. Terraform runs remain queued indefinitely when using the `agent` run pipeline mode unless the **Enable agents functionality** checkbox is checked in the [admin interface](/terraform/enterprise/application-administration/admin-access). The logs for `tfe-task-worker` will show `[ERROR] core: Unexpected HTTP response code: method=POST url=https://terraform.example.com/api/agent/register status=404`. This is resolved in Terraform Enterprise v202303-1.
 1. [April 6, 2023] The `tfe-admin node-drain` command does not currently work when the `run_pipeline_mode` configuration setting is set to `agent`. See the notes under the _Highlights_ section for more details regarding this setting. This issue is fixed in the v202305-1 release.
 1. Saving boolean `false` variable values causes 500 errors. This has been fixed in [`v202303-1`](/terraform/enterprise/releases/2023/v202303-1#bug-fixes).
-1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://support.hashicorp.com/hc/en-us/articles/31715716966419-Issue-with-OIDC-Vault-key-rotation-mechanism-to-incorrectly-identify-the-newest-signing-key).
+1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://www.ibm.com/support/pages/node/7265719).
 
 ## Breaking Changes
 
-1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://support.hashicorp.com/hc/en-us/articles/13138701895699-Updating-Workload-Identity-for-Projects) on your cloud provider to expect project information in this claim.
+1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://www.ibm.com/support/pages/node/7265900) on your cloud provider to expect project information in this claim.
 
 ## Deprecations and End of Support
 

--- a/content/terraform-enterprise/1.1.x/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/1.1.x/docs/enterprise/releases/2023/v202302-1.mdx
@@ -18,11 +18,11 @@ Last required release: [v202207-2 (642)](/terraform/enterprise/releases/2022/v20
 1. Terraform runs remain queued indefinitely when using the `agent` run pipeline mode unless the **Enable agents functionality** checkbox is checked in the [admin interface](/terraform/enterprise/application-administration/admin-access). The logs for `tfe-task-worker` will show `[ERROR] core: Unexpected HTTP response code: method=POST url=https://terraform.example.com/api/agent/register status=404`. This is resolved in Terraform Enterprise v202303-1.
 1. [April 6, 2023] The `tfe-admin node-drain` command does not currently work when the `run_pipeline_mode` configuration setting is set to `agent`. See the notes under the _Highlights_ section for more details regarding this setting. This issue is fixed in the v202305-1 release.
 1. Saving boolean `false` variable values causes 500 errors. This has been fixed in [`v202303-1`](/terraform/enterprise/releases/2023/v202303-1#bug-fixes).
-1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://support.hashicorp.com/hc/en-us/articles/31715716966419-Issue-with-OIDC-Vault-key-rotation-mechanism-to-incorrectly-identify-the-newest-signing-key).
+1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://www.ibm.com/support/pages/node/7265719).
 
 ## Breaking Changes
 
-1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://support.hashicorp.com/hc/en-us/articles/13138701895699-Updating-Workload-Identity-for-Projects) on your cloud provider to expect project information in this claim.
+1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://www.ibm.com/support/pages/node/7265900) on your cloud provider to expect project information in this claim.
 
 ## Deprecations and End of Support
 

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/releases/2023/v202302-1.mdx
@@ -18,11 +18,11 @@ Last required release: [v202207-2 (642)](/terraform/enterprise/releases/2022/v20
 1. Terraform runs remain queued indefinitely when using the `agent` run pipeline mode unless the **Enable agents functionality** checkbox is checked in the [admin interface](/terraform/enterprise/application-administration/admin-access). The logs for `tfe-task-worker` will show `[ERROR] core: Unexpected HTTP response code: method=POST url=https://terraform.example.com/api/agent/register status=404`. This is resolved in Terraform Enterprise v202303-1.
 1. [April 6, 2023] The `tfe-admin node-drain` command does not currently work when the `run_pipeline_mode` configuration setting is set to `agent`. See the notes under the _Highlights_ section for more details regarding this setting. This issue is fixed in the v202305-1 release.
 1. Saving boolean `false` variable values causes 500 errors. This has been fixed in [`v202303-1`](/terraform/enterprise/releases/2023/v202303-1#bug-fixes).
-1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://support.hashicorp.com/hc/en-us/articles/31715716966419-Issue-with-OIDC-Vault-key-rotation-mechanism-to-incorrectly-identify-the-newest-signing-key).
+1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://www.ibm.com/support/pages/node/7265719).
 
 ## Breaking Changes
 
-1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://support.hashicorp.com/hc/en-us/articles/13138701895699-Updating-Workload-Identity-for-Projects) on your cloud provider to expect project information in this claim.
+1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://www.ibm.com/support/pages/node/7265900) on your cloud provider to expect project information in this claim.
 
 ## Deprecations and End of Support
 

--- a/content/terraform-enterprise/2.0.x/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/2.0.x/docs/enterprise/releases/2023/v202302-1.mdx
@@ -18,11 +18,11 @@ Last required release: [v202207-2 (642)](/terraform/enterprise/releases/2022/v20
 1. Terraform runs remain queued indefinitely when using the `agent` run pipeline mode unless the **Enable agents functionality** checkbox is checked in the [admin interface](/terraform/enterprise/application-administration/admin-access). The logs for `tfe-task-worker` will show `[ERROR] core: Unexpected HTTP response code: method=POST url=https://terraform.example.com/api/agent/register status=404`. This is resolved in Terraform Enterprise v202303-1.
 1. [April 6, 2023] The `tfe-admin node-drain` command does not currently work when the `run_pipeline_mode` configuration setting is set to `agent`. See the notes under the _Highlights_ section for more details regarding this setting. This issue is fixed in the v202305-1 release.
 1. Saving boolean `false` variable values causes 500 errors. This has been fixed in [`v202303-1`](/terraform/enterprise/releases/2023/v202303-1#bug-fixes).
-1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://support.hashicorp.com/hc/en-us/articles/31715716966419-Issue-with-OIDC-Vault-key-rotation-mechanism-to-incorrectly-identify-the-newest-signing-key).
+1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://www.ibm.com/support/pages/node/7265719).
 
 ## Breaking Changes
 
-1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://support.hashicorp.com/hc/en-us/articles/13138701895699-Updating-Workload-Identity-for-Projects) on your cloud provider to expect project information in this claim.
+1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://www.ibm.com/support/pages/node/7265900) on your cloud provider to expect project information in this claim.
 
 ## Deprecations and End of Support
 

--- a/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202302-1/docs/enterprise/releases/2023/v202302-1.mdx
@@ -18,11 +18,11 @@ Last required release: [v202207-2 (642)](/terraform/enterprise/releases/2022/v20
 1. Terraform runs remain queued indefinitely when using the `agent` run pipeline mode unless the **Enable agents functionality** checkbox is checked in the [admin interface](/terraform/enterprise/admin/application/admin-access). The logs for `tfe-task-worker` will show `[ERROR] core: Unexpected HTTP response code: method=POST url=https://terraform.example.com/api/agent/register status=404`. This is resolved in Terraform Enterprise v202303-1.
 1. [April 6, 2023] The `tfe-admin node-drain` command does not currently work when the `run_pipeline_mode` configuration setting is set to `agent`. See the notes under the _Highlights_ section for more details regarding this setting. This issue is fixed in the v202304-1 release.
 1. Saving boolean `false` variable values causes 500 errors. This has been fixed in [`v202303-1`](/terraform/enterprise/releases/2023/v202303-1#bug-fixes).
-1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://support.hashicorp.com/hc/en-us/articles/31715716966419-Issue-with-OIDC-Vault-key-rotation-mechanism-to-incorrectly-identify-the-newest-signing-key).
+1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://www.ibm.com/support/pages/node/7265719).
 
 ## Breaking Changes
 
-1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://support.hashicorp.com/hc/en-us/articles/13138701895699-Updating-Workload-Identity-for-Projects) on your cloud provider to expect project information in this claim.
+1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://www.ibm.com/support/pages/node/7265900) on your cloud provider to expect project information in this claim.
 
 ## Deprecations and End of Support
 

--- a/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202303-1/docs/enterprise/releases/2023/v202302-1.mdx
@@ -18,11 +18,11 @@ Last required release: [v202207-2 (642)](/terraform/enterprise/releases/2022/v20
 1. Terraform runs remain queued indefinitely when using the `agent` run pipeline mode unless the **Enable agents functionality** checkbox is checked in the [admin interface](/terraform/enterprise/admin/application/admin-access). The logs for `tfe-task-worker` will show `[ERROR] core: Unexpected HTTP response code: method=POST url=https://terraform.example.com/api/agent/register status=404`. This is resolved in Terraform Enterprise v202303-1.
 1. [April 6, 2023] The `tfe-admin node-drain` command does not currently work when the `run_pipeline_mode` configuration setting is set to `agent`. See the notes under the _Highlights_ section for more details regarding this setting. This issue is fixed in the v202304-1 release.
 1. Saving boolean `false` variable values causes 500 errors. This has been fixed in [`v202303-1`](/terraform/enterprise/releases/2023/v202303-1#bug-fixes).
-1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://support.hashicorp.com/hc/en-us/articles/31715716966419-Issue-with-OIDC-Vault-key-rotation-mechanism-to-incorrectly-identify-the-newest-signing-key).
+1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://www.ibm.com/support/pages/node/7265719).
 
 ## Breaking Changes
 
-1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://support.hashicorp.com/hc/en-us/articles/13138701895699-Updating-Workload-Identity-for-Projects) on your cloud provider to expect project information in this claim.
+1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://www.ibm.com/support/pages/node/7265900) on your cloud provider to expect project information in this claim.
 
 ## Deprecations and End of Support
 

--- a/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202304-1/docs/enterprise/releases/2023/v202302-1.mdx
@@ -18,11 +18,11 @@ Last required release: [v202207-2 (642)](/terraform/enterprise/releases/2022/v20
 1. Terraform runs remain queued indefinitely when using the `agent` run pipeline mode unless the **Enable agents functionality** checkbox is checked in the [admin interface](/terraform/enterprise/admin/application/admin-access). The logs for `tfe-task-worker` will show `[ERROR] core: Unexpected HTTP response code: method=POST url=https://terraform.example.com/api/agent/register status=404`. This is resolved in Terraform Enterprise v202303-1.
 1. [April 6, 2023] The `tfe-admin node-drain` command does not currently work when the `run_pipeline_mode` configuration setting is set to `agent`. See the notes under the _Highlights_ section for more details regarding this setting. This issue is fixed in the v202304-1 release.
 1. Saving boolean `false` variable values causes 500 errors. This has been fixed in [`v202303-1`](/terraform/enterprise/releases/2023/v202303-1#bug-fixes).
-1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://support.hashicorp.com/hc/en-us/articles/31715716966419-Issue-with-OIDC-Vault-key-rotation-mechanism-to-incorrectly-identify-the-newest-signing-key).
+1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://www.ibm.com/support/pages/node/7265719).
 
 ## Breaking Changes
 
-1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://support.hashicorp.com/hc/en-us/articles/13138701895699-Updating-Workload-Identity-for-Projects) on your cloud provider to expect project information in this claim.
+1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://www.ibm.com/support/pages/node/7265900) on your cloud provider to expect project information in this claim.
 
 ## Deprecations and End of Support
 

--- a/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202305-1/docs/enterprise/releases/2023/v202302-1.mdx
@@ -21,7 +21,7 @@ Last required release: [v202207-2 (642)](/terraform/enterprise/releases/2022/v20
 
 ## Breaking Changes
 
-1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://support.hashicorp.com/hc/en-us/articles/13138701895699-Updating-Workload-Identity-for-Projects) on your cloud provider to expect project information in this claim.
+1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://www.ibm.com/support/pages/node/7265900) on your cloud provider to expect project information in this claim.
 
 ## Deprecations and End of Support
 

--- a/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202305-2/docs/enterprise/releases/2023/v202302-1.mdx
@@ -18,11 +18,11 @@ Last required release: [v202207-2 (642)](/terraform/enterprise/releases/2022/v20
 1. Terraform runs remain queued indefinitely when using the `agent` run pipeline mode unless the **Enable agents functionality** checkbox is checked in the [admin interface](/terraform/enterprise/admin/application/admin-access). The logs for `tfe-task-worker` will show `[ERROR] core: Unexpected HTTP response code: method=POST url=https://terraform.example.com/api/agent/register status=404`. This is resolved in Terraform Enterprise v202303-1.
 1. [April 6, 2023] The `tfe-admin node-drain` command does not currently work when the `run_pipeline_mode` configuration setting is set to `agent`. See the notes under the _Highlights_ section for more details regarding this setting. This issue is fixed in the v202304-1 release.
 1. Saving boolean `false` variable values causes 500 errors. This has been fixed in [`v202303-1`](/terraform/enterprise/releases/2023/v202303-1#bug-fixes).
-1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://support.hashicorp.com/hc/en-us/articles/31715716966419-Issue-with-OIDC-Vault-key-rotation-mechanism-to-incorrectly-identify-the-newest-signing-key).
+1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://www.ibm.com/support/pages/node/7265719).
 
 ## Breaking Changes
 
-1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://support.hashicorp.com/hc/en-us/articles/13138701895699-Updating-Workload-Identity-for-Projects) on your cloud provider to expect project information in this claim.
+1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://www.ibm.com/support/pages/node/7265900) on your cloud provider to expect project information in this claim.
 
 ## Deprecations and End of Support
 

--- a/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202306-1/docs/enterprise/releases/2023/v202302-1.mdx
@@ -18,11 +18,11 @@ Last required release: [v202207-2 (642)](/terraform/enterprise/releases/2022/v20
 1. Terraform runs remain queued indefinitely when using the `agent` run pipeline mode unless the **Enable agents functionality** checkbox is checked in the [admin interface](/terraform/enterprise/admin/application/admin-access). The logs for `tfe-task-worker` will show `[ERROR] core: Unexpected HTTP response code: method=POST url=https://terraform.example.com/api/agent/register status=404`. This is resolved in Terraform Enterprise v202303-1.
 1. [April 6, 2023] The `tfe-admin node-drain` command does not currently work when the `run_pipeline_mode` configuration setting is set to `agent`. See the notes under the _Highlights_ section for more details regarding this setting. This issue is fixed in the v202304-1 release.
 1. Saving boolean `false` variable values causes 500 errors. This has been fixed in [`v202303-1`](/terraform/enterprise/releases/2023/v202303-1#bug-fixes).
-1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://support.hashicorp.com/hc/en-us/articles/31715716966419-Issue-with-OIDC-Vault-key-rotation-mechanism-to-incorrectly-identify-the-newest-signing-key).
+1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://www.ibm.com/support/pages/node/7265719).
 
 ## Breaking Changes
 
-1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://support.hashicorp.com/hc/en-us/articles/13138701895699-Updating-Workload-Identity-for-Projects) on your cloud provider to expect project information in this claim.
+1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://www.ibm.com/support/pages/node/7265900) on your cloud provider to expect project information in this claim.
 
 ## Deprecations and End of Support
 

--- a/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202307-1/docs/enterprise/releases/2023/v202302-1.mdx
@@ -18,11 +18,11 @@ Last required release: [v202207-2 (642)](/terraform/enterprise/releases/2022/v20
 1. Terraform runs remain queued indefinitely when using the `agent` run pipeline mode unless the **Enable agents functionality** checkbox is checked in the [admin interface](/terraform/enterprise/admin/application/admin-access). The logs for `tfe-task-worker` will show `[ERROR] core: Unexpected HTTP response code: method=POST url=https://terraform.example.com/api/agent/register status=404`. This is resolved in Terraform Enterprise v202303-1.
 1. [April 6, 2023] The `tfe-admin node-drain` command does not currently work when the `run_pipeline_mode` configuration setting is set to `agent`. See the notes under the _Highlights_ section for more details regarding this setting. This issue is fixed in the v202304-1 release.
 1. Saving boolean `false` variable values causes 500 errors. This has been fixed in [`v202303-1`](/terraform/enterprise/releases/2023/v202303-1#bug-fixes).
-1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://support.hashicorp.com/hc/en-us/articles/31715716966419-Issue-with-OIDC-Vault-key-rotation-mechanism-to-incorrectly-identify-the-newest-signing-key).
+1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://www.ibm.com/support/pages/node/7265719).
 
 ## Breaking Changes
 
-1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://support.hashicorp.com/hc/en-us/articles/13138701895699-Updating-Workload-Identity-for-Projects) on your cloud provider to expect project information in this claim.
+1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://www.ibm.com/support/pages/node/7265900) on your cloud provider to expect project information in this claim.
 
 ## Deprecations and End of Support
 

--- a/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202308-1/docs/enterprise/releases/2023/v202302-1.mdx
@@ -18,11 +18,11 @@ Last required release: [v202207-2 (642)](/terraform/enterprise/releases/2022/v20
 1. Terraform runs remain queued indefinitely when using the `agent` run pipeline mode unless the **Enable agents functionality** checkbox is checked in the [admin interface](/terraform/enterprise/admin/application/admin-access). The logs for `tfe-task-worker` will show `[ERROR] core: Unexpected HTTP response code: method=POST url=https://terraform.example.com/api/agent/register status=404`. This is resolved in Terraform Enterprise v202303-1.
 1. [April 6, 2023] The `tfe-admin node-drain` command does not currently work when the `run_pipeline_mode` configuration setting is set to `agent`. See the notes under the _Highlights_ section for more details regarding this setting. This issue is fixed in the v202304-1 release.
 1. Saving boolean `false` variable values causes 500 errors. This has been fixed in [`v202303-1`](/terraform/enterprise/releases/2023/v202303-1#bug-fixes).
-1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://support.hashicorp.com/hc/en-us/articles/31715716966419-Issue-with-OIDC-Vault-key-rotation-mechanism-to-incorrectly-identify-the-newest-signing-key).
+1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://www.ibm.com/support/pages/node/7265719).
 
 ## Breaking Changes
 
-1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://support.hashicorp.com/hc/en-us/articles/13138701895699-Updating-Workload-Identity-for-Projects) on your cloud provider to expect project information in this claim.
+1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://www.ibm.com/support/pages/node/7265900) on your cloud provider to expect project information in this claim.
 
 ## Deprecations and End of Support
 

--- a/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202309-1/docs/enterprise/releases/2023/v202302-1.mdx
@@ -18,11 +18,11 @@ Last required release: [v202207-2 (642)](/terraform/enterprise/releases/2022/v20
 1. Terraform runs remain queued indefinitely when using the `agent` run pipeline mode unless the **Enable agents functionality** checkbox is checked in the [admin interface](/terraform/enterprise/application-administration/admin-access). The logs for `tfe-task-worker` will show `[ERROR] core: Unexpected HTTP response code: method=POST url=https://terraform.example.com/api/agent/register status=404`. This is resolved in Terraform Enterprise v202303-1.
 1. [April 6, 2023] The `tfe-admin node-drain` command does not currently work when the `run_pipeline_mode` configuration setting is set to `agent`. See the notes under the _Highlights_ section for more details regarding this setting. This issue is fixed in the v202304-1 release.
 1. Saving boolean `false` variable values causes 500 errors. This has been fixed in [`v202303-1`](/terraform/enterprise/releases/2023/v202303-1#bug-fixes).
-1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://support.hashicorp.com/hc/en-us/articles/31715716966419-Issue-with-OIDC-Vault-key-rotation-mechanism-to-incorrectly-identify-the-newest-signing-key).
+1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://www.ibm.com/support/pages/node/7265719).
 
 ## Breaking Changes
 
-1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://support.hashicorp.com/hc/en-us/articles/13138701895699-Updating-Workload-Identity-for-Projects) on your cloud provider to expect project information in this claim.
+1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://www.ibm.com/support/pages/node/7265900) on your cloud provider to expect project information in this claim.
 
 ## Deprecations and End of Support
 

--- a/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202310-1/docs/enterprise/releases/2023/v202302-1.mdx
@@ -18,11 +18,11 @@ Last required release: [v202207-2 (642)](/terraform/enterprise/releases/2022/v20
 1. Terraform runs remain queued indefinitely when using the `agent` run pipeline mode unless the **Enable agents functionality** checkbox is checked in the [admin interface](/terraform/enterprise/application-administration/admin-access). The logs for `tfe-task-worker` will show `[ERROR] core: Unexpected HTTP response code: method=POST url=https://terraform.example.com/api/agent/register status=404`. This is resolved in Terraform Enterprise v202303-1.
 1. [April 6, 2023] The `tfe-admin node-drain` command does not currently work when the `run_pipeline_mode` configuration setting is set to `agent`. See the notes under the _Highlights_ section for more details regarding this setting. This issue is fixed in the v202305-1 release.
 1. Saving boolean `false` variable values causes 500 errors. This has been fixed in [`v202303-1`](/terraform/enterprise/releases/2023/v202303-1#bug-fixes).
-1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://support.hashicorp.com/hc/en-us/articles/31715716966419-Issue-with-OIDC-Vault-key-rotation-mechanism-to-incorrectly-identify-the-newest-signing-key).
+1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://www.ibm.com/support/pages/node/7265719).
 
 ## Breaking Changes
 
-1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://support.hashicorp.com/hc/en-us/articles/13138701895699-Updating-Workload-Identity-for-Projects) on your cloud provider to expect project information in this claim.
+1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://www.ibm.com/support/pages/node/7265900) on your cloud provider to expect project information in this claim.
 
 ## Deprecations and End of Support
 

--- a/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202311-1/docs/enterprise/releases/2023/v202302-1.mdx
@@ -18,11 +18,11 @@ Last required release: [v202207-2 (642)](/terraform/enterprise/releases/2022/v20
 1. Terraform runs remain queued indefinitely when using the `agent` run pipeline mode unless the **Enable agents functionality** checkbox is checked in the [admin interface](/terraform/enterprise/application-administration/admin-access). The logs for `tfe-task-worker` will show `[ERROR] core: Unexpected HTTP response code: method=POST url=https://terraform.example.com/api/agent/register status=404`. This is resolved in Terraform Enterprise v202303-1.
 1. [April 6, 2023] The `tfe-admin node-drain` command does not currently work when the `run_pipeline_mode` configuration setting is set to `agent`. See the notes under the _Highlights_ section for more details regarding this setting. This issue is fixed in the v202305-1 release.
 1. Saving boolean `false` variable values causes 500 errors. This has been fixed in [`v202303-1`](/terraform/enterprise/releases/2023/v202303-1#bug-fixes).
-1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://support.hashicorp.com/hc/en-us/articles/31715716966419-Issue-with-OIDC-Vault-key-rotation-mechanism-to-incorrectly-identify-the-newest-signing-key).
+1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://www.ibm.com/support/pages/node/7265719).
 
 ## Breaking Changes
 
-1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://support.hashicorp.com/hc/en-us/articles/13138701895699-Updating-Workload-Identity-for-Projects) on your cloud provider to expect project information in this claim.
+1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://www.ibm.com/support/pages/node/7265900) on your cloud provider to expect project information in this claim.
 
 ## Deprecations and End of Support
 

--- a/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202312-1/docs/enterprise/releases/2023/v202302-1.mdx
@@ -18,11 +18,11 @@ Last required release: [v202207-2 (642)](/terraform/enterprise/releases/2022/v20
 1. Terraform runs remain queued indefinitely when using the `agent` run pipeline mode unless the **Enable agents functionality** checkbox is checked in the [admin interface](/terraform/enterprise/application-administration/admin-access). The logs for `tfe-task-worker` will show `[ERROR] core: Unexpected HTTP response code: method=POST url=https://terraform.example.com/api/agent/register status=404`. This is resolved in Terraform Enterprise v202303-1.
 1. [April 6, 2023] The `tfe-admin node-drain` command does not currently work when the `run_pipeline_mode` configuration setting is set to `agent`. See the notes under the _Highlights_ section for more details regarding this setting. This issue is fixed in the v202305-1 release.
 1. Saving boolean `false` variable values causes 500 errors. This has been fixed in [`v202303-1`](/terraform/enterprise/releases/2023/v202303-1#bug-fixes).
-1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://support.hashicorp.com/hc/en-us/articles/31715716966419-Issue-with-OIDC-Vault-key-rotation-mechanism-to-incorrectly-identify-the-newest-signing-key).
+1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://www.ibm.com/support/pages/node/7265719).
 
 ## Breaking Changes
 
-1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://support.hashicorp.com/hc/en-us/articles/13138701895699-Updating-Workload-Identity-for-Projects) on your cloud provider to expect project information in this claim.
+1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://www.ibm.com/support/pages/node/7265900) on your cloud provider to expect project information in this claim.
 
 ## Deprecations and End of Support
 

--- a/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202401-1/docs/enterprise/releases/2023/v202302-1.mdx
@@ -21,7 +21,7 @@ Last required release: [v202207-2 (642)](/terraform/enterprise/releases/2022/v20
 
 ## Breaking Changes
 
-1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://support.hashicorp.com/hc/en-us/articles/13138701895699-Updating-Workload-Identity-for-Projects) on your cloud provider to expect project information in this claim.
+1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://www.ibm.com/support/pages/node/7265900) on your cloud provider to expect project information in this claim.
 
 ## Deprecations and End of Support
 

--- a/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202401-2/docs/enterprise/releases/2023/v202302-1.mdx
@@ -18,11 +18,11 @@ Last required release: [v202207-2 (642)](/terraform/enterprise/releases/2022/v20
 1. Terraform runs remain queued indefinitely when using the `agent` run pipeline mode unless the **Enable agents functionality** checkbox is checked in the [admin interface](/terraform/enterprise/application-administration/admin-access). The logs for `tfe-task-worker` will show `[ERROR] core: Unexpected HTTP response code: method=POST url=https://terraform.example.com/api/agent/register status=404`. This is resolved in Terraform Enterprise v202303-1.
 1. [April 6, 2023] The `tfe-admin node-drain` command does not currently work when the `run_pipeline_mode` configuration setting is set to `agent`. See the notes under the _Highlights_ section for more details regarding this setting. This issue is fixed in the v202305-1 release.
 1. Saving boolean `false` variable values causes 500 errors. This has been fixed in [`v202303-1`](/terraform/enterprise/releases/2023/v202303-1#bug-fixes).
-1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://support.hashicorp.com/hc/en-us/articles/31715716966419-Issue-with-OIDC-Vault-key-rotation-mechanism-to-incorrectly-identify-the-newest-signing-key).
+1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://www.ibm.com/support/pages/node/7265719).
 
 ## Breaking Changes
 
-1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://support.hashicorp.com/hc/en-us/articles/13138701895699-Updating-Workload-Identity-for-Projects) on your cloud provider to expect project information in this claim.
+1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://www.ibm.com/support/pages/node/7265900) on your cloud provider to expect project information in this claim.
 
 ## Deprecations and End of Support
 

--- a/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202402-1/docs/enterprise/releases/2023/v202302-1.mdx
@@ -21,7 +21,7 @@ Last required release: [v202207-2 (642)](/terraform/enterprise/releases/2022/v20
 
 ## Breaking Changes
 
-1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://support.hashicorp.com/hc/en-us/articles/13138701895699-Updating-Workload-Identity-for-Projects) on your cloud provider to expect project information in this claim.
+1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://www.ibm.com/support/pages/node/7265900) on your cloud provider to expect project information in this claim.
 
 ## Deprecations and End of Support
 

--- a/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202402-2/docs/enterprise/releases/2023/v202302-1.mdx
@@ -18,11 +18,11 @@ Last required release: [v202207-2 (642)](/terraform/enterprise/releases/2022/v20
 1. Terraform runs remain queued indefinitely when using the `agent` run pipeline mode unless the **Enable agents functionality** checkbox is checked in the [admin interface](/terraform/enterprise/application-administration/admin-access). The logs for `tfe-task-worker` will show `[ERROR] core: Unexpected HTTP response code: method=POST url=https://terraform.example.com/api/agent/register status=404`. This is resolved in Terraform Enterprise v202303-1.
 1. [April 6, 2023] The `tfe-admin node-drain` command does not currently work when the `run_pipeline_mode` configuration setting is set to `agent`. See the notes under the _Highlights_ section for more details regarding this setting. This issue is fixed in the v202305-1 release.
 1. Saving boolean `false` variable values causes 500 errors. This has been fixed in [`v202303-1`](/terraform/enterprise/releases/2023/v202303-1#bug-fixes).
-1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://support.hashicorp.com/hc/en-us/articles/31715716966419-Issue-with-OIDC-Vault-key-rotation-mechanism-to-incorrectly-identify-the-newest-signing-key).
+1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://www.ibm.com/support/pages/node/7265719).
 
 ## Breaking Changes
 
-1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://support.hashicorp.com/hc/en-us/articles/13138701895699-Updating-Workload-Identity-for-Projects) on your cloud provider to expect project information in this claim.
+1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://www.ibm.com/support/pages/node/7265900) on your cloud provider to expect project information in this claim.
 
 ## Deprecations and End of Support
 

--- a/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202404-1/docs/enterprise/releases/2023/v202302-1.mdx
@@ -21,7 +21,7 @@ Last required release: [v202207-2 (642)](/terraform/enterprise/releases/2022/v20
 
 ## Breaking Changes
 
-1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://support.hashicorp.com/hc/en-us/articles/13138701895699-Updating-Workload-Identity-for-Projects) on your cloud provider to expect project information in this claim.
+1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://www.ibm.com/support/pages/node/7265900) on your cloud provider to expect project information in this claim.
 
 ## Deprecations and End of Support
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/releases/2023/v202302-1.mdx
@@ -18,11 +18,11 @@ Last required release: [v202207-2 (642)](/terraform/enterprise/releases/2022/v20
 1. Terraform runs remain queued indefinitely when using the `agent` run pipeline mode unless the **Enable agents functionality** checkbox is checked in the [admin interface](/terraform/enterprise/application-administration/admin-access). The logs for `tfe-task-worker` will show `[ERROR] core: Unexpected HTTP response code: method=POST url=https://terraform.example.com/api/agent/register status=404`. This is resolved in Terraform Enterprise v202303-1.
 1. [April 6, 2023] The `tfe-admin node-drain` command does not currently work when the `run_pipeline_mode` configuration setting is set to `agent`. See the notes under the _Highlights_ section for more details regarding this setting. This issue is fixed in the v202305-1 release.
 1. Saving boolean `false` variable values causes 500 errors. This has been fixed in [`v202303-1`](/terraform/enterprise/releases/2023/v202303-1#bug-fixes).
-1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://support.hashicorp.com/hc/en-us/articles/31715716966419-Issue-with-OIDC-Vault-key-rotation-mechanism-to-incorrectly-identify-the-newest-signing-key).
+1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://www.ibm.com/support/pages/node/7265719).
 
 ## Breaking Changes
 
-1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://support.hashicorp.com/hc/en-us/articles/13138701895699-Updating-Workload-Identity-for-Projects) on your cloud provider to expect project information in this claim.
+1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://www.ibm.com/support/pages/node/7265900) on your cloud provider to expect project information in this claim.
 
 ## Deprecations and End of Support
 

--- a/content/terraform-enterprise/v202405-1/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202405-1/docs/enterprise/releases/2023/v202302-1.mdx
@@ -18,11 +18,11 @@ Last required release: [v202207-2 (642)](/terraform/enterprise/releases/2022/v20
 1. Terraform runs remain queued indefinitely when using the `agent` run pipeline mode unless the **Enable agents functionality** checkbox is checked in the [admin interface](/terraform/enterprise/application-administration/admin-access). The logs for `tfe-task-worker` will show `[ERROR] core: Unexpected HTTP response code: method=POST url=https://terraform.example.com/api/agent/register status=404`. This is resolved in Terraform Enterprise v202303-1.
 1. [April 6, 2023] The `tfe-admin node-drain` command does not currently work when the `run_pipeline_mode` configuration setting is set to `agent`. See the notes under the _Highlights_ section for more details regarding this setting. This issue is fixed in the v202305-1 release.
 1. Saving boolean `false` variable values causes 500 errors. This has been fixed in [`v202303-1`](/terraform/enterprise/releases/2023/v202303-1#bug-fixes).
-1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://support.hashicorp.com/hc/en-us/articles/31715716966419-Issue-with-OIDC-Vault-key-rotation-mechanism-to-incorrectly-identify-the-newest-signing-key).
+1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://www.ibm.com/support/pages/node/7265719).
 
 ## Breaking Changes
 
-1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://support.hashicorp.com/hc/en-us/articles/13138701895699-Updating-Workload-Identity-for-Projects) on your cloud provider to expect project information in this claim.
+1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://www.ibm.com/support/pages/node/7265900) on your cloud provider to expect project information in this claim.
 
 ## Deprecations and End of Support
 

--- a/content/terraform-enterprise/v202406-1/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202406-1/docs/enterprise/releases/2023/v202302-1.mdx
@@ -18,11 +18,11 @@ Last required release: [v202207-2 (642)](/terraform/enterprise/releases/2022/v20
 1. Terraform runs remain queued indefinitely when using the `agent` run pipeline mode unless the **Enable agents functionality** checkbox is checked in the [admin interface](/terraform/enterprise/application-administration/admin-access). The logs for `tfe-task-worker` will show `[ERROR] core: Unexpected HTTP response code: method=POST url=https://terraform.example.com/api/agent/register status=404`. This is resolved in Terraform Enterprise v202303-1.
 1. [April 6, 2023] The `tfe-admin node-drain` command does not currently work when the `run_pipeline_mode` configuration setting is set to `agent`. See the notes under the _Highlights_ section for more details regarding this setting. This issue is fixed in the v202305-1 release.
 1. Saving boolean `false` variable values causes 500 errors. This has been fixed in [`v202303-1`](/terraform/enterprise/releases/2023/v202303-1#bug-fixes).
-1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://support.hashicorp.com/hc/en-us/articles/31715716966419-Issue-with-OIDC-Vault-key-rotation-mechanism-to-incorrectly-identify-the-newest-signing-key).
+1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://www.ibm.com/support/pages/node/7265719).
 
 ## Breaking Changes
 
-1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://support.hashicorp.com/hc/en-us/articles/13138701895699-Updating-Workload-Identity-for-Projects) on your cloud provider to expect project information in this claim.
+1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://www.ibm.com/support/pages/node/7265900) on your cloud provider to expect project information in this claim.
 
 ## Deprecations and End of Support
 

--- a/content/terraform-enterprise/v202407-1/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202407-1/docs/enterprise/releases/2023/v202302-1.mdx
@@ -18,11 +18,11 @@ Last required release: [v202207-2 (642)](/terraform/enterprise/releases/2022/v20
 1. Terraform runs remain queued indefinitely when using the `agent` run pipeline mode unless the **Enable agents functionality** checkbox is checked in the [admin interface](/terraform/enterprise/application-administration/admin-access). The logs for `tfe-task-worker` will show `[ERROR] core: Unexpected HTTP response code: method=POST url=https://terraform.example.com/api/agent/register status=404`. This is resolved in Terraform Enterprise v202303-1.
 1. [April 6, 2023] The `tfe-admin node-drain` command does not currently work when the `run_pipeline_mode` configuration setting is set to `agent`. See the notes under the _Highlights_ section for more details regarding this setting. This issue is fixed in the v202305-1 release.
 1. Saving boolean `false` variable values causes 500 errors. This has been fixed in [`v202303-1`](/terraform/enterprise/releases/2023/v202303-1#bug-fixes).
-1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://support.hashicorp.com/hc/en-us/articles/31715716966419-Issue-with-OIDC-Vault-key-rotation-mechanism-to-incorrectly-identify-the-newest-signing-key).
+1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://www.ibm.com/support/pages/node/7265719).
 
 ## Breaking Changes
 
-1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://support.hashicorp.com/hc/en-us/articles/13138701895699-Updating-Workload-Identity-for-Projects) on your cloud provider to expect project information in this claim.
+1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://www.ibm.com/support/pages/node/7265900) on your cloud provider to expect project information in this claim.
 
 ## Deprecations and End of Support
 

--- a/content/terraform-enterprise/v202408-1/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202408-1/docs/enterprise/releases/2023/v202302-1.mdx
@@ -18,11 +18,11 @@ Last required release: [v202207-2 (642)](/terraform/enterprise/releases/2022/v20
 1. Terraform runs remain queued indefinitely when using the `agent` run pipeline mode unless the **Enable agents functionality** checkbox is checked in the [admin interface](/terraform/enterprise/application-administration/admin-access). The logs for `tfe-task-worker` will show `[ERROR] core: Unexpected HTTP response code: method=POST url=https://terraform.example.com/api/agent/register status=404`. This is resolved in Terraform Enterprise v202303-1.
 1. [April 6, 2023] The `tfe-admin node-drain` command does not currently work when the `run_pipeline_mode` configuration setting is set to `agent`. See the notes under the _Highlights_ section for more details regarding this setting. This issue is fixed in the v202305-1 release.
 1. Saving boolean `false` variable values causes 500 errors. This has been fixed in [`v202303-1`](/terraform/enterprise/releases/2023/v202303-1#bug-fixes).
-1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://support.hashicorp.com/hc/en-us/articles/31715716966419-Issue-with-OIDC-Vault-key-rotation-mechanism-to-incorrectly-identify-the-newest-signing-key).
+1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://www.ibm.com/support/pages/node/7265719).
 
 ## Breaking Changes
 
-1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://support.hashicorp.com/hc/en-us/articles/13138701895699-Updating-Workload-Identity-for-Projects) on your cloud provider to expect project information in this claim.
+1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://www.ibm.com/support/pages/node/7265900) on your cloud provider to expect project information in this claim.
 
 ## Deprecations and End of Support
 

--- a/content/terraform-enterprise/v202409-1/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202409-1/docs/enterprise/releases/2023/v202302-1.mdx
@@ -18,11 +18,11 @@ Last required release: [v202207-2 (642)](/terraform/enterprise/releases/2022/v20
 1. Terraform runs remain queued indefinitely when using the `agent` run pipeline mode unless the **Enable agents functionality** checkbox is checked in the [admin interface](/terraform/enterprise/application-administration/admin-access). The logs for `tfe-task-worker` will show `[ERROR] core: Unexpected HTTP response code: method=POST url=https://terraform.example.com/api/agent/register status=404`. This is resolved in Terraform Enterprise v202303-1.
 1. [April 6, 2023] The `tfe-admin node-drain` command does not currently work when the `run_pipeline_mode` configuration setting is set to `agent`. See the notes under the _Highlights_ section for more details regarding this setting. This issue is fixed in the v202305-1 release.
 1. Saving boolean `false` variable values causes 500 errors. This has been fixed in [`v202303-1`](/terraform/enterprise/releases/2023/v202303-1#bug-fixes).
-1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://support.hashicorp.com/hc/en-us/articles/31715716966419-Issue-with-OIDC-Vault-key-rotation-mechanism-to-incorrectly-identify-the-newest-signing-key).
+1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://www.ibm.com/support/pages/node/7265719).
 
 ## Breaking Changes
 
-1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://support.hashicorp.com/hc/en-us/articles/13138701895699-Updating-Workload-Identity-for-Projects) on your cloud provider to expect project information in this claim.
+1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://www.ibm.com/support/pages/node/7265900) on your cloud provider to expect project information in this claim.
 
 ## Deprecations and End of Support
 

--- a/content/terraform-enterprise/v202409-2/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202409-2/docs/enterprise/releases/2023/v202302-1.mdx
@@ -18,11 +18,11 @@ Last required release: [v202207-2 (642)](/terraform/enterprise/releases/2022/v20
 1. Terraform runs remain queued indefinitely when using the `agent` run pipeline mode unless the **Enable agents functionality** checkbox is checked in the [admin interface](/terraform/enterprise/application-administration/admin-access). The logs for `tfe-task-worker` will show `[ERROR] core: Unexpected HTTP response code: method=POST url=https://terraform.example.com/api/agent/register status=404`. This is resolved in Terraform Enterprise v202303-1.
 1. [April 6, 2023] The `tfe-admin node-drain` command does not currently work when the `run_pipeline_mode` configuration setting is set to `agent`. See the notes under the _Highlights_ section for more details regarding this setting. This issue is fixed in the v202305-1 release.
 1. Saving boolean `false` variable values causes 500 errors. This has been fixed in [`v202303-1`](/terraform/enterprise/releases/2023/v202303-1#bug-fixes).
-1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://support.hashicorp.com/hc/en-us/articles/31715716966419-Issue-with-OIDC-Vault-key-rotation-mechanism-to-incorrectly-identify-the-newest-signing-key).
+1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://www.ibm.com/support/pages/node/7265719).
 
 ## Breaking Changes
 
-1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://support.hashicorp.com/hc/en-us/articles/13138701895699-Updating-Workload-Identity-for-Projects) on your cloud provider to expect project information in this claim.
+1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://www.ibm.com/support/pages/node/7265900) on your cloud provider to expect project information in this claim.
 
 ## Deprecations and End of Support
 

--- a/content/terraform-enterprise/v202409-3/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202409-3/docs/enterprise/releases/2023/v202302-1.mdx
@@ -18,11 +18,11 @@ Last required release: [v202207-2 (642)](/terraform/enterprise/releases/2022/v20
 1. Terraform runs remain queued indefinitely when using the `agent` run pipeline mode unless the **Enable agents functionality** checkbox is checked in the [admin interface](/terraform/enterprise/application-administration/admin-access). The logs for `tfe-task-worker` will show `[ERROR] core: Unexpected HTTP response code: method=POST url=https://terraform.example.com/api/agent/register status=404`. This is resolved in Terraform Enterprise v202303-1.
 1. [April 6, 2023] The `tfe-admin node-drain` command does not currently work when the `run_pipeline_mode` configuration setting is set to `agent`. See the notes under the _Highlights_ section for more details regarding this setting. This issue is fixed in the v202305-1 release.
 1. Saving boolean `false` variable values causes 500 errors. This has been fixed in [`v202303-1`](/terraform/enterprise/releases/2023/v202303-1#bug-fixes).
-1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://support.hashicorp.com/hc/en-us/articles/31715716966419-Issue-with-OIDC-Vault-key-rotation-mechanism-to-incorrectly-identify-the-newest-signing-key).
+1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://www.ibm.com/support/pages/node/7265719).
 
 ## Breaking Changes
 
-1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://support.hashicorp.com/hc/en-us/articles/13138701895699-Updating-Workload-Identity-for-Projects) on your cloud provider to expect project information in this claim.
+1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://www.ibm.com/support/pages/node/7265900) on your cloud provider to expect project information in this claim.
 
 ## Deprecations and End of Support
 

--- a/content/terraform-enterprise/v202410-1/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202410-1/docs/enterprise/releases/2023/v202302-1.mdx
@@ -18,11 +18,11 @@ Last required release: [v202207-2 (642)](/terraform/enterprise/releases/2022/v20
 1. Terraform runs remain queued indefinitely when using the `agent` run pipeline mode unless the **Enable agents functionality** checkbox is checked in the [admin interface](/terraform/enterprise/application-administration/admin-access). The logs for `tfe-task-worker` will show `[ERROR] core: Unexpected HTTP response code: method=POST url=https://terraform.example.com/api/agent/register status=404`. This is resolved in Terraform Enterprise v202303-1.
 1. [April 6, 2023] The `tfe-admin node-drain` command does not currently work when the `run_pipeline_mode` configuration setting is set to `agent`. See the notes under the _Highlights_ section for more details regarding this setting. This issue is fixed in the v202305-1 release.
 1. Saving boolean `false` variable values causes 500 errors. This has been fixed in [`v202303-1`](/terraform/enterprise/releases/2023/v202303-1#bug-fixes).
-1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://support.hashicorp.com/hc/en-us/articles/31715716966419-Issue-with-OIDC-Vault-key-rotation-mechanism-to-incorrectly-identify-the-newest-signing-key).
+1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://www.ibm.com/support/pages/node/7265719).
 
 ## Breaking Changes
 
-1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://support.hashicorp.com/hc/en-us/articles/13138701895699-Updating-Workload-Identity-for-Projects) on your cloud provider to expect project information in this claim.
+1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://www.ibm.com/support/pages/node/7265900) on your cloud provider to expect project information in this claim.
 
 ## Deprecations and End of Support
 

--- a/content/terraform-enterprise/v202411-1/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202411-1/docs/enterprise/releases/2023/v202302-1.mdx
@@ -18,11 +18,11 @@ Last required release: [v202207-2 (642)](/terraform/enterprise/releases/2022/v20
 1. Terraform runs remain queued indefinitely when using the `agent` run pipeline mode unless the **Enable agents functionality** checkbox is checked in the [admin interface](/terraform/enterprise/application-administration/admin-access). The logs for `tfe-task-worker` will show `[ERROR] core: Unexpected HTTP response code: method=POST url=https://terraform.example.com/api/agent/register status=404`. This is resolved in Terraform Enterprise v202303-1.
 1. [April 6, 2023] The `tfe-admin node-drain` command does not currently work when the `run_pipeline_mode` configuration setting is set to `agent`. See the notes under the _Highlights_ section for more details regarding this setting. This issue is fixed in the v202305-1 release.
 1. Saving boolean `false` variable values causes 500 errors. This has been fixed in [`v202303-1`](/terraform/enterprise/releases/2023/v202303-1#bug-fixes).
-1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://support.hashicorp.com/hc/en-us/articles/31715716966419-Issue-with-OIDC-Vault-key-rotation-mechanism-to-incorrectly-identify-the-newest-signing-key).
+1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://www.ibm.com/support/pages/node/7265719).
 
 ## Breaking Changes
 
-1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://support.hashicorp.com/hc/en-us/articles/13138701895699-Updating-Workload-Identity-for-Projects) on your cloud provider to expect project information in this claim.
+1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://www.ibm.com/support/pages/node/7265900) on your cloud provider to expect project information in this claim.
 
 ## Deprecations and End of Support
 

--- a/content/terraform-enterprise/v202411-2/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202411-2/docs/enterprise/releases/2023/v202302-1.mdx
@@ -18,11 +18,11 @@ Last required release: [v202207-2 (642)](/terraform/enterprise/releases/2022/v20
 1. Terraform runs remain queued indefinitely when using the `agent` run pipeline mode unless the **Enable agents functionality** checkbox is checked in the [admin interface](/terraform/enterprise/application-administration/admin-access). The logs for `tfe-task-worker` will show `[ERROR] core: Unexpected HTTP response code: method=POST url=https://terraform.example.com/api/agent/register status=404`. This is resolved in Terraform Enterprise v202303-1.
 1. [April 6, 2023] The `tfe-admin node-drain` command does not currently work when the `run_pipeline_mode` configuration setting is set to `agent`. See the notes under the _Highlights_ section for more details regarding this setting. This issue is fixed in the v202305-1 release.
 1. Saving boolean `false` variable values causes 500 errors. This has been fixed in [`v202303-1`](/terraform/enterprise/releases/2023/v202303-1#bug-fixes).
-1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://support.hashicorp.com/hc/en-us/articles/31715716966419-Issue-with-OIDC-Vault-key-rotation-mechanism-to-incorrectly-identify-the-newest-signing-key).
+1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://www.ibm.com/support/pages/node/7265719).
 
 ## Breaking Changes
 
-1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://support.hashicorp.com/hc/en-us/articles/13138701895699-Updating-Workload-Identity-for-Projects) on your cloud provider to expect project information in this claim.
+1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://www.ibm.com/support/pages/node/7265900) on your cloud provider to expect project information in this claim.
 
 ## Deprecations and End of Support
 

--- a/content/terraform-enterprise/v202501-1/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202501-1/docs/enterprise/releases/2023/v202302-1.mdx
@@ -18,11 +18,11 @@ Last required release: [v202207-2 (642)](/terraform/enterprise/releases/2022/v20
 1. Terraform runs remain queued indefinitely when using the `agent` run pipeline mode unless the **Enable agents functionality** checkbox is checked in the [admin interface](/terraform/enterprise/application-administration/admin-access). The logs for `tfe-task-worker` will show `[ERROR] core: Unexpected HTTP response code: method=POST url=https://terraform.example.com/api/agent/register status=404`. This is resolved in Terraform Enterprise v202303-1.
 1. [April 6, 2023] The `tfe-admin node-drain` command does not currently work when the `run_pipeline_mode` configuration setting is set to `agent`. See the notes under the _Highlights_ section for more details regarding this setting. This issue is fixed in the v202305-1 release.
 1. Saving boolean `false` variable values causes 500 errors. This has been fixed in [`v202303-1`](/terraform/enterprise/releases/2023/v202303-1#bug-fixes).
-1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://support.hashicorp.com/hc/en-us/articles/31715716966419-Issue-with-OIDC-Vault-key-rotation-mechanism-to-incorrectly-identify-the-newest-signing-key).
+1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://www.ibm.com/support/pages/node/7265719).
 
 ## Breaking Changes
 
-1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://support.hashicorp.com/hc/en-us/articles/13138701895699-Updating-Workload-Identity-for-Projects) on your cloud provider to expect project information in this claim.
+1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://www.ibm.com/support/pages/node/7265900) on your cloud provider to expect project information in this claim.
 
 ## Deprecations and End of Support
 

--- a/content/terraform-enterprise/v202502-1/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202502-1/docs/enterprise/releases/2023/v202302-1.mdx
@@ -18,11 +18,11 @@ Last required release: [v202207-2 (642)](/terraform/enterprise/releases/2022/v20
 1. Terraform runs remain queued indefinitely when using the `agent` run pipeline mode unless the **Enable agents functionality** checkbox is checked in the [admin interface](/terraform/enterprise/application-administration/admin-access). The logs for `tfe-task-worker` will show `[ERROR] core: Unexpected HTTP response code: method=POST url=https://terraform.example.com/api/agent/register status=404`. This is resolved in Terraform Enterprise v202303-1.
 1. [April 6, 2023] The `tfe-admin node-drain` command does not currently work when the `run_pipeline_mode` configuration setting is set to `agent`. See the notes under the _Highlights_ section for more details regarding this setting. This issue is fixed in the v202305-1 release.
 1. Saving boolean `false` variable values causes 500 errors. This has been fixed in [`v202303-1`](/terraform/enterprise/releases/2023/v202303-1#bug-fixes).
-1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://support.hashicorp.com/hc/en-us/articles/31715716966419-Issue-with-OIDC-Vault-key-rotation-mechanism-to-incorrectly-identify-the-newest-signing-key).
+1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://www.ibm.com/support/pages/node/7265719).
 
 ## Breaking Changes
 
-1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://support.hashicorp.com/hc/en-us/articles/13138701895699-Updating-Workload-Identity-for-Projects) on your cloud provider to expect project information in this claim.
+1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://www.ibm.com/support/pages/node/7265900) on your cloud provider to expect project information in this claim.
 
 ## Deprecations and End of Support
 

--- a/content/terraform-enterprise/v202502-2/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202502-2/docs/enterprise/releases/2023/v202302-1.mdx
@@ -18,11 +18,11 @@ Last required release: [v202207-2 (642)](/terraform/enterprise/releases/2022/v20
 1. Terraform runs remain queued indefinitely when using the `agent` run pipeline mode unless the **Enable agents functionality** checkbox is checked in the [admin interface](/terraform/enterprise/application-administration/admin-access). The logs for `tfe-task-worker` will show `[ERROR] core: Unexpected HTTP response code: method=POST url=https://terraform.example.com/api/agent/register status=404`. This is resolved in Terraform Enterprise v202303-1.
 1. [April 6, 2023] The `tfe-admin node-drain` command does not currently work when the `run_pipeline_mode` configuration setting is set to `agent`. See the notes under the _Highlights_ section for more details regarding this setting. This issue is fixed in the v202305-1 release.
 1. Saving boolean `false` variable values causes 500 errors. This has been fixed in [`v202303-1`](/terraform/enterprise/releases/2023/v202303-1#bug-fixes).
-1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://support.hashicorp.com/hc/en-us/articles/31715716966419-Issue-with-OIDC-Vault-key-rotation-mechanism-to-incorrectly-identify-the-newest-signing-key).
+1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://www.ibm.com/support/pages/node/7265719).
 
 ## Breaking Changes
 
-1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://support.hashicorp.com/hc/en-us/articles/13138701895699-Updating-Workload-Identity-for-Projects) on your cloud provider to expect project information in this claim.
+1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://www.ibm.com/support/pages/node/7265900) on your cloud provider to expect project information in this claim.
 
 ## Deprecations and End of Support
 

--- a/content/terraform-enterprise/v202503-1/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202503-1/docs/enterprise/releases/2023/v202302-1.mdx
@@ -18,11 +18,11 @@ Last required release: [v202207-2 (642)](/terraform/enterprise/releases/2022/v20
 1. Terraform runs remain queued indefinitely when using the `agent` run pipeline mode unless the **Enable agents functionality** checkbox is checked in the [admin interface](/terraform/enterprise/application-administration/admin-access). The logs for `tfe-task-worker` will show `[ERROR] core: Unexpected HTTP response code: method=POST url=https://terraform.example.com/api/agent/register status=404`. This is resolved in Terraform Enterprise v202303-1.
 1. [April 6, 2023] The `tfe-admin node-drain` command does not currently work when the `run_pipeline_mode` configuration setting is set to `agent`. See the notes under the _Highlights_ section for more details regarding this setting. This issue is fixed in the v202305-1 release.
 1. Saving boolean `false` variable values causes 500 errors. This has been fixed in [`v202303-1`](/terraform/enterprise/releases/2023/v202303-1#bug-fixes).
-1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://support.hashicorp.com/hc/en-us/articles/31715716966419-Issue-with-OIDC-Vault-key-rotation-mechanism-to-incorrectly-identify-the-newest-signing-key).
+1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://www.ibm.com/support/pages/node/7265719).
 
 ## Breaking Changes
 
-1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://support.hashicorp.com/hc/en-us/articles/13138701895699-Updating-Workload-Identity-for-Projects) on your cloud provider to expect project information in this claim.
+1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://www.ibm.com/support/pages/node/7265900) on your cloud provider to expect project information in this claim.
 
 ## Deprecations and End of Support
 

--- a/content/terraform-enterprise/v202504-1/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202504-1/docs/enterprise/releases/2023/v202302-1.mdx
@@ -18,11 +18,11 @@ Last required release: [v202207-2 (642)](/terraform/enterprise/releases/2022/v20
 1. Terraform runs remain queued indefinitely when using the `agent` run pipeline mode unless the **Enable agents functionality** checkbox is checked in the [admin interface](/terraform/enterprise/application-administration/admin-access). The logs for `tfe-task-worker` will show `[ERROR] core: Unexpected HTTP response code: method=POST url=https://terraform.example.com/api/agent/register status=404`. This is resolved in Terraform Enterprise v202303-1.
 1. [April 6, 2023] The `tfe-admin node-drain` command does not currently work when the `run_pipeline_mode` configuration setting is set to `agent`. See the notes under the _Highlights_ section for more details regarding this setting. This issue is fixed in the v202305-1 release.
 1. Saving boolean `false` variable values causes 500 errors. This has been fixed in [`v202303-1`](/terraform/enterprise/releases/2023/v202303-1#bug-fixes).
-1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://support.hashicorp.com/hc/en-us/articles/31715716966419-Issue-with-OIDC-Vault-key-rotation-mechanism-to-incorrectly-identify-the-newest-signing-key).
+1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://www.ibm.com/support/pages/node/7265719).
 
 ## Breaking Changes
 
-1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://support.hashicorp.com/hc/en-us/articles/13138701895699-Updating-Workload-Identity-for-Projects) on your cloud provider to expect project information in this claim.
+1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://www.ibm.com/support/pages/node/7265900) on your cloud provider to expect project information in this claim.
 
 ## Deprecations and End of Support
 

--- a/content/terraform-enterprise/v202505-1/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202505-1/docs/enterprise/releases/2023/v202302-1.mdx
@@ -18,11 +18,11 @@ Last required release: [v202207-2 (642)](/terraform/enterprise/releases/2022/v20
 1. Terraform runs remain queued indefinitely when using the `agent` run pipeline mode unless the **Enable agents functionality** checkbox is checked in the [admin interface](/terraform/enterprise/application-administration/admin-access). The logs for `tfe-task-worker` will show `[ERROR] core: Unexpected HTTP response code: method=POST url=https://terraform.example.com/api/agent/register status=404`. This is resolved in Terraform Enterprise v202303-1.
 1. [April 6, 2023] The `tfe-admin node-drain` command does not currently work when the `run_pipeline_mode` configuration setting is set to `agent`. See the notes under the _Highlights_ section for more details regarding this setting. This issue is fixed in the v202305-1 release.
 1. Saving boolean `false` variable values causes 500 errors. This has been fixed in [`v202303-1`](/terraform/enterprise/releases/2023/v202303-1#bug-fixes).
-1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://support.hashicorp.com/hc/en-us/articles/31715716966419-Issue-with-OIDC-Vault-key-rotation-mechanism-to-incorrectly-identify-the-newest-signing-key).
+1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://www.ibm.com/support/pages/node/7265719).
 
 ## Breaking Changes
 
-1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://support.hashicorp.com/hc/en-us/articles/13138701895699-Updating-Workload-Identity-for-Projects) on your cloud provider to expect project information in this claim.
+1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://www.ibm.com/support/pages/node/7265900) on your cloud provider to expect project information in this claim.
 
 ## Deprecations and End of Support
 

--- a/content/terraform-enterprise/v202506-1/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202506-1/docs/enterprise/releases/2023/v202302-1.mdx
@@ -18,11 +18,11 @@ Last required release: [v202207-2 (642)](/terraform/enterprise/releases/2022/v20
 1. Terraform runs remain queued indefinitely when using the `agent` run pipeline mode unless the **Enable agents functionality** checkbox is checked in the [admin interface](/terraform/enterprise/application-administration/admin-access). The logs for `tfe-task-worker` will show `[ERROR] core: Unexpected HTTP response code: method=POST url=https://terraform.example.com/api/agent/register status=404`. This is resolved in Terraform Enterprise v202303-1.
 1. [April 6, 2023] The `tfe-admin node-drain` command does not currently work when the `run_pipeline_mode` configuration setting is set to `agent`. See the notes under the _Highlights_ section for more details regarding this setting. This issue is fixed in the v202305-1 release.
 1. Saving boolean `false` variable values causes 500 errors. This has been fixed in [`v202303-1`](/terraform/enterprise/releases/2023/v202303-1#bug-fixes).
-1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://support.hashicorp.com/hc/en-us/articles/31715716966419-Issue-with-OIDC-Vault-key-rotation-mechanism-to-incorrectly-identify-the-newest-signing-key).
+1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://www.ibm.com/support/pages/node/7265719).
 
 ## Breaking Changes
 
-1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://support.hashicorp.com/hc/en-us/articles/13138701895699-Updating-Workload-Identity-for-Projects) on your cloud provider to expect project information in this claim.
+1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://www.ibm.com/support/pages/node/7265900) on your cloud provider to expect project information in this claim.
 
 ## Deprecations and End of Support
 

--- a/content/terraform-enterprise/v202507-1/docs/enterprise/releases/2023/v202302-1.mdx
+++ b/content/terraform-enterprise/v202507-1/docs/enterprise/releases/2023/v202302-1.mdx
@@ -18,11 +18,11 @@ Last required release: [v202207-2 (642)](/terraform/enterprise/releases/2022/v20
 1. Terraform runs remain queued indefinitely when using the `agent` run pipeline mode unless the **Enable agents functionality** checkbox is checked in the [admin interface](/terraform/enterprise/application-administration/admin-access). The logs for `tfe-task-worker` will show `[ERROR] core: Unexpected HTTP response code: method=POST url=https://terraform.example.com/api/agent/register status=404`. This is resolved in Terraform Enterprise v202303-1.
 1. [April 6, 2023] The `tfe-admin node-drain` command does not currently work when the `run_pipeline_mode` configuration setting is set to `agent`. See the notes under the _Highlights_ section for more details regarding this setting. This issue is fixed in the v202305-1 release.
 1. Saving boolean `false` variable values causes 500 errors. This has been fixed in [`v202303-1`](/terraform/enterprise/releases/2023/v202303-1#bug-fixes).
-1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://support.hashicorp.com/hc/en-us/articles/31715716966419-Issue-with-OIDC-Vault-key-rotation-mechanism-to-incorrectly-identify-the-newest-signing-key).
+1. [Updated August 14, 2024] Runs that rely on dynamic provider credentials and workload identity will fail after a certain number of signing key rotations. This problem is fixed in v202407-1, and you can avoid it by upgrading v202407-1 or above. For details on additional workarounds, including manually trimming keys, refer to [our support article](https://www.ibm.com/support/pages/node/7265719).
 
 ## Breaking Changes
 
-1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://support.hashicorp.com/hc/en-us/articles/13138701895699-Updating-Workload-Identity-for-Projects) on your cloud provider to expect project information in this claim.
+1. The sub claim for workload identity tokens now contains project information. You must [update the trust relationship](https://www.ibm.com/support/pages/node/7265900) on your cloud provider to expect project information in this claim.
 
 ## Deprecations and End of Support
 


### PR DESCRIPTION
## Summary

Replaces legacy HashiCorp support URLs with IBM equivalents across all affected version directories.

| | |
|---|---|
| **Product** | Terraform Enterprise |
| **Document path** | `docs/enterprise/releases/2023/v202302-1.mdx` |
| **Old URL 1** | `https://support.hashicorp.com/hc/en-us/articles/13138701895699-Updating-Workload-Identity-for-Projects` |
| **New URL 1** | `https://www.ibm.com/support/pages/node/7265900` |
| **Old URL 2** | `https://support.hashicorp.com/hc/en-us/articles/31715716966419-Issue-with-OIDC-Vault-key-rotation-mechanism-to-incorrectly-identify-the-newest-signing-key` |
| **New URL 2** | `https://www.ibm.com/support/pages/node/7265719` |
| **Versions updated** | 40 |

Part of the IBM DevDoc KB Remapping effort.