### PR TITLE
docs(tfe): replace support.hashicorp.com link in variables/index.mdx

### DIFF
--- a/content/terraform-enterprise/1.0.x/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/1.0.x/docs/enterprise/workspaces/variables/index.mdx
@@ -34,7 +34,7 @@ Environment variables can store provider credentials and other data. Refer to yo
 
 You can use the `TFE_PARALLELISM` environment variable when your infrastructure providers produce errors on concurrent operations or use non-standard rate limiting. The `TFE_PARALLELISM` variable sets the  `-parallelism=<N>` flag for  `terraform plan` and `terraform apply`  ([more about `parallelism`](/terraform/internals/graph#walking-the-graph)). Valid values are between 1 and 256, inclusive, and the default is `10`. HCP Terraform agents do not support `TFE_PARALLELISM`, but you can specify flags as environment variables directly via [`TF_CLI_ARGS_name`](/terraform/cli/config/environment-variables#tf-cli-args). In these cases, use `TF_CLI_ARGS_plan="-parallelism=<N>"` or `TF_CLI_ARGS_apply="-parallelism=<N>"` instead.
 
-!> **Warning:** We recommend reading and understanding [Terraform parallelism](https://support.hashicorp.com/hc/en-us/articles/10348130482451) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice. 
+!> **Warning:** We recommend reading and understanding [Terraform parallelism](https://www.ibm.com/support/pages/node/7265511) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice. 
 
 #### Dynamic credentials
 

--- a/content/terraform-enterprise/1.1.x/docs/enterprise/variables/index.mdx
+++ b/content/terraform-enterprise/1.1.x/docs/enterprise/variables/index.mdx
@@ -42,7 +42,7 @@ To learn more about accessing environment variable values in Stacks, refer to [V
 
 In workspaces, you can use the `TFE_PARALLELISM` environment variable when your infrastructure providers produce errors on concurrent operations or use non-standard rate limiting. The `TFE_PARALLELISM` variable sets the  `-parallelism=<N>` flag for  `terraform plan` and `terraform apply`  ([more about `parallelism`](/terraform/internals/graph#walking-the-graph)). Valid values are between 1 and 256, inclusive, and the default is `10`. HCP Terraform agents do not support `TFE_PARALLELISM`, but you can specify flags as environment variables directly via [`TF_CLI_ARGS_name`](/terraform/cli/config/environment-variables#tf-cli-args). In these cases, use `TF_CLI_ARGS_plan="-parallelism=<N>"` or `TF_CLI_ARGS_apply="-parallelism=<N>"` instead.
 
-!> **Warning:** We recommend reading and understanding [Terraform parallelism](https://support.hashicorp.com/hc/en-us/articles/10348130482451) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice.
+!> **Warning:** We recommend reading and understanding [Terraform parallelism](https://www.ibm.com/support/pages/node/7265511) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice.
 
 #### Dynamic credentials
 

--- a/content/terraform-enterprise/1.2.x/docs/enterprise/variables/index.mdx
+++ b/content/terraform-enterprise/1.2.x/docs/enterprise/variables/index.mdx
@@ -42,7 +42,7 @@ To learn more about accessing environment variable values in Stacks, refer to [V
 
 In workspaces, you can use the `TFE_PARALLELISM` environment variable when your infrastructure providers produce errors on concurrent operations or use non-standard rate limiting. The `TFE_PARALLELISM` variable sets the  `-parallelism=<N>` flag for  `terraform plan` and `terraform apply`  ([more about `parallelism`](/terraform/internals/graph#walking-the-graph)). Valid values are between 1 and 256, inclusive, and the default is `10`. HCP Terraform agents do not support `TFE_PARALLELISM`, but you can specify flags as environment variables directly via [`TF_CLI_ARGS_name`](/terraform/cli/config/environment-variables#tf-cli-args). In these cases, use `TF_CLI_ARGS_plan="-parallelism=<N>"` or `TF_CLI_ARGS_apply="-parallelism=<N>"` instead.
 
-!> **Warning:** We recommend reading and understanding [Terraform parallelism](https://support.hashicorp.com/hc/en-us/articles/10348130482451) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice.
+!> **Warning:** We recommend reading and understanding [Terraform parallelism](https://www.ibm.com/support/pages/node/7265511) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice.
 
 #### Dynamic credentials
 

--- a/content/terraform-enterprise/2.0.x/docs/enterprise/variables/index.mdx
+++ b/content/terraform-enterprise/2.0.x/docs/enterprise/variables/index.mdx
@@ -38,7 +38,7 @@ To learn more about accessing environment variable values in Stacks, refer to [V
 
 In workspaces, you can use the `TFE_PARALLELISM` environment variable when your infrastructure providers produce errors on concurrent operations or use non-standard rate limiting. The `TFE_PARALLELISM` variable sets the  `-parallelism=<N>` flag for  `terraform plan` and `terraform apply`  ([more about `parallelism`](/terraform/internals/graph#walking-the-graph)). Valid values are between 1 and 256, inclusive, and the default is `10`. HCP Terraform agents do not support `TFE_PARALLELISM`, but you can specify flags as environment variables directly via [`TF_CLI_ARGS_name`](/terraform/cli/config/environment-variables#tf-cli-args). In these cases, use `TF_CLI_ARGS_plan="-parallelism=<N>"` or `TF_CLI_ARGS_apply="-parallelism=<N>"` instead.
 
-!> **Warning:** We recommend reading and understanding [Terraform parallelism](https://support.hashicorp.com/hc/en-us/articles/10348130482451) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice.
+!> **Warning:** We recommend reading and understanding [Terraform parallelism](https://www.ibm.com/support/pages/node/7265511) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice.
 
 #### Dynamic credentials
 

--- a/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202404-2/docs/enterprise/workspaces/variables/index.mdx
@@ -34,7 +34,7 @@ Environment variables can store provider credentials and other data. Refer to yo
 
 You can use the `TFE_PARALLELISM` environment variable when your infrastructure providers produce errors on concurrent operations or use non-standard rate limiting. The `TFE_PARALLELISM` variable sets the  `-parallelism=<N>` flag for  `terraform plan` and `terraform apply`  ([more about `parallelism`](/terraform/internals/graph#walking-the-graph)). Valid values are between 1 and 256, inclusive, and the default is `10`. HCP Terraform agents do not support `TFE_PARALLELISM`, but you can specify flags as environment variables directly via [`TF_CLI_ARGS_name`](/terraform/cli/config/environment-variables#tf-cli-args). In these cases, use `TF_CLI_ARGS_plan="-parallelism=<N>"` or `TF_CLI_ARGS_apply="-parallelism=<N>"` instead.
 
-!> **Warning:** We recommend reading and understanding [Terraform parallelism](https://support.hashicorp.com/hc/en-us/articles/10348130482451) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice. 
+!> **Warning:** We recommend reading and understanding [Terraform parallelism](https://www.ibm.com/support/pages/node/7265511) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice. 
 
 #### Dynamic Credentials
 

--- a/content/terraform-enterprise/v202406-1/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202406-1/docs/enterprise/workspaces/variables/index.mdx
@@ -34,7 +34,7 @@ Environment variables can store provider credentials and other data. Refer to yo
 
 You can use the `TFE_PARALLELISM` environment variable when your infrastructure providers produce errors on concurrent operations or use non-standard rate limiting. The `TFE_PARALLELISM` variable sets the  `-parallelism=<N>` flag for  `terraform plan` and `terraform apply`  ([more about `parallelism`](/terraform/internals/graph#walking-the-graph)). Valid values are between 1 and 256, inclusive, and the default is `10`. HCP Terraform agents do not support `TFE_PARALLELISM`, but you can specify flags as environment variables directly via [`TF_CLI_ARGS_name`](/terraform/cli/config/environment-variables#tf-cli-args). In these cases, use `TF_CLI_ARGS_plan="-parallelism=<N>"` or `TF_CLI_ARGS_apply="-parallelism=<N>"` instead.
 
-!> **Warning:** We recommend reading and understanding [Terraform parallelism](https://support.hashicorp.com/hc/en-us/articles/10348130482451) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice. 
+!> **Warning:** We recommend reading and understanding [Terraform parallelism](https://www.ibm.com/support/pages/node/7265511) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice. 
 
 #### Dynamic Credentials
 

--- a/content/terraform-enterprise/v202407-1/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202407-1/docs/enterprise/workspaces/variables/index.mdx
@@ -34,7 +34,7 @@ Environment variables can store provider credentials and other data. Refer to yo
 
 You can use the `TFE_PARALLELISM` environment variable when your infrastructure providers produce errors on concurrent operations or use non-standard rate limiting. The `TFE_PARALLELISM` variable sets the  `-parallelism=<N>` flag for  `terraform plan` and `terraform apply`  ([more about `parallelism`](/terraform/internals/graph#walking-the-graph)). Valid values are between 1 and 256, inclusive, and the default is `10`. HCP Terraform agents do not support `TFE_PARALLELISM`, but you can specify flags as environment variables directly via [`TF_CLI_ARGS_name`](/terraform/cli/config/environment-variables#tf-cli-args). In these cases, use `TF_CLI_ARGS_plan="-parallelism=<N>"` or `TF_CLI_ARGS_apply="-parallelism=<N>"` instead.
 
-!> **Warning:** We recommend reading and understanding [Terraform parallelism](https://support.hashicorp.com/hc/en-us/articles/10348130482451) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice. 
+!> **Warning:** We recommend reading and understanding [Terraform parallelism](https://www.ibm.com/support/pages/node/7265511) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice. 
 
 #### Dynamic Credentials
 

--- a/content/terraform-enterprise/v202408-1/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202408-1/docs/enterprise/workspaces/variables/index.mdx
@@ -34,7 +34,7 @@ Environment variables can store provider credentials and other data. Refer to yo
 
 You can use the `TFE_PARALLELISM` environment variable when your infrastructure providers produce errors on concurrent operations or use non-standard rate limiting. The `TFE_PARALLELISM` variable sets the  `-parallelism=<N>` flag for  `terraform plan` and `terraform apply`  ([more about `parallelism`](/terraform/internals/graph#walking-the-graph)). Valid values are between 1 and 256, inclusive, and the default is `10`. HCP Terraform agents do not support `TFE_PARALLELISM`, but you can specify flags as environment variables directly via [`TF_CLI_ARGS_name`](/terraform/cli/config/environment-variables#tf-cli-args). In these cases, use `TF_CLI_ARGS_plan="-parallelism=<N>"` or `TF_CLI_ARGS_apply="-parallelism=<N>"` instead.
 
-!> **Warning:** We recommend reading and understanding [Terraform parallelism](https://support.hashicorp.com/hc/en-us/articles/10348130482451) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice. 
+!> **Warning:** We recommend reading and understanding [Terraform parallelism](https://www.ibm.com/support/pages/node/7265511) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice. 
 
 #### Dynamic Credentials
 

--- a/content/terraform-enterprise/v202409-1/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202409-1/docs/enterprise/workspaces/variables/index.mdx
@@ -34,7 +34,7 @@ Environment variables can store provider credentials and other data. Refer to yo
 
 You can use the `TFE_PARALLELISM` environment variable when your infrastructure providers produce errors on concurrent operations or use non-standard rate limiting. The `TFE_PARALLELISM` variable sets the  `-parallelism=<N>` flag for  `terraform plan` and `terraform apply`  ([more about `parallelism`](/terraform/internals/graph#walking-the-graph)). Valid values are between 1 and 256, inclusive, and the default is `10`. HCP Terraform agents do not support `TFE_PARALLELISM`, but you can specify flags as environment variables directly via [`TF_CLI_ARGS_name`](/terraform/cli/config/environment-variables#tf-cli-args). In these cases, use `TF_CLI_ARGS_plan="-parallelism=<N>"` or `TF_CLI_ARGS_apply="-parallelism=<N>"` instead.
 
-!> **Warning:** We recommend reading and understanding [Terraform parallelism](https://support.hashicorp.com/hc/en-us/articles/10348130482451) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice. 
+!> **Warning:** We recommend reading and understanding [Terraform parallelism](https://www.ibm.com/support/pages/node/7265511) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice. 
 
 #### Dynamic Credentials
 

--- a/content/terraform-enterprise/v202409-2/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202409-2/docs/enterprise/workspaces/variables/index.mdx
@@ -34,7 +34,7 @@ Environment variables can store provider credentials and other data. Refer to yo
 
 You can use the `TFE_PARALLELISM` environment variable when your infrastructure providers produce errors on concurrent operations or use non-standard rate limiting. The `TFE_PARALLELISM` variable sets the  `-parallelism=<N>` flag for  `terraform plan` and `terraform apply`  ([more about `parallelism`](/terraform/internals/graph#walking-the-graph)). Valid values are between 1 and 256, inclusive, and the default is `10`. HCP Terraform agents do not support `TFE_PARALLELISM`, but you can specify flags as environment variables directly via [`TF_CLI_ARGS_name`](/terraform/cli/config/environment-variables#tf-cli-args). In these cases, use `TF_CLI_ARGS_plan="-parallelism=<N>"` or `TF_CLI_ARGS_apply="-parallelism=<N>"` instead.
 
-!> **Warning:** We recommend reading and understanding [Terraform parallelism](https://support.hashicorp.com/hc/en-us/articles/10348130482451) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice. 
+!> **Warning:** We recommend reading and understanding [Terraform parallelism](https://www.ibm.com/support/pages/node/7265511) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice. 
 
 #### Dynamic Credentials
 

--- a/content/terraform-enterprise/v202409-3/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202409-3/docs/enterprise/workspaces/variables/index.mdx
@@ -34,7 +34,7 @@ Environment variables can store provider credentials and other data. Refer to yo
 
 You can use the `TFE_PARALLELISM` environment variable when your infrastructure providers produce errors on concurrent operations or use non-standard rate limiting. The `TFE_PARALLELISM` variable sets the  `-parallelism=<N>` flag for  `terraform plan` and `terraform apply`  ([more about `parallelism`](/terraform/internals/graph#walking-the-graph)). Valid values are between 1 and 256, inclusive, and the default is `10`. HCP Terraform agents do not support `TFE_PARALLELISM`, but you can specify flags as environment variables directly via [`TF_CLI_ARGS_name`](/terraform/cli/config/environment-variables#tf-cli-args). In these cases, use `TF_CLI_ARGS_plan="-parallelism=<N>"` or `TF_CLI_ARGS_apply="-parallelism=<N>"` instead.
 
-!> **Warning:** We recommend reading and understanding [Terraform parallelism](https://support.hashicorp.com/hc/en-us/articles/10348130482451) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice. 
+!> **Warning:** We recommend reading and understanding [Terraform parallelism](https://www.ibm.com/support/pages/node/7265511) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice. 
 
 #### Dynamic Credentials
 

--- a/content/terraform-enterprise/v202410-1/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202410-1/docs/enterprise/workspaces/variables/index.mdx
@@ -34,7 +34,7 @@ Environment variables can store provider credentials and other data. Refer to yo
 
 You can use the `TFE_PARALLELISM` environment variable when your infrastructure providers produce errors on concurrent operations or use non-standard rate limiting. The `TFE_PARALLELISM` variable sets the  `-parallelism=<N>` flag for  `terraform plan` and `terraform apply`  ([more about `parallelism`](/terraform/internals/graph#walking-the-graph)). Valid values are between 1 and 256, inclusive, and the default is `10`. HCP Terraform agents do not support `TFE_PARALLELISM`, but you can specify flags as environment variables directly via [`TF_CLI_ARGS_name`](/terraform/cli/config/environment-variables#tf-cli-args). In these cases, use `TF_CLI_ARGS_plan="-parallelism=<N>"` or `TF_CLI_ARGS_apply="-parallelism=<N>"` instead.
 
-!> **Warning:** We recommend reading and understanding [Terraform parallelism](https://support.hashicorp.com/hc/en-us/articles/10348130482451) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice. 
+!> **Warning:** We recommend reading and understanding [Terraform parallelism](https://www.ibm.com/support/pages/node/7265511) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice. 
 
 #### Dynamic Credentials
 

--- a/content/terraform-enterprise/v202411-1/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202411-1/docs/enterprise/workspaces/variables/index.mdx
@@ -34,7 +34,7 @@ Environment variables can store provider credentials and other data. Refer to yo
 
 You can use the `TFE_PARALLELISM` environment variable when your infrastructure providers produce errors on concurrent operations or use non-standard rate limiting. The `TFE_PARALLELISM` variable sets the  `-parallelism=<N>` flag for  `terraform plan` and `terraform apply`  ([more about `parallelism`](/terraform/internals/graph#walking-the-graph)). Valid values are between 1 and 256, inclusive, and the default is `10`. HCP Terraform agents do not support `TFE_PARALLELISM`, but you can specify flags as environment variables directly via [`TF_CLI_ARGS_name`](/terraform/cli/config/environment-variables#tf-cli-args). In these cases, use `TF_CLI_ARGS_plan="-parallelism=<N>"` or `TF_CLI_ARGS_apply="-parallelism=<N>"` instead.
 
-!> **Warning:** We recommend reading and understanding [Terraform parallelism](https://support.hashicorp.com/hc/en-us/articles/10348130482451) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice. 
+!> **Warning:** We recommend reading and understanding [Terraform parallelism](https://www.ibm.com/support/pages/node/7265511) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice. 
 
 #### Dynamic Credentials
 

--- a/content/terraform-enterprise/v202411-2/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202411-2/docs/enterprise/workspaces/variables/index.mdx
@@ -34,7 +34,7 @@ Environment variables can store provider credentials and other data. Refer to yo
 
 You can use the `TFE_PARALLELISM` environment variable when your infrastructure providers produce errors on concurrent operations or use non-standard rate limiting. The `TFE_PARALLELISM` variable sets the  `-parallelism=<N>` flag for  `terraform plan` and `terraform apply`  ([more about `parallelism`](/terraform/internals/graph#walking-the-graph)). Valid values are between 1 and 256, inclusive, and the default is `10`. HCP Terraform agents do not support `TFE_PARALLELISM`, but you can specify flags as environment variables directly via [`TF_CLI_ARGS_name`](/terraform/cli/config/environment-variables#tf-cli-args). In these cases, use `TF_CLI_ARGS_plan="-parallelism=<N>"` or `TF_CLI_ARGS_apply="-parallelism=<N>"` instead.
 
-!> **Warning:** We recommend reading and understanding [Terraform parallelism](https://support.hashicorp.com/hc/en-us/articles/10348130482451) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice. 
+!> **Warning:** We recommend reading and understanding [Terraform parallelism](https://www.ibm.com/support/pages/node/7265511) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice. 
 
 #### Dynamic Credentials
 

--- a/content/terraform-enterprise/v202501-1/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202501-1/docs/enterprise/workspaces/variables/index.mdx
@@ -34,7 +34,7 @@ Environment variables can store provider credentials and other data. Refer to yo
 
 You can use the `TFE_PARALLELISM` environment variable when your infrastructure providers produce errors on concurrent operations or use non-standard rate limiting. The `TFE_PARALLELISM` variable sets the  `-parallelism=<N>` flag for  `terraform plan` and `terraform apply`  ([more about `parallelism`](/terraform/internals/graph#walking-the-graph)). Valid values are between 1 and 256, inclusive, and the default is `10`. HCP Terraform agents do not support `TFE_PARALLELISM`, but you can specify flags as environment variables directly via [`TF_CLI_ARGS_name`](/terraform/cli/config/environment-variables#tf-cli-args). In these cases, use `TF_CLI_ARGS_plan="-parallelism=<N>"` or `TF_CLI_ARGS_apply="-parallelism=<N>"` instead.
 
-!> **Warning:** We recommend reading and understanding [Terraform parallelism](https://support.hashicorp.com/hc/en-us/articles/10348130482451) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice. 
+!> **Warning:** We recommend reading and understanding [Terraform parallelism](https://www.ibm.com/support/pages/node/7265511) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice. 
 
 #### Dynamic credentials
 

--- a/content/terraform-enterprise/v202502-1/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202502-1/docs/enterprise/workspaces/variables/index.mdx
@@ -34,7 +34,7 @@ Environment variables can store provider credentials and other data. Refer to yo
 
 You can use the `TFE_PARALLELISM` environment variable when your infrastructure providers produce errors on concurrent operations or use non-standard rate limiting. The `TFE_PARALLELISM` variable sets the  `-parallelism=<N>` flag for  `terraform plan` and `terraform apply`  ([more about `parallelism`](/terraform/internals/graph#walking-the-graph)). Valid values are between 1 and 256, inclusive, and the default is `10`. HCP Terraform agents do not support `TFE_PARALLELISM`, but you can specify flags as environment variables directly via [`TF_CLI_ARGS_name`](/terraform/cli/config/environment-variables#tf-cli-args). In these cases, use `TF_CLI_ARGS_plan="-parallelism=<N>"` or `TF_CLI_ARGS_apply="-parallelism=<N>"` instead.
 
-!> **Warning:** We recommend reading and understanding [Terraform parallelism](https://support.hashicorp.com/hc/en-us/articles/10348130482451) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice. 
+!> **Warning:** We recommend reading and understanding [Terraform parallelism](https://www.ibm.com/support/pages/node/7265511) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice. 
 
 #### Dynamic credentials
 

--- a/content/terraform-enterprise/v202502-2/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202502-2/docs/enterprise/workspaces/variables/index.mdx
@@ -34,7 +34,7 @@ Environment variables can store provider credentials and other data. Refer to yo
 
 You can use the `TFE_PARALLELISM` environment variable when your infrastructure providers produce errors on concurrent operations or use non-standard rate limiting. The `TFE_PARALLELISM` variable sets the  `-parallelism=<N>` flag for  `terraform plan` and `terraform apply`  ([more about `parallelism`](/terraform/internals/graph#walking-the-graph)). Valid values are between 1 and 256, inclusive, and the default is `10`. HCP Terraform agents do not support `TFE_PARALLELISM`, but you can specify flags as environment variables directly via [`TF_CLI_ARGS_name`](/terraform/cli/config/environment-variables#tf-cli-args). In these cases, use `TF_CLI_ARGS_plan="-parallelism=<N>"` or `TF_CLI_ARGS_apply="-parallelism=<N>"` instead.
 
-!> **Warning:** We recommend reading and understanding [Terraform parallelism](https://support.hashicorp.com/hc/en-us/articles/10348130482451) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice. 
+!> **Warning:** We recommend reading and understanding [Terraform parallelism](https://www.ibm.com/support/pages/node/7265511) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice. 
 
 #### Dynamic credentials
 

--- a/content/terraform-enterprise/v202503-1/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202503-1/docs/enterprise/workspaces/variables/index.mdx
@@ -34,7 +34,7 @@ Environment variables can store provider credentials and other data. Refer to yo
 
 You can use the `TFE_PARALLELISM` environment variable when your infrastructure providers produce errors on concurrent operations or use non-standard rate limiting. The `TFE_PARALLELISM` variable sets the  `-parallelism=<N>` flag for  `terraform plan` and `terraform apply`  ([more about `parallelism`](/terraform/internals/graph#walking-the-graph)). Valid values are between 1 and 256, inclusive, and the default is `10`. HCP Terraform agents do not support `TFE_PARALLELISM`, but you can specify flags as environment variables directly via [`TF_CLI_ARGS_name`](/terraform/cli/config/environment-variables#tf-cli-args). In these cases, use `TF_CLI_ARGS_plan="-parallelism=<N>"` or `TF_CLI_ARGS_apply="-parallelism=<N>"` instead.
 
-!> **Warning:** We recommend reading and understanding [Terraform parallelism](https://support.hashicorp.com/hc/en-us/articles/10348130482451) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice. 
+!> **Warning:** We recommend reading and understanding [Terraform parallelism](https://www.ibm.com/support/pages/node/7265511) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice. 
 
 #### Dynamic credentials
 

--- a/content/terraform-enterprise/v202504-1/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202504-1/docs/enterprise/workspaces/variables/index.mdx
@@ -34,7 +34,7 @@ Environment variables can store provider credentials and other data. Refer to yo
 
 You can use the `TFE_PARALLELISM` environment variable when your infrastructure providers produce errors on concurrent operations or use non-standard rate limiting. The `TFE_PARALLELISM` variable sets the  `-parallelism=<N>` flag for  `terraform plan` and `terraform apply`  ([more about `parallelism`](/terraform/internals/graph#walking-the-graph)). Valid values are between 1 and 256, inclusive, and the default is `10`. HCP Terraform agents do not support `TFE_PARALLELISM`, but you can specify flags as environment variables directly via [`TF_CLI_ARGS_name`](/terraform/cli/config/environment-variables#tf-cli-args). In these cases, use `TF_CLI_ARGS_plan="-parallelism=<N>"` or `TF_CLI_ARGS_apply="-parallelism=<N>"` instead.
 
-!> **Warning:** We recommend reading and understanding [Terraform parallelism](https://support.hashicorp.com/hc/en-us/articles/10348130482451) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice. 
+!> **Warning:** We recommend reading and understanding [Terraform parallelism](https://www.ibm.com/support/pages/node/7265511) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice. 
 
 #### Dynamic credentials
 

--- a/content/terraform-enterprise/v202505-1/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202505-1/docs/enterprise/workspaces/variables/index.mdx
@@ -34,7 +34,7 @@ Environment variables can store provider credentials and other data. Refer to yo
 
 You can use the `TFE_PARALLELISM` environment variable when your infrastructure providers produce errors on concurrent operations or use non-standard rate limiting. The `TFE_PARALLELISM` variable sets the  `-parallelism=<N>` flag for  `terraform plan` and `terraform apply`  ([more about `parallelism`](/terraform/internals/graph#walking-the-graph)). Valid values are between 1 and 256, inclusive, and the default is `10`. HCP Terraform agents do not support `TFE_PARALLELISM`, but you can specify flags as environment variables directly via [`TF_CLI_ARGS_name`](/terraform/cli/config/environment-variables#tf-cli-args). In these cases, use `TF_CLI_ARGS_plan="-parallelism=<N>"` or `TF_CLI_ARGS_apply="-parallelism=<N>"` instead.
 
-!> **Warning:** We recommend reading and understanding [Terraform parallelism](https://support.hashicorp.com/hc/en-us/articles/10348130482451) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice. 
+!> **Warning:** We recommend reading and understanding [Terraform parallelism](https://www.ibm.com/support/pages/node/7265511) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice. 
 
 #### Dynamic credentials
 

--- a/content/terraform-enterprise/v202506-1/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202506-1/docs/enterprise/workspaces/variables/index.mdx
@@ -34,7 +34,7 @@ Environment variables can store provider credentials and other data. Refer to yo
 
 You can use the `TFE_PARALLELISM` environment variable when your infrastructure providers produce errors on concurrent operations or use non-standard rate limiting. The `TFE_PARALLELISM` variable sets the  `-parallelism=<N>` flag for  `terraform plan` and `terraform apply`  ([more about `parallelism`](/terraform/internals/graph#walking-the-graph)). Valid values are between 1 and 256, inclusive, and the default is `10`. HCP Terraform agents do not support `TFE_PARALLELISM`, but you can specify flags as environment variables directly via [`TF_CLI_ARGS_name`](/terraform/cli/config/environment-variables#tf-cli-args). In these cases, use `TF_CLI_ARGS_plan="-parallelism=<N>"` or `TF_CLI_ARGS_apply="-parallelism=<N>"` instead.
 
-!> **Warning:** We recommend reading and understanding [Terraform parallelism](https://support.hashicorp.com/hc/en-us/articles/10348130482451) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice. 
+!> **Warning:** We recommend reading and understanding [Terraform parallelism](https://www.ibm.com/support/pages/node/7265511) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice. 
 
 #### Dynamic credentials
 

--- a/content/terraform-enterprise/v202507-1/docs/enterprise/workspaces/variables/index.mdx
+++ b/content/terraform-enterprise/v202507-1/docs/enterprise/workspaces/variables/index.mdx
@@ -34,7 +34,7 @@ Environment variables can store provider credentials and other data. Refer to yo
 
 You can use the `TFE_PARALLELISM` environment variable when your infrastructure providers produce errors on concurrent operations or use non-standard rate limiting. The `TFE_PARALLELISM` variable sets the  `-parallelism=<N>` flag for  `terraform plan` and `terraform apply`  ([more about `parallelism`](/terraform/internals/graph#walking-the-graph)). Valid values are between 1 and 256, inclusive, and the default is `10`. HCP Terraform agents do not support `TFE_PARALLELISM`, but you can specify flags as environment variables directly via [`TF_CLI_ARGS_name`](/terraform/cli/config/environment-variables#tf-cli-args). In these cases, use `TF_CLI_ARGS_plan="-parallelism=<N>"` or `TF_CLI_ARGS_apply="-parallelism=<N>"` instead.
 
-!> **Warning:** We recommend reading and understanding [Terraform parallelism](https://support.hashicorp.com/hc/en-us/articles/10348130482451) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice. 
+!> **Warning:** We recommend reading and understanding [Terraform parallelism](https://www.ibm.com/support/pages/node/7265511) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice. 
 
 #### Dynamic credentials
 


### PR DESCRIPTION
## Summary

Replaces legacy HashiCorp support URL with IBM equivalent across all affected version directories.

| | |
|---|---|
| **Product** | Terraform Enterprise |
| **Document paths** | `docs/enterprise/variables/index.mdx`<br>`docs/enterprise/workspaces/variables/index.mdx` |
| **Old URL** | `https://support.hashicorp.com/hc/en-us/articles/10348130482451` |
| **New URL** | `https://www.ibm.com/support/pages/node/7265511` |
| **Versions updated** | 22 |

Part of the IBM DevDoc KB Remapping effort.