### PR TITLE
docs(packer): replace support.hashicorp.com links in HCP Packer datasource and registry docs

### DIFF
--- a/content/packer/v1.10.x/content/docs/datasources/hcp/hcp-packer-artifact.mdx
+++ b/content/packer/v1.10.x/content/docs/datasources/hcp/hcp-packer-artifact.mdx
@@ -28,7 +28,7 @@ the [Get Started with HCP Packer tutorials](/packer/tutorials/hcp-get-started).
 
 ~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry.
 An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries
-with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
+with billing issues. Contact [HashiCorp Support](https://www.ibm.com/mysupport) with questions.
 
 ## Revoked Versions
 

--- a/content/packer/v1.10.x/content/docs/datasources/hcp/hcp-packer-image.mdx
+++ b/content/packer/v1.10.x/content/docs/datasources/hcp/hcp-packer-image.mdx
@@ -27,7 +27,7 @@ provide a source image to various Packer builders.
 
 To get started with HCP Packer, refer to the [HCP Packer documentation](/hcp/docs/packer) or try the [Get Started with HCP Packer tutorials](/packer/tutorials/hcp-get-started).
 
-~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
+~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://www.ibm.com/mysupport) with questions.
 
 ## Revoked Iterations
 

--- a/content/packer/v1.10.x/content/docs/datasources/hcp/hcp-packer-iteration.mdx
+++ b/content/packer/v1.10.x/content/docs/datasources/hcp/hcp-packer-iteration.mdx
@@ -27,7 +27,7 @@ HCP for a source image for various Packer builders.
 
 To get started with HCP Packer, refer to the [HCP Packer documentation](/hcp/docs/packer) or try the [Get Started with HCP Packer tutorials](/packer/tutorials/hcp-get-started).
 
-~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
+~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://www.ibm.com/mysupport) with questions.
 
 ## Revoked Iterations
 

--- a/content/packer/v1.10.x/content/docs/datasources/hcp/hcp-packer-version.mdx
+++ b/content/packer/v1.10.x/content/docs/datasources/hcp/hcp-packer-version.mdx
@@ -28,7 +28,7 @@ To get started with HCP Packer, refer to the [HCP Packer documentation](/hcp/doc
 
 ~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry.
 An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries
-with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
+with billing issues. Contact [HashiCorp Support](https://www.ibm.com/mysupport) with questions.
 
 ## Revoked Versions
 

--- a/content/packer/v1.10.x/content/docs/templates/hcl_templates/blocks/build/hcp_packer_registry.mdx
+++ b/content/packer/v1.10.x/content/docs/templates/hcl_templates/blocks/build/hcp_packer_registry.mdx
@@ -26,7 +26,7 @@ registry if the appropriate HCP credentials are set (`HCP_CLIENT_ID` and
 and exit immediately to avoid any potential artifact drift between the defined
 builders (source blocks) and the HCP Packer registry.
 
-~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
+~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://www.ibm.com/mysupport) with questions.
 
 ```hcl
 # file: builds.pkr.hcl

--- a/content/packer/v1.11.x/content/docs/datasources/hcp/hcp-packer-artifact.mdx
+++ b/content/packer/v1.11.x/content/docs/datasources/hcp/hcp-packer-artifact.mdx
@@ -28,7 +28,7 @@ the [Get Started with HCP Packer tutorials](/packer/tutorials/hcp-get-started).
 
 ~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry.
 An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries
-with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
+with billing issues. Contact [HashiCorp Support](https://www.ibm.com/mysupport) with questions.
 
 ## Revoked Versions
 

--- a/content/packer/v1.11.x/content/docs/datasources/hcp/hcp-packer-image.mdx
+++ b/content/packer/v1.11.x/content/docs/datasources/hcp/hcp-packer-image.mdx
@@ -27,7 +27,7 @@ provide a source image to various Packer builders.
 
 To get started with HCP Packer, refer to the [HCP Packer documentation](/hcp/docs/packer) or try the [Get Started with HCP Packer tutorials](/packer/tutorials/hcp-get-started).
 
-~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
+~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://www.ibm.com/mysupport) with questions.
 
 ## Revoked Iterations
 

--- a/content/packer/v1.11.x/content/docs/datasources/hcp/hcp-packer-iteration.mdx
+++ b/content/packer/v1.11.x/content/docs/datasources/hcp/hcp-packer-iteration.mdx
@@ -27,7 +27,7 @@ HCP for a source image for various Packer builders.
 
 To get started with HCP Packer, refer to the [HCP Packer documentation](/hcp/docs/packer) or try the [Get Started with HCP Packer tutorials](/packer/tutorials/hcp-get-started).
 
-~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
+~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://www.ibm.com/mysupport) with questions.
 
 ## Revoked Iterations
 

--- a/content/packer/v1.11.x/content/docs/datasources/hcp/hcp-packer-version.mdx
+++ b/content/packer/v1.11.x/content/docs/datasources/hcp/hcp-packer-version.mdx
@@ -28,7 +28,7 @@ To get started with HCP Packer, refer to the [HCP Packer documentation](/hcp/doc
 
 ~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry.
 An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries
-with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
+with billing issues. Contact [HashiCorp Support](https://www.ibm.com/mysupport) with questions.
 
 ## Revoked Versions
 

--- a/content/packer/v1.11.x/content/docs/templates/hcl_templates/blocks/build/hcp_packer_registry.mdx
+++ b/content/packer/v1.11.x/content/docs/templates/hcl_templates/blocks/build/hcp_packer_registry.mdx
@@ -26,7 +26,7 @@ registry if the appropriate HCP credentials are set (`HCP_CLIENT_ID` and
 and exit immediately to avoid any potential artifact drift between the defined
 builders (source blocks) and the HCP Packer registry.
 
-~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
+~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://www.ibm.com/mysupport) with questions.
 
 ```hcl
 # file: builds.pkr.hcl

--- a/content/packer/v1.12.x/content/docs/datasources/hcp/hcp-packer-artifact.mdx
+++ b/content/packer/v1.12.x/content/docs/datasources/hcp/hcp-packer-artifact.mdx
@@ -25,7 +25,7 @@ the [Get Started with HCP Packer tutorials](/packer/tutorials/hcp-get-started).
 
 ~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry.
 An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries
-with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
+with billing issues. Contact [HashiCorp Support](https://www.ibm.com/mysupport) with questions.
 
 ## Revoked Versions
 

--- a/content/packer/v1.12.x/content/docs/datasources/hcp/hcp-packer-image.mdx
+++ b/content/packer/v1.12.x/content/docs/datasources/hcp/hcp-packer-image.mdx
@@ -22,7 +22,7 @@ provide a source image to various Packer builders.
 
 To get started with HCP Packer, refer to the [HCP Packer documentation](/hcp/docs/packer) or try the [Get Started with HCP Packer tutorials](/packer/tutorials/hcp-get-started).
 
-~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
+~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://www.ibm.com/mysupport) with questions.
 
 ## Revoked Iterations
 

--- a/content/packer/v1.12.x/content/docs/datasources/hcp/hcp-packer-iteration.mdx
+++ b/content/packer/v1.12.x/content/docs/datasources/hcp/hcp-packer-iteration.mdx
@@ -22,7 +22,7 @@ HCP for a source image for various Packer builders.
 
 To get started with HCP Packer, refer to the [HCP Packer documentation](/hcp/docs/packer) or try the [Get Started with HCP Packer tutorials](/packer/tutorials/hcp-get-started).
 
-~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
+~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://www.ibm.com/mysupport) with questions.
 
 ## Revoked Iterations
 

--- a/content/packer/v1.12.x/content/docs/datasources/hcp/hcp-packer-version.mdx
+++ b/content/packer/v1.12.x/content/docs/datasources/hcp/hcp-packer-version.mdx
@@ -25,7 +25,7 @@ To get started with HCP Packer, refer to the [HCP Packer documentation](/hcp/doc
 [Get Started with HCP Packer tutorials](/packer/tutorials/hcp-get-started).
 
 Packer prints an error if you try to reference metadata from a deactivated or deleted registry.
-An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
+An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://www.ibm.com/mysupport) with questions.
 
 ## Revoked Versions
 

--- a/content/packer/v1.12.x/content/docs/templates/hcl_templates/blocks/build/hcp_packer_registry.mdx
+++ b/content/packer/v1.12.x/content/docs/templates/hcl_templates/blocks/build/hcp_packer_registry.mdx
@@ -29,7 +29,7 @@ registry if the appropriate HCP credentials are set (`HCP_CLIENT_ID` and
 and exit immediately to avoid any potential artifact drift between the defined
 builders (source blocks) and the HCP Packer registry.
 
-~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
+~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://www.ibm.com/mysupport) with questions.
 
 ```hcl
 # file: builds.pkr.hcl

--- a/content/packer/v1.13.x/content/docs/datasources/hcp/hcp-packer-artifact.mdx
+++ b/content/packer/v1.13.x/content/docs/datasources/hcp/hcp-packer-artifact.mdx
@@ -25,7 +25,7 @@ the [Get Started with HCP Packer tutorials](/packer/tutorials/hcp-get-started).
 
 ~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry.
 An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries
-with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
+with billing issues. Contact [HashiCorp Support](https://www.ibm.com/mysupport) with questions.
 
 ## Revoked Versions
 

--- a/content/packer/v1.13.x/content/docs/datasources/hcp/hcp-packer-image.mdx
+++ b/content/packer/v1.13.x/content/docs/datasources/hcp/hcp-packer-image.mdx
@@ -22,7 +22,7 @@ provide a source image to various Packer builders.
 
 To get started with HCP Packer, refer to the [HCP Packer documentation](/hcp/docs/packer) or try the [Get Started with HCP Packer tutorials](/packer/tutorials/hcp-get-started).
 
-~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
+~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://www.ibm.com/mysupport) with questions.
 
 ## Revoked Iterations
 

--- a/content/packer/v1.13.x/content/docs/datasources/hcp/hcp-packer-iteration.mdx
+++ b/content/packer/v1.13.x/content/docs/datasources/hcp/hcp-packer-iteration.mdx
@@ -22,7 +22,7 @@ HCP for a source image for various Packer builders.
 
 To get started with HCP Packer, refer to the [HCP Packer documentation](/hcp/docs/packer) or try the [Get Started with HCP Packer tutorials](/packer/tutorials/hcp-get-started).
 
-~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
+~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://www.ibm.com/mysupport) with questions.
 
 ## Revoked Iterations
 

--- a/content/packer/v1.13.x/content/docs/datasources/hcp/hcp-packer-version.mdx
+++ b/content/packer/v1.13.x/content/docs/datasources/hcp/hcp-packer-version.mdx
@@ -25,7 +25,7 @@ To get started with HCP Packer, refer to the [HCP Packer documentation](/hcp/doc
 [Get Started with HCP Packer tutorials](/packer/tutorials/hcp-get-started).
 
 Packer prints an error if you try to reference metadata from a deactivated or deleted registry.
-An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
+An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://www.ibm.com/mysupport) with questions.
 
 ## Revoked Versions
 

--- a/content/packer/v1.13.x/content/docs/templates/hcl_templates/blocks/build/hcp_packer_registry.mdx
+++ b/content/packer/v1.13.x/content/docs/templates/hcl_templates/blocks/build/hcp_packer_registry.mdx
@@ -29,7 +29,7 @@ registry if the appropriate HCP credentials are set (`HCP_CLIENT_ID` and
 and exit immediately to avoid any potential artifact drift between the defined
 builders (source blocks) and the HCP Packer registry.
 
-~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
+~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://www.ibm.com/mysupport) with questions.
 
 ```hcl
 # file: builds.pkr.hcl

--- a/content/packer/v1.14.x/content/docs/datasources/hcp/hcp-packer-artifact.mdx
+++ b/content/packer/v1.14.x/content/docs/datasources/hcp/hcp-packer-artifact.mdx
@@ -25,7 +25,7 @@ the [Get Started with HCP Packer tutorials](/packer/tutorials/hcp-get-started).
 
 ~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry.
 An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries
-with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
+with billing issues. Contact [HashiCorp Support](https://www.ibm.com/mysupport) with questions.
 
 ## Revoked Versions
 

--- a/content/packer/v1.14.x/content/docs/datasources/hcp/hcp-packer-image.mdx
+++ b/content/packer/v1.14.x/content/docs/datasources/hcp/hcp-packer-image.mdx
@@ -22,7 +22,7 @@ provide a source image to various Packer builders.
 
 To get started with HCP Packer, refer to the [HCP Packer documentation](/hcp/docs/packer) or try the [Get Started with HCP Packer tutorials](/packer/tutorials/hcp-get-started).
 
-~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
+~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://www.ibm.com/mysupport) with questions.
 
 ## Revoked Iterations
 

--- a/content/packer/v1.14.x/content/docs/datasources/hcp/hcp-packer-iteration.mdx
+++ b/content/packer/v1.14.x/content/docs/datasources/hcp/hcp-packer-iteration.mdx
@@ -22,7 +22,7 @@ HCP for a source image for various Packer builders.
 
 To get started with HCP Packer, refer to the [HCP Packer documentation](/hcp/docs/packer) or try the [Get Started with HCP Packer tutorials](/packer/tutorials/hcp-get-started).
 
-~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
+~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://www.ibm.com/mysupport) with questions.
 
 ## Revoked Iterations
 

--- a/content/packer/v1.14.x/content/docs/datasources/hcp/hcp-packer-version.mdx
+++ b/content/packer/v1.14.x/content/docs/datasources/hcp/hcp-packer-version.mdx
@@ -25,7 +25,7 @@ To get started with HCP Packer, refer to the [HCP Packer documentation](/hcp/doc
 [Get Started with HCP Packer tutorials](/packer/tutorials/hcp-get-started).
 
 Packer prints an error if you try to reference metadata from a deactivated or deleted registry.
-An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
+An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://www.ibm.com/mysupport) with questions.
 
 ## Revoked Versions
 

--- a/content/packer/v1.14.x/content/docs/templates/hcl_templates/blocks/build/hcp_packer_registry.mdx
+++ b/content/packer/v1.14.x/content/docs/templates/hcl_templates/blocks/build/hcp_packer_registry.mdx
@@ -29,7 +29,7 @@ registry if the appropriate HCP credentials are set (`HCP_CLIENT_ID` and
 and exit immediately to avoid any potential artifact drift between the defined
 builders (source blocks) and the HCP Packer registry.
 
-~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
+~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://www.ibm.com/mysupport) with questions.
 
 ```hcl
 # file: builds.pkr.hcl

--- a/content/packer/v1.15.x/content/docs/datasources/hcp/hcp-packer-artifact.mdx
+++ b/content/packer/v1.15.x/content/docs/datasources/hcp/hcp-packer-artifact.mdx
@@ -25,7 +25,7 @@ the [Get Started with HCP Packer tutorials](/packer/tutorials/hcp-get-started).
 
 ~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry.
 An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries
-with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
+with billing issues. Contact [HashiCorp Support](https://www.ibm.com/mysupport) with questions.
 
 ## Revoked Versions
 

--- a/content/packer/v1.15.x/content/docs/datasources/hcp/hcp-packer-image.mdx
+++ b/content/packer/v1.15.x/content/docs/datasources/hcp/hcp-packer-image.mdx
@@ -22,7 +22,7 @@ provide a source image to various Packer builders.
 
 To get started with HCP Packer, refer to the [HCP Packer documentation](/hcp/docs/packer) or try the [Get Started with HCP Packer tutorials](/packer/tutorials/hcp-get-started).
 
-~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
+~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://www.ibm.com/mysupport) with questions.
 
 ## Revoked Iterations
 

--- a/content/packer/v1.15.x/content/docs/datasources/hcp/hcp-packer-iteration.mdx
+++ b/content/packer/v1.15.x/content/docs/datasources/hcp/hcp-packer-iteration.mdx
@@ -22,7 +22,7 @@ HCP for a source image for various Packer builders.
 
 To get started with HCP Packer, refer to the [HCP Packer documentation](/hcp/docs/packer) or try the [Get Started with HCP Packer tutorials](/packer/tutorials/hcp-get-started).
 
-~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
+~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://www.ibm.com/mysupport) with questions.
 
 ## Revoked Iterations
 

--- a/content/packer/v1.15.x/content/docs/datasources/hcp/hcp-packer-version.mdx
+++ b/content/packer/v1.15.x/content/docs/datasources/hcp/hcp-packer-version.mdx
@@ -25,7 +25,7 @@ To get started with HCP Packer, refer to the [HCP Packer documentation](/hcp/doc
 [Get Started with HCP Packer tutorials](/packer/tutorials/hcp-get-started).
 
 Packer prints an error if you try to reference metadata from a deactivated or deleted registry.
-An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
+An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://www.ibm.com/mysupport) with questions.
 
 ## Revoked Versions
 

--- a/content/packer/v1.15.x/content/docs/templates/hcl_templates/blocks/build/hcp_packer_registry.mdx
+++ b/content/packer/v1.15.x/content/docs/templates/hcl_templates/blocks/build/hcp_packer_registry.mdx
@@ -29,7 +29,7 @@ registry if the appropriate HCP credentials are set (`HCP_CLIENT_ID` and
 and exit immediately to avoid any potential artifact drift between the defined
 builders (source blocks) and the HCP Packer registry.
 
-~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
+~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://www.ibm.com/mysupport) with questions.
 
 ```hcl
 # file: builds.pkr.hcl

--- a/content/packer/v1.16.x/content/docs/datasources/hcp/hcp-packer-artifact.mdx
+++ b/content/packer/v1.16.x/content/docs/datasources/hcp/hcp-packer-artifact.mdx
@@ -25,7 +25,7 @@ the [Get Started with HCP Packer tutorials](/packer/tutorials/hcp-get-started).
 
 ~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry.
 An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries
-with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
+with billing issues. Contact [HashiCorp Support](https://www.ibm.com/mysupport) with questions.
 
 ## Revoked Versions
 

--- a/content/packer/v1.16.x/content/docs/datasources/hcp/hcp-packer-image.mdx
+++ b/content/packer/v1.16.x/content/docs/datasources/hcp/hcp-packer-image.mdx
@@ -22,7 +22,7 @@ provide a source image to various Packer builders.
 
 To get started with HCP Packer, refer to the [HCP Packer documentation](/hcp/docs/packer) or try the [Get Started with HCP Packer tutorials](/packer/tutorials/hcp-get-started).
 
-~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
+~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://www.ibm.com/mysupport) with questions.
 
 ## Revoked Iterations
 

--- a/content/packer/v1.16.x/content/docs/datasources/hcp/hcp-packer-iteration.mdx
+++ b/content/packer/v1.16.x/content/docs/datasources/hcp/hcp-packer-iteration.mdx
@@ -22,7 +22,7 @@ HCP for a source image for various Packer builders.
 
 To get started with HCP Packer, refer to the [HCP Packer documentation](/hcp/docs/packer) or try the [Get Started with HCP Packer tutorials](/packer/tutorials/hcp-get-started).
 
-~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
+~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://www.ibm.com/mysupport) with questions.
 
 ## Revoked Iterations
 

--- a/content/packer/v1.16.x/content/docs/datasources/hcp/hcp-packer-version.mdx
+++ b/content/packer/v1.16.x/content/docs/datasources/hcp/hcp-packer-version.mdx
@@ -25,7 +25,7 @@ To get started with HCP Packer, refer to the [HCP Packer documentation](/hcp/doc
 [Get Started with HCP Packer tutorials](/packer/tutorials/hcp-get-started).
 
 Packer prints an error if you try to reference metadata from a deactivated or deleted registry.
-An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
+An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://www.ibm.com/mysupport) with questions.
 
 ## Revoked Versions
 

--- a/content/packer/v1.16.x/content/docs/templates/hcl_templates/blocks/build/hcp_packer_registry.mdx
+++ b/content/packer/v1.16.x/content/docs/templates/hcl_templates/blocks/build/hcp_packer_registry.mdx
@@ -29,7 +29,7 @@ registry if the appropriate HCP credentials are set (`HCP_CLIENT_ID` and
 and exit immediately to avoid any potential artifact drift between the defined
 builders (source blocks) and the HCP Packer registry.
 
-~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
+~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://www.ibm.com/mysupport) with questions.
 
 ```hcl
 # file: builds.pkr.hcl

--- a/content/packer/v1.8.x/content/docs/datasources/hcp/hcp-packer-image.mdx
+++ b/content/packer/v1.8.x/content/docs/datasources/hcp/hcp-packer-image.mdx
@@ -25,7 +25,7 @@ provide a source image to various Packer builders.
 
 To get started with HCP Packer, refer to the [HCP Packer documentation](https://cloud.hashicorp.com/docs/packer) or try the [Get Started with HCP Packer tutorials](https://learn.hashicorp.com/collections/packer/hcp-get-started).
 
-~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
+~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://www.ibm.com/mysupport) with questions.
 
 ## Revoked Iterations
 

--- a/content/packer/v1.8.x/content/docs/datasources/hcp/hcp-packer-iteration.mdx
+++ b/content/packer/v1.8.x/content/docs/datasources/hcp/hcp-packer-iteration.mdx
@@ -25,7 +25,7 @@ HCP for a source image for various Packer builders.
 
 To get started with HCP Packer, refer to the [HCP Packer documentation](https://cloud.hashicorp.com/docs/packer) or try the [Get Started with HCP Packer tutorials](https://learn.hashicorp.com/collections/packer/hcp-get-started).
 
-~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
+~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://www.ibm.com/mysupport) with questions.
 
 ## Revoked Iterations
 

--- a/content/packer/v1.8.x/content/docs/templates/hcl_templates/blocks/build/hcp_packer_registry.mdx
+++ b/content/packer/v1.8.x/content/docs/templates/hcl_templates/blocks/build/hcp_packer_registry.mdx
@@ -26,7 +26,7 @@ registry if the appropriate HCP credentials are set (`HCP_CLIENT_ID` and
 and exit immediately to avoid any potential artifact drift between the defined
 builders (source blocks) and the HCP Packer registry.
 
-~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
+~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://www.ibm.com/mysupport) with questions.
 
 ```hcl
 # file: builds.pkr.hcl

--- a/content/packer/v1.9.x/content/docs/datasources/hcp/hcp-packer-image.mdx
+++ b/content/packer/v1.9.x/content/docs/datasources/hcp/hcp-packer-image.mdx
@@ -25,7 +25,7 @@ provide a source image to various Packer builders.
 
 To get started with HCP Packer, refer to the [HCP Packer documentation](/hcp/docs/packer) or try the [Get Started with HCP Packer tutorials](/packer/tutorials/hcp-get-started).
 
-~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
+~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://www.ibm.com/mysupport) with questions.
 
 ## Revoked Iterations
 

--- a/content/packer/v1.9.x/content/docs/datasources/hcp/hcp-packer-iteration.mdx
+++ b/content/packer/v1.9.x/content/docs/datasources/hcp/hcp-packer-iteration.mdx
@@ -25,7 +25,7 @@ HCP for a source image for various Packer builders.
 
 To get started with HCP Packer, refer to the [HCP Packer documentation](/hcp/docs/packer) or try the [Get Started with HCP Packer tutorials](/packer/tutorials/hcp-get-started).
 
-~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
+~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://www.ibm.com/mysupport) with questions.
 
 ## Revoked Iterations
 

--- a/content/packer/v1.9.x/content/docs/templates/hcl_templates/blocks/build/hcp_packer_registry.mdx
+++ b/content/packer/v1.9.x/content/docs/templates/hcl_templates/blocks/build/hcp_packer_registry.mdx
@@ -26,7 +26,7 @@ registry if the appropriate HCP credentials are set (`HCP_CLIENT_ID` and
 and exit immediately to avoid any potential artifact drift between the defined
 builders (source blocks) and the HCP Packer registry.
 
-~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://support.hashicorp.com/) with questions.
+~> **Note:** You will receive an error if you try to reference metadata from a deactivated or deleted registry. An administrator can manually deactivate or delete a registry, and HCP Packer automatically deactivates registries with billing issues. Contact [HashiCorp Support](https://www.ibm.com/mysupport) with questions.
 
 ```hcl
 # file: builds.pkr.hcl


### PR DESCRIPTION
## Summary

Replaces legacy HashiCorp support URL with IBM equivalent across all affected version directories.

| | |
|---|---|
| **Product** | Packer |
| **Document paths** | `content/docs/datasources/hcp/hcp-packer-artifact.mdx`<br>`content/docs/datasources/hcp/hcp-packer-image.mdx`<br>`content/docs/datasources/hcp/hcp-packer-iteration.mdx`<br>`content/docs/datasources/hcp/hcp-packer-version.mdx`<br>`content/docs/templates/hcl_templates/blocks/build/hcp_packer_registry.mdx` |
| **Old URL** | `https://support.hashicorp.com/` |
| **New URL** | `https://www.ibm.com/mysupport` |
| **Versions updated** | 41 |

Part of the IBM DevDoc KB Remapping effort.