### PR TITLE
docs(vagrant): replace support.hashicorp.com link in intro/support.mdx

### DIFF
--- a/content/vagrant/v2.4.3/content/intro/support.mdx
+++ b/content/vagrant/v2.4.3/content/intro/support.mdx
@@ -11,7 +11,7 @@ last_modified: 2025-11-20T11:55:22-05:00
 # Contact Support
 
 To submit a support ticket:
-1.  Visit the HashiCorp [Support Page](https://support.hashicorp.com/hc/en-us) to explore our support knowledge base for answers to your questions. If you do not find what you need, click `Open a new ticket` to get in touch with us directly.
+1.  Visit the HashiCorp [Support Page](https://www.ibm.com/mysupport) to explore our support knowledge base for answers to your questions. If you do not find what you need, click `Open a new ticket` to get in touch with us directly.
 2. Submit a new support ticket by selecting `Cloud Customer` and choose `HCP Vagrant` from the dropdown menu.
 
 ### Free Support

--- a/content/vagrant/v2.4.4/content/intro/support.mdx
+++ b/content/vagrant/v2.4.4/content/intro/support.mdx
@@ -11,7 +11,7 @@ last_modified: 2025-11-20T11:55:22-05:00
 # Contact Support
 
 To submit a support ticket:
-1.  Visit the HashiCorp [Support Page](https://support.hashicorp.com/hc/en-us) to explore our support knowledge base for answers to your questions. If you do not find what you need, click `Open a new ticket` to get in touch with us directly.
+1.  Visit the HashiCorp [Support Page](https://www.ibm.com/mysupport) to explore our support knowledge base for answers to your questions. If you do not find what you need, click `Open a new ticket` to get in touch with us directly.
 2. Submit a new support ticket by selecting `Cloud Customer` and choose `HCP Vagrant` from the dropdown menu.
 
 ### Free Support

--- a/content/vagrant/v2.4.5/content/intro/support.mdx
+++ b/content/vagrant/v2.4.5/content/intro/support.mdx
@@ -11,7 +11,7 @@ last_modified: 2025-11-20T11:55:22-05:00
 # Contact Support
 
 To submit a support ticket:
-1.  Visit the HashiCorp [Support Page](https://support.hashicorp.com/hc/en-us) to explore our support knowledge base for answers to your questions. If you do not find what you need, click `Open a new ticket` to get in touch with us directly.
+1.  Visit the HashiCorp [Support Page](https://www.ibm.com/mysupport) to explore our support knowledge base for answers to your questions. If you do not find what you need, click `Open a new ticket` to get in touch with us directly.
 2. Submit a new support ticket by selecting `Cloud Customer` and choose `HCP Vagrant` from the dropdown menu.
 
 ### Free Support

--- a/content/vagrant/v2.4.6/content/intro/support.mdx
+++ b/content/vagrant/v2.4.6/content/intro/support.mdx
@@ -11,7 +11,7 @@ last_modified: 2025-11-20T11:55:22-05:00
 # Contact Support
 
 To submit a support ticket:
-1.  Visit the HashiCorp [Support Page](https://support.hashicorp.com/hc/en-us) to explore our support knowledge base for answers to your questions. If you do not find what you need, click `Open a new ticket` to get in touch with us directly.
+1.  Visit the HashiCorp [Support Page](https://www.ibm.com/mysupport) to explore our support knowledge base for answers to your questions. If you do not find what you need, click `Open a new ticket` to get in touch with us directly.
 2. Submit a new support ticket by selecting `Cloud Customer` and choose `HCP Vagrant` from the dropdown menu.
 
 ### Free Support

--- a/content/vagrant/v2.4.7/content/intro/support.mdx
+++ b/content/vagrant/v2.4.7/content/intro/support.mdx
@@ -11,7 +11,7 @@ last_modified: 2025-11-20T11:55:22-05:00
 # Contact Support
 
 To submit a support ticket:
-1.  Visit the HashiCorp [Support Page](https://support.hashicorp.com/hc/en-us) to explore our support knowledge base for answers to your questions. If you do not find what you need, click `Open a new ticket` to get in touch with us directly.
+1.  Visit the HashiCorp [Support Page](https://www.ibm.com/mysupport) to explore our support knowledge base for answers to your questions. If you do not find what you need, click `Open a new ticket` to get in touch with us directly.
 2. Submit a new support ticket by selecting `Cloud Customer` and choose `HCP Vagrant` from the dropdown menu.
 
 ### Free Support

--- a/content/vagrant/v2.4.8/content/intro/support.mdx
+++ b/content/vagrant/v2.4.8/content/intro/support.mdx
@@ -11,7 +11,7 @@ last_modified: 2025-11-20T11:55:22-05:00
 # Contact Support
 
 To submit a support ticket:
-1.  Visit the HashiCorp [Support Page](https://support.hashicorp.com/hc/en-us) to explore our support knowledge base for answers to your questions. If you do not find what you need, click `Open a new ticket` to get in touch with us directly.
+1.  Visit the HashiCorp [Support Page](https://www.ibm.com/mysupport) to explore our support knowledge base for answers to your questions. If you do not find what you need, click `Open a new ticket` to get in touch with us directly.
 2. Submit a new support ticket by selecting `Cloud Customer` and choose `HCP Vagrant` from the dropdown menu.
 
 ### Free Support

--- a/content/vagrant/v2.4.9/content/intro/support.mdx
+++ b/content/vagrant/v2.4.9/content/intro/support.mdx
@@ -11,7 +11,7 @@ last_modified: 2025-11-20T11:55:22-05:00
 # Contact Support
 
 To submit a support ticket:
-1.  Visit the HashiCorp [Support Page](https://support.hashicorp.com/hc/en-us) to explore our support knowledge base for answers to your questions. If you do not find what you need, click `Open a new ticket` to get in touch with us directly.
+1.  Visit the HashiCorp [Support Page](https://www.ibm.com/mysupport) to explore our support knowledge base for answers to your questions. If you do not find what you need, click `Open a new ticket` to get in touch with us directly.
 2. Submit a new support ticket by selecting `Cloud Customer` and choose `HCP Vagrant` from the dropdown menu.
 
 @include "@global/vagrant-eol.mdx"


### PR DESCRIPTION
## Summary

Replaces legacy HashiCorp support URL with IBM equivalent across all affected version directories.

| | |
|---|---|
| **Product** | Vagrant |
| **Document path** | `content/intro/support.mdx` |
| **Old URL** | `https://support.hashicorp.com/hc/en-us` |
| **New URL** | `https://www.ibm.com/mysupport` |
| **Versions updated** | 7 |

Part of the IBM DevDoc KB Remapping effort.