### PR TITLE
HVD-2068: Clarify Nomad rootless client permission requirements

### DIFF
--- a/content/validated-designs/docs/docs/nomad/installation-guide/change-log.mdx
+++ b/content/validated-designs/docs/docs/nomad/installation-guide/change-log.mdx
@@ -9,6 +9,10 @@ last_modified: 2026-07-03T10:00:00.000Z
 
 # Changelog
 
+## 2026-09
+
+- Clarified Nomad server versus client user-permission requirements: servers run as a dedicated non-root `nomad` user, while clients must run as `root` due to Linux capability requirements for OS isolation and task drivers such as `exec` and `java`. Corrected the systemd unit examples in the cloud and on-premises deployment guides to match, and added guidance on the unsupported nature of rootless Nomad clients, relevant to GPU/AI node pool design.
+
 ## 2026-08
 
 - Restructured legacy Nomad HVD content into the HVD 2.0 Nomad Installation Guide as part of the Installation / Administration / User guide migration.

--- a/content/validated-designs/docs/docs/nomad/installation-guide/change-log.mdx
+++ b/content/validated-designs/docs/docs/nomad/installation-guide/change-log.mdx
@@ -11,7 +11,8 @@ last_modified: 2026-07-03T10:00:00.000Z
 
 ## 2026-09
 
-- Clarified Nomad server versus client user-permission requirements: servers run as a dedicated non-root `nomad` user, while clients must run as `root` due to Linux capability requirements for OS isolation and task drivers such as `exec` and `java`. Corrected the systemd unit examples in the cloud and on-premises deployment guides to match, and added guidance on the unsupported nature of rootless Nomad clients, relevant to GPU/AI node pool design.
+- Clarified Nomad server vs. client root/non-root permission requirements
+- Corrected inconsistent systemd unit examples for servers and clients
 
 ## 2026-08
 

--- a/content/validated-designs/docs/docs/nomad/installation-guide/cloud-deployment.mdx
+++ b/content/validated-designs/docs/docs/nomad/installation-guide/cloud-deployment.mdx
@@ -402,6 +402,15 @@ If you are using a <a href="https://developer.hashicorp.com/nomad/docs/configura
 
 ### Starting Nomad
 
+#### Create the Nomad service user
+
+Nomad servers run as a dedicated, minimally privileged user. Create the `nomad` system user and group, and make sure the Nomad data directory has this user as owner:
+
+```shell
+sudo useradd --system --home /etc/nomad.d --shell /bin/false nomad
+sudo chown -R nomad:nomad /opt/nomad /etc/nomad.d
+```
+
 #### Set up Nomad service
 
 ```shell
@@ -417,10 +426,8 @@ After=network-online.target
 
 [Service]
 
-# Nomad servers should be run as the nomad user.
-# Nomad clients should be run as root
-User=root
-Group=root
+User=nomad
+Group=nomad
 
 ExecReload=/bin/kill -HUP $MAINPID
 ExecStart=/usr/local/bin/nomad agent -config /etc/nomad.d
@@ -497,6 +504,12 @@ nomad -autocomplete-install && complete -C /usr/bin/nomad nomad
 
 This section provides guidance on deploying and managing Nomad clients. Nomad clients are responsible for running tasks and jobs scheduled by the Nomad servers. They register with the server cluster, receive work assignments, and execute tasks.
 
+<Note>
+
+Unlike Nomad servers, Nomad client agents must run as `root`. Clients perform privileged OS isolation operations (cgroups, namespace isolation, `bridge` networking) and the built-in `exec` and `java` task drivers require root privileges to bind-mount task volumes. Do not apply the `nomad` non-root user configuration from the server deployment steps to your client nodes — when you reach the "Set up Nomad service" step below, leave `User=root` and `Group=root` in the systemd unit for client nodes.
+
+</Note>
+
 #### Preparation
 
 Many of the preparation steps for Nomad clients are similar to those for servers. Refer to the <a href="/validated-designs/nomad/installation-guide/cloud-deployment#platform-specific-guidance" target="_blank">Platform-specific guidance</a> section for details on the following:
@@ -511,7 +524,11 @@ Organize these instance families within Nomad using <a href="/validated-designs/
 
 #### Deployment process
 
-Follow the steps in the <a href="/validated-designs/nomad/installation-guide/cloud-deployment#preparation" target="_blank">preparation</a> and <a href="/validated-designs/nomad/installation-guide/cloud-deployment#deployment-process" target="_blank">installation process</a> sections of the server deployment section, with a few key differences in configuration. Spread your clients across availability zones.
+Follow the steps in the <a href="/validated-designs/nomad/installation-guide/cloud-deployment#preparation" target="_blank">preparation</a> and <a href="/validated-designs/nomad/installation-guide/cloud-deployment#starting-nomad" target="_blank">Starting Nomad</a> sections of the server deployment section, with the following differences:
+
+- Spread your clients across availability zones.
+- Skip the "Create the Nomad service user" step. Nomad client agents must run as `root` — do not create or use a dedicated `nomad` user for client nodes.
+- In the systemd unit file, leave `User=root` and `Group=root` as shown, rather than substituting the `nomad` user used for servers.
 
 #### Client TLS configuration
 

--- a/content/validated-designs/docs/docs/nomad/installation-guide/detailed-design.mdx
+++ b/content/validated-designs/docs/docs/nomad/installation-guide/detailed-design.mdx
@@ -157,11 +157,23 @@ Some load balancers, such as Nginx, do not allow for both TLS passthrough and th
 
 ## Software
 
-To deploy production Nomad, this Validated Design only requires the Nomad Enterprise software binaries to be installed on the Nomad servers and clients. 
+To deploy production Nomad, this Validated Design only requires the Nomad Enterprise software binaries to be installed on the Nomad servers and clients.
 
-The Nomad server process should not be run as root.
+Nomad servers and clients have different, and opposing, user permission requirements.
 
-Instead, a dedicated user should be created and used both to run the Nomad service as well as to protect the files used by and created by Nomad.
+### Server user requirements
+
+The Nomad server process must not run as root. Instead, create a dedicated `nomad` user with the minimal set of required privileges and use it both to run the Nomad service and to own the files used and created by Nomad.
+
+### Client user requirements
+
+The Nomad client process must run as `root`. Nomad clients perform privileged OS isolation operations — including mounting tmpfs filesystems, configuring cgroups and namespace isolation, and setting up `bridge` networking — that require root privileges or the equivalent `CAP_SYS_ADMIN` and `CAP_NET_ADMIN` Linux capabilities. The built-in `exec` and `java` task drivers, which run in-process with the client agent, also require the client agent to run as `root` to bind-mount task volumes.
+
+<Note>
+
+It is possible to run Nomad clients as a non-root user with `CAP_SYS_ADMIN` and `CAP_NET_ADMIN` capabilities, or fully rootless with additional kernel and container runtime configuration. However, these capabilities are nearly functionally equivalent to running as root, and rootless client configurations are not officially supported or well-tested by HashiCorp. This is relevant when designing GPU or AI/ML node pools, where task drivers and device access patterns place additional demands on the client's privileged operations. See the <a href="https://developer.hashicorp.com/nomad/docs/deploy/production/requirements#rootless-nomad-clients" target="_blank" rel="noreferrer">Rootless Nomad clients</a> section of the Nomad production requirements documentation for more detail before pursuing this configuration.
+
+</Note>
 
 ## Nomad License
 

--- a/content/validated-designs/docs/docs/nomad/installation-guide/on-premises-deployment.mdx
+++ b/content/validated-designs/docs/docs/nomad/installation-guide/on-premises-deployment.mdx
@@ -255,6 +255,13 @@ If you are using a <a href="https://developer.hashicorp.com/nomad/docs/configura
 <Tabs>
 <Tab heading="Manual" group="manual">
 
+Create the `nomad` system user and set ownership of the data directory. Nomad servers run as this dedicated, minimally privileged user:
+
+```
+sudo useradd --system --home /etc/nomad.d --shell /bin/false nomad
+sudo chown -R nomad:nomad /opt/nomad /etc/nomad.d
+```
+
 Create the Nomad service file:
 
 ```
@@ -270,10 +277,8 @@ After=network-online.target
 
 [Service]
 
-# Nomad servers should be run as the nomad user.
-# Nomad clients should be run as root
-User=root
-Group=root
+User=nomad
+Group=nomad
 
 ExecReload=/bin/kill -HUP $MAINPID
 ExecStart=/usr/local/bin/nomad agent -config /etc/nomad.d
@@ -361,6 +366,12 @@ nomad -autocomplete-install && complete -C /usr/bin/nomad nomad
 
 ### Client installation
 The client installation process is similar to the server installation, with a few key differences in the configuration. Nomad clients are responsible for running tasks and jobs scheduled by the Nomad servers. They register with the server cluster, receive work assignments, and execute tasks.
+
+<Note>
+
+Unlike Nomad servers, Nomad client agents must run as `root`. Clients perform privileged OS isolation operations (cgroups, namespace isolation, `bridge` networking) and the built-in `exec` and `java` task drivers require root privileges to bind-mount task volumes. When you configure the client systemd unit using the <a href="/validated-designs/nomad/installation-guide/on-premises-deployment#starting-nomad" target="_blank">Starting Nomad</a> steps preceding this section, leave `User=root` and `Group=root` rather than substituting the `nomad` user used for servers, and do not run the `useradd`/`chown` steps for client nodes.
+
+</Note>
 
 #### Client TLS configuration
 Nomad clients must use a different certificate than the server nodes. From the same directory as the CA certificate you generated during the server installation steps:


### PR DESCRIPTION
## Summary

Corrects the Nomad HVD Installation Guide, which incorrectly implied Nomad servers and clients share the same non-root user requirement. In practice, **Nomad servers should run as a dedicated non-root `nomad` user**, but **Nomad clients must run as `root`** — client agents perform privileged OS isolation operations (cgroups, namespace isolation, `bridge` networking) and the built-in `exec` and `java` task drivers require root to bind-mount task volumes.

**Jira:** https://hashicorp.atlassian.net/browse/HVD-2068

## Changes

- `detailed-design.mdx`: split the single "run Nomad as non-root" guidance into separate server and client sections, explaining why clients must run as root and noting that rootless/capability-based client configurations are unsupported and relevant to GPU/AI node pool design.
- `cloud-deployment.mdx` / `on-premises-deployment.mdx`: added steps to create the dedicated `nomad` user for servers, corrected the systemd unit example (previously left `User=root`/`Group=root` with a comment contradicting the intent), and added explicit callouts telling client deployers to keep `User=root`/`Group=root` and skip the server user-creation step.
- `change-log.mdx`: recorded the correction.

This is a documentation-only change — no Terraform module changes are included.

## Follow-up needed

> ⚠️ **Needs-author (blocking-for-parity, not for this PR):** The HVD Terraform module currently deploys both Nomad servers *and* clients as non-root, which now diverges from these corrected docs. This should be tracked and addressed as a separate follow-up (module change or module-behavior documentation), not resolved in this docs-only PR.

## Notes

This is a draft PR. Please review the content for accuracy, tone, and alignment with surrounding HVD pages before requesting review.