### PR TITLE
docs(vault): document LDAP auto-auth password_file_path format

### DIFF
--- a/content/vault/v2.x/content/docs/agent-and-proxy/autoauth/methods/ldap.mdx
+++ b/content/vault/v2.x/content/docs/agent-and-proxy/autoauth/methods/ldap.mdx
@@ -16,7 +16,11 @@ method](/vault/docs/auth/ldap).
 
 ## Configuration
 
-- `password_file_path` `(string: required)` - The path to the password file
+- `password_file_path` `(string: required)` - Path to a regular file or symlink
+  whose entire contents are used as the LDAP password. The file is plain text
+  with no JSON or other encoding. Vault Agent and Vault Proxy do not trim
+  whitespace or a trailing newline, so write the password alone with no
+  trailing newline (for example, `printf '%s' 'secret' > /path/to/password`).
 
 - `username` `(string: required)` - The username to authenticate against on Vault
 


### PR DESCRIPTION
## Summary

Documents the file format for `password_file_path` in the Vault Agent/Proxy LDAP auto-auth method.

The docs previously only said “the path to the password file,” with no guidance on contents. From the implementation, Agent/Proxy reads the **entire file** as the password string (plain text, no JSON/encoding) and does **not** trim a trailing newline.

**Evidence** (`hashicorp/vault` `command/agentproxyshared/auth/ldap/ldap.go`, `ingressPass`):

```go
pass, err := os.ReadFile(k.passwordFilePath)
// ...
k.latestPass.Store(string(pass))
```

No `TrimSpace` / newline stripping is applied before the value is sent as `"password"` in `Authenticate`.

Closes / relates to: hashicorp/vault#29901

## Change

Minimal update to the `password_file_path` config bullet on the current (`v2.x`) LDAP auto-auth page, including a `printf` example that avoids a trailing newline.

## Test plan

- [ ] Preview MDX renders cleanly on the LDAP auto-auth page
- [ ] Confirm wording matches agent behavior above