### PR TITLE
Add Stacks policy enforcement doc link to changelog entry

### DIFF
--- a/content/terraform-docs-common/docs/cloud-docs/changelog.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/changelog.mdx
@@ -16,7 +16,7 @@ Keep track of changes to HCP Terraform.
 
 ## 2026-09-10
 
-* Terraform policy can now evaluate policies against Stacks. Evaluations are triggered during a deployment run, and occur post-plan.
+* Terraform policy can now evaluate [policies against Stacks](/terraform/cloud-docs/stacks/policy-enforcement) (beta). Evaluations are triggered during a deployment run, and occur post-plan.
 
 ## 2026-09-05
 


### PR DESCRIPTION
Link the "policies against Stacks" changelog entry (2026-09-10) to the official Stacks policy enforcement documentation and note that the feature is in beta.

Please go to the `Preview` tab and select the appropriate template:

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
