### PR TITLE
vault/pki: remove stale Consul CA provider support.hashicorp.com callout

### DIFF
--- a/content/vault/v1.11.x/content/docs/release-notes/1.11.0.mdx
+++ b/content/vault/v1.11.x/content/docs/release-notes/1.11.0.mdx
@@ -108,9 +108,7 @@ Previously, KMIP did not support certain operations such as import, decrypt, enc
 
 ## Known issues
 
-When you use Vault 1.11.0+ as a Consul's Connect CA, you may encounter an issue generating the leaf certificates ([GH-15525](https://github.com/hashicorp/consul/pull/15525)). Upgrade your [Consul version that includes the fix](https://support.hashicorp.com/hc/en-us/articles/11308460105491#01GMC24E6PPGXMRX8DMT4HZYTW) to avoid running into this problem. 
-
--> Refer to this [Knowledge Base article](https://support.hashicorp.com/hc/en-us/articles/11308460105491) for more details.
+When you use Vault 1.11.0+ as a Consul Connect CA, you may encounter an issue generating leaf certificates ([GH-15525](https://github.com/hashicorp/consul/pull/15525)). Upgrade to Consul 1.15.0+ to avoid this issue.
 
 ## Feature deprecations and EOL
 

--- a/content/vault/v1.11.x/content/docs/secrets/pki/index.mdx
+++ b/content/vault/v1.11.x/content/docs/secrets/pki/index.mdx
@@ -12,8 +12,6 @@ last_modified: 2023-09-27T00:00:00.000Z
 
 @include 'x509-sha1-deprecation.mdx'
 
--> **Vault as Consul CA provider:** If you are using Vault 1.11.0+ as a Connect CA, run a Consul version which includes the fix for [GH-15525](https://github.com/hashicorp/consul/pull/15525). Refer to this [Knowledge Base article](https://support.hashicorp.com/hc/en-us/articles/11308460105491) for more details.
-
 The PKI secrets engine generates dynamic X.509 certificates. With this secrets
 engine, services can get certificates without going through the usual manual
 process of generating a private key and CSR, submitting to a CA, and waiting for

--- a/content/vault/v1.12.x/content/docs/release-notes/1.11.0.mdx
+++ b/content/vault/v1.12.x/content/docs/release-notes/1.11.0.mdx
@@ -108,9 +108,7 @@ Previously, KMIP did not support certain operations such as import, decrypt, enc
 
 ## Known issues
 
-When you use Vault 1.11.0+ as a Consul's Connect CA, you may encounter an issue generating the leaf certificates ([GH-15525](https://github.com/hashicorp/consul/pull/15525)). Upgrade your [Consul version that includes the fix](https://support.hashicorp.com/hc/en-us/articles/11308460105491#01GMC24E6PPGXMRX8DMT4HZYTW) to avoid running into this problem. 
-
--> Refer to this [Knowledge Base article](https://support.hashicorp.com/hc/en-us/articles/11308460105491) for more details.
+When you use Vault 1.11.0+ as a Consul Connect CA, you may encounter an issue generating leaf certificates ([GH-15525](https://github.com/hashicorp/consul/pull/15525)). Upgrade to Consul 1.15.0+ to avoid this issue.
 
 ## Feature deprecations and EOL
 

--- a/content/vault/v1.12.x/content/docs/secrets/pki/index.mdx
+++ b/content/vault/v1.12.x/content/docs/secrets/pki/index.mdx
@@ -12,8 +12,6 @@ last_modified: 2023-09-27T00:00:00.000Z
 
 @include 'x509-sha1-deprecation.mdx'
 
--> **Vault as Consul CA provider:** If you are using Vault 1.11.0+ as a Connect CA, run a Consul version which includes the fix for [GH-15525](https://github.com/hashicorp/consul/pull/15525). Refer to this [Knowledge Base article](https://support.hashicorp.com/hc/en-us/articles/11308460105491) for more details.
-
 The PKI secrets engine generates dynamic X.509 certificates. With this secrets
 engine, services can get certificates without going through the usual manual
 process of generating a private key and CSR, submitting to a CA, and waiting for

--- a/content/vault/v1.13.x/content/docs/release-notes/1.11.0.mdx
+++ b/content/vault/v1.13.x/content/docs/release-notes/1.11.0.mdx
@@ -108,9 +108,7 @@ Previously, KMIP did not support certain operations such as import, decrypt, enc
 
 ## Known issues
 
-When you use Vault 1.11.0+ as a Consul's Connect CA, you may encounter an issue generating the leaf certificates ([GH-15525](https://github.com/hashicorp/consul/pull/15525)). Upgrade your [Consul version that includes the fix](https://support.hashicorp.com/hc/en-us/articles/11308460105491#01GMC24E6PPGXMRX8DMT4HZYTW) to avoid running into this problem. 
-
--> Refer to this [Knowledge Base article](https://support.hashicorp.com/hc/en-us/articles/11308460105491) for more details.
+When you use Vault 1.11.0+ as a Consul Connect CA, you may encounter an issue generating leaf certificates ([GH-15525](https://github.com/hashicorp/consul/pull/15525)). Upgrade to Consul 1.15.0+ to avoid this issue.
 
 ## Feature deprecations and EOL
 

--- a/content/vault/v1.13.x/content/docs/secrets/pki/index.mdx
+++ b/content/vault/v1.13.x/content/docs/secrets/pki/index.mdx
@@ -12,8 +12,6 @@ last_modified: 2023-09-27T00:00:00.000Z
 
 @include 'x509-sha1-deprecation.mdx'
 
--> **Vault as Consul CA provider:** If you are using Vault 1.11.0+ as a Connect CA, run a Consul version which includes the fix for [GH-15525](https://github.com/hashicorp/consul/pull/15525). Refer to this [Knowledge Base article](https://support.hashicorp.com/hc/en-us/articles/11308460105491) for more details.
-
 The PKI secrets engine generates dynamic X.509 certificates. With this secrets
 engine, services can get certificates without going through the usual manual
 process of generating a private key and CSR, submitting to a CA, and waiting for

--- a/content/vault/v1.14.x/content/docs/release-notes/1.11.0.mdx
+++ b/content/vault/v1.14.x/content/docs/release-notes/1.11.0.mdx
@@ -108,9 +108,7 @@ Previously, KMIP did not support certain operations such as import, decrypt, enc
 
 ## Known issues
 
-When you use Vault 1.11.0+ as a Consul's Connect CA, you may encounter an issue generating the leaf certificates ([GH-15525](https://github.com/hashicorp/consul/pull/15525)). Upgrade your [Consul version that includes the fix](https://support.hashicorp.com/hc/en-us/articles/11308460105491#01GMC24E6PPGXMRX8DMT4HZYTW) to avoid running into this problem. 
-
--> Refer to this [Knowledge Base article](https://support.hashicorp.com/hc/en-us/articles/11308460105491) for more details.
+When you use Vault 1.11.0+ as a Consul Connect CA, you may encounter an issue generating leaf certificates ([GH-15525](https://github.com/hashicorp/consul/pull/15525)). Upgrade to Consul 1.15.0+ to avoid this issue.
 
 ## Feature deprecations and EOL
 

--- a/content/vault/v1.14.x/content/docs/secrets/pki/index.mdx
+++ b/content/vault/v1.14.x/content/docs/secrets/pki/index.mdx
@@ -12,8 +12,6 @@ last_modified: 2023-09-27T00:00:00.000Z
 
 @include 'x509-sha1-deprecation.mdx'
 
--> **Vault as Consul CA provider:** If you are using Vault 1.11.0+ as a Connect CA, run a Consul version which includes the fix for [GH-15525](https://github.com/hashicorp/consul/pull/15525). Refer to this [Knowledge Base article](https://support.hashicorp.com/hc/en-us/articles/11308460105491) for more details.
-
 The PKI secrets engine generates dynamic X.509 certificates. With this secrets
 engine, services can get certificates without going through the usual manual
 process of generating a private key and CSR, submitting to a CA, and waiting for

--- a/content/vault/v1.15.x/content/docs/release-notes/1.11.0.mdx
+++ b/content/vault/v1.15.x/content/docs/release-notes/1.11.0.mdx
@@ -108,9 +108,7 @@ Previously, KMIP did not support certain operations such as import, decrypt, enc
 
 ## Known issues
 
-When you use Vault 1.11.0+ as a Consul's Connect CA, you may encounter an issue generating the leaf certificates ([GH-15525](https://github.com/hashicorp/consul/pull/15525)). Upgrade your [Consul version that includes the fix](https://support.hashicorp.com/hc/en-us/articles/11308460105491#01GMC24E6PPGXMRX8DMT4HZYTW) to avoid running into this problem. 
-
--> Refer to this [Knowledge Base article](https://support.hashicorp.com/hc/en-us/articles/11308460105491) for more details.
+When you use Vault 1.11.0+ as a Consul Connect CA, you may encounter an issue generating leaf certificates ([GH-15525](https://github.com/hashicorp/consul/pull/15525)). Upgrade to Consul 1.15.0+ to avoid this issue.
 
 ## Feature deprecations and EOL
 

--- a/content/vault/v1.15.x/content/docs/secrets/pki/index.mdx
+++ b/content/vault/v1.15.x/content/docs/secrets/pki/index.mdx
@@ -12,8 +12,6 @@ last_modified: 2023-09-27T00:00:00.000Z
 
 @include 'x509-sha1-deprecation.mdx'
 
--> **Vault as Consul CA provider:** If you are using Vault 1.11.0+ as a Connect CA, run a Consul version which includes the fix for [GH-15525](https://github.com/hashicorp/consul/pull/15525). Refer to this [Knowledge Base article](https://support.hashicorp.com/hc/en-us/articles/11308460105491) for more details.
-
 The PKI secrets engine generates dynamic X.509 certificates. With this secrets
 engine, services can get certificates without going through the usual manual
 process of generating a private key and CSR, submitting to a CA, and waiting for

--- a/content/vault/v1.16.x/content/docs/release-notes/1.11.0.mdx
+++ b/content/vault/v1.16.x/content/docs/release-notes/1.11.0.mdx
@@ -108,9 +108,7 @@ Previously, KMIP did not support certain operations such as import, decrypt, enc
 
 ## Known issues
 
-When you use Vault 1.11.0+ as a Consul's Connect CA, you may encounter an issue generating the leaf certificates ([GH-15525](https://github.com/hashicorp/consul/pull/15525)). Upgrade your [Consul version that includes the fix](https://support.hashicorp.com/hc/en-us/articles/11308460105491#01GMC24E6PPGXMRX8DMT4HZYTW) to avoid running into this problem. 
-
--> Refer to this [Knowledge Base article](https://support.hashicorp.com/hc/en-us/articles/11308460105491) for more details.
+When you use Vault 1.11.0+ as a Consul Connect CA, you may encounter an issue generating leaf certificates ([GH-15525](https://github.com/hashicorp/consul/pull/15525)). Upgrade to Consul 1.15.0+ to avoid this issue.
 
 ## Feature deprecations and EOL
 

--- a/content/vault/v1.16.x/content/docs/secrets/pki/index.mdx
+++ b/content/vault/v1.16.x/content/docs/secrets/pki/index.mdx
@@ -12,8 +12,6 @@ last_modified: 2025-07-02T11:30:26-05:00
 
 @include 'x509-sha1-deprecation.mdx'
 
--> **Vault as Consul CA provider:** If you are using Vault 1.11.0+ as a Connect CA, run a Consul version which includes the fix for [GH-15525](https://github.com/hashicorp/consul/pull/15525). Refer to this [Knowledge Base article](https://support.hashicorp.com/hc/en-us/articles/11308460105491) for more details.
-
 The PKI secrets engine generates dynamic X.509 certificates. With this secrets
 engine, services can get certificates without going through the usual manual
 process of generating a private key and CSR, submitting to a CA, and waiting for

--- a/content/vault/v1.17.x/content/docs/release-notes/1.11.0.mdx
+++ b/content/vault/v1.17.x/content/docs/release-notes/1.11.0.mdx
@@ -108,9 +108,7 @@ Previously, KMIP did not support certain operations such as import, decrypt, enc
 
 ## Known issues
 
-When you use Vault 1.11.0+ as a Consul's Connect CA, you may encounter an issue generating the leaf certificates ([GH-15525](https://github.com/hashicorp/consul/pull/15525)). Upgrade your [Consul version that includes the fix](https://support.hashicorp.com/hc/en-us/articles/11308460105491#01GMC24E6PPGXMRX8DMT4HZYTW) to avoid running into this problem. 
-
--> Refer to this [Knowledge Base article](https://support.hashicorp.com/hc/en-us/articles/11308460105491) for more details.
+When you use Vault 1.11.0+ as a Consul Connect CA, you may encounter an issue generating leaf certificates ([GH-15525](https://github.com/hashicorp/consul/pull/15525)). Upgrade to Consul 1.15.0+ to avoid this issue.
 
 ## Feature deprecations and EOL
 

--- a/content/vault/v1.17.x/content/docs/secrets/pki/index.mdx
+++ b/content/vault/v1.17.x/content/docs/secrets/pki/index.mdx
@@ -12,8 +12,6 @@ last_modified: 2025-07-02T11:30:26-05:00
 
 @include 'x509-sha1-deprecation.mdx'
 
--> **Vault as Consul CA provider:** If you are using Vault 1.11.0+ as a Connect CA, run a Consul version which includes the fix for [GH-15525](https://github.com/hashicorp/consul/pull/15525). Refer to this [Knowledge Base article](https://support.hashicorp.com/hc/en-us/articles/11308460105491) for more details.
-
 The PKI secrets engine generates dynamic X.509 certificates. With this secrets
 engine, services can get certificates without going through the usual manual
 process of generating a private key and CSR, submitting to a CA, and waiting for

--- a/content/vault/v1.18.x/content/docs/release-notes/1.11.0.mdx
+++ b/content/vault/v1.18.x/content/docs/release-notes/1.11.0.mdx
@@ -108,9 +108,7 @@ Previously, KMIP did not support certain operations such as import, decrypt, enc
 
 ## Known issues
 
-When you use Vault 1.11.0+ as a Consul's Connect CA, you may encounter an issue generating the leaf certificates ([GH-15525](https://github.com/hashicorp/consul/pull/15525)). Upgrade your [Consul version that includes the fix](https://support.hashicorp.com/hc/en-us/articles/11308460105491#01GMC24E6PPGXMRX8DMT4HZYTW) to avoid running into this problem. 
-
--> Refer to this [Knowledge Base article](https://support.hashicorp.com/hc/en-us/articles/11308460105491) for more details.
+When you use Vault 1.11.0+ as a Consul Connect CA, you may encounter an issue generating leaf certificates ([GH-15525](https://github.com/hashicorp/consul/pull/15525)). Upgrade to Consul 1.15.0+ to avoid this issue.
 
 ## Feature deprecations and EOL
 

--- a/content/vault/v1.18.x/content/docs/secrets/pki/index.mdx
+++ b/content/vault/v1.18.x/content/docs/secrets/pki/index.mdx
@@ -12,16 +12,6 @@ last_modified: 2025-07-18T10:33:02-04:00
 
 @include 'x509-sha1-deprecation.mdx'
 
-<Note title="Vault as Consul CA provider">
-
-If you are using Vault 1.11.0+ as a Connect CA, run a Consul version which
-includes the fix for [GH-15525](https://github.com/hashicorp/consul/pull/15525).
-Refer to this [Knowledge Base
-article](https://support.hashicorp.com/hc/en-us/articles/11308460105491) for
-more details.
-
-</Note>
-
 The PKI secrets engine generates dynamic X.509 certificates. With this secrets
 engine, services can get certificates without going through the usual manual
 process of generating a private key and CSR, submitting to a CA, and waiting for

--- a/content/vault/v1.19.x/content/docs/secrets/pki/index.mdx
+++ b/content/vault/v1.19.x/content/docs/secrets/pki/index.mdx
@@ -12,16 +12,6 @@ last_modified: 2025-07-02T11:30:26-05:00
 
 @include 'x509-sha1-deprecation.mdx'
 
-<Note title="Vault as Consul CA provider">
-
-If you are using Vault 1.11.0+ as a Connect CA, run a Consul version which
-includes the fix for [GH-15525](https://github.com/hashicorp/consul/pull/15525).
-Refer to this [Knowledge Base
-article](https://support.hashicorp.com/hc/en-us/articles/11308460105491) for
-more details.
-
-</Note>
-
 The PKI secrets engine generates dynamic X.509 certificates. With this secrets
 engine, services can get certificates without going through the usual manual
 process of generating a private key and CSR, submitting to a CA, and waiting for

--- a/content/vault/v1.20.x/content/docs/secrets/pki/index.mdx
+++ b/content/vault/v1.20.x/content/docs/secrets/pki/index.mdx
@@ -12,16 +12,6 @@ last_modified: 2025-07-01T14:39:24-05:00
 
 @include 'x509-sha1-deprecation.mdx'
 
-<Note title="Vault as Consul CA provider">
-
-If you are using Vault 1.11.0+ as a Connect CA, run a Consul version which
-includes the fix for [GH-15525](https://github.com/hashicorp/consul/pull/15525).
-Refer to this [Knowledge Base
-article](https://support.hashicorp.com/hc/en-us/articles/11308460105491) for
-more details.
-
-</Note>
-
 The PKI secrets engine generates dynamic X.509 certificates. With this secrets
 engine, services can get certificates without going through the usual manual
 process of generating a private key and CSR, submitting to a CA, and waiting for

--- a/content/vault/v1.21.x/content/docs/secrets/pki/index.mdx
+++ b/content/vault/v1.21.x/content/docs/secrets/pki/index.mdx
@@ -12,16 +12,6 @@ last_modified: 2025-10-22T13:53:42-07:00
 
 @include 'x509-sha1-deprecation.mdx'
 
-<Note title="Vault as Consul CA provider">
-
-If you are using Vault 1.11.0+ as a Connect CA, run a Consul version which
-includes the fix for [GH-15525](https://github.com/hashicorp/consul/pull/15525).
-Refer to this [Knowledge Base
-article](https://support.hashicorp.com/hc/en-us/articles/11308460105491) for
-more details.
-
-</Note>
-
 The PKI secrets engine generates dynamic X.509 certificates. With this secrets
 engine, services can get certificates without going through the usual manual
 process of generating a private key and CSR, submitting to a CA, and waiting for

--- a/content/vault/v2.x/content/docs/secrets/pki/index.mdx
+++ b/content/vault/v2.x/content/docs/secrets/pki/index.mdx
@@ -12,16 +12,6 @@ last_modified: 2026-04-15T00:15:51.000Z
 
 @include 'x509-sha1-deprecation.mdx'
 
-<Note title="Vault as Consul CA provider">
-
-If you are using Vault 1.11.0+ as a Connect CA, run a Consul version which
-includes the fix for [GH-15525](https://github.com/hashicorp/consul/pull/15525).
-Refer to this [Knowledge Base
-article](https://support.hashicorp.com/hc/en-us/articles/11308460105491) for
-more details.
-
-</Note>
-
 The PKI secrets engine generates dynamic X.509 certificates. With this secrets
 engine, services can get certificates without going through the usual manual
 process of generating a private key and CSR, submitting to a CA, and waiting for


### PR DESCRIPTION
## Description

Removes the stale "Vault as Consul CA provider" callout from the PKI secrets engine overview page across all affected versions. The callout linked to a `support.hashicorp.com` KB article (11308460105491) for a Consul bug fix (GH-15525) that has been shipped for years. The KB article is no longer available as an IBM Support resource.

| Version | File | Change |
|---------|------|--------|
| v1.11.x | `content/docs/secrets/pki/index.mdx` | Removed `->` blockquote callout |
| v1.12.x | `content/docs/secrets/pki/index.mdx` | Removed `->` blockquote callout |
| v1.13.x | `content/docs/secrets/pki/index.mdx` | Removed `->` blockquote callout |
| v1.14.x | `content/docs/secrets/pki/index.mdx` | Removed `->` blockquote callout |
| v1.15.x | `content/docs/secrets/pki/index.mdx` | Removed `->` blockquote callout |
| v1.16.x | `content/docs/secrets/pki/index.mdx` | Removed `->` blockquote callout |
| v1.17.x | `content/docs/secrets/pki/index.mdx` | Removed `->` blockquote callout |
| v1.18.x | `content/docs/secrets/pki/index.mdx` | Removed `<Note>` component callout |
| v1.19.x | `content/docs/secrets/pki/index.mdx` | Removed `<Note>` component callout |
| v1.20.x | `content/docs/secrets/pki/index.mdx` | Removed `<Note>` component callout |
| v1.21.x | `content/docs/secrets/pki/index.mdx` | Removed `<Note>` component callout |
| v2.x | `content/docs/secrets/pki/index.mdx` | Removed `<Note>` component callout |
| v1.11.x | `content/docs/release-notes/1.11.0.mdx` | Rewrote known issue; removed KB link and `->` callout |
| v1.12.x | `content/docs/release-notes/1.11.0.mdx` | Rewrote known issue; removed KB link and `->` callout |
| v1.13.x | `content/docs/release-notes/1.11.0.mdx` | Rewrote known issue; removed KB link and `->` callout |
| v1.14.x | `content/docs/release-notes/1.11.0.mdx` | Rewrote known issue; removed KB link and `->` callout |
| v1.15.x | `content/docs/release-notes/1.11.0.mdx` | Rewrote known issue; removed KB link and `->` callout |
| v1.16.x | `content/docs/release-notes/1.11.0.mdx` | Rewrote known issue; removed KB link and `->` callout |
| v1.17.x | `content/docs/release-notes/1.11.0.mdx` | Rewrote known issue; removed KB link and `->` callout |
| v1.18.x | `content/docs/release-notes/1.11.0.mdx` | Rewrote known issue; removed KB link and `->` callout |
