### PR TITLE
feat(TF-40058): Clarify unknown RUM counts in Explorer API docs

### DIFF
--- a/content/terraform-docs-common/docs/cloud-docs/api-docs/explorer.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/api-docs/explorer.mdx
@@ -110,7 +110,7 @@ fields available for each view type are detailed below:
 | `checks_failed`                   | `number`   | The number of checks that completed and failed. |
 | `checks_passed`                   | `number`   | The number of checks that completed and passed. |
 | `checks_unknown`                  | `number`   | The number of checks that could not be assessed. |
-| `current_rum_count`               | `number`   | The number of [resources under management](/terraform/cloud-docs/overview/estimate-hcp-terraform-cost#what-is-a-managed-resource) (RUM). |
+| `current_rum_count`               | `number` or `null` | The number of [resources under management](/terraform/cloud-docs/overview#what-is-a-managed-resource) (RUM). HCP Terraform returns `null` when the count is unknown, including while it calculates the count. A `null` value does not mean the workspace has zero resources. |
 | `current_run_applied_at`          | `datetime` | Represents the time that this workspace's current run was applied. |
 | `current_run_external_id`         | `string`   | The external ID of this workspace's current run. |
 | `current_run_status`              | `string`   | The status of this workspace's current run. |
@@ -379,7 +379,7 @@ _Show data for all workspaces_
         "checks-failed": 0,
         "checks-passed": 0,
         "checks-unknown": 0,
-        "current-rum-count": 0,
+        "current-rum-count": null,
         "current-run-applied-at": "2023-08-18T16:24:59.000+00:00",
         "current-run-external-id": "run-9MmJaoQTvDCh5wUa",
         "current-run-status": "applied",
@@ -451,6 +451,11 @@ contain data that represents the current state of the system, but in some cases
 a small delay may be necessary before querying for data that has recently been
 updated.
 
+-> **Note:** An empty `current_rum_count` field means that HCP Terraform has not
+determined the workspace's RUM count. This can occur while HCP Terraform
+calculates the count. The empty field does not mean the workspace has zero
+resources.
+
 ### Query parameters
 
 This GET endpoint supports the same query string parameters as the Explorer [Query
@@ -475,7 +480,7 @@ _Show data for all workspaces_
 ```csv
 all_checks_succeeded,current_rum_count,checks_errored,checks_failed,checks_passed,checks_unknown,current_run_applied_at,current_run_external_id,current_run_status,drifted,external_id,module_count,modules,organization_name,project_external_id,project_name,provider_count,providers,resources_drifted,resources_undrifted,state_version_terraform_version,vcs_repo_identifier,workspace_created_at,workspace_name,workspace_terraform_version,workspace_updated_at
 "true","0","0","0","0","0","","run-rdoEKh2Gy3K6SbCZ","planned_and_finished","false","ws-j2sAeWRxou1b5HYf","0","","acme-corp","prj-V61QLE8tvs4NvVZG","Default Project","0","","0","0","1.5.7","","2023-10-17T21:56:45+00:00","payments-service","1.5.7","2023-12-13T15:48:16+00:00"
-"true","0","0","0","0","0","2023-08-18T16:24:59+00:00","run-9MmJaoQTvDCh5wUa","applied","true","ws-igUVNQSYVXRkhYuo","0","","acme-corp","prj-uU2xNqGeG86U9WgT","web","0","","3","3","1.4.5","acmecorp/api","2023-04-25T17:09:14+00:00","api-service","1.4.5","2023-12-13T15:29:03+00:00"
+"true","","0","0","0","0","2023-08-18T16:24:59+00:00","run-9MmJaoQTvDCh5wUa","applied","true","ws-igUVNQSYVXRkhYuo","0","","acme-corp","prj-uU2xNqGeG86U9WgT","web","0","","3","3","1.4.5","acmecorp/api","2023-04-25T17:09:14+00:00","api-service","1.4.5","2023-12-13T15:29:03+00:00"
 ```
 
 ## List saved views


### PR DESCRIPTION
Clarify unknown RUM counts in Explorer API docs

Please go to the `Preview` tab and select the appropriate template:

* [Boundary](?expand=1&labels=Boundary&title=Boundary+Docs&template=boundary_pull_request_template.md)
* [Consul](?expand=1&labels=Consul&title=Consul+Docs&template=consul_pull_request_template.md)
* [HCP services](?expand=1&template=hcp_pull_request_template.md)
* [Nomad](?expand=1&labels=Nomad,Runtime&title=Nomad+Docs&template=nomad_pull_request_template.md)

### Terraform

* [HCP Terraform](?expand=1&labels=hcp,terraform&title=HCP+Terraform+Docs&template=hcp_terraform_pull_request_template.md)
* [Terraform](?expand=1&labels=terraform&title=Terraform+Docs&template=terraform_pull_request_template.md)
* [Terraform Enterprise](?expand=1&template=ptfe_release_pull_request_template.md)
