### PR TITLE
docs: remove duplicate 'the' in custom Sentinel policy docs

### DIFF
--- a/content/terraform-docs-common/docs/cloud-docs/policy-enforcement/define-policies/custom-sentinel.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/policy-enforcement/define-policies/custom-sentinel.mdx
@@ -33,7 +33,7 @@ HCP Terraform provides four imports to define policy rules for the plan, configu
 - [tfstate](/terraform/cloud-docs/policy-enforcement/import-reference/tfstate-v2) - Access the Terraform [state](/terraform/language/state). Terraform uses state to map real-world resources to your configuration.
 - [tfrun](/terraform/cloud-docs/policy-enforcement/import-reference/tfrun) - Access data associated with a [run in HCP Terraform](/terraform/cloud-docs/workspaces/run/remote-operations). For example, you could retrieve the run's workspace.
 
-You can create mocks of these imports to use with the the [Sentinel
+You can create mocks of these imports to use with the [Sentinel
 CLI](/sentinel/docs/commands) mocking and testing features. Refer to [Mocking Terraform Sentinel Data](/terraform/cloud-docs/policy-enforcement/test/sentinel) for more details.
 
 <!-- BEGIN: TFC:only name:pnp-callout -->


### PR DESCRIPTION
Tiny docs fix: `with the the` → `with the` in the custom Sentinel policy docs.