### PR TITLE
docs: remove duplicate 'the' in HYOK configure docs

### DIFF
--- a/content/terraform-docs-common/docs/cloud-docs/hold-your-own-key/configure.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/hold-your-own-key/configure.mdx
@@ -656,5 +656,5 @@ must:
 
 1. Revoke the key in HCP Terraform.
 1. Wait until all workspaces have been migrated off of the key, which you can
-   check on the the **HYOK Encryption** page.
+   check on the **HYOK Encryption** page.
 1. Revoke the key in the KMS itself.


### PR DESCRIPTION
Tiny docs fix: `on the the` → `on the` in the HYOK Encryption configuration docs.