### PR TITLE
docs: remove duplicate 'the' in publish modules docs

### DIFF
--- a/content/terraform-docs-common/docs/cloud-docs/registry/publish-modules.mdx
+++ b/content/terraform-docs-common/docs/cloud-docs/registry/publish-modules.mdx
@@ -141,7 +141,7 @@ To release a new version of a module using the branch-based publishing workflow,
 
 ## Update publish settings
 
-After publishing your module, you can change between tag-based and branch-based publishing. To update your module's publish settings, navigate to the the module overview page, click the **Manage Module for Organization** dropdown, and then click **Publish Settings**.
+After publishing your module, you can change between tag-based and branch-based publishing. To update your module's publish settings, navigate to the module overview page, click the **Manage Module for Organization** dropdown, and then click **Publish Settings**.
 
 - To change from tag-based to branch-based publishing, you must configure a **Module branch** and [create a new module version](#branch-based-publishing-workflow), as HCP Terraform will not automatically create one.
 


### PR DESCRIPTION
Tiny docs fix: `to the the module` → `to the module` in the private registry publish modules docs.